### PR TITLE
Refactor task registration to skip intermediate base classes

### DIFF
--- a/src/qdash/workflow/tasks/base.py
+++ b/src/qdash/workflow/tasks/base.py
@@ -55,7 +55,11 @@ class BaseTask(ABC):
         if backend is None:
             raise ValueError(f"{cls.__name__} に backend を定義してください")
         task_name = getattr(cls, "name", cls.__name__)
-        BaseTask.registry.setdefault(backend, {})[task_name] = cls
+        
+        # Skip registration for intermediate base classes (those with empty name)
+        # Only concrete task implementations should be registered
+        if task_name:
+            BaseTask.registry.setdefault(backend, {})[task_name] = cls
 
     def __init__(self, params: dict[str, Any] | None = None) -> None:
         """Initialize task with parameters.

--- a/src/qdash/workflow/tasks/fake/base.py
+++ b/src/qdash/workflow/tasks/fake/base.py
@@ -16,7 +16,8 @@ class FakeTask(BaseTask):
     """
 
     backend: str = "fake"
-    task_type: Literal["global", "qubit", "coupling", "system"]  # Must be defined in subclass
+    # name is empty to prevent registration in BaseTask.registry
+    # Only concrete subclasses with a name should be registered
 
     def batch_run(self, session: "FakeSession", qids: list[str]) -> RunResult:
         """Default implementation for batch run.

--- a/src/qdash/workflow/tasks/qubex/base.py
+++ b/src/qdash/workflow/tasks/qubex/base.py
@@ -14,7 +14,8 @@ class QubexTask(BaseTask):
     """
 
     backend: str = "qubex"
-    task_type: Literal["global", "qubit", "coupling", "system"]  # Must be defined in subclass
+    # name is empty to prevent registration in BaseTask.registry
+    # Only concrete subclasses with a name should be registered
 
     def batch_run(self, session: "QubexSession", qids: list[str]) -> RunResult:
         """Default implementation for batch run.


### PR DESCRIPTION
Modify task registration logic to ensure only concrete implementations are registered, preventing intermediate base classes from cluttering the registry. This enhances discoverability of task implementations.