### PR TITLE
Add additional output parameters for Rabi oscillation and improve CheckSkew box handling

### DIFF
--- a/src/qdash/workflow/tasks/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/tasks/one_qubit_coarse/check_rabi.py
@@ -44,6 +44,10 @@ class CheckRabi(BaseTask):
         "rabi_frequency": OutputParameterModel(
             unit="MHz", description="Rabi oscillation frequency"
         ),
+        "rabi_phase": OutputParameterModel(unit="a.u.", description="Rabi oscillation phase"),
+        "rabi_offset": OutputParameterModel(unit="a.u.", description="Rabi oscillation offset"),
+        "rabi_angle": OutputParameterModel(unit="degree", description="Rabi angle (in degree)"),
+        "rabi_noise": OutputParameterModel(unit="a.u.", description="Rabi oscillation noise"),
     }
 
     def preprocess(self, exp: Experiment, qid: str) -> PreProcessResult:  # noqa: ARG002
@@ -62,6 +66,12 @@ class CheckRabi(BaseTask):
         self.output_parameters["rabi_frequency"].error = (
             result.data[label].fit()["frequency_err"] * 1000
         )
+        self.output_parameters["rabi_phase"].value = result.rabi_params[label].phase
+        self.output_parameters["rabi_phase"].error = result.data[label].fit()["phase_err"]
+        self.output_parameters["rabi_offset"].value = result.rabi_params[label].offset
+        self.output_parameters["rabi_offset"].error = result.data[label].fit()["offset_err"]
+        self.output_parameters["rabi_angle"].value = result.rabi_params[label].angle
+        self.output_parameters["rabi_noise"].value = result.rabi_params[label].noise
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result.data[label].fit()["fig"]]
         raw_data = [result.data[label].data]

--- a/src/qdash/workflow/tasks/system/check_skew.py
+++ b/src/qdash/workflow/tasks/system/check_skew.py
@@ -46,7 +46,7 @@ class CheckSkew(BaseTask):
         qc = exp.tool.get_qubecalib()
         qc.sysdb.load_box_yaml("/app/config/box.yaml")
         setting = SkewSetting.from_yaml("/app/config/skew.yaml")
-        boxes = [list(exp.boxes), setting.monitor_box_name]
+        boxes = [*list(exp.boxes), setting.monitor_box_name]
         system = qc.sysdb.create_quel1system(*boxes)
         system.initialize()
         system.resync(*boxes)


### PR DESCRIPTION
Introduce new output parameters for Rabi oscillation, including phase, offset, angle, and noise. Update the handling of boxes in the CheckSkew functionality to streamline the process.