### PR TITLE
Fix devcontainer setup for node_modules caching and dependencies path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -116,8 +116,13 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
     -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
     -x
 
-# Copy frontend dependencies (optional)
-# This speeds up the initial bun install
-COPY --from=frontend-deps /workspace/qdash/ui/node_modules /tmp/node_modules_cache
+# Setup node_modules cache directory
+# This will be used by postCreateCommand
+RUN mkdir -p /workspace/qdash/ui && \
+    touch /workspace/qdash/ui/.bunfig.toml
+
+# Copy frontend dependencies to correct location
+# This pre-populates node_modules before volume mount
+COPY --from=frontend-deps /workspace/qdash/ui/node_modules /workspace/qdash/ui/node_modules
 
 WORKDIR /workspace/qdash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -63,6 +63,9 @@
   "overrideCommand": false,
   "shutdownAction": "none",
 
+  // Run bun install after container creation
+  "postCreateCommand": "cd /workspace/qdash/ui && bun install",
+
   // Disable features (reduce build time)
   "features": {}
 }


### PR DESCRIPTION
Update the Dockerfile to create a node_modules cache directory and correct the path for copying frontend dependencies, ensuring proper setup during container creation.