### PR TITLE
Update metrics API for unlimited history items

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -471,8 +471,6 @@ pyasn1-modules==0.4.1
     # via service-identity
 pybind11-stubgen==2.5.5
     # via quel-ic-config
-pycairo==1.28.0
-    # via pygobject
 pycparser==2.22
     # via cffi
 pydantic==2.4.2
@@ -494,8 +492,6 @@ pygments==2.19.1
     #   jupyter-console
     #   nbconvert
     #   rich
-pygobject==3.50.0
-    # via qubecalib
 pylabrad==0.98.2
     # via e7awgsw
 pymongo==4.8.0
@@ -564,9 +560,9 @@ pyzmq==27.0.1
     #   jupyter-server
 qctrl-visualizer==8.0.2
     # via qubex
-qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@f991bb009f948ad426ce6bcc340b6f263740ad17
+qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@487227c1154aa087e55b9fee1eabda2a164d299c
     # via qubex
-qubex @ git+https://github.com/amachino/qubex.git@9c0558decf91a05e6d6c5778a43165e5bf877203
+qubex @ git+https://github.com/amachino/qubex.git@d20176016f4bf2f1e1dd18f24d0091e3fb8efd73
 quel-clock-master @ git+https://github.com/quel-inc/quelware.git@c839e8b1a6fde4b4ece3d5f415015829857e775e#subdirectory=quel_clock_master
     # via
     #   qubecalib

--- a/docs/design/task-editor-design.md
+++ b/docs/design/task-editor-design.md
@@ -9,12 +9,14 @@ This document describes the design and implementation plan for the Task Editor f
 ### Current State
 
 **Tasks Page (`/ui/src/app/tasks/page.tsx`)**
+
 - Displays task metadata: name, description, task_type, input/output parameters
 - Data source: `/api/task` endpoint (fetches from TaskDocument in MongoDB)
 - UI features: Grid/List view toggle, detail modal
 - **Limitation**: Shows only parameter definitions, not actual implementation code
 
 **Actual Task Implementation (`src/qdash/workflow/tasks/`)**
+
 - Python classes inheriting from `BaseTask`
 - Contains rich information:
   - `preprocess()`, `postprocess()`, `run()`, `batch_run()` method implementations
@@ -40,6 +42,7 @@ This document describes the design and implementation plan for the Task Editor f
   ```
 
 **Files Editor (`/ui/src/app/files/page.tsx`)**
+
 - Monaco Editor with syntax highlighting
 - File tree navigation
 - Edit functionality with lock/unlock mechanism
@@ -49,6 +52,7 @@ This document describes the design and implementation plan for the Task Editor f
 ### Problem Statement
 
 Users currently have **limited visibility** into task implementations:
+
 - Can only see parameter definitions (metadata)
 - Cannot understand the actual algorithm logic
 - Difficult to debug or troubleshoot calibration issues
@@ -91,6 +95,7 @@ Users currently have **limited visibility** into task implementations:
 ### Implementation Approach: Option A (Recommended)
 
 **Extend Existing Tasks Page**
+
 - Maintain current metadata view (Grid/List)
 - Add "View Code" button to each task card
 - Click to open Monaco Editor modal or separate tab
@@ -99,6 +104,7 @@ Users currently have **limited visibility** into task implementations:
 ### Alternative: Option B
 
 **Dedicated Task Editor Page**
+
 - Create `/tasks/editor` as independent page
 - Same layout as Files Editor
 - Task-specific features (parameter highlighting, doc generation)
@@ -111,26 +117,30 @@ Users currently have **limited visibility** into task implementations:
 
 QDash uses a **hybrid approach** for configuration management:
 
-| Configuration Type | Storage | Git Managed | Edit Method | Example Use Cases |
-|-------------------|---------|-------------|-------------|-------------------|
-| **Environment-specific** | `.env` | ❌ | Manual edit | Ports, credentials, API keys |
-| **Application settings** | YAML | ✅ | UI Editor | Metrics definitions, chip configs |
+| Configuration Type       | Storage | Git Managed | Edit Method | Example Use Cases                 |
+| ------------------------ | ------- | ----------- | ----------- | --------------------------------- |
+| **Environment-specific** | `.env`  | ❌          | Manual edit | Ports, credentials, API keys      |
+| **Application settings** | YAML    | ✅          | UI Editor   | Metrics definitions, chip configs |
 
 ### Rationale
 
 **Security**
+
 - `.env`: Contains secrets (passwords, API keys) → Never commit to Git
 - YAML: Public settings → Safe to version control
 
 **Portability**
+
 - `.env`: Different values per environment (dev/staging/prod)
 - YAML: Shared across all environments
 
 **Version Control**
+
 - YAML: Track configuration change history
 - Critical for chip settings rollback and diff review
 
 **UI Editing**
+
 - Files Editor already supports YAML editing
 - Git integration (pull/push) implemented
 
@@ -139,12 +149,14 @@ QDash uses a **hybrid approach** for configuration management:
 #### Recommended: Hybrid Approach
 
 **Environment Variable (`.env`)**
+
 ```bash
 # Task Editor paths
 TASK_BASE_PATH="./src/qdash/workflow/tasks"
 ```
 
 **Application Configuration (`config/qdash.yaml`)**
+
 ```yaml
 # QDash Application Configuration
 app:
@@ -154,7 +166,7 @@ app:
 # Task Editor configuration
 task_editor:
   enabled: true
-  read_only: false  # Set to true in production
+  read_only: false # Set to true in production
 
   # Backend-specific settings
   backends:
@@ -172,7 +184,7 @@ task_editor:
 # Files Editor configuration (existing)
 files_editor:
   enabled: true
-  base_path: "config/qubex"  # Equivalent to CONFIG_PATH
+  base_path: "config/qubex" # Equivalent to CONFIG_PATH
   git_enabled: true
 
 # UI feature flags
@@ -619,20 +631,29 @@ export const getTaskFileTree = async (params?: { backend?: string }) => {
 };
 
 export const getTaskFileContent = async (params: { path: string }) => {
-  return apiClient.get<{ path: string; content: string; language: string; read_only: boolean }>(
-    "/tasks/files/content",
-    { params }
-  );
+  return apiClient.get<{
+    path: string;
+    content: string;
+    language: string;
+    read_only: boolean;
+  }>("/tasks/files/content", { params });
 };
 
-export const saveTaskFileContent = async (data: { path: string; content: string }) => {
-  return apiClient.post<{ message: string; path: string }>("/tasks/files/save", data);
+export const saveTaskFileContent = async (data: {
+  path: string;
+  content: string;
+}) => {
+  return apiClient.post<{ message: string; path: string }>(
+    "/tasks/files/save",
+    data,
+  );
 };
 ```
 
 ## Implementation Plan
 
 ### Phase 1: Backend Foundation
+
 1. ✅ Create `config/qdash.yaml` configuration file
 2. ✅ Add `TASK_BASE_PATH` to `.env.example`
 3. ✅ Implement `task_editor_config.py` loader
@@ -642,6 +663,7 @@ export const saveTaskFileContent = async (data: { path: string; content: string 
 7. ✅ Implement `validate_task_file_path()` security function
 
 ### Phase 2: Frontend Integration
+
 1. ✅ Create API client functions (`getTaskFileTree`, etc.)
 2. ✅ Add "View Code" button to TaskCard component
 3. ✅ Create `/tasks/editor` page (reuse Files Editor components)
@@ -651,6 +673,7 @@ export const saveTaskFileContent = async (data: { path: string; content: string 
 7. ✅ Add save functionality with syntax validation
 
 ### Phase 3: Testing & Documentation
+
 1. ⬜ Test with different task files (qubex, fake backends)
 2. ⬜ Test read-only mode enforcement
 3. ⬜ Test path traversal security
@@ -658,6 +681,7 @@ export const saveTaskFileContent = async (data: { path: string; content: string 
 5. ⬜ Add user guide to docs/
 
 ### Phase 4: Optional Enhancements
+
 1. ⬜ Git integration for task files (similar to Files Editor)
 2. ⬜ Syntax highlighting for task-specific patterns (parameters, etc.)
 3. ⬜ Auto-generate task documentation from code
@@ -727,7 +751,7 @@ TASK_BASE_PATH="./src/qdash/workflow/tasks"
 ```yaml
 task_editor:
   enabled: true
-  read_only: false  # Set to true in production to prevent edits
+  read_only: false # Set to true in production to prevent edits
 
   backends:
     qubex:

--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -2323,7 +2323,7 @@
       "get": {
         "tags": ["metrics"],
         "summary": "Get Qubit Metric History",
-        "description": "Get historical metric data for a specific qubit with task_id for figure display.\n\nThis endpoint queries ExecutionHistoryDocument to retrieve the calibration\nhistory for a specific metric, including multiple executions on the same day.\nEach history item includes task_id for displaying calibration figures.\n\nArgs:\n----\n    chip_id: The chip identifier\n    qid: The qubit identifier (e.g., \"0\", \"Q00\")\n    metric: Metric name to retrieve history for\n    limit: Maximum number of history items to return (1-100)\n    within_days: Optional filter to only include data from last N days\n    current_user: Current authenticated user\n\nReturns:\n-------\n    QubitMetricHistoryResponse with historical metric data and task_ids",
+        "description": "Get historical metric data for a specific qubit with task_id for figure display.\n\nThis endpoint queries ExecutionHistoryDocument to retrieve the calibration\nhistory for a specific metric, including multiple executions on the same day.\nEach history item includes task_id for displaying calibration figures.\n\nArgs:\n----\n    chip_id: The chip identifier\n    qid: The qubit identifier (e.g., \"0\", \"Q00\")\n    metric: Metric name to retrieve history for\n    limit: Maximum number of history items (None for unlimited within time range)\n    within_days: Optional filter to only include data from last N days\n    current_user: Current authenticated user\n\nReturns:\n-------\n    QubitMetricHistoryResponse with historical metric data and task_ids",
         "operationId": "metrics-get_qubit_metric_history",
         "security": [
           {
@@ -2365,14 +2365,19 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "description": "Max number of history items",
-              "default": 20,
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Max number of history items (None for unlimited)",
               "title": "Limit"
             },
-            "description": "Max number of history items"
+            "description": "Max number of history items (None for unlimited)"
           },
           {
             "name": "within_days",
@@ -2423,7 +2428,7 @@
       "get": {
         "tags": ["metrics"],
         "summary": "Get Coupling Metric History",
-        "description": "Get historical metric data for a specific coupling with task_id for figure display.\n\nThis endpoint queries ExecutionHistoryDocument to retrieve the calibration\nhistory for a specific coupling metric, including multiple executions on the same day.\nEach history item includes task_id for displaying calibration figures.\n\nArgs:\n----\n    chip_id: The chip identifier\n    coupling_id: The coupling identifier (e.g., \"0-1\", \"2-3\")\n    metric: Metric name to retrieve history for\n    limit: Maximum number of history items to return (1-100)\n    within_days: Optional filter to only include data from last N days\n    current_user: Current authenticated user\n\nReturns:\n-------\n    QubitMetricHistoryResponse with historical metric data and task_ids\n    (Note: qid field contains coupling_id for coupling metrics)",
+        "description": "Get historical metric data for a specific coupling with task_id for figure display.\n\nThis endpoint queries ExecutionHistoryDocument to retrieve the calibration\nhistory for a specific coupling metric, including multiple executions on the same day.\nEach history item includes task_id for displaying calibration figures.\n\nArgs:\n----\n    chip_id: The chip identifier\n    coupling_id: The coupling identifier (e.g., \"0-1\", \"2-3\")\n    metric: Metric name to retrieve history for\n    limit: Maximum number of history items (None for unlimited within time range)\n    within_days: Optional filter to only include data from last N days\n    current_user: Current authenticated user\n\nReturns:\n-------\n    QubitMetricHistoryResponse with historical metric data and task_ids\n    (Note: qid field contains coupling_id for coupling metrics)",
         "operationId": "metrics-get_coupling_metric_history",
         "security": [
           {
@@ -2465,14 +2470,19 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "description": "Max number of history items",
-              "default": 20,
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Max number of history items (None for unlimited)",
               "title": "Limit"
             },
-            "description": "Max number of history items"
+            "description": "Max number of history items (None for unlimited)"
           },
           {
             "name": "within_days",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,5 +128,5 @@ agent = [
 ]
 
 [tool.uv.sources]
-qubex = { git = "https://github.com/amachino/qubex.git", tag = "v1.4.3" }
+qubex = { git = "https://github.com/amachino/qubex.git", tag = "develop" }
 strands-agents = { git = "https://github.com/strands-agents/sdk-python.git" }

--- a/src/qdash/workflow/requirements.txt
+++ b/src/qdash/workflow/requirements.txt
@@ -402,8 +402,6 @@ pyasn1-modules==0.4.1
     # via service-identity
 pybind11-stubgen==2.5.5
     # via quel-ic-config
-pycairo==1.28.0
-    # via pygobject
 pycparser==2.22
     # via cffi
 pydantic==2.4.2
@@ -421,8 +419,6 @@ pygments==2.19.1
     #   jupyter-console
     #   nbconvert
     #   rich
-pygobject==3.50.0
-    # via qubecalib
 pylabrad==0.98.2
     # via e7awgsw
 pymongo==4.8.0
@@ -473,9 +469,9 @@ pyzmq==27.0.1
     #   jupyter-server
 qctrl-visualizer==8.0.2
     # via qubex
-qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@f991bb009f948ad426ce6bcc340b6f263740ad17
+qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@487227c1154aa087e55b9fee1eabda2a164d299c
     # via qubex
-qubex @ git+https://github.com/amachino/qubex.git@9c0558decf91a05e6d6c5778a43165e5bf877203
+qubex @ git+https://github.com/amachino/qubex.git@d20176016f4bf2f1e1dd18f24d0091e3fb8efd73
 quel-clock-master @ git+https://github.com/quel-inc/quelware.git@c839e8b1a6fde4b4ece3d5f415015829857e775e#subdirectory=quel_clock_master
     # via
     #   qubecalib

--- a/ui/src/client/metrics/metrics.ts
+++ b/ui/src/client/metrics/metrics.ts
@@ -740,7 +740,7 @@ Args:
     chip_id: The chip identifier
     qid: The qubit identifier (e.g., "0", "Q00")
     metric: Metric name to retrieve history for
-    limit: Maximum number of history items to return (1-100)
+    limit: Maximum number of history items (None for unlimited within time range)
     within_days: Optional filter to only include data from last N days
     current_user: Current authenticated user
 
@@ -952,7 +952,7 @@ Args:
     chip_id: The chip identifier
     coupling_id: The coupling identifier (e.g., "0-1", "2-3")
     metric: Metric name to retrieve history for
-    limit: Maximum number of history items to return (1-100)
+    limit: Maximum number of history items (None for unlimited within time range)
     within_days: Optional filter to only include data from last N days
     current_user: Current authenticated user
 

--- a/ui/src/schemas/metricsGetCouplingMetricHistoryParams.ts
+++ b/ui/src/schemas/metricsGetCouplingMetricHistoryParams.ts
@@ -12,11 +12,9 @@ export type MetricsGetCouplingMetricHistoryParams = {
    */
   metric: string;
   /**
-   * Max number of history items
-   * @minimum 1
-   * @maximum 100
+   * Max number of history items (None for unlimited)
    */
-  limit?: number;
+  limit?: number | null;
   /**
    * Filter to last N days
    */

--- a/ui/src/schemas/metricsGetQubitMetricHistoryParams.ts
+++ b/ui/src/schemas/metricsGetQubitMetricHistoryParams.ts
@@ -12,11 +12,9 @@ export type MetricsGetQubitMetricHistoryParams = {
    */
   metric: string;
   /**
-   * Max number of history items
-   * @minimum 1
-   * @maximum 100
+   * Max number of history items (None for unlimited)
    */
-  limit?: number;
+  limit?: number | null;
   /**
    * Filter to last N days
    */

--- a/uv.lock
+++ b/uv.lock
@@ -2706,23 +2706,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycairo"
-version = "1.28.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/d9/412da520de9052b7e80bfc810ec10f5cb3dbfa4aa3e23c2820dc61cdb3d0/pycairo-1.28.0.tar.gz", hash = "sha256:26ec5c6126781eb167089a123919f87baa2740da2cca9098be8b3a6b91cc5fbc", size = 662477, upload-time = "2025-04-14T20:11:08.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/67/6e5d6328c6037f0479017f51e97f5cbb79a68ed6e93f671dac17cb47bf2e/pycairo-1.28.0-cp310-cp310-win32.whl", hash = "sha256:53e6dbc98456f789965dad49ef89ce2c62f9a10fc96c8d084e14da0ffb73d8a6", size = 750438, upload-time = "2025-04-14T20:10:43.722Z" },
-    { url = "https://files.pythonhosted.org/packages/00/79/e941186c2275333643504f57711b157ba17e81a2be805346585ad7fd382e/pycairo-1.28.0-cp310-cp310-win_amd64.whl", hash = "sha256:c8ab91a75025f984bc327ada335c787efb61c929ea0512063793cb36cee503d4", size = 841526, upload-time = "2025-04-14T20:10:45.557Z" },
-    { url = "https://files.pythonhosted.org/packages/84/4b/3495baabd3c830bf80bf112a0e645342bfe8f3fc05ed6423444adf62d496/pycairo-1.28.0-cp310-cp310-win_arm64.whl", hash = "sha256:e955328c1a5147bf71ee94e206413ce15e12630296a79788fcd246c80e5337b8", size = 691866, upload-time = "2025-04-16T19:30:17.73Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/94/47d75f4eaac865f32e0550ed42869f8b3c4036f8e2b1e6163e9548f4d44f/pycairo-1.28.0-cp311-cp311-win32.whl", hash = "sha256:0fee15f5d72b13ba5fd065860312493dc1bca6ff2dce200ee9d704e11c94e60a", size = 750441, upload-time = "2025-04-14T20:10:48.311Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/02/1169a2917b043998585f9dd0f36da618947fdf9b6cc0e9ff9852aa4d548b/pycairo-1.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:6339979bfec8b58a06476094a9a5c104bd5a99932ddaff16ca0d9203d2f4482c", size = 841536, upload-time = "2025-04-14T20:10:51.112Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/99/13031086fb4d4ea71568d9ce74e03afbb2e18047f1e6b4e8674851f0414f/pycairo-1.28.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6ae15392e28ebfc0b35d8dc05d395d3b6be4bad9ad4caecf0fa12c8e7150225", size = 691895, upload-time = "2025-04-16T19:30:20.724Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/d7/206d7945aac5c6c889e7fea4011410d1311455a1d8dfce66106d8d700b7f/pycairo-1.28.0-cp312-cp312-win32.whl", hash = "sha256:c00cfbb7f30eb7ca1d48886712932e2d91e8835a8496f4e423878296ceba573e", size = 750594, upload-time = "2025-04-14T20:10:53.72Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/ba/259fc9a4d3afdad1e5b9db52b9d8a5df67f70dd787167185e8ec8a1af007/pycairo-1.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:d50d190f5033992b55050b9f337ee42a45c3568445d5e5d7987bab96c278d8a6", size = 841767, upload-time = "2025-04-14T20:10:56.711Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/08/aa0903612ea0e8686ad6af58d4fb9cbab8ee0b0831201cddf7abd578d045/pycairo-1.28.0-cp312-cp312-win_arm64.whl", hash = "sha256:957e0340ee1c279d197d4f7cfa96f6d8b48e453eec711fca999748d752468ff4", size = 691687, upload-time = "2025-04-16T19:30:23.729Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -2823,15 +2806,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
 ]
-
-[[package]]
-name = "pygobject"
-version = "3.50.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycairo" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/58/d34e67a79631177e3c08e7d02b5165147f590171f2cae6769502af5f7f7e/pygobject-3.50.0.tar.gz", hash = "sha256:4500ad3dbf331773d8dedf7212544c999a76fc96b63a91b3dcac1e5925a1d103", size = 1080367, upload-time = "2024-09-12T12:05:22.579Z" }
 
 [[package]]
 name = "pylabrad"
@@ -3300,15 +3274,15 @@ workflow = [
     { name = "pymongo", specifier = "==4.8.0" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "pyyaml", specifier = "==6.0.1" },
-    { name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?tag=v1.4.3" },
+    { name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?tag=develop" },
     { name = "reportlab", specifier = ">=4.4.1" },
     { name = "slack-sdk", specifier = "==3.36.0" },
 ]
 
 [[package]]
 name = "qubecalib"
-version = "3.1.15"
-source = { git = "https://github.com/qiqb-osaka/qube-calib.git?rev=3.1.15#f991bb009f948ad426ce6bcc340b6f263740ad17" }
+version = "3.1.16b1"
+source = { git = "https://github.com/qiqb-osaka/qube-calib.git?rev=3.1.16beta1#487227c1154aa087e55b9fee1eabda2a164d299c" }
 dependencies = [
     { name = "aiocoap" },
     { name = "e7awgsw" },
@@ -3316,7 +3290,6 @@ dependencies = [
     { name = "matplotlib" },
     { name = "numpy" },
     { name = "plotly" },
-    { name = "pygobject" },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "pyyaml" },
@@ -3328,8 +3301,8 @@ dependencies = [
 
 [[package]]
 name = "qubex"
-version = "1.4.3+9c0558d"
-source = { git = "https://github.com/amachino/qubex.git?tag=v1.4.3#9c0558decf91a05e6d6c5778a43165e5bf877203" }
+version = "1.4.3+d201760"
+source = { git = "https://github.com/amachino/qubex.git?tag=develop#d20176016f4bf2f1e1dd18f24d0091e3fb8efd73" }
 dependencies = [
     { name = "cma" },
     { name = "cvxopt" },


### PR DESCRIPTION
Enhance the metrics API to allow unlimited history items by adjusting the limit parameter to accept null values. Update dependencies to the latest versions.

