### PR TITLE
Update parameter mappings for qubit frequency

### DIFF
--- a/src/qdash/api/routers/metrics.py
+++ b/src/qdash/api/routers/metrics.py
@@ -71,7 +71,7 @@ def extract_qubit_metrics(chip: ChipDocument, within_hours: int | None = None) -
     """
     # Field mapping from DB to display names
     field_map = {
-        "bare_frequency": "qubit_frequency",
+        "qubit_frequency": "qubit_frequency",
         "anharmonicity": "anharmonicity",
         "t1": "t1",
         "t2_echo": "t2_echo",

--- a/src/qdash/datamodel/qubit.py
+++ b/src/qdash/datamodel/qubit.py
@@ -71,9 +71,9 @@ class QubitModel(BaseModel):
             raise TypeError(msg)
         return cleaned
 
-    def get_bare_frequency(self) -> float | None:
+    def get_qubit_frequency(self) -> float | None:
         """Get the bare frequency of the qubit."""
-        v = self.data.get("bare_frequency")
+        v = self.data.get("qubit_frequency")
         if v is None:
             return None
         return float(v.get("value", 0.0))

--- a/src/qdash/slack_agent/agent.py
+++ b/src/qdash/slack_agent/agent.py
@@ -203,7 +203,7 @@ async def get_chip_parameters(
 
     # Field mapping based on chip_report implementation
     qubit_field_map = {
-        "bare_frequency": "qubit_frequency",
+        "qubit_frequency": "qubit_frequency",
         "t1": "t1",
         "t2_echo": "t2_echo",
         "t2_star": "t2_star",

--- a/src/qdash/workflow/core/calibration/params_updater.py
+++ b/src/qdash/workflow/core/calibration/params_updater.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from qdash.datamodel.task import OutputParameterModel
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+if TYPE_CHECKING:
+    from qdash.workflow.core.session.base import BaseSession
+
+
+class ParamsUpdater(Protocol):
+    """Protocol for backend-specific parameter updaters."""
+
+    def update(self, qid: str, output_parameters: dict[str, Any]) -> None: ...
+
+
+def get_params_updater(session: "BaseSession", chip_id: str | None = None) -> ParamsUpdater | None:
+    """Resolve a backend-specific params updater for the given session."""
+    qubex_updater = _resolve_qubex_updater(session, chip_id)
+    if qubex_updater is not None:
+        return qubex_updater
+    return None
+
+
+def _resolve_qubex_updater(session: "BaseSession", chip_id: str | None) -> ParamsUpdater | None:
+    try:
+        from qdash.workflow.core.session.qubex import QubexSession
+    except ImportError:
+        return None
+
+    if not isinstance(session, QubexSession):
+        return None
+
+    return _QubexParamsUpdater(session, chip_id)
+
+
+class _QubexParamsUpdater:
+    """Synchronize calibration results with Qubex params YAML files."""
+
+    PARAM_FILE_MAP: dict[str, str] = {
+        "t1": "t1.yaml",
+        "t2_echo": "t2_echo.yaml",
+        "t2_star": "t2_star.yaml",
+        "readout_amplitude": "readout_amplitude.yaml",
+        "resonator_frequency": "readout_frequency.yaml",
+        "readout_frequency": "readout_frequency.yaml",
+        "control_amplitude": "control_amplitude.yaml",
+        "qubit_frequency": "qubit_frequency.yaml",
+    }
+
+    def __init__(self, session: Any, chip_id: str | None) -> None:
+        self._session = session
+        self._chip_id = chip_id
+        self._yaml = YAML(typ="rt")
+        self._yaml.preserve_quotes = True
+        self._yaml.width = None
+        self._yaml.indent(mapping=2, sequence=4, offset=2)
+
+    def update(self, qid: str, output_parameters: dict[str, Any]) -> None:
+        params_dir = self._resolve_params_dir()
+        if params_dir is None:
+            return
+
+        label = self._resolve_qubit_label(qid)
+        if label is None:
+            return
+
+        for key, param in output_parameters.items():
+            file_name = self.PARAM_FILE_MAP.get(key)
+            if file_name is None:
+                continue
+
+            value = self._extract_value(param)
+            if value is None:
+                continue
+
+            file_path = params_dir / file_name
+            self._update_yaml(file_path, label, value)
+
+    def _resolve_params_dir(self) -> Path | None:
+        config_dir = getattr(self._session, "config", {}).get("params_dir")
+        if config_dir:
+            path = Path(config_dir)
+            if path.exists():
+                return path
+
+        try:
+            session_obj = self._session.get_session()
+        except Exception:
+            session_obj = None
+
+        if session_obj is not None:
+            params_path = getattr(session_obj, "params_path", None)
+            if params_path:
+                path = Path(params_path)
+                if path.exists():
+                    return path
+
+        chip_id = getattr(self._session, "config", {}).get("chip_id") or self._chip_id
+        if not chip_id:
+            return None
+
+        for candidate in (
+            Path(f"/app/config/qubex/{chip_id}/params"),
+            Path("config") / "qubex" / chip_id / "params",
+        ):
+            if candidate.exists():
+                return candidate
+
+        return None
+
+    def _resolve_qubit_label(self, qid: str) -> str | None:
+        try:
+            index = int(qid)
+        except ValueError:
+            return qid
+
+        try:
+            experiment = self._session.get_session()
+        except Exception:
+            return None
+
+        get_label = getattr(experiment, "get_qubit_label", None)
+        if callable(get_label):
+            return cast(str, get_label(index))
+        return None
+
+    @staticmethod
+    def _extract_value(param: Any) -> float | int | str | None:
+        if isinstance(param, OutputParameterModel):
+            return _QubexParamsUpdater._coerce_value(param.value)
+
+        value = getattr(param, "value", param)
+        return _QubexParamsUpdater._coerce_value(value)
+
+    @staticmethod
+    def _coerce_value(value: Any) -> float | int | str | None:
+        if value is None:
+            return None
+
+        if hasattr(value, "item"):
+            try:
+                value = value.item()
+            except Exception:
+                pass
+
+        if isinstance(value, (int, float)):
+            numeric = float(value)
+            if numeric != numeric:  # NaN guard
+                return None
+            return numeric
+
+        return value
+
+    def _update_yaml(self, file_path: Path, qubit_label: str, value: float | int | str) -> None:
+        if not file_path.exists():
+            return
+
+        with file_path.open("r") as fp:
+            data = self._yaml.load(fp) or CommentedMap()
+
+        if not isinstance(data, CommentedMap):
+            data = CommentedMap(data)
+
+        section = data.get("data")
+        if section is None or not isinstance(section, dict):
+            section = CommentedMap()
+            data["data"] = section
+        elif not isinstance(section, CommentedMap):
+            section = CommentedMap(section)
+            data["data"] = section
+
+        current_value = section.get(qubit_label)
+        if self._values_equal(current_value, value):
+            return
+
+        if isinstance(section, CommentedMap):
+            self._set_ordered(section, qubit_label, value)
+        else:
+            section[qubit_label] = value
+
+        with file_path.open("w") as fp:
+            self._yaml.dump(data, fp)
+
+    @staticmethod
+    def _values_equal(current: Any, new: Any) -> bool:
+        if current is None and new is None:
+            return True
+        if isinstance(current, (int, float)) and isinstance(new, (int, float)):
+            return abs(float(current) - float(new)) <= 1e-9
+        return current == new
+
+    @staticmethod
+    def _label_index(label: str) -> int | None:
+        if len(label) < 3 or label[0] not in {"Q", "q"}:
+            return None
+        try:
+            return int(label[1:])
+        except ValueError:
+            return None
+
+    def _set_ordered(self, section: CommentedMap, label: str, value: float | int | str) -> None:
+        if label in section:
+            section[label] = value
+            return
+
+        label_index = self._label_index(label)
+        if label_index is None:
+            section[label] = value
+            return
+
+        insert_pos = None
+        for idx, existing in enumerate(section):
+            existing_index = self._label_index(existing)
+            if existing_index is None:
+                continue
+            if label_index < existing_index:
+                insert_pos = idx
+                break
+
+        if insert_pos is None:
+            section[label] = value
+        else:
+            section.insert(insert_pos, label, value)

--- a/src/qdash/workflow/examples/adaptive_freq_calibration.py
+++ b/src/qdash/workflow/examples/adaptive_freq_calibration.py
@@ -75,7 +75,7 @@ def adaptive_freq_calibration(
 
             # Step 1: Measure qubit frequency
             freq_result = session.execute_task("CheckFreq", qid)
-            measured_freq = freq_result["bare_frequency"]
+            measured_freq = freq_result["qubit_frequency"]
 
             logger.info(f"Qubit {qid} - Measured frequency: {measured_freq:.6f} GHz")
 
@@ -170,7 +170,7 @@ def adaptive_multi_task_calibration(
 
             # Step 1: Measure qubit frequency
             freq_result = session.execute_task("CheckFreq", qid)
-            measured_freq = freq_result["bare_frequency"]
+            measured_freq = freq_result["qubit_frequency"]
 
             logger.info(f"Qubit {qid} - Measured frequency: {measured_freq:.6f} GHz")
 

--- a/src/qdash/workflow/examples/templates/iterative_chevron_pattern_flow.py
+++ b/src/qdash/workflow/examples/templates/iterative_chevron_pattern_flow.py
@@ -68,11 +68,11 @@ def calibrate_group(
             logger.info("    Executing ChevronPattern...")
             result = session.execute_task("ChevronPattern", qid, task_details=task_details)
 
-            logger.info(f"    ✓ ChevronPattern completed: bare_frequency={result.get('bare_frequency')} GHz")
+            logger.info(f"    ✓ ChevronPattern completed: qubit_frequency={result.get('qubit_frequency')} GHz")
 
             results[qid] = {
                 "iteration": iteration,
-                "bare_frequency": result.get("bare_frequency"),
+                "qubit_frequency": result.get("qubit_frequency"),
                 "task_id": result.get("task_id"),
                 "status": "success",
             }
@@ -224,7 +224,7 @@ def iterative_chevron_pattern_flow(
             logger.info(f"Iteration {iteration + 1} summary:")
             for qid, result in iteration_results.items():
                 if result["status"] == "success":
-                    logger.info(f"  Q{qid}: bare_frequency = {result['bare_frequency']} GHz")
+                    logger.info(f"  Q{qid}: qubit_frequency = {result['qubit_frequency']} GHz")
                 else:
                     logger.error(f"  Q{qid}: FAILED - {result.get('error')}")
 

--- a/src/qdash/workflow/examples/templates/retry_calibration.py
+++ b/src/qdash/workflow/examples/templates/retry_calibration.py
@@ -121,7 +121,7 @@ def _execute_ramsey_with_fallback(
         ramsey_result = session.execute_task("CheckRamsey", qid, task_details=task_details)
 
         # Extract values from OutputParameterModel if needed
-        measured_freq_raw = ramsey_result.get("bare_frequency")
+        measured_freq_raw = ramsey_result.get("qubit_frequency")
         ramsey_freq_raw = ramsey_result.get("ramsey_frequency")
         t2_star_raw = ramsey_result.get("t2_star")
 

--- a/src/qdash/workflow/tasks/qubex/one_qubit_coarse/check_qubit_frequency.py
+++ b/src/qdash/workflow/tasks/qubex/one_qubit_coarse/check_qubit_frequency.py
@@ -44,7 +44,7 @@ class CheckQubitFrequency(QubexTask):
         ),
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "bare_frequency": OutputParameterModel(unit="GHz", description="Qubit frequency"),
+        "qubit_frequency": OutputParameterModel(unit="GHz", description="Qubit frequency"),
     }
 
     def postprocess(
@@ -53,7 +53,7 @@ class CheckQubitFrequency(QubexTask):
         self.get_experiment(session)
         label = self.get_qubit_label(session, qid)
         result = run_result.raw_result
-        self.output_parameters["bare_frequency"].value = result[label]
+        self.output_parameters["qubit_frequency"].value = result[label]
         output_parameters = self.attach_execution_id(execution_id)
         figures: list[go.Figure] = []
         return PostProcessResult(output_parameters=output_parameters, figures=figures)

--- a/src/qdash/workflow/tasks/qubex/one_qubit_coarse/check_ramsey.py
+++ b/src/qdash/workflow/tasks/qubex/one_qubit_coarse/check_ramsey.py
@@ -44,7 +44,7 @@ class CheckRamsey(QubexTask):
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
         "ramsey_frequency": OutputParameterModel(unit="MHz", description="Ramsey oscillation frequency"),
-        "bare_frequency": OutputParameterModel(unit="GHz", description="Qubit bare frequency"),
+        "qubit_frequency": OutputParameterModel(unit="GHz", description="Qubit bare frequency"),
         "t2_star": OutputParameterModel(unit="μs", description="T2* time"),
     }
 
@@ -214,7 +214,7 @@ class CheckRamsey(QubexTask):
 
         self.output_parameters["ramsey_frequency"].value = selected_fit["f"] * 1000  # convert to MHz
         self.output_parameters["ramsey_frequency"].error = selected_fit["f_err"] * 1000
-        self.output_parameters["bare_frequency"].value = selected_result.bare_freq
+        self.output_parameters["qubit_frequency"].value = selected_result.bare_freq
         self.output_parameters["t2_star"].value = selected_result.t2 * 0.001  # convert to μs
         self.output_parameters["t2_star"].error = selected_fit["tau_err"] * 0.001  # convert to μs
         output_parameters = self.attach_execution_id(execution_id)

--- a/src/qdash/workflow/tasks/qubex/one_qubit_coarse/chevron_pattern.py
+++ b/src/qdash/workflow/tasks/qubex/one_qubit_coarse/chevron_pattern.py
@@ -19,7 +19,7 @@ class ChevronPattern(QubexTask):
     timeout: int = 60 * 240
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "bare_frequency": OutputParameterModel(unit="GHz", description="Qubit bare frequency"),
+        "qubit_frequency": OutputParameterModel(unit="GHz", description="Qubit bare frequency"),
     }
 
     def make_figure(self, result: Any, label: str) -> go.Figure:
@@ -67,7 +67,7 @@ class ChevronPattern(QubexTask):
         self.get_experiment(session)
         label = self.get_qubit_label(session, qid)
         result = run_result.raw_result
-        self.output_parameters["bare_frequency"].value = result["resonant_frequencies"][label]
+        self.output_parameters["qubit_frequency"].value = result["resonant_frequencies"][label]
         output_parameters = self.attach_execution_id(execution_id)
         figures = [self.make_figure(result, label)]
         return PostProcessResult(output_parameters=output_parameters, figures=figures)

--- a/src/qdash/workflow/worker/flows/gateway_integration/task.py
+++ b/src/qdash/workflow/worker/flows/gateway_integration/task.py
@@ -68,7 +68,7 @@ def generate_device_topology_request(request: DeviceTopologyRequest, save_path: 
         msg = "No current chip found in the database."
         raise ValueError(msg)
     for qid, qubit in chip.qubits.items():
-        if qubit.get_bare_frequency() is not None:
+        if qubit.get_qubit_frequency() is not None:
             request.qubits.append(qid)
     save_path = save_path / "device_topology_request.json"
     # Save request data to file

--- a/src/qdash/workflow/worker/flows/push_props/create_props.py
+++ b/src/qdash/workflow/worker/flows/push_props/create_props.py
@@ -12,7 +12,7 @@ from qdash.workflow.worker.flows.push_props.processor import _process_data
 from ruamel.yaml.comments import CommentedMap
 
 qubit_field_map = {
-    "bare_frequency": "qubit_frequency",
+    "qubit_frequency": "qubit_frequency",
     # "resonator_frequency": "resonator_frequency",
     "t1": "t1",
     "t2_echo": "t2_echo",

--- a/src/tools/converter.py
+++ b/src/tools/converter.py
@@ -99,7 +99,7 @@ def _process_qubit_data(qubit_data: dict) -> QubitProperties:
         return qubit_props
     for key, value in qubit_data.items():
         v = value.get("value")
-        if key == "bare_frequency":
+        if key == "qubit_frequency":
             qubit_props.qubit_frequency = v
         elif key == "t1":
             qubit_props.t1 = v * 1e3 if v is not None else None  # Convert to ns

--- a/src/tools/get_two_qubit_pair.py
+++ b/src/tools/get_two_qubit_pair.py
@@ -102,7 +102,7 @@ def filter_cr_pairs_by_mux(cr_pairs: list[str], mux_list: list[int]) -> list[str
     return filtered_pairs
 
 
-def extract_bare_frequency(qubits: dict[str, QubitModel]) -> dict[str, float]:
+def extract_qubit_frequency(qubits: dict[str, QubitModel]) -> dict[str, float]:
     """Extract bare frequency values from qubit data.
 
     Args:
@@ -116,8 +116,8 @@ def extract_bare_frequency(qubits: dict[str, QubitModel]) -> dict[str, float]:
     """
     result = {}
     for qid, qubit in qubits.items():
-        if qubit.data and "bare_frequency" in qubit.data:
-            result[qid] = qubit.data["bare_frequency"]["value"]
+        if qubit.data and "qubit_frequency" in qubit.data:
+            result[qid] = qubit.data["qubit_frequency"]["value"]
     return result
 
 
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     chip_doc = ChipDocument.get_current_chip(username)
     two_qubit_list = get_two_qubit_pair_list(chip_doc)
 
-    bare_freq = extract_bare_frequency(chip_doc.qubits)
+    bare_freq = extract_qubit_frequency(chip_doc.qubits)
     print(two_qubit_list)
     print(len(two_qubit_list), "couplings found.")
     print(bare_freq)

--- a/src/tools/greedy.py
+++ b/src/tools/greedy.py
@@ -85,11 +85,11 @@ def cr_pair_list(two_qubit_list: list[str], bare_freq: dict[str, float]) -> list
     ]
 
 
-def extract_bare_frequency(qubits: dict[str, QubitModel]) -> dict[str, float]:
+def extract_qubit_frequency(qubits: dict[str, QubitModel]) -> dict[str, float]:
     return {
-        qid: qubit.data["bare_frequency"]["value"]
+        qid: qubit.data["qubit_frequency"]["value"]
         for qid, qubit in qubits.items()
-        if qubit.data and "bare_frequency" in qubit.data
+        if qubit.data and "qubit_frequency" in qubit.data
     }
 
 
@@ -337,7 +337,7 @@ if __name__ == "__main__":
     # create schedule directory
     chip_doc = ChipDocument.get_current_chip("admin")
     two_qubit_list = get_two_qubit_pair_list(chip_doc)
-    bare_freq = extract_bare_frequency(chip_doc.qubits)
+    bare_freq = extract_qubit_frequency(chip_doc.qubits)
     cr_pairs = cr_pair_list(two_qubit_list, bare_freq)
     cr_pairs = [pair for pair in cr_pairs if not set(pair.split("-")) & EXCLUDE_QUBITS]
 


### PR DESCRIPTION
Refactor the code to replace instances of "bare_frequency" with "qubit_frequency" for consistency in parameter naming across various functions and classes. This change enhances clarity and aligns with the updated data model.