### PR TITLE
Add 25-minute timeout to coupling tasks

### DIFF
--- a/src/qdash/workflow/tasks/benchmark/zx90_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/tasks/benchmark/zx90_interleaved_randoized_benchmarking.py
@@ -19,6 +19,7 @@ class ZX90InterleavedRandomizedBenchmarking(BaseTask):
 
     name: str = "ZX90InterleavedRandomizedBenchmarking"
     task_type: str = "coupling"
+    timeout: int = 60 * 25  # 25 minutes
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {
         "n_cliffords_range": InputParameterModel(
             unit="a.u.",

--- a/src/qdash/workflow/tasks/two_qubit/check_bell_state.py
+++ b/src/qdash/workflow/tasks/two_qubit/check_bell_state.py
@@ -16,6 +16,7 @@ class CheckBellState(BaseTask):
 
     name: str = "CheckBellState"
     task_type: str = "coupling"
+    timeout: int = 60 * 25  # 25 minutes
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 

--- a/src/qdash/workflow/tasks/two_qubit/check_bell_state_tomography.py
+++ b/src/qdash/workflow/tasks/two_qubit/check_bell_state_tomography.py
@@ -18,6 +18,7 @@ class CheckBellStateTomography(BaseTask):
 
     name: str = "CheckBellStateTomography"
     task_type: str = "coupling"
+    timeout: int = 60 * 25  # 25 minutes
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
         "bell_state_fidelity": OutputParameterModel(

--- a/src/qdash/workflow/tasks/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/tasks/two_qubit/check_cross_resonance.py
@@ -18,6 +18,7 @@ class CheckCrossResonance(BaseTask):
 
     name: str = "CheckCrossResonance"
     task_type: str = "coupling"
+    timeout: int = 60 * 25  # 25 minutes
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
         "cr_amplitude": OutputParameterModel(

--- a/src/qdash/workflow/tasks/two_qubit/check_zx90.py
+++ b/src/qdash/workflow/tasks/two_qubit/check_zx90.py
@@ -16,6 +16,7 @@ class CheckZX90(BaseTask):
 
     name: str = "CheckZX90"
     task_type: str = "coupling"
+    timeout: int = 60 * 25  # 25 minutes
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {
         "repetitions": InputParameterModel(
             unit="a.u.",

--- a/src/qdash/workflow/tasks/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/tasks/two_qubit/create_zx90.py
@@ -16,6 +16,7 @@ class CreateZX90(BaseTask):
 
     name: str = "CreateZX90"
     task_type: str = "coupling"
+    timeout: int = 60 * 25  # 25 minutes
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
         "cr_amplitude": OutputParameterModel(


### PR DESCRIPTION
Introduce a timeout of 25 minutes for multiple coupling tasks to enhance task management and prevent indefinite execution.