### PR TITLE
Add best_data field for calibration tracking

### DIFF
--- a/src/qdash/datamodel/coupling.py
+++ b/src/qdash/datamodel/coupling.py
@@ -36,4 +36,8 @@ class CouplingModel(BaseModel):
     status: str = Field("pending", description="The status of the coupling")
     chip_id: str | None = Field(None, description="The chip ID")
     data: dict = Field(..., description="The data of the coupling")
+    best_data: dict = Field(
+        default_factory=dict,
+        description="The best calibration results, focusing on fidelity metrics",
+    )
     edge_info: EdgeInfoModel = Field(..., description="The edge information")

--- a/src/qdash/datamodel/qubit.py
+++ b/src/qdash/datamodel/qubit.py
@@ -47,6 +47,10 @@ class QubitModel(BaseModel):
     status: str = Field("pending", description="The status of the qubit")
     chip_id: str | None = Field(None, description="The chip ID")
     data: dict = Field(..., description="The data of the qubit")
+    best_data: dict = Field(
+        default_factory=dict,
+        description="The best calibration results, focusing on fidelity metrics",
+    )
     node_info: NodeInfoModel = Field(..., description="The node information")
 
     @field_validator("data", mode="before")

--- a/src/qdash/db/init/chip.py
+++ b/src/qdash/db/init/chip.py
@@ -34,6 +34,7 @@ def generate_qubit_data(num_qubits: int, pos: dict, chip_id: str) -> dict:
                 ),
             ),
             data={},
+            best_data={},
         )
     return qubits
 

--- a/src/qdash/db/init/chip.py
+++ b/src/qdash/db/init/chip.py
@@ -59,6 +59,7 @@ def generate_coupling_data(edges: list[tuple[int, int]], chip_id: str) -> dict:
             status="pending",
             chip_id=chip_id,
             data={},
+            best_data={},
             edge_info=EdgeInfoModel(size=4, fill="", source=f"{edge[0]}", target=f"{edge[1]}"),
         )
     return coupling

--- a/src/qdash/db/init/coupling.py
+++ b/src/qdash/db/init/coupling.py
@@ -32,6 +32,7 @@ def generate_coupling(edges: list, username: str, chip_id: str) -> list:
             status="pending",
             chip_id=chip_id,
             data={},
+            best_data={},
             edge_info=EdgeInfoModel(size=4, fill="", source=f"{edge[0]}", target=f"{edge[1]}"),
             system_info={},
         )

--- a/src/qdash/db/init/qubit.py
+++ b/src/qdash/db/init/qubit.py
@@ -99,6 +99,7 @@ def generate_dummy_data(num_qubits: int, pos: dict, username: str, chip_id: str)
                 ),
             ),
             data={},
+            best_data={},
             system_info={},
         )
         data.append(qubit_data)

--- a/src/qdash/dbmodel/coupling.py
+++ b/src/qdash/dbmodel/coupling.py
@@ -28,6 +28,10 @@ class CouplingDocument(Document):
     status: str = Field("pending", description="The status of the coupling")
     chip_id: str = Field(..., description="The chip ID")
     data: dict = Field(..., description="The data of the coupling")
+    best_data: dict = Field(
+        default_factory=dict,
+        description="The best calibration results, focusing on fidelity metrics",
+    )
     edge_info: EdgeInfoModel = Field(..., description="The edge information")
 
     system_info: SystemInfoModel = Field(..., description="The system information")
@@ -54,6 +58,40 @@ class CouplingDocument(Document):
                 existing[key] = value
         return existing
 
+    @staticmethod
+    def update_best_data(current_best: dict, new_data: dict) -> dict:
+        """Update best_data with new calibration results if they are better.
+
+        Only updates fidelity-related metrics when the new values are higher
+        (better fidelity = higher value).
+        """
+        fidelity_metrics = [
+            "zx90_gate_fidelity",
+            "bell_state_fidelity",
+        ]
+
+        for metric in fidelity_metrics:
+            if metric in new_data:
+                new_param = new_data[metric]
+                new_value = new_param.value if hasattr(new_param, "value") else 0.0
+                # Initialize if metric doesn't exist in best_data or new value is better
+                current_value = (
+                    current_best[metric].get("value", 0.0) if metric in current_best else 0.0
+                )
+                if metric not in current_best or new_value > current_value:
+                    # Convert OutputParameterModel to dict for storage
+                    current_best[metric] = {
+                        "value": new_param.value,
+                        "value_type": new_param.value_type,
+                        "error": new_param.error,
+                        "unit": new_param.unit,
+                        "description": new_param.description,
+                        "calibrated_at": new_param.calibrated_at,
+                        "execution_id": new_param.execution_id,
+                    }
+
+        return current_best
+
     @classmethod
     def update_calib_data(
         cls, username: str, qid: str, chip_id: str, output_parameters: dict
@@ -63,6 +101,10 @@ class CouplingDocument(Document):
         if coupling_doc is None:
             raise ValueError(f"Coupling {qid} not found in chip {chip_id}")
         coupling_doc.data = CouplingDocument.merge_calib_data(coupling_doc.data, output_parameters)
+        # Update best_data if new results are better
+        coupling_doc.best_data = CouplingDocument.update_best_data(
+            coupling_doc.best_data, output_parameters
+        )
         coupling_doc.system_info.update_time()
         coupling_doc.save()
         chip_doc = ChipDocument.find_one({"username": username, "chip_id": chip_id}).run()
@@ -72,6 +114,7 @@ class CouplingDocument(Document):
             qid=qid,
             chip_id=chip_id,
             data=coupling_doc.data,
+            best_data=coupling_doc.best_data,
             edge_info=coupling_doc.edge_info,
             username=username,
         )

--- a/src/qdash/dbmodel/coupling_history.py
+++ b/src/qdash/dbmodel/coupling_history.py
@@ -28,6 +28,10 @@ class CouplingHistoryDocument(Document):
     status: str = Field(..., description="The status of the coupling")
     chip_id: str = Field(..., description="The chip ID")
     data: dict = Field(..., description="The data of the coupling")
+    best_data: dict = Field(
+        default_factory=dict,
+        description="The best calibration results, focusing on fidelity metrics",
+    )
     edge_info: EdgeInfoModel = Field(..., description="The edge information")
     system_info: SystemInfoModel = Field(..., description="The system information")
     recorded_date: str = Field(
@@ -70,6 +74,7 @@ class CouplingHistoryDocument(Document):
         if existing_history:
             history = existing_history
             history.data = coupling.data
+            history.best_data = coupling.best_data
             history.status = coupling.status
             history.edge_info = coupling.edge_info
         else:
@@ -79,6 +84,7 @@ class CouplingHistoryDocument(Document):
                 status=coupling.status,
                 chip_id=coupling.chip_id,
                 data=coupling.data,
+                best_data=coupling.best_data,
                 edge_info=coupling.edge_info,
                 system_info=SystemInfoModel(
                     created_at=pendulum.now(tz="Asia/Tokyo").to_iso8601_string(),

--- a/src/qdash/dbmodel/qubit.py
+++ b/src/qdash/dbmodel/qubit.py
@@ -74,10 +74,23 @@ class QubitDocument(Document):
 
         for metric in fidelity_metrics:
             if metric in new_data:
-                new_value = new_data[metric].get("value", 0.0)
-                # Initialize if metric doesn't exist in best_data
-                if metric not in current_best or new_value > current_best[metric].get("value", 0.0):
-                    current_best[metric] = new_data[metric].copy()
+                new_param = new_data[metric]
+                new_value = new_param.value if hasattr(new_param, "value") else 0.0
+                # Initialize if metric doesn't exist in best_data or new value is better
+                current_value = (
+                    current_best[metric].get("value", 0.0) if metric in current_best else 0.0
+                )
+                if metric not in current_best or new_value > current_value:
+                    # Convert OutputParameterModel to dict for storage
+                    current_best[metric] = {
+                        "value": new_param.value,
+                        "value_type": new_param.value_type,
+                        "error": new_param.error,
+                        "unit": new_param.unit,
+                        "description": new_param.description,
+                        "calibrated_at": new_param.calibrated_at,
+                        "execution_id": new_param.execution_id,
+                    }
 
         return current_best
 

--- a/src/qdash/dbmodel/qubit_history.py
+++ b/src/qdash/dbmodel/qubit_history.py
@@ -28,6 +28,10 @@ class QubitHistoryDocument(Document):
     status: str = Field(..., description="The status of the qubit")
     chip_id: str = Field(..., description="The chip ID")
     data: dict = Field(..., description="The data of the qubit")
+    best_data: dict = Field(
+        default_factory=dict,
+        description="The best calibration results, focusing on fidelity metrics",
+    )
     node_info: NodeInfoModel = Field(..., description="The node information")
     system_info: SystemInfoModel = Field(..., description="The system information")
     recorded_date: str = Field(
@@ -70,6 +74,7 @@ class QubitHistoryDocument(Document):
         if existing_history:
             history = existing_history
             history.data = qubit.data
+            history.best_data = qubit.best_data
             history.status = qubit.status
             history.node_info = qubit.node_info
         else:
@@ -80,6 +85,7 @@ class QubitHistoryDocument(Document):
                 status=qubit.status,
                 chip_id=qubit.chip_id,
                 data=qubit.data,
+                best_data=qubit.best_data,
                 node_info=qubit.node_info,
                 system_info=SystemInfoModel(
                     created_at=pendulum.now(tz="Asia/Tokyo").to_iso8601_string(),

--- a/src/qdash/workflow/handler.py
+++ b/src/qdash/workflow/handler.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 
 import pendulum
@@ -97,7 +98,7 @@ def main_flow(
         ui_url = ui_url.replace("127.0.0.1", "localhost").replace("prefect-server", "localhost")
     logger.info(f"Execution ID: {execution_id}")
     exectuion_is_locked = ExecutionLockDocument.get_lock_status()
-    commit_id = update_config()
+    commit_id = "local" if os.getenv("CONFIG_REPO_URL") == "" else update_config()
     if exectuion_is_locked:
         logger.error("Calibration is already running.")
         error_message = "Calibration is already running."


### PR DESCRIPTION
Introduce a new `best_data` field in the Qubit, Coupling, and QubitHistory models to enhance calibration tracking. Implement a function to retrieve the best chip properties and improve messaging in Slack reports.