### PR TITLE
Add timeout functionality for task execution

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -601,6 +601,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 threadpoolctl==3.5.0
     # via scikit-learn
+timeout-decorator==0.5.0
 tinycss2==1.4.0
     # via bleach
 toml==0.10.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ workflow = [
     "filelock>=3.17.0",
     "gitpython>=3.1.44",
     "reportlab>=4.4.1",
+    "timeout-decorator>=0.5.0",
 ]
 dev = [
     "ruff==0.5.5",

--- a/src/qdash/workflow/requirements.txt
+++ b/src/qdash/workflow/requirements.txt
@@ -559,6 +559,7 @@ terminado==0.18.1
     #   jupyter-server-terminals
 threadpoolctl==3.5.0
     # via scikit-learn
+timeout-decorator==0.5.0
 tinycss2==1.4.0
     # via bleach
 toml==0.10.2

--- a/src/qdash/workflow/tasks/benchmark/x90_interleaved_randomized_benchmarking.py
+++ b/src/qdash/workflow/tasks/benchmark/x90_interleaved_randomized_benchmarking.py
@@ -63,6 +63,7 @@ class X90InterleavedRandomizedBenchmarking(BaseTask):
         return PostProcessResult(output_parameters=output_parameters, figures=figures)
 
     def run(self, exp: Experiment, qid: str) -> RunResult:
+        """Run the X90 interleaved randomized benchmarking task with timeout."""
         label = qid_to_label(qid)
         result = exp.interleaved_randomized_benchmarking(
             target=label,

--- a/src/qdash/workflow/tasks/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/tasks/two_qubit/check_cross_resonance.py
@@ -2,6 +2,7 @@ from typing import ClassVar
 
 import numpy as np
 import plotly.graph_objects as go
+import timeout_decorator
 from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_cr_label, qid_to_cr_pair
 from qdash.workflow.tasks.base import (
@@ -83,6 +84,7 @@ class CheckCrossResonance(BaseTask):
             output_parameters=output_parameters, figures=figures, raw_data=raw_data
         )
 
+    @timeout_decorator.timeout(60 * 30, use_signals=False)
     def run(self, exp: Experiment, qid: str) -> RunResult:
         control, target = qid_to_cr_pair(qid)
         raw_result = exp.obtain_cr_params(control, target)

--- a/src/qdash/workflow/tasks/two_qubit/check_zx90.py
+++ b/src/qdash/workflow/tasks/two_qubit/check_zx90.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+import timeout_decorator
 from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_cr_pair
 from qdash.workflow.tasks.base import (
@@ -40,6 +41,7 @@ class CheckZX90(BaseTask):
             output_parameters=self.attach_execution_id(execution_id), figures=figures
         )
 
+    @timeout_decorator.timeout(60 * 30, use_signals=False)
     def run(self, exp: Experiment, qid: str) -> RunResult:
         cr_control, cr_target = qid_to_cr_pair(qid)
         zx90_pulse = exp.zx90(cr_control, cr_target)

--- a/src/qdash/workflow/tasks/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/tasks/two_qubit/create_zx90.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
 
+import timeout_decorator
 from qdash.datamodel.task import InputParameterModel, OutputParameterModel
 from qdash.workflow.calibration.util import qid_to_cr_label, qid_to_cr_pair
 from qdash.workflow.tasks.base import (
@@ -60,6 +61,7 @@ class CreateZX90(BaseTask):
             output_parameters=output_parameters, figures=figures, raw_data=raw_data
         )
 
+    @timeout_decorator.timeout(60 * 30, use_signals=False)
     def run(self, exp: Experiment, qid: str) -> RunResult:
         control, target = qid_to_cr_pair(qid)
         raw_result = exp.calibrate_zx90(control, target)

--- a/uv.lock
+++ b/uv.lock
@@ -2658,6 +2658,7 @@ workflow = [
     { name = "qubex", extra = ["backend"] },
     { name = "reportlab" },
     { name = "slack-sdk" },
+    { name = "timeout-decorator" },
 ]
 
 [package.metadata]
@@ -2699,6 +2700,7 @@ workflow = [
     { name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?tag=v1.3.7" },
     { name = "reportlab", specifier = ">=4.4.1" },
     { name = "slack-sdk", specifier = "==3.31.0" },
+    { name = "timeout-decorator", specifier = ">=0.5.0" },
 ]
 
 [[package]]
@@ -3231,6 +3233,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/bd/55/b5148dcbf72f5cde2
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl", hash = "sha256:56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467", size = 18414, upload-time = "2024-04-29T13:50:14.014Z" },
 ]
+
+[[package]]
+name = "timeout-decorator"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/f8/0802dd14c58b5d3d72bb9caa4315535f58787a1dc50b81bbbcaaa15451be/timeout-decorator-0.5.0.tar.gz", hash = "sha256:6a2f2f58db1c5b24a2cc79de6345760377ad8bdc13813f5265f6c3e63d16b3d7", size = 4754, upload-time = "2020-11-15T00:53:06.506Z" }
 
 [[package]]
 name = "tinycss2"


### PR DESCRIPTION
Introduce the `timeout-decorator` library to enforce execution time limits on tasks, enhancing reliability and preventing long-running processes.