### PR TITLE
Add history tracking for chips, couplings, and qubits

### DIFF
--- a/src/qdash/datamodel/chip.py
+++ b/src/qdash/datamodel/chip.py
@@ -18,6 +18,7 @@ class ChipModel(BaseModel):
     """
 
     chip_id: str = Field(..., description="The chip ID")
+    username: str = Field(..., description="The username of the user who created the chip")
     size: int = Field(..., description="The size of the chip")
     qubits: dict[str, QubitModel] = Field(..., description="The qubits of the chip")
     couplings: dict[str, CouplingModel] = Field(..., description="The couplings of the chip")

--- a/src/qdash/dbmodel/chip_history.py
+++ b/src/qdash/dbmodel/chip_history.py
@@ -1,0 +1,81 @@
+from typing import ClassVar
+
+import pendulum
+from bunnet import Document
+from pydantic import ConfigDict, Field
+from pymongo import ASCENDING, IndexModel
+from qdash.datamodel.coupling import CouplingModel
+from qdash.datamodel.qubit import QubitModel
+from qdash.datamodel.system_info import SystemInfoModel
+from qdash.dbmodel.chip import ChipDocument
+
+
+class ChipHistoryDocument(Document):
+    """Data model for chip history.
+
+    Attributes
+    ----------
+        chip_id (str): The chip ID. e.g. "chip1".
+        size (int): The size of the chip.
+        qubits (dict): The qubits of the chip.
+        couplings (dict): The couplings of the chip.
+        installed_at (str): The time when the system information was created.
+        system_info (SystemInfo): The system information.
+        recorded_date (str): The date when this history record was created (YYYY-MM-DD).
+
+    """
+
+    chip_id: str = Field(..., description="The chip ID")
+    username: str = Field(..., description="The username of the user who created the chip")
+    size: int = Field(..., description="The size of the chip")
+    qubits: dict[str, QubitModel] = Field({}, description="The qubits of the chip")
+    couplings: dict[str, CouplingModel] = Field({}, description="The couplings of the chip")
+    installed_at: str = Field(..., description="The time when the system information was created")
+    system_info: SystemInfoModel = Field(..., description="The system information")
+    recorded_date: str = Field(
+        default_factory=lambda: pendulum.now(tz="Asia/Tokyo").format("YYYY-MM-DD"),
+        description="The date when this history record was created",
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+    )
+
+    class Settings:
+        """Settings for the document."""
+
+        name = "chip_history"
+        indexes: ClassVar = [
+            IndexModel(
+                [("chip_id", ASCENDING), ("username", ASCENDING), ("recorded_date", ASCENDING)],
+                unique=True,
+            )
+        ]
+
+    @classmethod
+    def create_history(cls, chip_doc: ChipDocument) -> "ChipHistoryDocument":
+        """Create a history record from a ChipDocument."""
+        today = pendulum.now(tz="Asia/Tokyo").format("YYYY-MM-DD")
+        existing_history = cls.find_one(
+            {
+                "chip_id": chip_doc.chip_id,
+                "username": chip_doc.username,
+                "recorded_date": today,
+            }
+        ).run()
+        if existing_history:
+            history = existing_history
+            history.qubits = chip_doc.qubits
+            history.couplings = chip_doc.couplings
+        else:
+            history = cls(
+                chip_id=chip_doc.chip_id,
+                username=chip_doc.username,
+                size=chip_doc.size,
+                qubits=chip_doc.qubits,
+                couplings=chip_doc.couplings,
+                installed_at=chip_doc.installed_at,
+                system_info=chip_doc.system_info,
+            )
+        history.save()
+        return history

--- a/src/qdash/dbmodel/coupling.py
+++ b/src/qdash/dbmodel/coupling.py
@@ -6,6 +6,7 @@ from pymongo import ASCENDING, IndexModel
 from qdash.datamodel.coupling import CouplingModel, EdgeInfoModel
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.chip import ChipDocument
+from qdash.dbmodel.coupling_history import CouplingHistoryDocument
 
 
 class CouplingDocument(Document):
@@ -71,6 +72,8 @@ class CouplingDocument(Document):
             qid=qid, chip_id=chip_id, data=coupling_doc.data, edge_info=coupling_doc.edge_info
         )
         chip_doc.update_coupling(qid, coupling_model)
+        # Update the coupling in the history document
+        CouplingHistoryDocument.create_history(coupling_model)
         return coupling_doc
 
     @classmethod

--- a/src/qdash/dbmodel/coupling_history.py
+++ b/src/qdash/dbmodel/coupling_history.py
@@ -1,0 +1,86 @@
+from typing import ClassVar
+
+import pendulum
+from bunnet import Document
+from pydantic import ConfigDict, Field
+from pymongo import ASCENDING, IndexModel
+from qdash.datamodel.coupling import CouplingModel, EdgeInfoModel
+from qdash.datamodel.system_info import SystemInfoModel
+
+
+class CouplingHistoryDocument(Document):
+    """Data model for coupling history.
+
+    Attributes
+    ----------
+        qid (str): The coupling ID. e.g. "0-1".
+        chip_id (str): The chip ID. e.g. "chip1".
+        data (dict): The data of the coupling.
+        status (str): The status of the coupling.
+        edge_info (EdgeInfoModel): The edge information.
+        system_info (SystemInfo): The system information.
+        recorded_date (str): The date when this history record was created (YYYY-MM-DD).
+
+    """
+
+    username: str = Field(..., description="The username of the user who created the coupling")
+    qid: str = Field(..., description="The coupling ID")
+    status: str = Field(..., description="The status of the coupling")
+    chip_id: str = Field(..., description="The chip ID")
+    data: dict = Field(..., description="The data of the coupling")
+    edge_info: EdgeInfoModel = Field(..., description="The edge information")
+    system_info: SystemInfoModel = Field(..., description="The system information")
+    recorded_date: str = Field(
+        default_factory=lambda: pendulum.now(tz="Asia/Tokyo").format("YYYY-MM-DD"),
+        description="The date when this history record was created",
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+    )
+
+    class Settings:
+        """Settings for the document."""
+
+        name = "coupling_history"
+        indexes: ClassVar = [
+            IndexModel(
+                [
+                    ("chip_id", ASCENDING),
+                    ("qid", ASCENDING),
+                    ("username", ASCENDING),
+                    ("recorded_date", ASCENDING),
+                ],
+                unique=True,
+            )
+        ]
+
+    @classmethod
+    def create_history(cls, coupling: CouplingModel) -> "CouplingHistoryDocument":
+        """Create a history record from a CouplingDocument."""
+        today = pendulum.now(tz="Asia/Tokyo").format("YYYY-MM-DD")
+        existing_history = cls.find_one(
+            {
+                "chip_id": coupling.chip_id,
+                "qid": coupling.qid,
+                "username": coupling.username,
+                "recorded_date": today,
+            }
+        ).run()
+        if existing_history:
+            history = existing_history
+            history.data = coupling.data
+            history.status = coupling.status
+            history.edge_info = coupling.edge_info
+        else:
+            history = cls(
+                username=coupling.username,
+                qid=coupling.qid,
+                status=coupling.status,
+                chip_id=coupling.chip_id,
+                data=coupling.data,
+                edge_info=coupling.edge_info,
+                system_info=coupling.system_info,
+            )
+        history.save()
+        return history

--- a/src/qdash/dbmodel/document_models.py
+++ b/src/qdash/dbmodel/document_models.py
@@ -1,12 +1,15 @@
 from qdash.dbmodel.calibration_note import CalibrationNoteDocument
 from qdash.dbmodel.chip import ChipDocument
+from qdash.dbmodel.chip_history import ChipHistoryDocument
 from qdash.dbmodel.coupling import CouplingDocument
+from qdash.dbmodel.coupling_history import CouplingHistoryDocument
 from qdash.dbmodel.execution_counter import ExecutionCounterDocument
 from qdash.dbmodel.execution_history import ExecutionHistoryDocument
 from qdash.dbmodel.execution_lock import ExecutionLockDocument
 from qdash.dbmodel.menu import MenuDocument
 from qdash.dbmodel.parameter import ParameterDocument
 from qdash.dbmodel.qubit import QubitDocument
+from qdash.dbmodel.qubit_history import QubitHistoryDocument
 from qdash.dbmodel.tag import TagDocument
 from qdash.dbmodel.task import TaskDocument
 from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
@@ -29,4 +32,7 @@ def document_models() -> list[str]:
         ExecutionLockDocument,
         TagDocument,
         CalibrationNoteDocument,
+        QubitHistoryDocument,
+        ChipHistoryDocument,
+        CouplingHistoryDocument,
     ]

--- a/src/qdash/dbmodel/qubit.py
+++ b/src/qdash/dbmodel/qubit.py
@@ -6,6 +6,7 @@ from pymongo import ASCENDING, IndexModel
 from qdash.datamodel.qubit import NodeInfoModel, QubitModel
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.chip import ChipDocument
+from qdash.dbmodel.qubit_history import QubitHistoryDocument
 
 
 class QubitDocument(Document):
@@ -72,6 +73,8 @@ class QubitDocument(Document):
             qid=qid, chip_id=chip_id, data=qubit_doc.data, node_info=qubit_doc.node_info
         )
         chip_doc.update_qubit(qid, qubit_model)
+        # Update History
+        QubitHistoryDocument.create_history(qubit_doc)
         return qubit_doc
 
     @classmethod

--- a/src/qdash/dbmodel/qubit_history.py
+++ b/src/qdash/dbmodel/qubit_history.py
@@ -1,0 +1,87 @@
+from typing import ClassVar
+
+import pendulum
+from bunnet import Document
+from pydantic import ConfigDict, Field
+from pymongo import ASCENDING, IndexModel
+from qdash.datamodel.qubit import NodeInfoModel, QubitModel
+from qdash.datamodel.system_info import SystemInfoModel
+
+
+class QubitHistoryDocument(Document):
+    """Data model for qubit history.
+
+    Attributes
+    ----------
+        qid (str): The qubit ID. e.g. "0".
+        chip_id (str): The chip ID. e.g. "chip1".
+        data (dict): The data of the qubit.
+        status (str): The status of the qubit.
+        node_info (NodeInfoModel): The node information.
+        system_info (SystemInfo): The system information.
+        recorded_date (str): The date when this history record was created (YYYY-MM-DD).
+
+    """
+
+    username: str = Field(..., description="The username of the user who created the qubit")
+    qid: str = Field(..., description="The qubit ID")
+    status: str = Field(..., description="The status of the qubit")
+    chip_id: str = Field(..., description="The chip ID")
+    data: dict = Field(..., description="The data of the qubit")
+    node_info: NodeInfoModel = Field(..., description="The node information")
+    system_info: SystemInfoModel = Field(..., description="The system information")
+    recorded_date: str = Field(
+        default_factory=lambda: pendulum.now(tz="Asia/Tokyo").format("YYYY-MM-DD"),
+        description="The date when this history record was created",
+    )
+
+    model_config = ConfigDict(
+        from_attributes=True,
+    )
+
+    class Settings:
+        """Settings for the document."""
+
+        name = "qubit_history"
+        indexes: ClassVar = [
+            IndexModel(
+                [
+                    ("chip_id", ASCENDING),
+                    ("qid", ASCENDING),
+                    ("username", ASCENDING),
+                    ("recorded_date", ASCENDING),
+                ],
+                unique=True,
+            )
+        ]
+
+    @classmethod
+    def create_history(cls, qubit: QubitModel) -> "QubitHistoryDocument":
+        """Create a history record from a QubitDocument."""
+        today = pendulum.now(tz="Asia/Tokyo").format("YYYY-MM-DD")
+        existing_history = cls.find_one(
+            {
+                "chip_id": qubit.chip_id,
+                "qid": qubit.qid,
+                "username": qubit.username,
+                "recorded_date": today,
+            }
+        ).run()
+        if existing_history:
+            history = existing_history
+            history.data = qubit.data
+            history.status = qubit.status
+            history.node_info = qubit.node_info
+        else:
+            # Create a new history record
+            history = cls(
+                username=qubit.username,
+                qid=qubit.qid,
+                status=qubit.status,
+                chip_id=qubit.chip_id,
+                data=qubit.data,
+                node_info=qubit.node_info,
+                system_info=qubit.system_info,
+            )
+        history.save()
+        return history

--- a/src/qdash/workflow/handler.py
+++ b/src/qdash/workflow/handler.py
@@ -8,6 +8,7 @@ from qdash.config import get_settings
 from qdash.datamodel.menu import MenuModel as Menu
 from qdash.dbmodel.calibration_note import CalibrationNoteDocument
 from qdash.dbmodel.chip import ChipDocument
+from qdash.dbmodel.chip_history import ChipHistoryDocument
 from qdash.dbmodel.execution_counter import ExecutionCounterDocument
 from qdash.dbmodel.execution_lock import ExecutionLockDocument
 from qdash.dbmodel.initialize import initialize
@@ -166,6 +167,9 @@ def main_flow(
                 menu, calib_dir, success_map, execution_id, task_names=menu.tasks
             )
         execution_manager = execution_manager.reload().complete_execution()
+        # Update ChipDocument and ChipHistoryDocument
+        chip_doc = ChipDocument.get_current_chip(username=menu.username)
+        ChipHistoryDocument.create_history(chip_doc)
     except Exception as e:
         logger.error(f"Failed to execute task: {e}")
         execution_manager = execution_manager.reload().fail_execution()


### PR DESCRIPTION
Introduce new document models to track the history of chips, couplings, and qubits, enabling better data management and retrieval. Update existing models to create history records upon modifications.