### PR TITLE
Implement database initialization modules and CLI package for qdash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,11 @@ packages = [
     "src/qdash/workflow",
     "src/qdash/dbmodel",
     "src/qdash/datamodel",
-    "src/qdash/neodbmodel"
+    "src/qdash/cli"
 ]
+
+[project.scripts]
+qdash = "qdash.cli:app"
 
 
 

--- a/src/qdash/__init__.py
+++ b/src/qdash/__init__.py
@@ -1,0 +1,3 @@
+"""qdash package."""
+
+__version__ = "0.1.0"

--- a/src/qdash/cli/__init__.py
+++ b/src/qdash/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI package for qdash."""
+
+from qdash.cli.main import app
+
+__all__ = ["app"]

--- a/src/qdash/cli/main.py
+++ b/src/qdash/cli/main.py
@@ -1,0 +1,117 @@
+"""Main module for qdash CLI."""
+
+import typer
+from qdash.db.init import (
+    init_chip_document,
+    init_coupling_document,
+    init_menu,
+    init_qubit_document,
+)
+
+app = typer.Typer(
+    name="qdash",
+    help="Command line interface for qdash",
+    add_completion=False,
+)
+
+
+@app.command()
+def version() -> None:
+    """Show qdash version."""
+    from qdash import __version__
+
+    typer.echo(f"qdash version: {__version__}")
+
+
+@app.command()
+def init_qubit_data(
+    username: str = typer.Option("admin", "--username", "-u", help="Username for initialization"),
+    chip_id: str = typer.Option("64Q", "--chip-id", "-c", help="Chip ID for initialization"),
+) -> None:
+    """Initialize qubit data."""
+    try:
+        typer.echo(f"Initializing qubit data for username: {username}")
+        typer.echo(f"Chip ID: {chip_id}")
+        init_qubit_document(username=username, chip_id=chip_id)
+        typer.echo(f"Qubit data initialized successfully (username: {username})")
+    except Exception as e:
+        typer.echo(f"Error initializing qubit data: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def init_coupling_data(
+    username: str = typer.Option("admin", "--username", "-u", help="Username for initialization"),
+    chip_id: str = typer.Option("64Q", "--chip-id", "-c", help="Chip ID for initialization"),
+) -> None:
+    """Initialize coupling data."""
+    try:
+        typer.echo(f"Initializing coupling data for username: {username}")
+        typer.echo(f"Chip ID: {chip_id}")
+        init_coupling_document(username=username, chip_id=chip_id)
+        typer.echo(f"Coupling data initialized successfully (username: {username})")
+    except Exception as e:
+        typer.echo(f"Error initializing coupling data: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def init_chip_data(
+    username: str = typer.Option("admin", "--username", "-u", help="Username for initialization"),
+    chip_id: str = typer.Option("64Q", "--chip-id", "-c", help="Chip ID for initialization"),
+) -> None:
+    """Initialize chip data."""
+    try:
+        typer.echo(f"Initializing chip data for username: {username}")
+        typer.echo(f"Chip ID: {chip_id}")
+        init_chip_document(username=username, chip_id=chip_id)
+        typer.echo(f"Chip data initialized successfully (username: {username})")
+    except Exception as e:
+        typer.echo(f"Error initializing chip data: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def init_menu_data(
+    username: str = typer.Option("admin", "--username", "-u", help="Username for initialization"),
+) -> None:
+    """Initialize menu data."""
+    try:
+        typer.echo(f"Initializing menu data for username: {username}")
+        init_menu(username=username)
+        typer.echo(f"Menu data initialized successfully (username: {username})")
+    except Exception as e:
+        typer.echo(f"Error initializing menu data: {e}", err=True)
+        raise typer.Exit(1)
+
+
+@app.command()
+def init_all_data(
+    username: str = typer.Option("admin", "--username", "-u", help="Username for initialization"),
+    chip_id: str = typer.Option("64Q", "--chip-id", "-c", help="Chip ID for initialization"),
+) -> None:
+    """Initialize all data."""
+    try:
+        typer.echo(f"Initializing data for username: {username}")
+        typer.echo(f"Chip ID: {chip_id}")
+
+        init_qubit_document(username=username, chip_id=chip_id)
+        typer.echo("Qubit data initialized")
+
+        init_coupling_document(username=username, chip_id=chip_id)
+        typer.echo("Coupling data initialized")
+
+        init_chip_document(username=username, chip_id=chip_id)
+        typer.echo("Chip data initialized")
+
+        init_menu(username=username)
+        typer.echo("Menu data initialized")
+
+        typer.echo("\nAll data initialized successfully")
+    except Exception as e:
+        typer.echo(f"Error during initialization: {e}", err=True)
+        raise typer.Exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/qdash/db/init/__init__.py
+++ b/src/qdash/db/init/__init__.py
@@ -1,0 +1,15 @@
+"""Database initialization package."""
+
+from qdash.db.init.chip import init_chip_document
+from qdash.db.init.coupling import init_coupling_document
+from qdash.db.init.initialize import initialize
+from qdash.db.init.menu import init_menu
+from qdash.db.init.qubit import init_qubit_document
+
+__all__ = [
+    "initialize",
+    "init_chip_document",
+    "init_coupling_document",
+    "init_qubit_document",
+    "init_menu",
+]

--- a/src/qdash/db/init/chip.py
+++ b/src/qdash/db/init/chip.py
@@ -1,9 +1,11 @@
+"""Chip initialization module."""
+
 from qdash.datamodel.coupling import CouplingModel, EdgeInfoModel
 from qdash.datamodel.qubit import NodeInfoModel, PositionModel, QubitModel
+from qdash.db.init.coupling import bi_direction
+from qdash.db.init.initialize import initialize
+from qdash.db.init.qubit import qubit_lattice
 from qdash.dbmodel.chip import ChipDocument
-from qdash.dbmodel.init_coupling import bi_direction
-from qdash.dbmodel.init_qubit import qubit_lattice
-from qdash.dbmodel.initialize import initialize
 
 
 def generate_qubit_data(num_qubits: int, pos: dict) -> dict:
@@ -61,7 +63,7 @@ def generate_coupling_data(edges: list[tuple[int, int]]) -> dict:
     return coupling
 
 
-def init_chip_document() -> ChipDocument:
+def init_chip_document(username: str, chip_id: str) -> ChipDocument:
     """Initialize and return a ChipDocument."""
     initialize()
     num_qubits = 64
@@ -70,8 +72,8 @@ def init_chip_document() -> ChipDocument:
     qubits = generate_qubit_data(num_qubits, pos)
     couplings = generate_coupling_data(edges)
     chip = ChipDocument(
-        username="admin",
-        chip_id="SAMPLE",
+        username=username,
+        chip_id=chip_id,
         size=64,
         qubits=qubits,
         couplings=couplings,
@@ -79,7 +81,3 @@ def init_chip_document() -> ChipDocument:
     )
     chip.save()
     return chip
-
-
-if __name__ == "__main__":
-    init_chip_document()

--- a/src/qdash/db/init/coupling.py
+++ b/src/qdash/db/init/coupling.py
@@ -1,7 +1,9 @@
+"""Coupling initialization module."""
+
 from qdash.datamodel.coupling import EdgeInfoModel
+from qdash.db.init.initialize import initialize
+from qdash.db.init.qubit import qubit_lattice
 from qdash.dbmodel.coupling import CouplingDocument
-from qdash.dbmodel.init_qubit import qubit_lattice
-from qdash.dbmodel.initialize import initialize
 
 
 def bi_direction(edges: list) -> list:
@@ -9,12 +11,14 @@ def bi_direction(edges: list) -> list:
     return edges + [(j, i) for i, j in edges]
 
 
-def generate_coupling(edges: list) -> list:
+def generate_coupling(edges: list, username: str, chip_id: str) -> list:
     """Generate coupling documents from edges.
 
     Args:
     ----
         edges (list): List of edges.
+        username (str): Username.
+        chip_id (str): Chip ID.
 
     Returns:
     -------
@@ -23,10 +27,10 @@ def generate_coupling(edges: list) -> list:
     """
     return [
         CouplingDocument(
-            username="admin",
+            username=username,
             qid=f"{edge[0]}-{edge[1]}",
             status="pending",
-            chip_id="SAMPLE",
+            chip_id=chip_id,
             data={},
             edge_info=EdgeInfoModel(size=4, fill="", source=f"{edge[0]}", target=f"{edge[1]}"),
             system_info={},
@@ -35,15 +39,11 @@ def generate_coupling(edges: list) -> list:
     ]
 
 
-def init_coupling() -> None:
+def init_coupling_document(username: str, chip_id: str) -> None:
     """Initialize coupling documents."""
+    initialize()
     _, edges, _ = qubit_lattice(n=64, d=4)
     edges = bi_direction(edges)
-    couplings = generate_coupling(edges)
+    couplings = generate_coupling(edges, username=username, chip_id=chip_id)
     for c in couplings:
         c.insert()
-
-
-if __name__ == "__main__":
-    initialize()
-    init_coupling()

--- a/src/qdash/db/init/initialize.py
+++ b/src/qdash/db/init/initialize.py
@@ -1,0 +1,18 @@
+"""Database initialization module."""
+
+import os
+
+from bunnet import init_bunnet
+from pymongo import MongoClient
+from qdash.dbmodel.document_models import document_models
+
+mongo_ip = os.getenv("MONGO_HOST")
+client: MongoClient = MongoClient(mongo_ip, 27017, username="root", password="example")  # noqa: S106
+
+
+def initialize() -> None:
+    """Initialize the repository and create initial data if needed."""
+    init_bunnet(
+        database=client.qubex,
+        document_models=document_models(),
+    )

--- a/src/qdash/db/init/menu.py
+++ b/src/qdash/db/init/menu.py
@@ -1,15 +1,19 @@
-from qdash.dbmodel.initialize import initialize
+"""Menu initialization module."""
+
+from qdash.db.init.initialize import initialize
 from qdash.dbmodel.menu import MenuDocument
 
-if __name__ == "__main__":
+
+def init_menu(username: str) -> None:
+    """Initialize menu document."""
     initialize()
-    menu = MenuDocument(
+    MenuDocument(
         name="OneQubitCheck",
-        username="admin",
+        username=username,
         description="description",
         qids=[["28", "29", "30", "31"]],
         tasks=["CheckStatus", "DumpBox", "CheckNoise", "CheckRabi"],
         notify_bool=False,
-        tags=["tag1", "tag2"],
+        tags=["debug"],
         system_info={},
     ).insert()

--- a/src/qdash/db/init/qubit.py
+++ b/src/qdash/db/init/qubit.py
@@ -1,22 +1,26 @@
+"""Qubit initialization module."""
+
 from qdash.datamodel.qubit import NodeInfoModel, PositionModel
-from qdash.dbmodel.initialize import initialize
+from qdash.db.init.initialize import initialize
 from qdash.dbmodel.qubit import QubitDocument
 
 
-def qubit_lattice(n, d):
-    """Generate qubit lattice structure for RQC square lattice
+def qubit_lattice(n: int, d: int) -> tuple[range, list, dict]:
+    """Generate qubit lattice structure for RQC square lattice.
+
     Args:
+    ----
         n (int): number of qubits
         d (int): number of mux in a line
+
     Returns:
-        nodes (list): list of the node labels
-        edges (list): list of the edge labels
-        pos (dict): dictionary of the positions of the nodes for the visualization
+    -------
+        tuple[range, list, dict]: nodes, edges, and positions
+
     """
 
-    def node(i, j, k):
-        q = 4 * (i * d + j) + k
-        return q
+    def node(i: int, j: int, k: int) -> int:
+        return 4 * (i * d + j) + k
 
     nodes = range(n)
     edges = []
@@ -48,18 +52,44 @@ def qubit_lattice(n, d):
     return nodes, edges, pos
 
 
-def correct(original: tuple, s: float):
+def correct(original: tuple, s: float) -> tuple:
+    """Correct position coordinates.
+
+    Args:
+    ----
+        original (tuple): Original coordinates
+        s (float): Scale factor
+
+    Returns:
+    -------
+        tuple: Corrected coordinates
+
+    """
     offset = (1 / 3, 10 / 3)
     offset_applied = tuple(x + y for x, y in zip(original, offset, strict=False))
     return tuple(x * s for x in offset_applied)
 
 
-def generate_dummy_data(num_qubits, pos: dict):
+def generate_dummy_data(num_qubits: int, pos: dict, username: str, chip_id: str) -> list:
+    """Generate dummy qubit data.
+
+    Args:
+    ----
+        num_qubits (int): Number of qubits
+        pos (dict): Position dictionary
+        username (str): Username
+        chip_id (str): Chip ID
+
+    Returns:
+    -------
+        list: List of QubitDocument objects
+
+    """
     data = []
     for i in range(num_qubits):
         qubit_data = QubitDocument(
-            username="admin",
-            chip_id="SAMPLE",
+            username=username,
+            chip_id=chip_id,
             qid=f"{i}",
             status="pending",
             node_info=NodeInfoModel(
@@ -75,14 +105,11 @@ def generate_dummy_data(num_qubits, pos: dict):
     return data
 
 
-def init_qubit_document():
+def init_qubit_document(username: str, chip_id: str) -> None:
+    """Initialize qubit documents."""
+    initialize()
     num_qubits = 64
     nodes, edges, pos = qubit_lattice(64, 4)
-    dummy_data = generate_dummy_data(num_qubits, pos)
+    dummy_data = generate_dummy_data(num_qubits, pos, username=username, chip_id=chip_id)
     for data in dummy_data:
         data.insert()
-
-
-if __name__ == "__main__":
-    initialize()
-    init_qubit_document()


### PR DESCRIPTION
Introduce a command line interface for qdash that allows users to initialize various data components, including qubit, coupling, chip, and menu data. The implementation includes database initialization modules to support these operations.