### PR TITLE
Fix qid formatting and enhance task timeouts

### DIFF
--- a/src/qdash/api/routers/device_topology.py
+++ b/src/qdash/api/routers/device_topology.py
@@ -98,7 +98,7 @@ def search_coupling_data_by_control_qid(cr_params: dict, search_term: str) -> di
 def qid_to_label(qid: str) -> str:
     """Convert a numeric qid string to a label with at least two digits. e.g. '0' -> 'Q00'."""
     if re.fullmatch(r"\d+", qid):
-        return "Q" + qid.zfill(3)
+        return "Q" + qid.zfill(2)
     error_message = "Invalid qid format."
     raise ValueError(error_message)
 
@@ -334,7 +334,7 @@ def get_device_topology(
             control, target = split_q_string(cr_key)
             cr_duration = cr_value.get("duration", 20)
             # Get coupling fidelity data with timestamp check
-            coupling_data = chip_docs.couplings[f"{control}-{target}"].data.get("zx90_gate_fidelity", {})
+            coupling_data = chip_docs.couplings[f"{control}-{target}"].data.get("bell_state_fidelity", {})
             # zx90_gate_fidelity = (
             #     coupling_data["value"]
             #     if is_within_24h(coupling_data.get("calibrated_at"))

--- a/src/qdash/workflow/tasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/tasks/qubex/cw/check_qubit_spectroscopy.py
@@ -16,6 +16,7 @@ class CheckQubitSpectroscopy(BaseTask):
     name: str = "CheckQubitSpectroscopy"
     backend: str = "qubex"
     task_type: str = "qubit"
+    timeout: int = 60 * 120
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 

--- a/src/qdash/workflow/tasks/qubex/cw/check_reflection_coefficient.py
+++ b/src/qdash/workflow/tasks/qubex/cw/check_reflection_coefficient.py
@@ -62,7 +62,7 @@ class CheckReflectionCoefficient(BaseTask):
         chip = ChipDocument.get_current_chip(username="admin")
         for label, qid in zip(labels, qids):
             result = exp.measure_reflection_coefficient(
-                target=label, center_frequency=chip.qubits[qid].data["coarse_resonator_frequency"]["value"]
+                target=label,  # center_frequency=chip.qubits[qid].data["coarse_resonator_frequency"]["value"]
             )
             results[label] = result
         exp.calib_note.save()

--- a/src/qdash/workflow/tasks/qubex/one_qubit_coarse/chevron_pattern.py
+++ b/src/qdash/workflow/tasks/qubex/one_qubit_coarse/chevron_pattern.py
@@ -18,6 +18,7 @@ class ChevronPattern(BaseTask):
     name: str = "ChevronPattern"
     backend: str = "qubex"
     task_type: str = "qubit"
+    timeout: int = 60 * 240
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
         "bare_frequency": OutputParameterModel(unit="GHz", description="Qubit bare frequency"),
@@ -81,25 +82,25 @@ class ChevronPattern(BaseTask):
         labels = [exp.get_qubit_label(int(qid))]
         from qubex.experiment.rabi_param import RabiParam
 
-        # rabi_param = RabiParam(
-        #     **{
-        #         "amplitude": 0.018757924680085324,
-        #         "angle": 0.2550564567234854,
-        #         "distance": -0.013257740996778011,
-        #         "frequency": 0.012516133217763476,
-        #         "noise": 0.00035153969656676054,
-        #         "offset": 0.0009658521547125462,
-        #         "phase": -0.02116097291450829,
-        #         "r2": 0.99857055386212,
-        #         "reference_phase": 2.403657416868579,
-        #         "target": "Q004",
-        #     }
-        # )
+        rabi_param = RabiParam(
+            **{
+                "amplitude": 0.018757924680085324,
+                "angle": 0.2550564567234854,
+                "distance": -0.013257740996778011,
+                "frequency": 0.012516133217763476,
+                "noise": 0.00035153969656676054,
+                "offset": 0.0009658521547125462,
+                "phase": -0.02116097291450829,
+                "r2": 0.99857055386212,
+                "reference_phase": 2.403657416868579,
+                "target": "Q04",
+            }
+        )
         result = exp.chevron_pattern(
             targets=labels,
-            detuning_range=np.linspace(-0.10, 0.10, 81),
+            detuning_range=np.linspace(-0.05, 0.05, 51),
             time_range=np.arange(0, 201, 4),
-            # rabi_params={labels[0]: rabi_param},
+            rabi_params={labels[0]: rabi_param},
         )
         exp.calib_note.save()
         return RunResult(raw_result=result)

--- a/src/qdash/workflow/worker/flows/push_props/create_props.py
+++ b/src/qdash/workflow/worker/flows/push_props/create_props.py
@@ -13,7 +13,7 @@ from ruamel.yaml.comments import CommentedMap
 
 qubit_field_map = {
     "bare_frequency": "qubit_frequency",
-    "resonator_frequency": "resonator_frequency",
+    # "resonator_frequency": "resonator_frequency",
     "t1": "t1",
     "t2_echo": "t2_echo",
     "t2_star": "t2_star",


### PR DESCRIPTION
Adjust qid formatting for consistency, update coupling fidelity data retrieval, and set timeouts for CheckQubitSpectroscopy and ChevronPattern tasks to improve performance. Additionally, uncomment RabiParam initialization and refine the detuning range in ChevronPattern.