### PR TITLE
Update README and refactor package structure

### DIFF
--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -4,30 +4,60 @@ A Python client library for accessing QDash API, auto-generated from OpenAPI spe
 
 ## Installation
 
-### From GitHub
+### Option 1: Install client standalone (Recommended for client-only usage)
 
 ```bash
-# Install directly from GitHub
+# Install directly from the client subdirectory
 pip install git+https://github.com/oqtopus-team/qdash.git#subdirectory=src/qdash/client
 
-# Install from specific branch
-pip install git+https://github.com/oqtopus-team/qdash.git@develop#subdirectory=src/qdash/client
-
-# Install from specific tag/release
-pip install git+https://github.com/oqtopus-team/qdash.git@v0.1.0#subdirectory=src/qdash/client
+# Or if you have the repository cloned locally
+cd src/qdash/client
+pip install .
 ```
 
-### From PyPI (when published)
+### Option 2: Install as part of the full QDash package
 
 ```bash
+# Install the entire QDash package
+pip install git+https://github.com/oqtopus-team/qdash.git
+
+# The client will be available as qdash.client
+```
+
+### Option 3: From PyPI (when published)
+
+```bash
+# Future release - client only
 pip install qdash-client
+
+# Or full package
+pip install qdash
+```
+
+## Usage
+
+When installed standalone (qdash-client):
+```python
+from qdash_client import Client
+from qdash_client.api.chip import list_chips, fetch_chip
+```
+
+When installed as part of qdash package:
+```python
+from qdash.client import Client
+from qdash.client.api.chip import list_chips, fetch_chip
 ```
 
 ## Usage
 
 ```python
-from client import Client
-from client.api.chip import list_chips, fetch_chip
+# When installed as standalone package (qdash-client)
+from qdash_client import Client
+from qdash_client.api.chip import list_chips, fetch_chip
+
+# Or when installed as part of qdash
+# from qdash.client import Client
+# from qdash.client.api.chip import list_chips, fetch_chip
 
 # Create client instance
 client = Client(base_url="http://localhost:5715")

--- a/src/qdash/client/__init__.py
+++ b/src/qdash/client/__init__.py
@@ -1,5 +1,7 @@
 """A client library for accessing QDash API"""
 
+__version__ = "0.1.0"
+
 from .client import AuthenticatedClient, Client
 
 __all__ = (

--- a/src/qdash/client/pyproject.toml
+++ b/src/qdash/client/pyproject.toml
@@ -1,15 +1,16 @@
 [project]
-name = "qdash-client"
+name = "qdash_client"
 version = "0.1.0"
 description = "Python client for QDash API"
-authors = [
-    {name = "orangekame3", email = "oqtopus-team@googlegroups.com"}
-]
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
+authors = [
+    {name = "oqtopus-team", email = "oqtopus-team@googlegroups.com"}
+]
 dependencies = [
-    "httpx>=0.27.0,<0.28.0",
-    "attrs>=23.1.0,<25.0.0",
+    "httpx>=0.24.0",
+    "attrs>=21.3.0",
+    "python-dateutil>=2.8.0",
 ]
 
 [build-system]

--- a/src/qdash/scripts/generate_client.py
+++ b/src/qdash/scripts/generate_client.py
@@ -179,7 +179,7 @@ def generate_client(config: ClientConfig) -> None:
 
         # Validate generated client structure
         expected_files = [
-            output_dir / f"{config.package_name}/__init__.py",
+            output_dir / "__init__.py",
             output_dir / "pyproject.toml",
             output_dir / "README.md",
         ]
@@ -192,11 +192,24 @@ def generate_client(config: ClientConfig) -> None:
         print(f"📁 Location: {output_dir}")
         print()
         print("🚀 To use the client:")
-        print(f"   1. Install: pip install -e {output_dir}")
-        print("   2. Import and use:")
-        print(f"      from {config.package_name} import Client")
-        print(f"      from {config.package_name}.api.chip import get_chips")
-        print("")
+        print()
+        print("   Option 1: Install standalone (recommended for client-only usage):")
+        print(f"      pip install {output_dir}")
+        print("      # Or from GitHub:")
+        print("      pip install git+https://github.com/oqtopus-team/qdash.git#subdirectory=src/qdash/client")
+        print()
+        print("   Option 2: Use as part of qdash package:")
+        print("      pip install git+https://github.com/oqtopus-team/qdash.git")
+        print()
+        print("   Import and use:")
+        print("      # Standalone installation:")
+        print("      from qdash_client import Client")
+        print("      from qdash_client.api.chip import get_chips")
+        print()
+        print("      # Or when installed with full qdash:")
+        print("      from qdash.client import Client")
+        print("      from qdash.client.api.chip import get_chips")
+        print()
         print(f"      client = Client(base_url='{config.api_url}')")
         print("      response = get_chips.sync_detailed(client=client)")
         print("      if response.status_code == 200:")

--- a/src/qdash_client/__init__.py
+++ b/src/qdash_client/__init__.py
@@ -1,5 +1,0 @@
-# Re-export everything from qdash.client for compatibility
-from qdash.client import *
-from qdash.client import __all__
-
-__version__ = "0.1.0"


### PR DESCRIPTION
Revise installation instructions and usage examples in the README. Rename the package to `qdash_client` and update dependencies accordingly. Remove deprecated files to streamline the package structure.