### PR TITLE
Add MUX region highlights and labels to metrics grids

### DIFF
--- a/ui/src/app/metrics/components/CouplingMetricsGrid.tsx
+++ b/ui/src/app/metrics/components/CouplingMetricsGrid.tsx
@@ -344,6 +344,42 @@ export function CouplingMetricsGrid({
             height: displayGridSize * (displayCellSize + 8),
           }}
         >
+          {/* MUX highlight overlay */}
+          <div className="absolute inset-0 pointer-events-none">
+            <div
+              className="grid gap-2 w-full h-full"
+              style={{
+                gridTemplateColumns: `repeat(${Math.floor(displayGridSize / MUX_SIZE)}, minmax(0, 1fr))`,
+              }}
+            >
+              {Array.from({
+                length: Math.pow(Math.floor(displayGridSize / MUX_SIZE), 2),
+              }).map((_, muxIndex) => {
+                const muxRow = Math.floor(
+                  muxIndex / Math.floor(displayGridSize / MUX_SIZE),
+                );
+                const muxCol =
+                  muxIndex % Math.floor(displayGridSize / MUX_SIZE);
+                const isEvenMux = (muxRow + muxCol) % 2 === 0;
+
+                return (
+                  <div
+                    key={muxIndex}
+                    className={`rounded-lg relative ${
+                      isEvenMux
+                        ? "bg-primary/5 border border-primary/10"
+                        : "bg-secondary/5 border border-secondary/10"
+                    }`}
+                  >
+                    {/* MUX number label */}
+                    <div className="absolute top-0.5 right-0.5 md:top-1 md:right-1 text-[0.5rem] md:text-xs font-semibold text-base-content/20 bg-base-100/30 backdrop-blur-sm px-1 rounded">
+                      MUX{muxIndex}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
           {/* Qubit cells (background) */}
           {Array.from({ length: gridSize === 8 ? 64 : 144 })
             .filter((_, qid) => isQubitInRegion(qid))

--- a/ui/src/app/metrics/components/QubitMetricsGrid.tsx
+++ b/ui/src/app/metrics/components/QubitMetricsGrid.tsx
@@ -273,11 +273,51 @@ export function QubitMetricsGrid({
       {/* Grid display */}
       <div className="flex-1 p-2 md:p-4 relative">
         <div
-          className="grid gap-1 md:gap-2 lg:gap-3 p-3 md:p-4 lg:p-6 bg-base-200/50 rounded-xl max-w-full"
+          className="grid gap-1 md:gap-2 lg:gap-3 p-3 md:p-4 lg:p-6 bg-base-200/50 rounded-xl max-w-full relative"
           style={{
             gridTemplateColumns: `repeat(${displayGridSize}, minmax(0, 1fr))`,
           }}
         >
+          {/* MUX highlight overlay */}
+          <div className="absolute inset-0 pointer-events-none p-3 md:p-4 lg:p-6">
+            <div
+              className="grid gap-1 md:gap-2 lg:gap-3 w-full h-full"
+              style={{
+                gridTemplateColumns: `repeat(${Math.floor(displayGridSize / MUX_SIZE)}, minmax(0, 1fr))`,
+              }}
+            >
+              {Array.from({
+                length: Math.pow(Math.floor(displayGridSize / MUX_SIZE), 2),
+              }).map((_, muxIndex) => {
+                const muxRow = Math.floor(
+                  muxIndex / Math.floor(displayGridSize / MUX_SIZE),
+                );
+                const muxCol =
+                  muxIndex % Math.floor(displayGridSize / MUX_SIZE);
+                const isEvenMux = (muxRow + muxCol) % 2 === 0;
+
+                return (
+                  <div
+                    key={muxIndex}
+                    className={`rounded-lg relative ${
+                      isEvenMux
+                        ? "bg-primary/5 border border-primary/10"
+                        : "bg-secondary/5 border border-secondary/10"
+                    }`}
+                    style={{
+                      gridColumn: `span 1`,
+                      gridRow: `span 1`,
+                    }}
+                  >
+                    {/* MUX number label */}
+                    <div className="absolute top-0.5 right-0.5 md:top-1 md:right-1 text-[0.5rem] md:text-xs font-semibold text-base-content/20 bg-base-100/30 backdrop-blur-sm px-1 rounded">
+                      MUX{muxIndex}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
           {Array.from({ length: displayGridSize * displayGridSize }).map(
             (_, index) => {
               const localRow = Math.floor(index / displayGridSize);


### PR DESCRIPTION
Enhance visual organization in qubit and coupling metrics grids by adding alternating colored overlays and MUX number labels. This improvement facilitates easier identification of qubits belonging to specific MUX regions.