### PR TITLE
Add task_type field to base task classes

### DIFF
--- a/src/qdash/workflow/tasks/fake/base.py
+++ b/src/qdash/workflow/tasks/fake/base.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from qdash.workflow.core.calibration.util import qid_to_label
 from qdash.workflow.tasks.base import BaseTask, RunResult
@@ -16,6 +16,7 @@ class FakeTask(BaseTask):
     """
 
     backend: str = "fake"
+    task_type: Literal["global", "qubit", "coupling", "system"]  # Must be defined in subclass
 
     def batch_run(self, session: "FakeSession", qids: list[str]) -> RunResult:
         """Default implementation for batch run.

--- a/src/qdash/workflow/tasks/qubex/base.py
+++ b/src/qdash/workflow/tasks/qubex/base.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from qdash.workflow.tasks.base import BaseTask, RunResult
 
@@ -14,6 +14,7 @@ class QubexTask(BaseTask):
     """
 
     backend: str = "qubex"
+    task_type: Literal["global", "qubit", "coupling", "system"]  # Must be defined in subclass
 
     def batch_run(self, session: "QubexSession", qids: list[str]) -> RunResult:
         """Default implementation for batch run.


### PR DESCRIPTION
Introduce a `task_type` literal field in the `FakeTask` and `QubexTask` classes to enforce explicit classification of task types, enhancing type safety and requiring subclasses to define their task type.