### PR TITLE
Update devcontainer name to use local workspace folder basename

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "qdash",
+  "name": "${localWorkspaceFolderBasename}",
   "dockerComposeFile": ["../compose.dev.yaml"],
   "service": "devcontainer",
   "workspaceFolder": "/workspace/qdash",


### PR DESCRIPTION
Change the devcontainer name to dynamically reflect the local workspace folder's basename.