### PR TITLE
Update r2_threshold in BaseTask from 0.9 to 0.7

### DIFF
--- a/src/qdash/workflow/tasks/base.py
+++ b/src/qdash/workflow/tasks/base.py
@@ -44,7 +44,7 @@ class BaseTask(ABC):
     task_type: Literal["global", "qubit", "coupling", "system"]
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
-    r2_threshold: float = 0.9
+    r2_threshold: float = 0.7
     registry: ClassVar[dict] = {}
 
     def __init_subclass__(cls, **kwargs) -> None:  # noqa: ANN003


### PR DESCRIPTION
Adjust the default value of `r2_threshold` in the `BaseTask` class to improve performance.