### PR TITLE
Remove unused isUrlInitialized prop from ChipSelector and DateSelector components

### DIFF
--- a/ui/src/app/chip/page.tsx
+++ b/ui/src/app/chip/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, Suspense } from "react";
+import React, { useState, useEffect, Suspense } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 import { useListMuxes, useFetchChip, useListChips } from "@/client/chip/chip";
 import { useDateNavigation } from "@/app/hooks/useDateNavigation";
@@ -324,7 +324,6 @@ function ChipPageContent() {
             <ChipSelector
               selectedChip={selectedChip}
               onChipSelect={setSelectedChip}
-              isUrlInitialized={isInitialized}
             />
 
             <DateSelector
@@ -332,7 +331,6 @@ function ChipPageContent() {
               selectedDate={selectedDate}
               onDateSelect={setSelectedDate}
               disabled={!selectedChip}
-              isUrlInitialized={isInitialized}
             />
 
             <TaskSelector

--- a/ui/src/app/components/ChipSelector/index.tsx
+++ b/ui/src/app/components/ChipSelector/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useListChips } from "@/client/chip/chip";
 import Select, { SingleValue } from "react-select";
 
@@ -13,13 +13,11 @@ interface ChipOption {
 interface ChipSelectorProps {
   selectedChip: string;
   onChipSelect: (chipId: string) => void;
-  isUrlInitialized?: boolean;
 }
 
 export function ChipSelector({
   selectedChip,
   onChipSelect,
-  isUrlInitialized = true,
 }: ChipSelectorProps) {
   const { data: chips, isLoading, isError } = useListChips();
 

--- a/ui/src/app/components/DateSelector/index.tsx
+++ b/ui/src/app/components/DateSelector/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { useFetchChipDates } from "@/client/chip/chip";
 import Select, { SingleValue } from "react-select";
 
@@ -14,7 +14,6 @@ interface DateSelectorProps {
   selectedDate: string;
   onDateSelect: (date: string) => void;
   disabled?: boolean;
-  isUrlInitialized?: boolean;
 }
 
 /**
@@ -25,7 +24,6 @@ export function DateSelector({
   selectedDate,
   onDateSelect,
   disabled = false,
-  isUrlInitialized = true,
 }: DateSelectorProps) {
   const {
     data: datesResponse,


### PR DESCRIPTION
Eliminate the unnecessary `isUrlInitialized` prop from both the ChipSelector and DateSelector components to streamline the code.