### PR TITLE
Update qubex dependency and input parameters for pulse tasks

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -509,7 +509,7 @@ qctrl-visualizer==8.0.2
     # via qubex
 qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@e81cb57adec024c91ff103311f5406f6feae97e3
     # via qubex
-qubex @ git+https://github.com/amachino/qubex.git@c0dd5bb7d2a9882009a5ac7fc0fd6d8becb7b2e8
+qubex @ git+https://github.com/amachino/qubex.git@6937eef778ae049fb22c59eda8b2859a906991ad
 quel-clock-master @ git+https://github.com/quel-inc/quelware.git@de4dd6caf967b025b7d529e41a1d6e8c3029cc66#subdirectory=quel_clock_master
     # via
     #   qubecalib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,4 +122,4 @@ dev = [
 ]
 
 [tool.uv.sources]
-qubex = { git = "https://github.com/amachino/qubex.git", rev = "v1.4.0" }
+qubex = { git = "https://github.com/amachino/qubex.git", tag = "v1.4.1b1" }

--- a/src/qdash/workflow/requirements.txt
+++ b/src/qdash/workflow/requirements.txt
@@ -475,7 +475,7 @@ qctrl-visualizer==8.0.2
     # via qubex
 qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@e81cb57adec024c91ff103311f5406f6feae97e3
     # via qubex
-qubex @ git+https://github.com/amachino/qubex.git@c0dd5bb7d2a9882009a5ac7fc0fd6d8becb7b2e8
+qubex @ git+https://github.com/amachino/qubex.git@6937eef778ae049fb22c59eda8b2859a906991ad
 quel-clock-master @ git+https://github.com/quel-inc/quelware.git@de4dd6caf967b025b7d529e41a1d6e8c3029cc66#subdirectory=quel_clock_master
     # via
     #   qubecalib

--- a/src/qdash/workflow/tasks/qubex/one_qubit_coarse/create_hpi_pulse.py
+++ b/src/qdash/workflow/tasks/qubex/one_qubit_coarse/create_hpi_pulse.py
@@ -8,9 +8,8 @@ from qdash.workflow.tasks.base import (
     PreProcessResult,
     RunResult,
 )
-from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
-
-# from qubex.measurement.measurement import DEFAULT_INTERVAL
+from qubex.experiment.experiment_constants import CALIBRATION_SHOTS, HPI_DURATION
+from qubex.measurement.measurement import DEFAULT_INTERVAL
 
 
 class CreateHPIPulse(BaseTask):
@@ -21,7 +20,7 @@ class CreateHPIPulse(BaseTask):
     task_type: str = "qubit"
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {
         "duration": InputParameterModel(
-            unit="ns", value_type="int", value=24, description="HPI pulse length"
+            unit="ns", value_type="int", value=HPI_DURATION, description="HPI pulse length"
         ),
         "shots": InputParameterModel(
             unit="",
@@ -32,7 +31,7 @@ class CreateHPIPulse(BaseTask):
         "interval": InputParameterModel(
             unit="ns",
             value_type="int",
-            value=300 * 1024,
+            value=DEFAULT_INTERVAL,
             description="Time interval for calibration",
         ),
     }

--- a/src/qdash/workflow/tasks/qubex/one_qubit_coarse/create_pi_pulse.py
+++ b/src/qdash/workflow/tasks/qubex/one_qubit_coarse/create_pi_pulse.py
@@ -8,9 +8,8 @@ from qdash.workflow.tasks.base import (
     PreProcessResult,
     RunResult,
 )
-from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
-
-# from qubex.measurement.measurement import DEFAULT_INTERVAL
+from qubex.experiment.experiment_constants import CALIBRATION_SHOTS, PI_DURATION
+from qubex.measurement.measurement import DEFAULT_INTERVAL
 
 
 class CreatePIPulse(BaseTask):
@@ -21,7 +20,7 @@ class CreatePIPulse(BaseTask):
     task_type: str = "qubit"
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {
         "duration": InputParameterModel(
-            unit="ns", value_type="int", value=36, description="PI pulse length"
+            unit="ns", value_type="int", value=PI_DURATION, description="PI pulse length"
         ),
         "shots": InputParameterModel(
             unit="",
@@ -32,7 +31,7 @@ class CreatePIPulse(BaseTask):
         "interval": InputParameterModel(
             unit="ns",
             value_type="int",
-            value=300 * 1024,
+            value=DEFAULT_INTERVAL,
             description="Time interval for calibration",
         ),
     }

--- a/src/qdash/workflow/tasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
+++ b/src/qdash/workflow/tasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
@@ -10,9 +10,8 @@ from qdash.workflow.tasks.base import (
     PreProcessResult,
     RunResult,
 )
-from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
-
-# from qubex.measurement.measurement import DEFAULT_INTERVAL
+from qubex.experiment.experiment_constants import CALIBRATION_SHOTS, DRAG_HPI_DURATION
+from qubex.measurement.measurement import DEFAULT_INTERVAL
 
 
 class CreateDRAGHPIPulse(BaseTask):
@@ -25,7 +24,7 @@ class CreateDRAGHPIPulse(BaseTask):
         "duration": InputParameterModel(
             unit="ns",
             value_type="int",
-            value=24,
+            value=DRAG_HPI_DURATION,
             description="HPI pulse length",
         ),
         "shots": InputParameterModel(
@@ -37,7 +36,7 @@ class CreateDRAGHPIPulse(BaseTask):
         "interval": InputParameterModel(
             unit="ns",
             value_type="int",
-            value=300 * 1024,
+            value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }

--- a/src/qdash/workflow/tasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
+++ b/src/qdash/workflow/tasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
@@ -10,9 +10,8 @@ from qdash.workflow.tasks.base import (
     PreProcessResult,
     RunResult,
 )
-from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
-
-# from qubex.measurement.measurement import DEFAULT_INTERVAL
+from qubex.experiment.experiment_constants import CALIBRATION_SHOTS, DRAG_PI_DURATION
+from qubex.measurement.measurement import DEFAULT_INTERVAL
 
 
 class CreateDRAGPIPulse(BaseTask):
@@ -25,7 +24,7 @@ class CreateDRAGPIPulse(BaseTask):
         "duration": InputParameterModel(
             unit="ns",
             value_type="int",
-            value=36,
+            value=DRAG_PI_DURATION,
             description="PI pulse length",
         ),
         "shots": InputParameterModel(
@@ -37,7 +36,7 @@ class CreateDRAGPIPulse(BaseTask):
         "interval": InputParameterModel(
             unit="ns",
             value_type="int",
-            value=300 * 1024,
+            value=DEFAULT_INTERVAL,
             description="Time interval",
         ),
     }

--- a/src/qdash/workflow/tasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/tasks/qubex/two_qubit/check_cross_resonance.py
@@ -19,11 +19,7 @@ class CheckCrossResonance(BaseTask):
     backend: str = "qubex"
     task_type: str = "coupling"
     timeout: int = 60 * 25  # 25 minutes
-    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
-        "ramptime": InputParameterModel(
-            unit="ns", value_type="int", value=128, description="Ramp time for the CR pulse."
-        ),
-    }
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
         "cr_amplitude": OutputParameterModel(
             unit="a.u.", value_type="float", description="Amplitude of the CR pulse."
@@ -105,7 +101,7 @@ class CheckCrossResonance(BaseTask):
 
         raw_result = exp.obtain_cr_params(
             control,
-            target,  # , ramptime=self.input_parameters["ramptime"].get_value()
+            target,
         )
         fit_result = exp.calib_note.get_cr_param(label)
         if fit_result is None:

--- a/src/qdash/workflow/tasks/qubex/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/tasks/qubex/two_qubit/create_zx90.py
@@ -17,20 +17,7 @@ class CreateZX90(BaseTask):
     backend: str = "qubex"
     task_type: str = "coupling"
     timeout: int = 60 * 25  # 25 minutes
-    input_parameters: ClassVar[dict[str, InputParameterModel]] = {
-        "ramptime": InputParameterModel(
-            unit="ns", value_type="int", value=128, description="Ramp time for the CR pulse."
-        ),
-        "duratoin": InputParameterModel(
-            unit="ns", value_type="int", value=256 + 128, description="Duration of the ZX90 pulse."
-        ),
-        "duration_buffer": InputParameterModel(
-            unit="ns",
-            value_type="float",
-            value=1.1,
-            description="Buffer duration for the ZX90 pulse.",
-        ),
-    }
+    input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
         "cr_amplitude": OutputParameterModel(
             unit="a.u.", value_type="float", description="Amplitude of the CR pulse."
@@ -87,9 +74,6 @@ class CreateZX90(BaseTask):
         raw_result = exp.calibrate_zx90(
             control,
             target,
-            # ramptime=self.input_parameters["ramptime"].get_value(),
-            # duration=self.input_parameters["duratoin"].get_value(),
-            # duration_buffer=self.input_parameters["duration_buffer"].get_value(),
         )
         fit_result = exp.calib_note.get_cr_param(label)
         if fit_result is None:

--- a/uv.lock
+++ b/uv.lock
@@ -2705,7 +2705,7 @@ workflow = [
     { name = "pymongo", specifier = "==4.8.0" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "pyyaml", specifier = "==6.0.1" },
-    { name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?rev=v1.4.0" },
+    { name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?tag=v1.4.1b1" },
     { name = "reportlab", specifier = ">=4.4.1" },
     { name = "slack-sdk", specifier = "==3.31.0" },
 ]
@@ -2732,8 +2732,8 @@ dependencies = [
 
 [[package]]
 name = "qubex"
-version = "1.4.0+c0dd5bb"
-source = { git = "https://github.com/amachino/qubex.git?rev=v1.4.0#c0dd5bb7d2a9882009a5ac7fc0fd6d8becb7b2e8" }
+version = "1.4.1b1+6937eef"
+source = { git = "https://github.com/amachino/qubex.git?tag=v1.4.1b1#6937eef778ae049fb22c59eda8b2859a906991ad" }
 dependencies = [
     { name = "cma" },
     { name = "cvxopt" },


### PR DESCRIPTION
Update the qubex dependency to version 1.4.1b1 and adjust input parameters for various pulse tasks to use constants for duration and interval. Remove unused input parameters in specific tasks.