### PR TITLE
Remove container_name from development container configuration

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -6,7 +6,6 @@ services:
     env_file:
       - .env
     command: sleep infinity
-    container_name: qdash-devcontainer
     volumes:
       - .:/workspace/qdash
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Eliminate the container_name setting from the development container configuration to simplify the setup.