### PR TITLE
Update Slack link in README for correct workspace access

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # QDash
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://oqtopus.slack.com/archives/C08KM5JPUEL)
+[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://join.slack.com/t/oqtopus/shared_invite/zt-3bpjb7yc3-Vg8IYSMY1m5wV3DR~TMSnw)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/oqtopus-team/qdash)
 
 QDash is a web application that provides a user-friendly interface to manage and monitor the execution of qubit calibration workflows.
@@ -42,7 +42,7 @@ or you can contact us by email:
 
 or you can join our Slack workspace:
 
-[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://oqtopus.slack.com/archives/C08KM5JPUEL)
+[![slack](https://img.shields.io/badge/slack-OQTOPUS-pink.svg?logo=slack&style=plastic")](https://join.slack.com/t/oqtopus/shared_invite/zt-3bpjb7yc3-Vg8IYSMY1m5wV3DR~TMSnw)
 
 ## LICENSE
 


### PR DESCRIPTION
Replace outdated Slack link in the README with the correct invite link for workspace access.