### PR TITLE
Add username field to CouplingModel and QubitModel

### DIFF
--- a/src/qdash/datamodel/coupling.py
+++ b/src/qdash/datamodel/coupling.py
@@ -29,6 +29,9 @@ class CouplingModel(BaseModel):
 
     """
 
+    username: str | None = Field(
+        None, description="The username of the user who created the coupling"
+    )
     qid: str = Field(..., description="The coupling ID")
     status: str = Field("pending", description="The status of the coupling")
     chip_id: str | None = Field(None, description="The chip ID")

--- a/src/qdash/datamodel/qubit.py
+++ b/src/qdash/datamodel/qubit.py
@@ -40,6 +40,7 @@ class QubitModel(BaseModel):
 
     """
 
+    username: None | str = Field(None, description="The username of the user who created the qubit")
     qid: str = Field(..., description="The qubit ID")
     status: str = Field("pending", description="The status of the qubit")
     chip_id: str | None = Field(None, description="The chip ID")

--- a/src/qdash/dbmodel/coupling.py
+++ b/src/qdash/dbmodel/coupling.py
@@ -69,7 +69,11 @@ class CouplingDocument(Document):
         if chip_doc is None:
             raise ValueError(f"Chip {chip_id} not found")
         coupling_model = CouplingModel(
-            qid=qid, chip_id=chip_id, data=coupling_doc.data, edge_info=coupling_doc.edge_info
+            qid=qid,
+            chip_id=chip_id,
+            data=coupling_doc.data,
+            edge_info=coupling_doc.edge_info,
+            username=username,
         )
         chip_doc.update_coupling(qid, coupling_model)
         # Update the coupling in the history document

--- a/src/qdash/dbmodel/coupling_history.py
+++ b/src/qdash/dbmodel/coupling_history.py
@@ -80,6 +80,10 @@ class CouplingHistoryDocument(Document):
                 chip_id=coupling.chip_id,
                 data=coupling.data,
                 edge_info=coupling.edge_info,
+                system_info=SystemInfoModel(
+                    created_at=pendulum.now(tz="Asia/Tokyo").to_iso8601_string(),
+                    updated_at=pendulum.now(tz="Asia/Tokyo").to_iso8601_string(),
+                ),
             )
         history.save()
         return history

--- a/src/qdash/dbmodel/coupling_history.py
+++ b/src/qdash/dbmodel/coupling_history.py
@@ -80,7 +80,6 @@ class CouplingHistoryDocument(Document):
                 chip_id=coupling.chip_id,
                 data=coupling.data,
                 edge_info=coupling.edge_info,
-                system_info=coupling.system_info,
             )
         history.save()
         return history

--- a/src/qdash/dbmodel/qubit.py
+++ b/src/qdash/dbmodel/qubit.py
@@ -70,11 +70,15 @@ class QubitDocument(Document):
         if chip_doc is None:
             raise ValueError(f"Chip {chip_id} not found")
         qubit_model = QubitModel(
-            qid=qid, chip_id=chip_id, data=qubit_doc.data, node_info=qubit_doc.node_info
+            qid=qid,
+            chip_id=chip_id,
+            data=qubit_doc.data,
+            node_info=qubit_doc.node_info,
+            username=username,
         )
         chip_doc.update_qubit(qid, qubit_model)
         # Update History
-        QubitHistoryDocument.create_history(qubit_doc)
+        QubitHistoryDocument.create_history(qubit_model)
         return qubit_doc
 
     @classmethod

--- a/src/qdash/dbmodel/qubit_history.py
+++ b/src/qdash/dbmodel/qubit_history.py
@@ -81,6 +81,10 @@ class QubitHistoryDocument(Document):
                 chip_id=qubit.chip_id,
                 data=qubit.data,
                 node_info=qubit.node_info,
+                system_info=SystemInfoModel(
+                    created_at=pendulum.now(tz="Asia/Tokyo").to_iso8601_string(),
+                    updated_at=pendulum.now(tz="Asia/Tokyo").to_iso8601_string(),
+                ),
             )
         history.save()
         return history

--- a/src/qdash/dbmodel/qubit_history.py
+++ b/src/qdash/dbmodel/qubit_history.py
@@ -81,7 +81,6 @@ class QubitHistoryDocument(Document):
                 chip_id=qubit.chip_id,
                 data=qubit.data,
                 node_info=qubit.node_info,
-                system_info=qubit.system_info,
             )
         history.save()
         return history


### PR DESCRIPTION
Introduce a username field to both CouplingModel and QubitModel, updating document creation to include the username of the user who created the respective models.