### PR TITLE
Update calibration API endpoints to singular form

### DIFF
--- a/backend/server/main.py
+++ b/backend/server/main.py
@@ -23,7 +23,6 @@ from dbmodel.two_qubit_calib_history import TwoQubitCalibHistoryModel
 from dbmodel.wiring_info import WiringInfoModel
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.openapi.utils import get_openapi
 from fastapi.routing import APIRoute
 from pymongo import MongoClient
 from server.routers import (

--- a/backend/server/routers/calibration.py
+++ b/backend/server/routers/calibration.py
@@ -2,7 +2,7 @@ import os
 import uuid
 from datetime import datetime
 from logging import getLogger
-from typing import Annotated, List, Optional
+from typing import Annotated, Optional
 
 import dateutil.tz
 from fastapi import APIRouter, Depends, HTTPException, Security
@@ -28,13 +28,13 @@ from server.schemas.calibration import (
 )
 from server.schemas.exception import InternalSeverError
 
-router = APIRouter()
+router = APIRouter(prefix="/calibration")
 logger = getLogger("uvicorn.app")
 prefect_host = os.getenv("PREFECT_HOST")
 
 
 @router.post(
-    "/calibrations",
+    "/",
     response_model=ExecuteCalibResponse,
     summary="Executes a calibration by creating a flow run from a deployment.",
     operation_id="execute_calib",
@@ -82,7 +82,7 @@ local_date = datetime.now(tz=ja)
 
 
 @router.post(
-    "/calibrations/schedule",
+    "/schedule",
     summary="Schedules a calibration.",
     operation_id="schedule_calib",
 )
@@ -130,7 +130,7 @@ async def schedule_calib(
 
 
 @router.get(
-    "/calibrations/schedule",
+    "/schedule",
     response_model=list[ScheduleCalibResponse],
     summary="Fetches all the calibration schedules.",
     operation_id="fetch_all_calib_schedule",
@@ -180,7 +180,7 @@ async def fetch_all_calib_schedule(
 
 
 @router.delete(
-    "/calibrations/schedule/{flow_run_id}",
+    "/schedule/{flow_run_id}",
     summary="Deletes a calibration schedule.",
     operation_id="delete_calib_schedule",
 )

--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -15,7 +15,7 @@
     "version": "0.0.1"
   },
   "paths": {
-    "/calibrations": {
+    "/calibration/": {
       "post": {
         "tags": [
           "calibration"
@@ -62,7 +62,7 @@
         ]
       }
     },
-    "/calibrations/schedule": {
+    "/calibration/schedule": {
       "get": {
         "tags": [
           "calibration"
@@ -134,7 +134,7 @@
         ]
       }
     },
-    "/calibrations/schedule/{flow_run_id}": {
+    "/calibration/schedule/{flow_run_id}": {
       "delete": {
         "tags": [
           "calibration"

--- a/ui/src/app/contexts/AuthContext.tsx
+++ b/ui/src/app/contexts/AuthContext.tsx
@@ -112,7 +112,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         // トークンとユーザー名を保存
         const token = response.data.access_token;
         document.cookie = `token=${encodeURIComponent(
-          token
+          token,
         )}; path=/; max-age=${7 * 24 * 60 * 60}; SameSite=Lax`;
         saveUsername(username);
       } catch (error) {
@@ -120,7 +120,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         throw error;
       }
     },
-    [loginMutation, saveUsername]
+    [loginMutation, saveUsername],
   );
 
   const logout = useCallback(async () => {

--- a/ui/src/app/login/page.tsx
+++ b/ui/src/app/login/page.tsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
       router.replace("/");
     } catch (err) {
       setError(
-        "ログインに失敗しました。ユーザーIDとパスワードを確認してください。"
+        "ログインに失敗しました。ユーザーIDとパスワードを確認してください。",
       );
     }
   };

--- a/ui/src/client/calibration/calibration.ts
+++ b/ui/src/client/calibration/calibration.ts
@@ -53,7 +53,7 @@ export const executeCalib = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<ExecuteCalibResponse>> => {
   return axios.post(
-    `http://localhost:5715/calibrations`,
+    `http://localhost:5715/calibration/`,
     executeCalibRequest,
     options,
   );
@@ -133,11 +133,11 @@ export const useExecuteCalib = <
 export const fetchAllCalibSchedule = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<ScheduleCalibResponse[]>> => {
-  return axios.get(`http://localhost:5715/calibrations/schedule`, options);
+  return axios.get(`http://localhost:5715/calibration/schedule`, options);
 };
 
 export const getFetchAllCalibScheduleQueryKey = () => {
-  return [`http://localhost:5715/calibrations/schedule`] as const;
+  return [`http://localhost:5715/calibration/schedule`] as const;
 };
 
 export const getFetchAllCalibScheduleQueryOptions = <
@@ -266,7 +266,7 @@ export const scheduleCalib = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<unknown>> => {
   return axios.post(
-    `http://localhost:5715/calibrations/schedule`,
+    `http://localhost:5715/calibration/schedule`,
     scheduleCalibRequest,
     options,
   );
@@ -348,7 +348,7 @@ export const deleteCalibSchedule = (
   options?: AxiosRequestConfig,
 ): Promise<AxiosResponse<unknown>> => {
   return axios.delete(
-    `http://localhost:5715/calibrations/schedule/${flowRunId}`,
+    `http://localhost:5715/calibration/schedule/${flowRunId}`,
     options,
   );
 };


### PR DESCRIPTION
Refactor the calibration API to use singular endpoint names, improving consistency and clarity in the routing structure. Adjust related routes and API documentation accordingly.