### PR TITLE
Remove deprecated calibration function aliases and improve documentation

### DIFF
--- a/src/qdash/workflow/examples/README.md
+++ b/src/qdash/workflow/examples/README.md
@@ -179,11 +179,6 @@ See the [Python Flow Helper Documentation](../helpers/) for complete API details
 - `adaptive_calibrate()` - Single qubit closed-loop helper
 - Use `parallel_map()` for parallel adaptive calibration with custom convergence logic
 
-**Deprecated (Backward Compatibility):**
-
-- `calibrate_qubits_parallel()` - Alias for `task_first` (NOT truly parallel)
-- `calibrate_qubits_serial()` - Alias for `qubit_first`
-
 ### Execution Modes Explained
 
 #### `calibrate_qubits_task_first(qids, tasks)` (Sequential)

--- a/src/qdash/workflow/examples/templates/custom_parallel_flow.py
+++ b/src/qdash/workflow/examples/templates/custom_parallel_flow.py
@@ -108,25 +108,32 @@ def custom_parallel_flow(
     logger.info(f"Group 2: {group2} (sequential)")
     logger.info("Groups will run in parallel")
 
-    # Initialize session
-    init_calibration(username, chip_id, all_qids)
+    try:
+        # Initialize session
+        init_calibration(username, chip_id, all_qids)
 
-    # TODO: Edit the tasks you want to run
-    tasks = ["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"]
+        # TODO: Edit the tasks you want to run
+        tasks = ["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"]
 
-    # Submit both groups for parallel execution
-    logger.info("Submitting groups for parallel execution...")
-    future1 = calibrate_group.submit(qids=group1, tasks=tasks)
-    future2 = calibrate_group.submit(qids=group2, tasks=tasks)
+        # Submit both groups for parallel execution
+        logger.info("Submitting groups for parallel execution...")
+        future1 = calibrate_group.submit(qids=group1, tasks=tasks)
+        future2 = calibrate_group.submit(qids=group2, tasks=tasks)
 
-    # Wait for completion
-    logger.info("Waiting for groups to complete...")
-    results1 = future1.result()
-    results2 = future2.result()
+        # Wait for completion
+        logger.info("Waiting for groups to complete...")
+        results1 = future1.result()
+        results2 = future2.result()
 
-    # Combine results
-    all_results = {**results1, **results2}
+        # Combine results
+        all_results = {**results1, **results2}
 
-    finish_calibration()
+        finish_calibration()
 
-    return all_results
+        return all_results
+
+    except Exception as e:
+        logger.error(f"Custom parallel calibration failed: {e}")
+        session = get_session()
+        session.fail_calibration(str(e))
+        raise

--- a/src/qdash/workflow/examples/templates/schedule_flow.py
+++ b/src/qdash/workflow/examples/templates/schedule_flow.py
@@ -2,7 +2,7 @@
 
 from prefect import flow, get_run_logger
 from qdash.datamodel.menu import BatchNode, ParallelNode, SerialNode
-from qdash.workflow.helpers import execute_schedule, finish_calibration, init_calibration
+from qdash.workflow.helpers import execute_schedule, finish_calibration, get_session, init_calibration
 
 
 @flow
@@ -32,23 +32,30 @@ def schedule_based_flow(
 
     logger.info(f"Starting schedule-based calibration for user={username}, chip_id={chip_id}, qids={qids}")
 
-    init_calibration(username, chip_id, qids, flow_name=flow_name)
+    try:
+        init_calibration(username, chip_id, qids, flow_name=flow_name)
 
-    # TODO: Define your custom schedule
-    # Example: Execute first two qubits in parallel, then all qubits together
-    # - SerialNode: Execute nodes one after another
-    # - ParallelNode: Execute qubits in parallel
-    # - BatchNode: Execute all qubits together
-    schedule = SerialNode(
-        serial=[ParallelNode(parallel=[qids[0], qids[1]] if len(qids) >= 2 else qids), BatchNode(batch=qids)]
-    )
-    logger.info(f"Executing custom schedule: {schedule}")
+        # TODO: Define your custom schedule
+        # Example: Execute first two qubits in parallel, then all qubits together
+        # - SerialNode: Execute nodes one after another
+        # - ParallelNode: Execute qubits in parallel
+        # - BatchNode: Execute all qubits together
+        schedule = SerialNode(
+            serial=[ParallelNode(parallel=[qids[0], qids[1]] if len(qids) >= 2 else qids), BatchNode(batch=qids)]
+        )
+        logger.info(f"Executing custom schedule: {schedule}")
 
-    # TODO: Edit the tasks you want to run
-    logger.info("Executing tasks according to custom schedule...")
-    results = execute_schedule(tasks=["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"], schedule=schedule)
+        # TODO: Edit the tasks you want to run
+        logger.info("Executing tasks according to custom schedule...")
+        results = execute_schedule(tasks=["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"], schedule=schedule)
 
-    finish_calibration()
+        finish_calibration()
 
-    logger.info("Schedule-based calibration completed successfully")
-    return results
+        logger.info("Schedule-based calibration completed successfully")
+        return results
+
+    except Exception as e:
+        logger.error(f"Schedule-based calibration failed: {e}")
+        session = get_session()
+        session.fail_calibration(str(e))
+        raise

--- a/src/qdash/workflow/examples/templates/sequential_flow.py
+++ b/src/qdash/workflow/examples/templates/sequential_flow.py
@@ -4,6 +4,7 @@ from prefect import flow, get_run_logger
 from qdash.workflow.helpers import (
     calibrate_qubits_qubit_first,
     finish_calibration,
+    get_session,
     init_calibration,
 )
 
@@ -35,14 +36,21 @@ def sequential_calibration_flow(
 
     logger.info(f"Starting sequential calibration for user={username}, chip_id={chip_id}, qids={qids}")
 
-    init_calibration(username, chip_id, qids, flow_name=flow_name)
+    try:
+        init_calibration(username, chip_id, qids, flow_name=flow_name)
 
-    # TODO: Edit the tasks you want to run sequentially
-    # Complete all tasks for each qubit before moving to the next qubit
-    logger.info("Executing tasks in qubit-first order (sequential per qubit)...")
-    results = calibrate_qubits_qubit_first(qids=qids, tasks=["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"])
+        # TODO: Edit the tasks you want to run sequentially
+        # Complete all tasks for each qubit before moving to the next qubit
+        logger.info("Executing tasks in qubit-first order (sequential per qubit)...")
+        results = calibrate_qubits_qubit_first(qids=qids, tasks=["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"])
 
-    finish_calibration()
+        finish_calibration()
 
-    logger.info("Sequential calibration completed successfully")
-    return results
+        logger.info("Sequential calibration completed successfully")
+        return results
+
+    except Exception as e:
+        logger.error(f"Sequential calibration failed: {e}")
+        session = get_session()
+        session.fail_calibration(str(e))
+        raise

--- a/src/qdash/workflow/helpers/__init__.py
+++ b/src/qdash/workflow/helpers/__init__.py
@@ -3,9 +3,7 @@
 from qdash.workflow.helpers.flow_helpers import (
     FlowSession,
     adaptive_calibrate,
-    calibrate_qubits_parallel,
     calibrate_qubits_qubit_first,
-    calibrate_qubits_serial,
     calibrate_qubits_task_first,
     execute_schedule,
     finish_calibration,
@@ -31,7 +29,4 @@ __all__ = [
     "execute_schedule",  # Custom orchestration using SerialNode/ParallelNode/BatchNode
     # === Adaptive Calibration ===
     "adaptive_calibrate",  # Single qubit closed-loop helper
-    # === Deprecated (Backward Compatibility) ===
-    "calibrate_qubits_parallel",  # DEPRECATED: Alias for task_first (NOT truly parallel)
-    "calibrate_qubits_serial",  # DEPRECATED: Alias for qubit_first
 ]

--- a/src/qdash/workflow/helpers/flow_helpers.py
+++ b/src/qdash/workflow/helpers/flow_helpers.py
@@ -655,28 +655,6 @@ def calibrate_qubits_task_first(
     return results
 
 
-def calibrate_qubits_parallel(
-    qids: list[str],
-    tasks: list[str],
-    task_details: dict[str, Any] | None = None,
-) -> dict[str, dict[str, Any]]:
-    """Alias for calibrate_qubits_task_first for backward compatibility.
-
-    .. deprecated::
-        Despite the name, this executes tasks SEQUENTIALLY.
-        For true parallel execution, use :func:`calibrate_parallel` instead.
-
-    Note:
-        This function is an alias for calibrate_qubits_task_first() and
-        executes tasks sequentially. The name "parallel" is misleading and
-        kept only for backward compatibility.
-
-        Use calibrate_parallel() from parallel_helpers for true parallel execution.
-
-    """
-    return calibrate_qubits_task_first(qids, tasks, task_details)
-
-
 def calibrate_qubits_qubit_first(
     qids: list[str],
     tasks: list[str],
@@ -727,24 +705,6 @@ def calibrate_qubits_qubit_first(
             results[qid].update(task_result)
 
     return results
-
-
-def calibrate_qubits_serial(
-    qids: list[str],
-    tasks: list[str],
-    task_details: dict[str, Any] | None = None,
-) -> dict[str, dict[str, Any]]:
-    """Alias for calibrate_qubits_qubit_first for backward compatibility.
-
-    Note:
-        This function is an alias for calibrate_qubits_qubit_first() and
-        executes tasks sequentially (qubit by qubit). The name is kept
-        for backward compatibility.
-
-        For true parallel execution, use :func:`calibrate_parallel` from parallel_helpers.
-
-    """
-    return calibrate_qubits_qubit_first(qids, tasks, task_details)
 
 
 def execute_schedule(

--- a/tests/qdash/workflow/helpers/test_flow_helpers.py
+++ b/tests/qdash/workflow/helpers/test_flow_helpers.py
@@ -301,32 +301,6 @@ class TestGlobalSessionHelpers:
 class TestHelperFunctionSignatures:
     """Test that helper functions have correct signatures."""
 
-    def test_calibrate_qubits_parallel_signature(self):
-        """Test calibrate_qubits_parallel has correct signature."""
-        from inspect import signature
-
-        from qdash.workflow.helpers.flow_helpers import calibrate_qubits_parallel
-
-        sig = signature(calibrate_qubits_parallel)
-        params = list(sig.parameters.keys())
-
-        assert "qids" in params
-        assert "tasks" in params
-        assert "task_details" in params
-
-    def test_calibrate_qubits_serial_signature(self):
-        """Test calibrate_qubits_serial has correct signature."""
-        from inspect import signature
-
-        from qdash.workflow.helpers.flow_helpers import calibrate_qubits_serial
-
-        sig = signature(calibrate_qubits_serial)
-        params = list(sig.parameters.keys())
-
-        assert "qids" in params
-        assert "tasks" in params
-        assert "task_details" in params
-
     def test_adaptive_calibrate_signature(self):
         """Test adaptive_calibrate has correct signature."""
         from inspect import signature

--- a/ui/src/app/chip/[chipId]/qubit/[qubitsId]/page.tsx
+++ b/ui/src/app/chip/[chipId]/qubit/[qubitsId]/page.tsx
@@ -4,7 +4,8 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import React, { useEffect, Suspense } from "react";
 
-import { BsArrowLeft, BsGraphUp, BsEye, BsClock } from "react-icons/bs";
+import { BsGraphUp, BsEye, BsClock } from "react-icons/bs";
+import { FaArrowLeft } from "react-icons/fa";
 
 import { QubitRadarChart } from "./components/QubitRadarChart";
 import { QubitTimeSeriesView } from "./components/QubitTimeSeriesView";
@@ -224,18 +225,18 @@ function QubitDetailPageContent() {
   return (
     <div className="w-full px-6 py-6" style={{ width: "calc(100vw - 20rem)" }}>
       <div className="space-y-6">
+        {/* Back navigation */}
+        <Link href="/chip" className="btn btn-ghost btn-sm gap-2 w-fit">
+          <FaArrowLeft />
+          Back to Chip View
+        </Link>
+
         {/* Header Section */}
         <div className="flex flex-col gap-6">
           <div className="flex justify-between items-center">
-            <div className="flex items-center gap-4">
-              <Link href="/chip" className="btn btn-ghost btn-sm">
-                <BsArrowLeft className="text-lg" />
-                Back to Chip View
-              </Link>
-              <h1 className="text-2xl font-bold">
-                Qubit {qubitId} Analysis - {chipData?.data?.chip_id || chipId}
-              </h1>
-            </div>
+            <h1 className="text-2xl font-bold">
+              Qubit {qubitId} Analysis - {chipData?.data?.chip_id || chipId}
+            </h1>
             <div className="join rounded-lg overflow-hidden">
               <button
                 className={`join-item btn btn-sm ${

--- a/ui/src/app/execution/[chip_id]/[execute_id]/client.tsx
+++ b/ui/src/app/execution/[chip_id]/[execute_id]/client.tsx
@@ -7,8 +7,10 @@ import {
   FaDownload,
   FaCalendarAlt,
   FaClock,
+  FaArrowLeft,
 } from "react-icons/fa";
 import { BsCheckCircle, BsXCircle, BsClock } from "react-icons/bs";
+import Link from "next/link";
 
 import ExecutionDAG from "./ExecutionDAG";
 
@@ -278,6 +280,12 @@ export default function ExecutionDetailClient({
   return (
     <div className="w-full px-4 py-6" style={{ width: "calc(100vw - 20rem)" }}>
       <div className="space-y-6">
+        {/* Back navigation */}
+        <Link href="/execution" className="btn btn-ghost btn-sm gap-2 w-fit">
+          <FaArrowLeft />
+          Back to Executions
+        </Link>
+
         <div className="space-y-4">
           <div className="flex justify-between items-center">
             <h1 className="text-3xl font-bold">{execution.name}</h1>

--- a/ui/src/app/flow/[name]/page.tsx
+++ b/ui/src/app/flow/[name]/page.tsx
@@ -283,7 +283,7 @@ export default function EditFlowPage() {
         )}
 
         {/* Main Editor Area */}
-        <div className="flex-1 flex overflow-hidden">
+        <div className="flex-1 flex overflow-hidden mb-4">
           {/* Editor */}
           <div className="flex-1 flex flex-col">
             <Editor
@@ -305,7 +305,8 @@ export default function EditFlowPage() {
                 fontSize: 14,
                 lineNumbers: "on",
                 automaticLayout: true,
-                scrollBeyondLastLine: false,
+                scrollBeyondLastLine: true,
+                padding: { top: 16, bottom: 16 },
                 wordWrap: "on",
                 folding: true,
                 renderLineHighlight: "all",


### PR DESCRIPTION
Eliminate references to deprecated helper function aliases in the documentation to enhance clarity. Update examples to reflect explicit sequential execution patterns, ensuring users understand the intended usage of the functions. This change addresses confusion caused by misleading names and improves overall documentation quality.