### PR TITLE
Implement URL state management for execution page

### DIFF
--- a/ui/src/app/hooks/useUrlState.ts
+++ b/ui/src/app/hooks/useUrlState.ts
@@ -21,8 +21,8 @@ interface UseChipUrlStateResult {
 }
 
 interface UseExecutionUrlStateResult {
-  selectedChip: string;
-  setSelectedChip: (chip: string) => void;
+  selectedChip: string | null;
+  setSelectedChip: (chip: string | null) => void;
   isInitialized: boolean;
 }
 
@@ -111,16 +111,16 @@ export function useExecutionUrlState(): UseExecutionUrlStateResult {
     setIsInitialized(true);
   }, []);
 
-  // Wrapped setter to handle URL updates
+  // Wrapped setter to handle URL updates - now accepts null explicitly
   const setSelectedChip = useCallback(
-    (chip: string) => {
+    (chip: string | null) => {
       setSelectedChipState(chip || null); // null removes the parameter from URL
     },
     [setSelectedChipState]
   );
 
   return {
-    selectedChip: selectedChip ?? "",
+    selectedChip,  // Return null as-is instead of converting to empty string
     setSelectedChip,
     isInitialized,
   };

--- a/ui/src/app/hooks/useUrlState.ts
+++ b/ui/src/app/hooks/useUrlState.ts
@@ -20,6 +20,12 @@ interface UseChipUrlStateResult {
   isInitialized: boolean; // Track if URL state has been initialized
 }
 
+interface UseExecutionUrlStateResult {
+  selectedChip: string;
+  setSelectedChip: (chip: string) => void;
+  isInitialized: boolean;
+}
+
 export function useChipUrlState(): UseChipUrlStateResult {
   const [isInitialized, setIsInitialized] = useState(false);
   
@@ -87,6 +93,35 @@ export function useChipUrlState(): UseChipUrlStateResult {
     setSelectedDate,
     setSelectedTask,
     setViewMode,
+    isInitialized,
+  };
+}
+
+export function useExecutionUrlState(): UseExecutionUrlStateResult {
+  const [isInitialized, setIsInitialized] = useState(false);
+  
+  // URL state management for execution page
+  const [selectedChip, setSelectedChipState] = useQueryState(
+    "chip",
+    parseAsString
+  );
+
+  // Mark as initialized after first render
+  useEffect(() => {
+    setIsInitialized(true);
+  }, []);
+
+  // Wrapped setter to handle URL updates
+  const setSelectedChip = useCallback(
+    (chip: string) => {
+      setSelectedChipState(chip || null); // null removes the parameter from URL
+    },
+    [setSelectedChipState]
+  );
+
+  return {
+    selectedChip: selectedChip ?? "",
+    setSelectedChip,
     isInitialized,
   };
 }


### PR DESCRIPTION
Introduce a custom hook for managing URL state on the execution page, allowing for better handling of selected chip IDs. The implementation ensures that the latest chip is set as default when no chip is selected from the URL. This enhances user experience by maintaining state consistency across navigation.