### PR TITLE
Update installation instructions for qdash_client in demo and README

### DIFF
--- a/examples/simple_client_demo.py
+++ b/examples/simple_client_demo.py
@@ -35,7 +35,7 @@ def main() -> None:
 
     except ImportError as e:
         print(f"❌ Import failed: {e}")
-        print("Solution: run 'task generate-python-client'")
+        print("Solution: pip install git+https://github.com/oqtopus-team/qdash.git#subdirectory=qdash_client")
     except Exception as e:
         print(f"⚠️  Connection failed: {e}")
         print("This is expected if QDash server is not running")

--- a/src/qdash/scripts/generate_client.py
+++ b/src/qdash/scripts/generate_client.py
@@ -217,7 +217,7 @@ def generate_client(config: ClientConfig) -> None:
         print("   Option 1: Install standalone (recommended for client-only usage):")
         print(f"      pip install {output_dir}")
         print("      # Or from GitHub:")
-        print("      pip install git+https://github.com/oqtopus-team/qdash.git#subdirectory=src/qdash/client")
+        print("      pip install git+https://github.com/oqtopus-team/qdash.git#subdirectory=qdash_client")
         print()
         print("   Option 2: Use as part of qdash package:")
         print("      pip install git+https://github.com/oqtopus-team/qdash.git")

--- a/templates/README.md.jinja
+++ b/templates/README.md.jinja
@@ -7,7 +7,7 @@ A Python client library for accessing QDash API, auto-generated from OpenAPI spe
 ### Option 1: Install client standalone (Recommended for client-only usage)
 
 ```bash
-# Install directly from the client subdirectory
+# Install directly from GitHub
 pip install git+https://github.com/oqtopus-team/qdash.git#subdirectory=qdash_client
 
 # Or if you have the repository cloned locally


### PR DESCRIPTION
Revise the installation instructions for the qdash_client to reflect the correct subdirectory path in both the demo and README files. This change clarifies the installation process for users.