### PR TITLE
feat(workflow): auto-register execution tags and use flow name as default tag

### DIFF
--- a/src/qdash/workflow/engine/calibration/execution_manager.py
+++ b/src/qdash/workflow/engine/calibration/execution_manager.py
@@ -13,6 +13,7 @@ from qdash.datamodel.execution import (
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.execution_history import ExecutionHistoryDocument
 from qdash.dbmodel.initialize import initialize
+from qdash.dbmodel.tag import TagDocument
 from qdash.workflow.engine.calibration.task_manager import TaskManager
 
 initialize()
@@ -307,6 +308,9 @@ class ExecutionManager(BaseModel):
     def save(self) -> "ExecutionManager":
         """Save the execution manager to the database."""
         ExecutionHistoryDocument.upsert_document(self.to_datamodel())
+        # Auto-register tags to TagDocument for UI tag selector
+        if self.tags:
+            TagDocument.insert_tags(self.tags, self.username)
         return self
 
     def to_datamodel(self) -> ExecutionModel:

--- a/src/qdash/workflow/flow/session.py
+++ b/src/qdash/workflow/flow/session.py
@@ -161,8 +161,9 @@ class FlowSession:
             self._lock_acquired = True
 
         # Set default tags and note
+        # Use name (which is flow_name or display_name) as default tag
         if tags is None:
-            tags = ["python_flow"]
+            tags = [name]
         if note is None:
             note = {}
 


### PR DESCRIPTION
- Auto-register tags to TagDocument when saving ExecutionManager for UI tag selector
- Change default tag from generic "python_flow" to flow name for better organization
- Enables automatic tag discovery in UI without manual tag creation

