### PR TITLE
Update Prefect image version to 2.20.18 in Dockerfile

### DIFF
--- a/src/qdash/workflow/Dockerfile
+++ b/src/qdash/workflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM prefecthq/prefect:2.20-python3.11 AS builder
+FROM prefecthq/prefect:2.20.18-python3.11 AS builder
 
 WORKDIR /app
 
@@ -24,7 +24,7 @@ RUN uv pip install --system --no-cache-dir -r requirements.txt
 RUN uv pip install --upgrade --system --no-cache-dir pydantic
 RUN uv pip install --upgrade --system --no-cache-dir pydantic-settings==2.3.4
 
-FROM prefecthq/prefect:2.20-python3.11
+FROM prefecthq/prefect:2.20.18-python3.11
 
 WORKDIR /app
 


### PR DESCRIPTION
Upgrade the Prefect image version in the Dockerfile to ensure compatibility and access to the latest features and fixes.