### PR TITLE
Add export-note command and enhance calibration note tracking

### DIFF
--- a/src/qdash/cli/export_note.py
+++ b/src/qdash/cli/export_note.py
@@ -1,0 +1,69 @@
+"""CLI command for exporting calibration notes from MongoDB to file."""
+
+import json
+from pathlib import Path
+
+import typer
+from qdash.dbmodel.calibration_note import CalibrationNoteDocument
+from qdash.dbmodel.initialize import initialize
+
+
+def export_calibration_note(
+    execution_id: str,
+    task_id: str = "master",
+    output: str | None = None,
+    username: str | None = None,
+    chip_id: str | None = None,
+) -> None:
+    """Export calibration note from MongoDB to file.
+
+    Args:
+    ----
+        execution_id: Execution ID (e.g., "20250130-001")
+        task_id: Task ID to export (default: "master")
+        output: Output file path (default: "{execution_id}_{task_id}.json")
+        username: Username filter (optional)
+        chip_id: Chip ID filter (optional)
+
+    """
+    # Initialize MongoDB connection
+    initialize()
+
+    # Build query
+    query: dict = {
+        "execution_id": execution_id,
+        "task_id": task_id,
+    }
+    if username:
+        query["username"] = username
+    if chip_id:
+        query["chip_id"] = chip_id
+
+    # Fetch document from MongoDB
+    doc = CalibrationNoteDocument.find_one(query).run()
+
+    if not doc:
+        query_str = ", ".join(f"{k}={v}" for k, v in query.items())
+        typer.echo(f"❌ No calibration note found for {query_str}", err=True)
+        raise typer.Exit(1)
+
+    # Determine output path
+    if output:
+        output_path = Path(output)
+    else:
+        output_path = Path(f"{execution_id}_{task_id}.json")
+
+    # Create parent directory if needed
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write to file
+    output_path.write_text(json.dumps(doc.note, indent=2, ensure_ascii=False))
+
+    typer.echo(f"✅ Exported calibration note to {output_path}")
+    typer.echo(f"   Execution ID: {execution_id}")
+    typer.echo(f"   Task ID: {task_id}")
+    if username:
+        typer.echo(f"   Username: {username}")
+    if chip_id:
+        typer.echo(f"   Chip ID: {chip_id}")
+    typer.echo(f"   Timestamp: {doc.timestamp}")

--- a/src/qdash/cli/main.py
+++ b/src/qdash/cli/main.py
@@ -127,5 +127,49 @@ def init_all_data(
         raise typer.Exit(1)
 
 
+@app.command()
+def export_note(
+    execution_id: str = typer.Option(..., "--execution-id", "-e", help="Execution ID (e.g., 20250130-001)"),
+    task_id: str = typer.Option("master", "--task-id", "-t", help="Task ID (default: master)"),
+    output: str = typer.Option(None, "--output", "-o", help="Output file path"),
+    username: str = typer.Option(None, "--username", "-u", help="Username filter (optional)"),
+    chip_id: str = typer.Option(None, "--chip-id", "-c", help="Chip ID filter (optional)"),
+) -> None:
+    """Export calibration note from MongoDB to file.
+
+    This command retrieves a calibration note from MongoDB and exports it to a JSON file.
+    Useful for debugging or archival purposes.
+
+    Examples:
+        # Export master note for execution
+        qdash export-note --execution-id 20250130-001
+
+        # Export specific task note
+        qdash export-note --execution-id 20250130-001 --task-id abc-123-def
+
+        # Export to specific file
+        qdash export-note -e 20250130-001 -o /path/to/output.json
+
+        # Filter by username
+        qdash export-note -e 20250130-001 -u alice
+
+        # Filter by chip ID
+        qdash export-note -e 20250130-001 -c 64Qv3
+    """
+    try:
+        from qdash.cli.export_note import export_calibration_note
+
+        export_calibration_note(
+            execution_id=execution_id,
+            task_id=task_id,
+            output=output,
+            username=username,
+            chip_id=chip_id,
+        )
+    except Exception as e:
+        typer.echo(f"❌ Error exporting calibration note: {e}", err=True)
+        raise typer.Exit(1)
+
+
 if __name__ == "__main__":
     app()

--- a/src/qdash/workflow/core/calibration/flow.py
+++ b/src/qdash/workflow/core/calibration/flow.py
@@ -332,6 +332,7 @@ def setup_calibration(
     if session.name == "qubex":
         session.save_note(
             username=menu.username,
+            chip_id=menu.chip_id,
             calib_dir=calib_dir,
             execution_id=execution_id,
             task_manager_id=task_manager.id,

--- a/src/qdash/workflow/core/calibration/task_manager.py
+++ b/src/qdash/workflow/core/calibration/task_manager.py
@@ -715,6 +715,7 @@ class TaskManager(BaseModel):
         if session.name == "qubex":
             session.update_note(
                 username=self.username,
+                chip_id=execution_manager.chip_id,
                 calib_dir=self.calib_dir,
                 execution_id=execution_manager.execution_id,
                 task_manager_id=self.id,

--- a/src/qdash/workflow/examples/README.md
+++ b/src/qdash/workflow/examples/README.md
@@ -104,6 +104,92 @@ def my_custom_flow(username, chip_id, qids, flow_name=None):
     return results
 ```
 
+## GitHub Integration
+
+Python Flow Editor supports GitHub integration for configuration management:
+
+### Pulling Latest Configuration
+
+Pull latest config from GitHub before calibration:
+
+```python
+from qdash.workflow.helpers import init_calibration, GitHubPushConfig
+
+session = init_calibration(
+    username, chip_id, qids, flow_name=flow_name,
+    enable_github_pull=True  # Pull latest config before starting
+)
+```
+
+### Pushing Calibration Results
+
+Push results to GitHub after calibration:
+
+```python
+from qdash.workflow.helpers import (
+    init_calibration,
+    finish_calibration,
+    GitHubPushConfig,
+    ConfigFileType,
+)
+
+# Configure GitHub push
+session = init_calibration(
+    username, chip_id, qids, flow_name=flow_name,
+    enable_github_pull=True,
+    github_push_config=GitHubPushConfig(
+        enabled=True,
+        file_types=[
+            ConfigFileType.CALIB_NOTE,  # Push calib_note.json
+            ConfigFileType.PROPS,       # Push props.yaml (with merge logic)
+        ],
+        commit_message=f"Update calibration results for {chip_id}",
+        branch="main"
+    )
+)
+
+# Calibration logic...
+
+# Push results to GitHub
+push_results = finish_calibration()
+print(f"GitHub push results: {push_results}")
+```
+
+### Available File Types
+
+- `ConfigFileType.CALIB_NOTE` - calibration/calib_note.json (direct copy)
+- `ConfigFileType.PROPS` - params/props.yaml (uses existing merge logic)
+- `ConfigFileType.PARAMS` - params/params.yaml (direct copy)
+- `ConfigFileType.ALL_PARAMS` - All *.yaml files in params/ directory
+
+### Environment Variables Required
+
+Set these environment variables for GitHub integration:
+
+```bash
+GITHUB_USER=your-username
+GITHUB_TOKEN=your-personal-access-token
+CONFIG_REPO_URL=https://github.com/your-org/your-config-repo.git
+```
+
+### Example in Templates
+
+All templates include commented-out GitHub integration examples.
+Simply uncomment and configure to enable:
+
+```python
+# Optional: GitHub integration (uncomment to enable)
+# from qdash.workflow.helpers import GitHubPushConfig, ConfigFileType
+# init_calibration(
+#     username, chip_id, qids, flow_name=flow_name,
+#     enable_github_pull=True,
+#     github_push_config=GitHubPushConfig(
+#         enabled=True,
+#         file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.PROPS]
+#     )
+# )
+```
+
 ## API Reference
 
 See the [Python Flow Helper Documentation](../helpers/) for complete API details.

--- a/src/qdash/workflow/examples/templates/coupling_calibration_flow.py
+++ b/src/qdash/workflow/examples/templates/coupling_calibration_flow.py
@@ -122,6 +122,10 @@ def my_coupling_flow(
 
     except Exception as e:
         logger.error(f"Coupling calibration failed: {e}")
-        session = get_session()
-        session.fail_calibration(str(e))
+        try:
+            session = get_session()
+            session.fail_calibration(str(e))
+        except RuntimeError:
+            # Session not initialized yet, skip fail_calibration
+            pass
         raise

--- a/src/qdash/workflow/examples/templates/custom_parallel_flow.py
+++ b/src/qdash/workflow/examples/templates/custom_parallel_flow.py
@@ -98,6 +98,17 @@ def custom_parallel_flow(
         # Initialize session
         init_calibration(username, chip_id, all_qids, flow_name=flow_name)
 
+        # Optional: GitHub integration (uncomment to enable)
+        # from qdash.workflow.helpers import GitHubPushConfig, ConfigFileType
+        # init_calibration(
+        #     username, chip_id, all_qids, flow_name=flow_name,
+        #     enable_github_pull=True,
+        #     github_push_config=GitHubPushConfig(
+        #         enabled=True,
+        #         file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.PROPS]
+        #     )
+        # )
+
         # TODO: Edit the tasks you want to run
         tasks = ["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"]
 
@@ -120,6 +131,10 @@ def custom_parallel_flow(
 
     except Exception as e:
         logger.error(f"Custom parallel calibration failed: {e}")
-        session = get_session()
-        session.fail_calibration(str(e))
+        try:
+            session = get_session()
+            session.fail_calibration(str(e))
+        except RuntimeError:
+            # Session not initialized yet, skip fail_calibration
+            pass
         raise

--- a/src/qdash/workflow/examples/templates/full_qubit_calibration.py
+++ b/src/qdash/workflow/examples/templates/full_qubit_calibration.py
@@ -115,6 +115,17 @@ def full_qubit_calibration(
         # Initialize session
         init_calibration(username, chip_id, all_qids, flow_name=flow_name)
 
+        # Optional: GitHub integration (uncomment to enable)
+        # from qdash.workflow.helpers import GitHubPushConfig, ConfigFileType
+        # init_calibration(
+        #     username, chip_id, all_qids, flow_name=flow_name,
+        #     enable_github_pull=True,
+        #     github_push_config=GitHubPushConfig(
+        #         enabled=True,
+        #         file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.PROPS]
+        #     )
+        # )
+
         # Complete 1-qubit calibration task suite
         tasks = [
             # Phase 1: Basic characterization
@@ -160,6 +171,10 @@ def full_qubit_calibration(
 
     except Exception as e:
         logger.error(f"Full qubit calibration failed: {e}")
-        session = get_session()
-        session.fail_calibration(str(e))
+        try:
+            session = get_session()
+            session.fail_calibration(str(e))
+        except RuntimeError:
+            # Session not initialized yet, skip fail_calibration
+            pass
         raise

--- a/src/qdash/workflow/examples/templates/iterative_chevron_pattern_flow.py
+++ b/src/qdash/workflow/examples/templates/iterative_chevron_pattern_flow.py
@@ -238,6 +238,10 @@ def iterative_chevron_pattern_flow(
 
     except Exception as e:
         logger.error(f"Iterative ChevronPattern calibration failed: {e}")
-        session = get_session()
-        session.fail_calibration(str(e))
+        try:
+            session = get_session()
+            session.fail_calibration(str(e))
+        except RuntimeError:
+            # Session not initialized yet, skip fail_calibration
+            pass
         raise

--- a/src/qdash/workflow/examples/templates/iterative_flow.py
+++ b/src/qdash/workflow/examples/templates/iterative_flow.py
@@ -189,6 +189,10 @@ def iterative_flow(
 
     except Exception as e:
         logger.error(f"Iterative calibration failed: {e}")
-        session = get_session()
-        session.fail_calibration(str(e))
+        try:
+            session = get_session()
+            session.fail_calibration(str(e))
+        except RuntimeError:
+            # Session not initialized yet, skip fail_calibration
+            pass
         raise

--- a/src/qdash/workflow/examples/templates/simple_flow.py
+++ b/src/qdash/workflow/examples/templates/simple_flow.py
@@ -84,6 +84,18 @@ def my_custom_flow(
         # Initialize calibration session
         init_calibration(username, chip_id, qids, flow_name=flow_name)
 
+        # Optional: GitHub integration (uncomment to enable)
+        # from qdash.workflow.helpers import GitHubPushConfig, ConfigFileType
+        # init_calibration(
+        #     username, chip_id, qids, flow_name=flow_name,
+        #     enable_github_pull=True,  # Pull latest config before calibration
+        #     github_push_config=GitHubPushConfig(
+        #         enabled=True,
+        #         file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.PROPS],
+        #         commit_message=f"Update calibration results for {chip_id}"
+        #     )
+        # )
+
         # TODO: Edit the tasks you want to run
         # Available tasks: CheckRabi, CreateHPIPulse, CheckHPIPulse, etc.
         tasks = ["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"]
@@ -103,6 +115,10 @@ def my_custom_flow(
 
     except Exception as e:
         logger.error(f"Calibration failed: {e}")
-        session = get_session()
-        session.fail_calibration(str(e))
+        try:
+            session = get_session()
+            session.fail_calibration(str(e))
+        except RuntimeError:
+            # Session not initialized yet, skip fail_calibration
+            pass
         raise

--- a/src/qdash/workflow/helpers/__init__.py
+++ b/src/qdash/workflow/helpers/__init__.py
@@ -8,6 +8,11 @@ from qdash.workflow.helpers.flow_helpers import (
     get_session,
     init_calibration,
 )
+from qdash.workflow.helpers.github_integration import (
+    ConfigFileType,
+    GitHubIntegration,
+    GitHubPushConfig,
+)
 from qdash.workflow.helpers.parallel_helpers import calibrate_parallel, parallel_map
 
 __all__ = [
@@ -17,6 +22,10 @@ __all__ = [
     "get_session",
     "finish_calibration",
     "generate_execution_id",
+    # === GitHub Integration ===
+    "GitHubIntegration",
+    "GitHubPushConfig",
+    "ConfigFileType",
     # === Parallel Execution (Recommended) ===
     "calibrate_parallel",  # True parallel execution across qubits using @task + submit
     "parallel_map",  # Generic parallel map for custom logic with Prefect UI visibility

--- a/src/qdash/workflow/helpers/github_integration.py
+++ b/src/qdash/workflow/helpers/github_integration.py
@@ -1,0 +1,375 @@
+"""GitHub integration for FlowSession - Pull/Push functionality.
+
+This module provides GitHub integration for calibration workflows, allowing:
+- Pull: Fetch latest configuration from GitHub repository
+- Push: Upload calibration results (calib_note.json, props.yaml, etc.)
+
+The implementation reuses existing push_props logic to maintain compatibility
+with the established merge strategy for props.yaml files.
+"""
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from prefect import get_run_logger
+
+
+class ConfigFileType(Enum):
+    """Configuration file types that can be pushed to GitHub.
+
+    Attributes:
+        CALIB_NOTE: calibration/calib_note.json (simple copy)
+        PROPS: params/props.yaml (uses ChipDocument merge logic)
+        PARAMS: params/params.yaml (simple copy)
+        ALL_PARAMS: All *.yaml files in params/ directory
+    """
+
+    CALIB_NOTE = "calib_note"
+    PROPS = "props"
+    PARAMS = "params"
+    ALL_PARAMS = "all_params"
+
+
+@dataclass
+class GitHubPushConfig:
+    """Configuration for GitHub push operations.
+
+    Attributes:
+        enabled: Whether to push to GitHub on finish_calibration()
+        file_types: List of file types to push (default: [CALIB_NOTE])
+        commit_message: Custom commit message (default: auto-generated)
+        branch: Target branch (default: "main")
+        props_within_24hrs: For PROPS type, only include data from last 24 hours
+
+    Example:
+        ```python
+        config = GitHubPushConfig(
+            enabled=True,
+            file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.PROPS],
+            commit_message="Update calibration results"
+        )
+        ```
+    """
+
+    enabled: bool = False
+    file_types: list[ConfigFileType] | None = None
+    commit_message: str | None = None
+    branch: str = "main"
+    props_within_24hrs: bool = False
+
+    def __post_init__(self) -> None:
+        """Set default file types if not provided."""
+        if self.file_types is None:
+            self.file_types = [ConfigFileType.CALIB_NOTE]
+
+
+class GitHubIntegration:
+    """GitHub integration handler for calibration workflows.
+
+    This class manages GitHub operations for FlowSession, including:
+    - Pulling latest configuration from repository
+    - Pushing calibration results with proper merge logic
+
+    The implementation reuses existing infrastructure:
+    - pull_github task for config synchronization
+    - push_props flow for props.yaml merge logic
+    - push_github task for file uploads
+
+    Attributes:
+        username: Username for the calibration session
+        chip_id: Target chip ID
+        execution_id: Unique execution identifier
+
+    Example:
+        ```python
+        integration = GitHubIntegration("user", "64Qv3", "20250101-001")
+
+        # Pull latest config
+        commit_id = integration.pull_config()
+
+        # Push results
+        config = GitHubPushConfig(
+            enabled=True,
+            file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.PROPS]
+        )
+        results = integration.push_files(config)
+        ```
+    """
+
+    def __init__(self, username: str, chip_id: str, execution_id: str) -> None:
+        """Initialize GitHub integration.
+
+        Args:
+            username: Username for the calibration session
+            chip_id: Target chip ID
+            execution_id: Unique execution identifier
+        """
+        self.username = username
+        self.chip_id = chip_id
+        self.execution_id = execution_id
+        self.logger = get_run_logger()
+
+    @staticmethod
+    def check_credentials() -> bool:
+        """Check if required GitHub credentials are configured.
+
+        Returns:
+            True if all required environment variables are set
+
+        Environment Variables:
+            GITHUB_USER: GitHub username
+            GITHUB_TOKEN: GitHub personal access token
+            CONFIG_REPO_URL: Repository URL for configuration files
+        """
+        required = ["GITHUB_USER", "GITHUB_TOKEN", "CONFIG_REPO_URL"]
+        return all(os.getenv(var) for var in required)
+
+    def pull_config(self, target_dir: str = "/app/config/qubex") -> str | None:
+        """Pull latest configuration from GitHub repository.
+
+        This method uses the existing pull_github task to fetch the latest
+        configuration files from the repository. A backup of the current
+        configuration is automatically created.
+
+        Args:
+            target_dir: Directory where config files will be updated
+
+        Returns:
+            Commit SHA of the pulled configuration, or None if pull failed
+
+        Example:
+            ```python
+            commit_id = integration.pull_config()
+            if commit_id:
+                print(f"Updated to commit: {commit_id}")
+            ```
+        """
+        try:
+            from qdash.workflow.worker.tasks.pull_github import pull_github
+
+            commit_id = pull_github(target_dir=target_dir)
+            self.logger.info(f"Pulled config from GitHub: {commit_id}")
+            return commit_id
+        except Exception as e:
+            self.logger.warning(f"Failed to pull from GitHub: {e}")
+            return None
+
+    def push_files(self, push_config: GitHubPushConfig) -> dict[str, Any]:
+        """Push calibration results to GitHub repository.
+
+        This method handles different file types with appropriate strategies:
+        - CALIB_NOTE: Direct copy of calib_note.json
+        - PROPS: Uses ChipDocument extraction and merge logic (existing implementation)
+        - PARAMS: Direct copy of params.yaml
+        - ALL_PARAMS: Copy all *.yaml files from params/ directory
+
+        Args:
+            push_config: Configuration specifying which files to push
+
+        Returns:
+            Dictionary mapping file types to commit SHAs or error messages
+
+        Example:
+            ```python
+            config = GitHubPushConfig(
+                enabled=True,
+                file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.PROPS]
+            )
+            results = integration.push_files(config)
+            # {"calib_note": "abc123def", "props": "def456ghi"}
+            ```
+        """
+        results: dict[str, Any] = {}
+
+        for file_type in push_config.file_types:
+            try:
+                if file_type == ConfigFileType.CALIB_NOTE:
+                    result = self._push_calib_note(push_config)
+                elif file_type == ConfigFileType.PROPS:
+                    result = self._push_props(push_config)
+                elif file_type == ConfigFileType.PARAMS:
+                    result = self._push_params_file(push_config)
+                elif file_type == ConfigFileType.ALL_PARAMS:
+                    result = self._push_all_params(push_config)
+
+                results[file_type.value] = result
+            except Exception as e:
+                self.logger.error(f"Failed to push {file_type.value}: {e}")
+                results[file_type.value] = f"Error: {e}"
+
+        return results
+
+    def _push_calib_note(self, config: GitHubPushConfig) -> str:
+        """Push calib_note.json (fetch master note from MongoDB and write to config dir).
+
+        This method:
+        1. Fetches the master calibration note from MongoDB (task_id="master")
+        2. Writes it to /app/config/qubex/{chip_id}/calibration/calib_note.json
+        3. Pushes to GitHub
+
+        Args:
+            config: Push configuration
+
+        Returns:
+            Commit SHA
+
+        Raises:
+            FileNotFoundError: If no master calibration note exists in MongoDB
+        """
+        import json
+
+        from qdash.dbmodel.calibration_note import CalibrationNoteDocument
+        from qdash.workflow.worker.tasks.push_github import push_github
+
+        # 1. Fetch master note from MongoDB
+        latest = (
+            CalibrationNoteDocument.find({"username": self.username, "task_id": "master", "chip_id": self.chip_id})
+            .sort([("timestamp", -1)])  # Sort by timestamp descending
+            .limit(1)
+            .run()
+        )
+
+        if not latest:
+            msg = f"No master calibration note found in MongoDB for user {self.username}"
+            raise FileNotFoundError(msg)
+
+        master_note = latest[0].note
+
+        # 2. Write to /app/config/qubex/{chip_id}/calibration/calib_note.json
+        calib_note_dir = f"/app/config/qubex/{self.chip_id}/calibration"
+        Path(calib_note_dir).mkdir(parents=True, exist_ok=True)
+
+        source_path = f"{calib_note_dir}/calib_note.json"
+        with Path(source_path).open("w", encoding="utf-8") as f:
+            json.dump(master_note, f, indent=4, ensure_ascii=False, sort_keys=True)
+
+        self.logger.info(f"Wrote master note to {source_path}")
+
+        # 3. Push to GitHub
+        repo_subpath = f"{self.chip_id}/calibration/calib_note.json"
+        commit_message = config.commit_message or f"Update calib_note.json from execution {self.execution_id}"
+
+        commit_sha = push_github(
+            source_path=source_path,
+            repo_subpath=repo_subpath,
+            commit_message=commit_message,
+            branch=config.branch,
+        )
+
+        self.logger.info(f"Pushed calib_note.json: {commit_sha}")
+        return str(commit_sha)
+
+    def _push_props(self, config: GitHubPushConfig) -> str:
+        """Push props.yaml using existing merge logic.
+
+        This method reuses the existing push_props implementation which:
+        1. Extracts chip properties from ChipDocument
+        2. Merges with existing props.yaml using ruamel.yaml (preserves comments)
+        3. Applies proper formatting (scientific notation, fidelity checks)
+        4. Pushes to GitHub
+
+        Args:
+            config: Push configuration
+
+        Returns:
+            Commit SHA
+        """
+        from qdash.workflow.worker.flows.push_props.create_props import create_chip_properties
+        from qdash.workflow.worker.tasks.push_github import push_github
+
+        source_path = f"/app/config/qubex/{self.chip_id}/params/props.yaml"
+        repo_subpath = f"{self.chip_id}/params/props.yaml"
+
+        # Use existing implementation to generate/merge props.yaml from ChipDocument
+        create_chip_properties(
+            username=self.username,
+            source_path=source_path,
+            target_path=source_path,
+            chip_id=self.chip_id,
+        )
+
+        commit_message = config.commit_message or f"Update props.yaml from execution {self.execution_id}"
+
+        commit_sha = push_github(
+            source_path=source_path,
+            repo_subpath=repo_subpath,
+            commit_message=commit_message,
+            branch=config.branch,
+        )
+
+        self.logger.info(f"Pushed props.yaml: {commit_sha}")
+        return str(commit_sha)
+
+    def _push_params_file(self, config: GitHubPushConfig) -> str:
+        """Push params.yaml (simple copy).
+
+        Args:
+            config: Push configuration
+
+        Returns:
+            Commit SHA
+
+        Raises:
+            FileNotFoundError: If params.yaml does not exist
+        """
+        from qdash.workflow.worker.tasks.push_github import push_github
+
+        source_path = f"/app/config/qubex/{self.chip_id}/params/params.yaml"
+        repo_subpath = f"{self.chip_id}/params/params.yaml"
+
+        if not Path(source_path).exists():
+            msg = f"params.yaml not found: {source_path}"
+            raise FileNotFoundError(msg)
+
+        commit_message = config.commit_message or f"Update params.yaml from execution {self.execution_id}"
+
+        commit_sha = push_github(
+            source_path=source_path,
+            repo_subpath=repo_subpath,
+            commit_message=commit_message,
+            branch=config.branch,
+        )
+
+        self.logger.info(f"Pushed params.yaml: {commit_sha}")
+        return str(commit_sha)
+
+    def _push_all_params(self, config: GitHubPushConfig) -> dict[str, str]:
+        """Push all yaml files in params directory.
+
+        Args:
+            config: Push configuration
+
+        Returns:
+            Dictionary mapping file names to commit SHAs or error messages
+        """
+        from qdash.workflow.worker.tasks.push_github import push_github
+
+        params_dir = Path(f"/app/config/qubex/{self.chip_id}/params")
+        results: dict[str, str] = {}
+
+        if not params_dir.exists():
+            self.logger.warning(f"Params directory not found: {params_dir}")
+            return {"error": f"Directory not found: {params_dir}"}
+
+        for yaml_file in params_dir.glob("*.yaml"):
+            source_path = str(yaml_file)
+            repo_subpath = f"{self.chip_id}/params/{yaml_file.name}"
+
+            try:
+                commit_sha = push_github(
+                    source_path=source_path,
+                    repo_subpath=repo_subpath,
+                    commit_message=config.commit_message
+                    or f"Update {yaml_file.name} from execution {self.execution_id}",
+                    branch=config.branch,
+                )
+                results[yaml_file.name] = str(commit_sha)
+                self.logger.info(f"Pushed {yaml_file.name}: {commit_sha}")
+            except Exception as e:
+                self.logger.error(f"Failed to push {yaml_file.name}: {e}")
+                results[yaml_file.name] = f"Error: {e}"
+
+        return results


### PR DESCRIPTION
Introduce a new CLI command to export calibration notes from MongoDB, improving data retrieval for debugging and analysis. Extend the CalibrationNoteDocument to include a chip_id field and optimize querying with a composite index. Enhance error handling in workflow templates to manage uninitialized sessions more gracefully.