### PR TITLE
Add backend field to menu and calibration models

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -2029,6 +2029,11 @@
             "type": "string",
             "title": "Description"
           },
+          "backend": {
+            "type": "string",
+            "title": "Backend",
+            "default": ""
+          },
           "schedule": {
             "anyOf": [
               {
@@ -2100,6 +2105,7 @@
         "title": "CreateMenuRequest",
         "description": "CreateMenuRequest is a Pydantic model for creating a menu item.",
         "example": {
+          "backend": "qubex",
           "batch_mode": false,
           "description": "This is a sample menu item.",
           "name": "CheckOneQubit",
@@ -2271,6 +2277,11 @@
             "type": "string",
             "title": "Description"
           },
+          "backend": {
+            "type": "string",
+            "title": "Backend",
+            "default": ""
+          },
           "schedule": {
             "anyOf": [
               {
@@ -2343,6 +2354,7 @@
         "description": "ExecuteCalibRequest is a subclass of MenuModel.",
         "examples": [
           {
+            "backend": "qubex",
             "chip_id": "chip1",
             "description": "check one qubit characteristics short",
             "name": "CheckRabi",
@@ -2579,6 +2591,11 @@
           "description": {
             "type": "string",
             "title": "Description"
+          },
+          "backend": {
+            "type": "string",
+            "title": "Backend",
+            "default": ""
           },
           "schedule": {
             "anyOf": [
@@ -2869,6 +2886,11 @@
           "description": {
             "type": "string",
             "title": "Description"
+          },
+          "backend": {
+            "type": "string",
+            "title": "Backend",
+            "default": ""
           },
           "schedule": {
             "anyOf": [
@@ -3745,6 +3767,11 @@
           "description": {
             "type": "string",
             "title": "Description"
+          },
+          "backend": {
+            "type": "string",
+            "title": "Backend",
+            "default": ""
           },
           "schedule": {
             "anyOf": [

--- a/src/qdash/api/routers/calibration.py
+++ b/src/qdash/api/routers/calibration.py
@@ -263,6 +263,7 @@ async def schedule_calib(
         name=menu.name,
         chip_id=menu.chip_id,
         username=menu.username,
+        backend=menu.backend,
         description=menu.description,
         schedule=menu.schedule,
         notify_bool=menu.notify_bool,

--- a/src/qdash/api/routers/menu.py
+++ b/src/qdash/api/routers/menu.py
@@ -37,6 +37,7 @@ class CreateMenuRequest(MenuModel):
                 "name": "CheckOneQubit",
                 "username": "admin",
                 "description": "This is a sample menu item.",
+                "backend": "qubex",
                 "qids": [["28", "29"]],
                 "batch_mode": False,
                 "notify_bool": False,
@@ -105,6 +106,7 @@ def list_menu(current_user: Annotated[User, Depends(get_current_active_user)]) -
             name=menu.name,
             chip_id=menu.chip_id,
             username=menu.username,
+            backend=menu.backend,
             description=menu.description,
             schedule=menu.schedule,
             tasks=menu.tasks,
@@ -162,6 +164,7 @@ def create_menu(
         name=request.name,
         chip_id=request.chip_id,
         username=current_user.username,
+        backend=request.backend,
         description=request.description,
         tasks=request.tasks,
         schedule=request.schedule,
@@ -325,6 +328,7 @@ def get_menu_by_name(
         chip_id=menu.chip_id,
         username=menu.username,
         description=menu.description,
+        backend=menu.backend,
         schedule=menu.schedule,
         tasks=menu.tasks,
         notify_bool=menu.notify_bool,
@@ -363,6 +367,7 @@ def update_menu(
         existing_menu.name = req.name
         existing_menu.chip_id = req.chip_id
         existing_menu.description = req.description
+        existing_menu.backend = req.backend
         existing_menu.schedule = req.schedule
         existing_menu.tasks = req.tasks
         existing_menu.notify_bool = req.notify_bool

--- a/src/qdash/api/schemas/calibration.py
+++ b/src/qdash/api/schemas/calibration.py
@@ -19,6 +19,7 @@ class ExecuteCalibRequest(MenuModel):
                     "description": "check one qubit characteristics short",
                     "qids": [["28"]],
                     "notify_bool": False,
+                    "backend": "qubex",
                     "tasks": [
                         "CheckRabi",
                     ],

--- a/src/qdash/datamodel/menu.py
+++ b/src/qdash/datamodel/menu.py
@@ -50,6 +50,7 @@ class MenuModel(BaseModel):
     chip_id: str
     username: str
     description: str
+    backend: str = ""
     schedule: ScheduleNode
     notify_bool: bool = False
     tasks: list[str] | None = Field(default=None)

--- a/src/qdash/dbmodel/menu.py
+++ b/src/qdash/dbmodel/menu.py
@@ -21,6 +21,7 @@ class MenuDocument(Document):
 
     name: str
     username: str
+    backend: str | None = Field(default="", description="The backend used for the menu.")
     description: str
     chip_id: str | None = Field(default=None)
     schedule: ScheduleNode = Field(

--- a/src/qdash/workflow/core/calibration/flow.py
+++ b/src/qdash/workflow/core/calibration/flow.py
@@ -33,7 +33,7 @@ from qdash.workflow.core.calibration.util import (
     update_active_tasks,
 )
 from qdash.workflow.core.session.base import BaseSession
-from qdash.workflow.core.session.factory import get_session
+from qdash.workflow.core.session.factory import create_session
 from qdash.workflow.tasks.active_protocols import generate_task_instances
 from qubex.version import get_package_version
 
@@ -331,8 +331,9 @@ def setup_calibration(
     # Initialize experiment
     note_path = Path(f"{calib_dir}/calib_note/{task_manager.id}.json")
     initialize()
-    session = get_session(
-        config={"username": menu.username, "qubits": labels, "note_path": note_path}
+    session = create_session(
+        backend=menu.backend,
+        config={"username": menu.username, "qubits": labels, "note_path": note_path},
     )
     session.connect()
     # Update parameters and tasks

--- a/src/qdash/workflow/core/session/factory.py
+++ b/src/qdash/workflow/core/session/factory.py
@@ -1,11 +1,8 @@
-from qdash.config import get_settings
 from qdash.workflow.core.session.base import BaseSession
 
 
-def get_session(config: dict) -> BaseSession:
+def create_session(backend: str, config: dict) -> BaseSession:
     """Return the appropriate session based on the backend configuration."""
-    settings = get_settings()
-    backend = settings.backend
     if backend == "qubex":
         return _load_qubex_session(config)
     if backend == "fake":

--- a/src/qdash/workflow/worker/scheduler/flow.py
+++ b/src/qdash/workflow/worker/scheduler/flow.py
@@ -38,6 +38,7 @@ def cron_scheduler_flow(menu_name: str) -> None:
     menu = MenuModel(
         name=menu.name,
         username=menu.username,
+        backend=menu.backend,
         chip_id=menu.chip_id,
         description=menu.description,
         schedule=menu.schedule,

--- a/ui/src/app/menu/editor/ExecuteConfirmModal.tsx
+++ b/ui/src/app/menu/editor/ExecuteConfirmModal.tsx
@@ -32,7 +32,7 @@ export function ExecuteConfirmModal({
   const handleConfirmClick = () => {
     if (isLocked) {
       toast.error(
-        "実行がロックされています。他のキャリブレーションが完了するまでお待ちください。",
+        "実行がロックされています。他のキャリブレーションが完了するまでお待ちください。"
       );
       return;
     }
@@ -43,6 +43,7 @@ export function ExecuteConfirmModal({
           name: menu.name,
           chip_id: menu.chip_id,
           username: user?.username ?? "default-user",
+          backend: menu.backend,
           description: menu.description,
           schedule: menu.schedule,
           notify_bool: menu.notify_bool,
@@ -65,7 +66,7 @@ export function ExecuteConfirmModal({
               >
                 View Details →
               </a>
-            </div>,
+            </div>
           );
           onClose();
         },
@@ -73,7 +74,7 @@ export function ExecuteConfirmModal({
           console.error("Error executing calibration:", error);
           toast.error("Error executing calibration");
         },
-      },
+      }
     );
   };
 
@@ -112,6 +113,18 @@ export function ExecuteConfirmModal({
               <h3 className="font-medium mb-2">Chip ID</h3>
               <p className="text-base-content/80">{menu.chip_id}</p>
             </div>
+
+            <div>
+              <h3 className="font-medium mb-2">Username</h3>
+              <p className="text-base-content/80">{menu.username}</p>
+            </div>
+
+            {menu.backend && (
+              <div>
+                <h3 className="font-medium mb-2">Backend</h3>
+                <p className="text-base-content/80">{menu.backend}</p>
+              </div>
+            )}
 
             <div>
               <h3 className="font-medium mb-2">Description</h3>

--- a/ui/src/app/tasks/page.tsx
+++ b/ui/src/app/tasks/page.tsx
@@ -163,7 +163,7 @@ export default function TasksPage() {
         acc[type].push(task);
         return acc;
       },
-      {}
+      {},
     ) || {};
 
   const TaskCard = ({ task }: { task: TaskResponse }) => (
@@ -259,7 +259,7 @@ export default function TasksPage() {
                   <TaskCard key={task.name} task={task} />
                 ) : (
                   <TaskRow key={task.name} task={task} />
-                )
+                ),
               )}
             </div>
           </div>

--- a/ui/src/schemas/createMenuRequest.ts
+++ b/ui/src/schemas/createMenuRequest.ts
@@ -18,6 +18,7 @@ export interface CreateMenuRequest {
   chip_id: string;
   username: string;
   description: string;
+  backend?: string;
   schedule: CreateMenuRequestSchedule;
   notify_bool?: boolean;
   tasks?: CreateMenuRequestTasks;

--- a/ui/src/schemas/executeCalibRequest.ts
+++ b/ui/src/schemas/executeCalibRequest.ts
@@ -18,6 +18,7 @@ export interface ExecuteCalibRequest {
   chip_id: string;
   username: string;
   description: string;
+  backend?: string;
   schedule: ExecuteCalibRequestSchedule;
   notify_bool?: boolean;
   tasks?: ExecuteCalibRequestTasks;

--- a/ui/src/schemas/getMenuResponse.ts
+++ b/ui/src/schemas/getMenuResponse.ts
@@ -18,6 +18,7 @@ export interface GetMenuResponse {
   chip_id: string;
   username: string;
   description: string;
+  backend?: string;
   schedule: GetMenuResponseSchedule;
   notify_bool?: boolean;
   tasks?: GetMenuResponseTasks;

--- a/ui/src/schemas/menuModel.ts
+++ b/ui/src/schemas/menuModel.ts
@@ -28,6 +28,7 @@ export interface MenuModel {
   chip_id: string;
   username: string;
   description: string;
+  backend?: string;
   schedule: MenuModelSchedule;
   notify_bool?: boolean;
   tasks?: MenuModelTasks;

--- a/ui/src/schemas/updateMenuRequest.ts
+++ b/ui/src/schemas/updateMenuRequest.ts
@@ -18,6 +18,7 @@ export interface UpdateMenuRequest {
   chip_id: string;
   username: string;
   description: string;
+  backend?: string;
   schedule: UpdateMenuRequestSchedule;
   notify_bool?: boolean;
   tasks?: UpdateMenuRequestTasks;


### PR DESCRIPTION
Introduce a backend field in the menu and calibration models, updating related schemas and components to accommodate this new attribute.