### PR TITLE
Standardize TaskSelector component width

### DIFF
--- a/ui/src/app/components/TaskSelector/index.tsx
+++ b/ui/src/app/components/TaskSelector/index.tsx
@@ -35,7 +35,7 @@ export function TaskSelector({
   };
 
   return (
-    <div className="w-full max-w-xs">
+    <div className="w-88">
       <label className="label">
         <span className="label-text font-medium">Select Task</span>
       </label>


### PR DESCRIPTION
Set a fixed width for the TaskSelector component to ensure consistency across the application.