### PR TITLE
Add bulk delete functionality for tasks with confirmation modal

### DIFF
--- a/ui/src/app/menu/editor/BulkDeleteTasksConfirmModal.tsx
+++ b/ui/src/app/menu/editor/BulkDeleteTasksConfirmModal.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { BsPlus } from "react-icons/bs";
+
+export function BulkDeleteTasksConfirmModal({
+  taskNames,
+  onConfirm,
+  onClose,
+}: {
+  taskNames: string[];
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 backdrop-blur-sm p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-base-100 rounded-xl w-full max-w-lg overflow-hidden flex flex-col shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 py-4 border-b border-base-300 flex items-center justify-between bg-base-100/80 backdrop-blur supports-[backdrop-filter]:bg-base-100/60">
+          <div>
+            <h2 className="text-2xl font-bold">Delete Tasks</h2>
+            <p className="text-base-content/70 mt-1">
+              This action cannot be undone
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="btn btn-ghost btn-sm btn-square hover:rotate-90 transition-transform"
+          >
+            <BsPlus className="text-xl rotate-45" />
+          </button>
+        </div>
+
+        <div className="p-6">
+          <p className="mb-4">
+            Are you sure you want to delete the following {taskNames.length}{" "}
+            tasks?
+          </p>
+          <div className="bg-base-200 rounded-lg p-3 max-h-48 overflow-y-auto">
+            <ul className="list-disc list-inside space-y-1">
+              {taskNames.map((name) => (
+                <li key={name} className="text-sm">
+                  {name}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-base-300 flex justify-end gap-2">
+          <button className="btn btn-ghost" onClick={onClose}>
+            Cancel
+          </button>
+          <button className="btn btn-error" onClick={onConfirm}>
+            Delete {taskNames.length} tasks
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/app/menu/editor/TaskDetailList.tsx
+++ b/ui/src/app/menu/editor/TaskDetailList.tsx
@@ -14,7 +14,8 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { BsGripVertical, BsTrash } from "react-icons/bs";
+import { BsGripVertical, BsTrash, BsCheck } from "react-icons/bs";
+import { useState, useCallback, useEffect } from "react";
 
 interface TaskDetailListProps {
   tasks: Record<string, any>;
@@ -22,19 +23,25 @@ interface TaskDetailListProps {
   onTaskSelect: (taskName: string, content: any) => void;
   onDragEnd: (result: any) => void;
   onDeleteTask?: (taskName: string) => void;
+  onBulkDeleteTasks?: (taskNames: string[]) => void;
 }
 
 function SortableItem({
   id,
+  content,
   isSelected,
+  isChecked,
   onSelect,
   onDelete,
+  onCheckboxChange,
 }: {
   id: string;
   content: any;
   isSelected: boolean;
+  isChecked: boolean;
   onSelect: () => void;
   onDelete?: (e: React.MouseEvent) => void;
+  onCheckboxChange: (checked: boolean) => void;
 }) {
   const {
     attributes,
@@ -54,11 +61,19 @@ function SortableItem({
     <div
       ref={setNodeRef}
       style={style}
-      className={`flex items-center gap-2 p-2 rounded cursor-pointer transition-colors ${
+      className={`group flex items-center gap-2 p-2 rounded cursor-pointer transition-colors ${
         isSelected ? "bg-primary/10" : "hover:bg-base-300/50"
       } ${isDragging ? "shadow-lg bg-base-300/50" : ""}`}
-      onClick={onSelect}
     >
+      <div
+        className="flex items-center justify-center w-5 h-5 rounded border border-base-content/20 hover:border-primary transition-colors cursor-pointer shrink-0"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCheckboxChange(!isChecked);
+        }}
+      >
+        {isChecked && <BsCheck className="text-primary text-base" />}
+      </div>
       <div
         {...attributes}
         {...listeners}
@@ -66,14 +81,19 @@ function SortableItem({
       >
         <BsGripVertical className="text-lg" />
       </div>
-      <span className="font-medium text-sm truncate">{id}</span>
+      <span
+        className="font-medium text-sm truncate cursor-pointer"
+        onClick={onSelect}
+      >
+        {id}
+      </span>
       {onDelete && (
         <button
           onClick={(e) => {
             e.stopPropagation();
             onDelete(e);
           }}
-          className="ml-auto btn btn-ghost btn-xs btn-square hover:text-error"
+          className="ml-auto btn btn-ghost btn-xs btn-square hover:text-error opacity-0 group-hover:opacity-100 transition-opacity"
         >
           <BsTrash className="text-sm" />
         </button>
@@ -88,14 +108,21 @@ export default function TaskDetailList({
   onTaskSelect,
   onDragEnd,
   onDeleteTask,
+  onBulkDeleteTasks,
 }: TaskDetailListProps) {
   const taskNames = Object.keys(tasks);
+  const [selectedTasks, setSelectedTasks] = useState<Set<string>>(new Set());
+
+  // Clear selection when tasks change
+  useEffect(() => {
+    setSelectedTasks(new Set());
+  }, [tasks]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
-    }),
+    })
   );
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -109,38 +136,90 @@ export default function TaskDetailList({
     }
   };
 
+  const handleCheckboxChange = useCallback(
+    (taskName: string, checked: boolean) => {
+      setSelectedTasks((prev) => {
+        const next = new Set(prev);
+        if (checked) {
+          next.add(taskName);
+        } else {
+          next.delete(taskName);
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedTasks((prev) => {
+      if (prev.size === taskNames.length) {
+        return new Set();
+      }
+      return new Set(taskNames);
+    });
+  }, [taskNames]);
+
   return (
-    <div className="h-full overflow-y-auto">
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext
-          items={taskNames}
-          strategy={verticalListSortingStrategy}
-        >
-          <div className="p-2 space-y-1">
-            {taskNames.map((taskName) => (
-              <SortableItem
-                key={taskName}
-                id={taskName}
-                content={tasks[taskName]}
-                isSelected={selectedTask === taskName}
-                onSelect={() => onTaskSelect(taskName, tasks[taskName])}
-                onDelete={
-                  onDeleteTask
-                    ? (e) => {
-                        e.stopPropagation();
-                        onDeleteTask(taskName);
-                      }
-                    : undefined
-                }
-              />
-            ))}
+    <div className="h-full flex flex-col">
+      {selectedTasks.size > 0 && (
+        <div className="px-4 py-2 border-b border-base-300 bg-base-200/90 flex items-center gap-4">
+          <div className="text-sm font-medium">
+            {selectedTasks.size} selected
           </div>
-        </SortableContext>
-      </DndContext>
+          <div className="flex-1" />
+          <button
+            className="btn btn-ghost btn-sm"
+            onClick={() => setSelectedTasks(new Set())}
+          >
+            Clear
+          </button>
+          {onBulkDeleteTasks && (
+            <button
+              className="btn btn-error btn-sm"
+              onClick={() => onBulkDeleteTasks(Array.from(selectedTasks))}
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      )}
+      <div className="flex-1 overflow-y-auto">
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={taskNames}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="p-2 space-y-1">
+              {taskNames.map((taskName) => (
+                <SortableItem
+                  key={taskName}
+                  id={taskName}
+                  content={tasks[taskName]}
+                  isSelected={selectedTask === taskName}
+                  isChecked={selectedTasks.has(taskName)}
+                  onSelect={() => onTaskSelect(taskName, tasks[taskName])}
+                  onDelete={
+                    onDeleteTask
+                      ? (e) => {
+                          e.stopPropagation();
+                          onDeleteTask(taskName);
+                        }
+                      : undefined
+                  }
+                  onCheckboxChange={(checked) =>
+                    handleCheckboxChange(taskName, checked)
+                  }
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Introduce a confirmation modal for bulk deletion of tasks, allowing users to select multiple tasks and confirm their deletion in a single action. This enhances user experience by providing a clear confirmation step before irreversible actions.