### PR TITLE
Refactor parameter types to use models

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -1933,7 +1933,7 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
-      "InputParameter": {
+      "InputParameterModel": {
         "properties": {
           "unit": {
             "type": "string",
@@ -1970,7 +1970,7 @@
           }
         },
         "type": "object",
-        "title": "InputParameter",
+        "title": "InputParameterModel",
         "description": "Input parameter class."
       },
       "LatestTaskGroupedByChipResponse": {
@@ -2553,14 +2553,14 @@
           },
           "input_parameters": {
             "additionalProperties": {
-              "$ref": "#/components/schemas/InputParameter"
+              "$ref": "#/components/schemas/InputParameterModel"
             },
             "type": "object",
             "title": "Input Parameters"
           },
           "output_parameters": {
             "additionalProperties": {
-              "$ref": "#/components/schemas/InputParameter"
+              "$ref": "#/components/schemas/InputParameterModel"
             },
             "type": "object",
             "title": "Output Parameters"

--- a/src/qdash/api/routers/chip.py
+++ b/src/qdash/api/routers/chip.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from qdash.api.lib.auth import get_current_active_user, get_optional_current_user
 from qdash.api.lib.current_user import get_current_user_id
 from qdash.api.schemas.auth import User
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import OutputParameterModel
 from qdash.dbmodel.chip import ChipDocument
 from qdash.dbmodel.execution_history import ExecutionHistoryDocument
 from qdash.dbmodel.task import TaskDocument
@@ -496,7 +496,7 @@ class TimeSeriesProjection(BaseModel):
 class TimeSeriesData(BaseModel):
     """TimeSeriesData is a Pydantic model that represents the time series data."""
 
-    data: dict[str, list[DataModel]] = {}
+    data: dict[str, list[OutputParameterModel]] = {}
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -543,7 +543,7 @@ def _fetch_timeseries_data(
     )
 
     # Create a dictionary to store time series data for each qid
-    timeseries_by_qid: dict[str, list[DataModel]] = {}
+    timeseries_by_qid: dict[str, list[OutputParameterModel]] = {}
 
     # Process task results
     for task_result in task_results:

--- a/src/qdash/api/routers/task.py
+++ b/src/qdash/api/routers/task.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-class InputParameter(BaseModel):
+class InputParameterModel(BaseModel):
     """Input parameter class."""
 
     unit: str = ""
@@ -31,8 +31,8 @@ class TaskResponse(BaseModel):
     name: str
     description: str
     task_type: str
-    input_parameters: dict[str, InputParameter]
-    output_parameters: dict[str, InputParameter]
+    input_parameters: dict[str, InputParameterModel]
+    output_parameters: dict[str, InputParameterModel]
 
 
 class ListTaskResponse(BaseModel):
@@ -69,10 +69,12 @@ def fetch_all_tasks(
                 description=task.description,
                 task_type=task.task_type,
                 input_parameters={
-                    name: InputParameter(**param) for name, param in task.input_parameters.items()
+                    name: InputParameterModel(**param)
+                    for name, param in task.input_parameters.items()
                 },
                 output_parameters={
-                    name: InputParameter(**param) for name, param in task.output_parameters.items()
+                    name: InputParameterModel(**param)
+                    for name, param in task.output_parameters.items()
                 },
             )
             for task in tasks

--- a/src/qdash/workflow/tasks/base.py
+++ b/src/qdash/workflow/tasks/base.py
@@ -1,68 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Literal
 
-import numpy as np
 import plotly.graph_objs as go
 from pydantic import BaseModel
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qubex.experiment import Experiment
-
-
-class InputParameter(BaseModel):
-    """Input parameter class."""
-
-    unit: str = ""
-    value_type: str = "float"
-    value: tuple | int | float | None = None
-    description: str = ""
-
-    def get_value(self) -> Any:
-        """Get the actual value based on value_type.
-
-        Returns
-        -------
-            The converted value based on value_type
-
-        """
-        if self.value_type == "np.linspace":
-            if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.linspace requires a tuple/list of (start, stop, num)")
-            start, stop, num = self.value
-            return np.linspace(float(start), float(stop), int(num))
-        elif self.value_type == "np.logspace":
-            if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.logspace requires a tuple/list of (start, stop, num)")
-            start, stop, num = self.value
-            return np.logspace(float(start), float(stop), int(num))
-        elif self.value_type == "np.arange":
-            if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.arange requires a tuple/list of (start, stop, step)")
-            start, stop, step = self.value
-            return np.arange(float(start), float(stop), float(step))
-        elif self.value_type == "range":
-            if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("range requires a tuple/list of (start, stop, step)")
-            start, stop, step = self.value
-            return range(int(start), int(stop), int(step))
-        elif self.value_type == "int":
-            if isinstance(self.value, str) and "*" in self.value:
-                # Handle expressions like "150 * 1024"
-                parts = [int(p.strip()) for p in self.value.split("*")]
-                result = 1
-                for p in parts:
-                    result *= p
-                return result
-            return int(self.value)
-        elif self.value_type == "float":
-            return float(self.value)
-        return self.value
-
-
-class OutputParameter(BaseModel):
-    """Output parameter class."""
-
-    unit: str = ""
-    description: str = ""
 
 
 class PreProcessResult(BaseModel):
@@ -74,7 +16,7 @@ class PreProcessResult(BaseModel):
 class PostProcessResult(BaseModel):
     """Result class."""
 
-    output_parameters: dict[str, DataModel]
+    output_parameters: dict[str, OutputParameterModel]
     figures: list[go.Figure] = []
     raw_data: list[Any] = []
 
@@ -95,8 +37,8 @@ class BaseTask(ABC):
 
     name: str = ""
     task_type: Literal["global", "qubit", "coupling"]
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
     registry: ClassVar[dict] = {}
 
     def __init_subclass__(cls, **kwargs) -> None:  # noqa: ANN003

--- a/src/qdash/workflow/tasks/benchmark/randomized_benchmarking.py
+++ b/src/qdash/workflow/tasks/benchmark/randomized_benchmarking.py
@@ -1,11 +1,9 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -20,34 +18,34 @@ class RandomizedBenchmarking(BaseTask):
 
     name: str = "RandomizedBenchmarking"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "n_cliffords_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "n_cliffords_range": InputParameterModel(
             unit="a.u.",
             value_type="np.arange",
             value=(0, 1001, 100),
             description="Number of cliffords range",
         ),
-        "n_trials": InputParameter(
+        "n_trials": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=30,
             description="Number of trials",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=CALIBRATION_SHOTS,
             description="Number of shots",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "average_gate_fidelity": OutputParameter(
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "average_gate_fidelity": OutputParameterModel(
             unit="",
             description="Average gate fidelity",
         ),
@@ -60,7 +58,7 @@ class RandomizedBenchmarking(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "average_gate_fidelity": DataModel(
+            "average_gate_fidelity": OutputParameterModel(
                 value=result["avg_gate_fidelity"],
                 unit=op["average_gate_fidelity"].unit,
                 description=op["average_gate_fidelity"].description,

--- a/src/qdash/workflow/tasks/benchmark/x180_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/tasks/benchmark/x180_interleaved_randoized_benchmarking.py
@@ -1,11 +1,9 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -21,34 +19,34 @@ class X180InterleavedRandomizedBenchmarking(BaseTask):
 
     name: str = "X180InterleavedRandomizedBenchmarking"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "n_cliffords_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "n_cliffords_range": InputParameterModel(
             unit="a.u.",
             value_type="np.arange",
             value=(0, 1001, 100),
             description="Number of cliffords range",
         ),
-        "n_trials": InputParameter(
+        "n_trials": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=30,
             description="Number of trials",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=CALIBRATION_SHOTS,
             description="Number of shots",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "x180_gate_fidelity": OutputParameter(
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "x180_gate_fidelity": OutputParameterModel(
             unit="",
             description="X180 gate fidelity",
         ),
@@ -61,7 +59,7 @@ class X180InterleavedRandomizedBenchmarking(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "x180_gate_fidelity": DataModel(
+            "x180_gate_fidelity": OutputParameterModel(
                 value=result["gate_fidelity"],
                 unit=op["x180_gate_fidelity"].unit,
                 description=op["x180_gate_fidelity"].description,

--- a/src/qdash/workflow/tasks/benchmark/x90_interleaved_randomized_benchmarking.py
+++ b/src/qdash/workflow/tasks/benchmark/x90_interleaved_randomized_benchmarking.py
@@ -1,11 +1,9 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -21,34 +19,34 @@ class X90InterleavedRandomizedBenchmarking(BaseTask):
 
     name: str = "X90InterleavedRandomizedBenchmarking"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "n_cliffords_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "n_cliffords_range": InputParameterModel(
             unit="a.u.",
             value_type="np.arange",
             value=(0, 1001, 100),
             description="Number of cliffords range",
         ),
-        "n_trials": InputParameter(
+        "n_trials": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=30,
             description="Number of trials",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=CALIBRATION_SHOTS,
             description="Number of shots",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "x90_gate_fidelity": OutputParameter(
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "x90_gate_fidelity": OutputParameterModel(
             unit="",
             description="X90 gate fidelity",
         ),
@@ -61,7 +59,7 @@ class X90InterleavedRandomizedBenchmarking(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "x90_gate_fidelity": DataModel(
+            "x90_gate_fidelity": OutputParameterModel(
                 value=result["gate_fidelity"],
                 unit=op["x90_gate_fidelity"].unit,
                 description=op["x90_gate_fidelity"].description,

--- a/src/qdash/workflow/tasks/benchmark/zx90_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/tasks/benchmark/zx90_interleaved_randoized_benchmarking.py
@@ -1,11 +1,9 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -20,34 +18,34 @@ class ZX90InterleavedRandomizedBenchmarking(BaseTask):
 
     name: str = "ZX90InterleavedRandomizedBenchmarking"
     task_type: str = "coupling"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "n_cliffords_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "n_cliffords_range": InputParameterModel(
             unit="a.u.",
             value_type="np.arange",
             value=(0, 1001, 100),
             description="Number of cliffords range",
         ),
-        "n_trials": InputParameter(
+        "n_trials": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=30,
             description="Number of trials",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=CALIBRATION_SHOTS,
             description="Number of shots",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "zx90_gate_fidelity": OutputParameter(
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "zx90_gate_fidelity": OutputParameterModel(
             unit="",
             description="ZX90 gate fidelity",
         ),
@@ -61,7 +59,7 @@ class ZX90InterleavedRandomizedBenchmarking(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "zx90_gate_fidelity": DataModel(
+            "zx90_gate_fidelity": OutputParameterModel(
                 value=result["mean"][label],
                 unit=op["zx90_gate_fidelity"].unit,
                 description=op["zx90_gate_fidelity"].description,

--- a/src/qdash/workflow/tasks/box_setup/check_noise.py
+++ b/src/qdash/workflow/tasks/box_setup/check_noise.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,8 +15,8 @@ class CheckNoise(BaseTask):
 
     name: str = "CheckNoise"
     task_type: str = "global"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/box_setup/check_status.py
+++ b/src/qdash/workflow/tasks/box_setup/check_status.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,8 +15,8 @@ class CheckStatus(BaseTask):
 
     name: str = "CheckStatus"
     task_type: str = "global"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/box_setup/configure.py
+++ b/src/qdash/workflow/tasks/box_setup/configure.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,8 +15,8 @@ class Configure(BaseTask):
 
     name: str = "Configure"
     task_type: str = "global"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/box_setup/dump_box.py
+++ b/src/qdash/workflow/tasks/box_setup/dump_box.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,8 +15,8 @@ class DumpBox(BaseTask):
 
     name: str = "DumpBox"
     task_type: str = "global"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/box_setup/link_up.py
+++ b/src/qdash/workflow/tasks/box_setup/link_up.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,8 +15,8 @@ class LinkUp(BaseTask):
 
     name: str = "LinkUp"
     task_type: str = "global"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/measurement/readout_classification.py
+++ b/src/qdash/workflow/tasks/measurement/readout_classification.py
@@ -2,11 +2,10 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -19,16 +18,16 @@ class ReadoutClassification(BaseTask):
 
     name: str = "ReadoutClassification"
     task_type: str = "qubit"
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "average_readout_fidelity": OutputParameter(
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "average_readout_fidelity": OutputParameterModel(
             unit="GHz",
             description="Average readout fidelity",
         ),
-        "readout_fidelity_0": OutputParameter(
+        "readout_fidelity_0": OutputParameterModel(
             unit="GHz",
             description="Readout fidelity with preparation state 0",
         ),
-        "readout_fidelity_1": OutputParameter(
+        "readout_fidelity_1": OutputParameterModel(
             unit="GHz",
             description="Readout fidelity with preparation state 1",
         ),
@@ -45,19 +44,19 @@ class ReadoutClassification(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "average_readout_fidelity": DataModel(
+            "average_readout_fidelity": OutputParameterModel(
                 value=result["average_readout_fidelity"][label],
                 unit=op["average_readout_fidelity"].unit,
                 description=op["average_readout_fidelity"].description,
                 execution_id=execution_id,
             ),
-            "readout_fidelity_0": DataModel(
+            "readout_fidelity_0": OutputParameterModel(
                 value=result["readout_fidelties"][label][0],
                 unit=op["readout_fidelity_0"].unit,
                 description=op["readout_fidelity_0"].description,
                 execution_id=execution_id,
             ),
-            "readout_fidelity_1": DataModel(
+            "readout_fidelity_1": OutputParameterModel(
                 value=result["readout_fidelties"][label][1],
                 unit=op["readout_fidelity_1"].unit,
                 description=op["readout_fidelity_1"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_effective_qubit_frequency.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_effective_qubit_frequency.py
@@ -1,11 +1,9 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -19,37 +17,37 @@ class CheckEffectiveQubitFrequency(BaseTask):
 
     name: str = "CheckEffectiveQubitFrequency"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "detuning": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "detuning": InputParameterModel(
             unit="GHz", value_type="float", value=0.001, description="Detuning"
         ),
-        "time_range": InputParameter(
+        "time_range": InputParameterModel(
             unit="ns",
             value_type="np.arange",
             value=(0, 20001, 100),
             description="Time range for effective qubit frequency",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="",
             value_type="int",
             value=DEFAULT_SHOTS,
             description="Number of shots for effective qubit frequency",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval for effective qubit frequency",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "effective_qubit_frequency": OutputParameter(
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "effective_qubit_frequency": OutputParameterModel(
             unit="GHz", description="Effective qubit frequency"
         ),
-        "effective_qubit_frequency_0": OutputParameter(
+        "effective_qubit_frequency_0": OutputParameterModel(
             unit="GHz", description="Effective qubit frequency for qubit 0"
         ),
-        "effective_qubit_frequency_1": OutputParameter(
+        "effective_qubit_frequency_1": OutputParameterModel(
             unit="GHz", description="Effective qubit frequency for qubit 1"
         ),
     }
@@ -62,19 +60,19 @@ class CheckEffectiveQubitFrequency(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "effective_qubit_frequency": DataModel(
+            "effective_qubit_frequency": OutputParameterModel(
                 value=result["effective_freq"][label],
                 unit=op["effective_qubit_frequency"].unit,
                 description=op["effective_qubit_frequency"].description,
                 execution_id=execution_id,
             ),
-            "effective_qubit_frequency_0": DataModel(
+            "effective_qubit_frequency_0": OutputParameterModel(
                 value=result["result_0"].data[label].bare_freq,
                 unit=op["effective_qubit_frequency_0"].unit,
                 description=op["effective_qubit_frequency_0"].description,
                 execution_id=execution_id,
             ),
-            "effective_qubit_frequency_1": DataModel(
+            "effective_qubit_frequency_1": OutputParameterModel(
                 value=result["result_1"].data[label].bare_freq,
                 unit=op["effective_qubit_frequency_1"].unit,
                 description=op["effective_qubit_frequency_1"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_hpi_pulse.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_hpi_pulse.py
@@ -1,10 +1,9 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -17,8 +16,8 @@ class CheckHPIPulse(BaseTask):
 
     name: str = "CheckHPIPulse"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_pi_pulse.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_pi_pulse.py
@@ -1,10 +1,9 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -17,8 +16,8 @@ class CheckPIPulse(BaseTask):
 
     name: str = "CheckPIPulse"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_qubit_frequency.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_qubit_frequency.py
@@ -2,12 +2,10 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -21,34 +19,34 @@ class CheckQubitFrequency(BaseTask):
 
     name: str = "CheckQubitFrequency"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "detuning_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "detuning_range": InputParameterModel(
             unit="GHz",
             value_type="np.linspace",
             value=(-0.01, 0.01, 21),
             description="Detuning range",
         ),
-        "time_range": InputParameter(
+        "time_range": InputParameterModel(
             unit="ns",
             value_type="range",
             value=(0, 101, 4),
             description="Time range",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=DEFAULT_SHOTS,
             description="Number of shots",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "qubit_frequency": OutputParameter(unit="GHz", description="Qubit frequency"),
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "qubit_frequency": OutputParameterModel(unit="GHz", description="Qubit frequency"),
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
@@ -59,7 +57,7 @@ class CheckQubitFrequency(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "qubit_frequency": DataModel(
+            "qubit_frequency": OutputParameterModel(
                 value=result[label],
                 unit=op["qubit_frequency"].unit,
                 description=op["qubit_frequency"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_rabi.py
@@ -1,11 +1,9 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -19,29 +17,33 @@ class CheckRabi(BaseTask):
 
     name: str = "CheckRabi"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "time_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "time_range": InputParameterModel(
             unit="ns",
             value_type="range",
             value=(0, 201, 4),
             description="Time range for Rabi oscillation",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=DEFAULT_SHOTS,
             description="Number of shots for Rabi oscillation",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval for Rabi oscillation",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "rabi_amplitude": OutputParameter(unit="a.u.", description="Rabi oscillation amplitude"),
-        "rabi_frequency": OutputParameter(unit="GHz", description="Rabi oscillation frequency"),
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "rabi_amplitude": OutputParameterModel(
+            unit="a.u.", description="Rabi oscillation amplitude"
+        ),
+        "rabi_frequency": OutputParameterModel(
+            unit="GHz", description="Rabi oscillation frequency"
+        ),
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:  # noqa: ARG002
@@ -54,13 +56,13 @@ class CheckRabi(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "rabi_amplitude": DataModel(
+            "rabi_amplitude": OutputParameterModel(
                 value=result.rabi_params[label].amplitude,
                 unit=op["rabi_amplitude"].unit,
                 description=op["rabi_amplitude"].description,
                 execution_id=execution_id,
             ),
-            "rabi_frequency": DataModel(
+            "rabi_frequency": OutputParameterModel(
                 value=result.rabi_params[label].frequency,
                 unit=op["rabi_frequency"].unit,
                 description=op["rabi_frequency"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_readout_frequency.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_readout_frequency.py
@@ -2,12 +2,10 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -21,34 +19,34 @@ class CheckReadoutFrequency(BaseTask):
 
     name: str = "CheckReadoutFrequency"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "detuning_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "detuning_range": InputParameterModel(
             unit="GHz",
             value_type="np.linspace",
             value=(-0.01, 0.01, 21),
             description="Detuning range",
         ),
-        "time_range": InputParameter(
+        "time_range": InputParameterModel(
             unit="ns",
             value_type="range",
             value=(0, 101, 4),
             description="Time range",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=DEFAULT_SHOTS,
             description="Number of shots",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "readout_frequency": OutputParameter(unit="GHz", description="Readout frequency"),
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "readout_frequency": OutputParameterModel(unit="GHz", description="Readout frequency"),
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:  # noqa: ARG002
@@ -59,7 +57,7 @@ class CheckReadoutFrequency(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "readout_frequency": DataModel(
+            "readout_frequency": OutputParameterModel(
                 value=result[label],
                 unit=op["readout_frequency"].unit,
                 description=op["readout_frequency"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_t1.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_t1.py
@@ -1,12 +1,10 @@
 from typing import ClassVar
 
 import numpy as np
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -20,28 +18,28 @@ class CheckT1(BaseTask):
 
     name: str = "CheckT1"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "time_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "time_range": InputParameterModel(
             unit="ns",
             value_type="np.logspace",
             value=(np.log10(100), np.log10(500 * 1000), 51),
             description="Time range for T1 time",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="",
             value_type="int",
             value=DEFAULT_SHOTS,
             description="Number of shots for T1 time",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval for T1 time",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "t1": OutputParameter(unit="ns", description="T1 time"),
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "t1": OutputParameterModel(unit="ns", description="T1 time"),
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:  # noqa: ARG002
@@ -52,7 +50,7 @@ class CheckT1(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "t1": DataModel(
+            "t1": OutputParameterModel(
                 value=result.data[label].t1,
                 unit=op["t1"].unit,
                 description=op["t1"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_t2_echo.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_t2_echo.py
@@ -1,12 +1,10 @@
 from typing import ClassVar
 
 import numpy as np
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -20,28 +18,28 @@ class CheckT2Echo(BaseTask):
 
     name: str = "CheckT2Echo"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "time_range": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "time_range": InputParameterModel(
             unit="ns",
             value_type="np.logspace",
             value=(np.log10(300), np.log10(100 * 1000), 51),
             description="Time range for T2 echo time",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="",
             value_type="int",
             value=DEFAULT_SHOTS,
             description="Number of shots for T2 echo time",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval for T2 echo time",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "t2_echo": OutputParameter(unit="ns", description="T2 echo time"),
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "t2_echo": OutputParameterModel(unit="ns", description="T2 echo time"),
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:  # noqa: ARG002
@@ -52,7 +50,7 @@ class CheckT2Echo(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "t2_echo": DataModel(
+            "t2_echo": OutputParameterModel(
                 value=result.data[label].t2,
                 unit=op["t2_echo"].unit,
                 description=op["t2_echo"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/chevron_pattern.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/chevron_pattern.py
@@ -1,11 +1,10 @@
 from typing import ClassVar
 
 import numpy as np
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -18,8 +17,8 @@ class ChevronPattern(BaseTask):
 
     name: str = "ChevronPattern"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/one_qubit_coarse/create_hpi_pulse.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/create_hpi_pulse.py
@@ -1,11 +1,9 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -20,25 +18,25 @@ class CreateHPIPulse(BaseTask):
 
     name: str = "CreateHPIPulse"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "hpi_length": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "hpi_length": InputParameterModel(
             unit="ns", value_type="int", value=HPI_DURATION, description="HPI pulse length"
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="",
             value_type="int",
             value=CALIBRATION_SHOTS,
             description="Number of shots for calibration",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval for calibration",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "hpi_amplitude": OutputParameter(unit="", description="HPI pulse amplitude")
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "hpi_amplitude": OutputParameterModel(unit="", description="HPI pulse amplitude")
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
@@ -49,7 +47,7 @@ class CreateHPIPulse(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "hpi_amplitude": DataModel(
+            "hpi_amplitude": OutputParameterModel(
                 value=result.data[label].calib_value,
                 unit=op["hpi_amplitude"].unit,
                 description=op["hpi_amplitude"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/create_pi_pulse.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/create_pi_pulse.py
@@ -1,11 +1,9 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -20,25 +18,25 @@ class CreatePIPulse(BaseTask):
 
     name: str = "CreatePIPulse"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "pi_length": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "pi_length": InputParameterModel(
             unit="ns", value_type="int", value=PI_DURATION, description="PI pulse length"
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="",
             value_type="int",
             value=CALIBRATION_SHOTS,
             description="Number of shots for calibration",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval for calibration",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "pi_amplitude": OutputParameter(unit="", description="PI pulse amplitude")
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "pi_amplitude": OutputParameterModel(unit="", description="PI pulse amplitude")
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
@@ -49,7 +47,7 @@ class CreatePIPulse(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "pi_amplitude": DataModel(
+            "pi_amplitude": OutputParameterModel(
                 value=result.data[label].calib_value,
                 unit=op["pi_amplitude"].unit,
                 description=op["pi_amplitude"].description,

--- a/src/qdash/workflow/tasks/one_qubit_coarse/rabi_oscillation.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/rabi_oscillation.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,8 +15,8 @@ class RabiOscillation(BaseTask):
 
     name: str = "RabiOscillation"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/one_qubit_fine/check_drag_hpi_pulse.py
+++ b/src/qdash/workflow/tasks/one_qubit_fine/check_drag_hpi_pulse.py
@@ -1,10 +1,9 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -17,8 +16,8 @@ class CheckDRAGHPIPulse(BaseTask):
 
     name: str = "CheckDRAGHPIPulse"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/one_qubit_fine/check_drag_pi_pulse.py
+++ b/src/qdash/workflow/tasks/one_qubit_fine/check_drag_pi_pulse.py
@@ -1,10 +1,9 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -17,8 +16,8 @@ class CheckDRAGPIPulse(BaseTask):
 
     name: str = "CheckDRAGPIPulse"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
         pass

--- a/src/qdash/workflow/tasks/one_qubit_fine/create_drag_hpi_pulse.py
+++ b/src/qdash/workflow/tasks/one_qubit_fine/create_drag_hpi_pulse.py
@@ -2,12 +2,10 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -22,29 +20,29 @@ class CreateDRAGHPIPulse(BaseTask):
 
     name: str = "CreateDRAGHPIPulse"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "hpi_length": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "hpi_length": InputParameterModel(
             unit="ns",
             value_type="int",
             value=HPI_DURATION,
             description="HPI pulse length",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=CALIBRATION_SHOTS,
             description="Number of shots",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "drag_hpi_beta": OutputParameter(unit="", description="DRAG HPI pulse beta"),
-        "drag_hpi_amplitude": OutputParameter(unit="", description="DRAG HPI pulse amplitude"),
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "drag_hpi_beta": OutputParameterModel(unit="", description="DRAG HPI pulse beta"),
+        "drag_hpi_amplitude": OutputParameterModel(unit="", description="DRAG HPI pulse amplitude"),
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
@@ -55,13 +53,13 @@ class CreateDRAGHPIPulse(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "drag_hpi_beta": DataModel(
+            "drag_hpi_beta": OutputParameterModel(
                 value=result["beta"][label],
                 unit=op["drag_hpi_beta"].unit,
                 description=op["drag_hpi_beta"].description,
                 execution_id=execution_id,
             ),
-            "drag_hpi_amplitude": DataModel(
+            "drag_hpi_amplitude": OutputParameterModel(
                 value=result["amplitude"][label],
                 unit=op["drag_hpi_amplitude"].unit,
                 description=op["drag_hpi_amplitude"].description,

--- a/src/qdash/workflow/tasks/one_qubit_fine/create_drag_pi_pulse.py
+++ b/src/qdash/workflow/tasks/one_qubit_fine/create_drag_pi_pulse.py
@@ -2,12 +2,10 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import DataModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -22,29 +20,29 @@ class CreateDRAGPIPulse(BaseTask):
 
     name: str = "CreateDRAGPIPulse"
     task_type: str = "qubit"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {
-        "pi_length": InputParameter(
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
+        "pi_length": InputParameterModel(
             unit="ns",
             value_type="int",
             value=PI_DURATION,
             description="PI pulse length",
         ),
-        "shots": InputParameter(
+        "shots": InputParameterModel(
             unit="a.u.",
             value_type="int",
             value=CALIBRATION_SHOTS,
             description="Number of shots",
         ),
-        "interval": InputParameter(
+        "interval": InputParameterModel(
             unit="ns",
             value_type="int",
             value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "drag_pi_beta": OutputParameter(unit="", description="DRAG PI pulse beta"),
-        "drag_pi_amplitude": OutputParameter(unit="", description="DRAG PI pulse amplitude"),
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "drag_pi_beta": OutputParameterModel(unit="", description="DRAG PI pulse beta"),
+        "drag_pi_amplitude": OutputParameterModel(unit="", description="DRAG PI pulse amplitude"),
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:
@@ -55,13 +53,13 @@ class CreateDRAGPIPulse(BaseTask):
         result = run_result.raw_result
         op = self.output_parameters
         output_param = {
-            "drag_pi_beta": DataModel(
+            "drag_pi_beta": OutputParameterModel(
                 value=result["beta"][label],
                 unit=op["drag_pi_beta"].unit,
                 description=op["drag_pi_beta"].description,
                 execution_id=execution_id,
             ),
-            "drag_pi_amplitude": DataModel(
+            "drag_pi_amplitude": OutputParameterModel(
                 value=result["amplitude"][label],
                 unit=op["drag_pi_amplitude"].unit,
                 description=op["drag_pi_amplitude"].description,

--- a/src/qdash/workflow/tasks/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/tasks/two_qubit/check_cross_resonance.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,12 +15,14 @@ class CheckCrossResonance(BaseTask):
 
     name: str = "CheckCrossResonance"
     task_type: str = "coupling"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "cr_amplitude": OutputParameter(unit="", description="Amplitude of the CR pulse."),
-        "cr_phase": OutputParameter(unit="", description="Phase of the CR pulse."),
-        "cancel_amplitude": OutputParameter(unit="", description="Amplitude of the cancel pulse."),
-        "cancel_phase": OutputParameter(unit="", description="Phase of the cancel pulse."),
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "cr_amplitude": OutputParameterModel(unit="", description="Amplitude of the CR pulse."),
+        "cr_phase": OutputParameterModel(unit="", description="Phase of the CR pulse."),
+        "cancel_amplitude": OutputParameterModel(
+            unit="", description="Amplitude of the cancel pulse."
+        ),
+        "cancel_phase": OutputParameterModel(unit="", description="Phase of the cancel pulse."),
     }
 
     # @staticmethod

--- a/src/qdash/workflow/tasks/two_qubit/create_fine_zx90.py
+++ b/src/qdash/workflow/tasks/two_qubit/create_fine_zx90.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,8 +15,10 @@ class CreateFineZX90(BaseTask):
 
     name: str = "CreateFineZX90"
     task_type: str = "coupling"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {"cr_amplitude": OutputParameter()}
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "cr_amplitude": OutputParameterModel()
+    }
 
     # @staticmethod
     # def determine_cr_pair(exp: Experiment) -> tuple[tuple[str, str], str]:

--- a/src/qdash/workflow/tasks/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/tasks/two_qubit/create_zx90.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,9 +15,9 @@ class CreateZX90(BaseTask):
 
     name: str = "CreateZX90"
     task_type: str = "coupling"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "cr_amplitude": OutputParameter(unit="", description="Amplitude of the ZX90 gate."),
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "cr_amplitude": OutputParameterModel(unit="", description="Amplitude of the ZX90 gate."),
     }
 
     # @staticmethod

--- a/src/qdash/workflow/tasks/two_qubit/optimize_zx90.py
+++ b/src/qdash/workflow/tasks/two_qubit/optimize_zx90.py
@@ -1,9 +1,8 @@
 from typing import ClassVar
 
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.tasks.base import (
     BaseTask,
-    InputParameter,
-    OutputParameter,
     PostProcessResult,
     PreProcessResult,
     RunResult,
@@ -16,12 +15,12 @@ class OptimizeZX90(BaseTask):
 
     name: str = "OptimizeZX90"
     task_type: str = "coupling"
-    input_parameters: ClassVar[dict[str, InputParameter]] = {}
-    output_parameters: ClassVar[dict[str, OutputParameter]] = {
-        "cr_amplitude": OutputParameter(unit="", description=""),
-        "cr_phase": OutputParameter(unit="", description=""),
-        "cancel_amplitude": OutputParameter(unit="", description=""),
-        "cancel_phase": OutputParameter(unit="", description=""),
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
+    output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
+        "cr_amplitude": OutputParameterModel(unit="", description=""),
+        "cr_phase": OutputParameterModel(unit="", description=""),
+        "cancel_amplitude": OutputParameterModel(unit="", description=""),
+        "cancel_phase": OutputParameterModel(unit="", description=""),
     }
 
     # @staticmethod


### PR DESCRIPTION
Update input and output parameter types across multiple tasks to utilize `InputParameterModel` and `OutputParameterModel` for improved consistency and clarity.