### PR TITLE
refactor(api): remove /api prefix from all route paths

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -15,7 +15,7 @@
     "version": "0.0.1"
   },
   "paths": {
-    "/api/auth/login": {
+    "/auth/login": {
       "post": {
         "tags": ["auth"],
         "summary": "Login",
@@ -58,7 +58,7 @@
         }
       }
     },
-    "/api/auth/register": {
+    "/auth/register": {
       "post": {
         "tags": ["auth"],
         "summary": "Register User",
@@ -101,7 +101,7 @@
         }
       }
     },
-    "/api/auth/me": {
+    "/auth/me": {
       "get": {
         "tags": ["auth"],
         "summary": "Read Users Me",
@@ -124,7 +124,7 @@
         }
       }
     },
-    "/api/auth/logout": {
+    "/auth/logout": {
       "post": {
         "tags": ["auth"],
         "summary": "Logout",
@@ -151,7 +151,7 @@
         }
       }
     },
-    "/api/executions/figure": {
+    "/executions/figure": {
       "get": {
         "tags": ["execution"],
         "summary": "Fetches a calibration figure by its path",
@@ -195,7 +195,7 @@
         }
       }
     },
-    "/api/executions/lock_status": {
+    "/executions/lock_status": {
       "get": {
         "tags": ["execution"],
         "summary": "Fetches the status of a calibration.",
@@ -215,7 +215,7 @@
         }
       }
     },
-    "/api/file/raw_data": {
+    "/file/raw_data": {
       "get": {
         "tags": ["file"],
         "summary": "download file",
@@ -249,7 +249,7 @@
         }
       }
     },
-    "/api/file/zip": {
+    "/file/zip": {
       "get": {
         "tags": ["file"],
         "summary": "download file or directory as zip",
@@ -283,7 +283,7 @@
         }
       }
     },
-    "/api/file/tree": {
+    "/file/tree": {
       "get": {
         "tags": ["file"],
         "summary": "Get file tree for entire config directory",
@@ -307,7 +307,7 @@
         }
       }
     },
-    "/api/file/content": {
+    "/file/content": {
       "get": {
         "tags": ["file"],
         "summary": "Get file content for editing",
@@ -392,7 +392,7 @@
         }
       }
     },
-    "/api/file/validate": {
+    "/file/validate": {
       "post": {
         "tags": ["file"],
         "summary": "Validate file content (YAML/JSON)",
@@ -434,7 +434,7 @@
         }
       }
     },
-    "/api/file/git/status": {
+    "/file/git/status": {
       "get": {
         "tags": ["file"],
         "summary": "Get Git status of config directory",
@@ -456,7 +456,7 @@
         }
       }
     },
-    "/api/file/git/pull": {
+    "/file/git/pull": {
       "post": {
         "tags": ["file"],
         "summary": "Pull latest config from Git repository",
@@ -478,7 +478,7 @@
         }
       }
     },
-    "/api/file/git/push": {
+    "/file/git/push": {
       "post": {
         "tags": ["file"],
         "summary": "Push config changes to Git repository",
@@ -520,7 +520,7 @@
         }
       }
     },
-    "/api/calibration/note": {
+    "/calibration/note": {
       "get": {
         "tags": ["calibration"],
         "summary": "Fetches all the cron schedules.",
@@ -540,7 +540,7 @@
         }
       }
     },
-    "/api/settings": {
+    "/settings": {
       "get": {
         "tags": ["settings"],
         "summary": "Get settings",
@@ -560,7 +560,7 @@
         }
       }
     },
-    "/api/chip": {
+    "/chip": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch all chips",
@@ -627,7 +627,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/dates": {
+    "/chip/{chip_id}/dates": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch available dates for a chip",
@@ -668,7 +668,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}": {
+    "/chip/{chip_id}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch a chip",
@@ -709,7 +709,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/execution": {
+    "/chip/{chip_id}/execution": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch executions",
@@ -781,7 +781,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/execution/{execution_id}": {
+    "/chip/{chip_id}/execution/{execution_id}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch an execution by its ID",
@@ -831,7 +831,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/mux/{mux_id}": {
+    "/chip/{chip_id}/mux/{mux_id}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch the multiplexer details",
@@ -881,7 +881,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/mux": {
+    "/chip/{chip_id}/mux": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch the multiplexers",
@@ -922,7 +922,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/task/qubit/{task_name}/history/{recorded_date}": {
+    "/chip/{chip_id}/task/qubit/{task_name}/history/{recorded_date}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch historical task results",
@@ -981,7 +981,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/task/qubit/{task_name}/latest": {
+    "/chip/{chip_id}/task/qubit/{task_name}/latest": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch latest qubit task results with optional outlier filtering",
@@ -1031,7 +1031,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/task/qubit/{qid}/task/{task_name}": {
+    "/chip/{chip_id}/task/qubit/{qid}/task/{task_name}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch Qubit Task History",
@@ -1095,7 +1095,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/task/coupling/{coupling_id}/task/{task_name}": {
+    "/chip/{chip_id}/task/coupling/{coupling_id}/task/{task_name}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch Coupling Task History",
@@ -1159,7 +1159,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/task/coupling/{task_name}/history/{recorded_date}": {
+    "/chip/{chip_id}/task/coupling/{task_name}/history/{recorded_date}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch historical task results",
@@ -1218,7 +1218,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/task/coupling/{task_name}/latest": {
+    "/chip/{chip_id}/task/coupling/{task_name}/latest": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch the multiplexers",
@@ -1268,7 +1268,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/parameter/{parameter}/qid/{qid}": {
+    "/chip/{chip_id}/parameter/{parameter}/qid/{qid}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch the timeseries task result by tag and parameter for a specific qid",
@@ -1354,7 +1354,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/parameter/{parameter}": {
+    "/chip/{chip_id}/parameter/{parameter}": {
       "get": {
         "tags": ["chip"],
         "summary": "Fetch the timeseries task result by tag and parameter for all qids",
@@ -1431,7 +1431,7 @@
         }
       }
     },
-    "/api/tasks": {
+    "/tasks": {
       "get": {
         "tags": ["task"],
         "summary": "Fetch all tasks",
@@ -1481,7 +1481,7 @@
         }
       }
     },
-    "/api/task/{task_id}": {
+    "/task/{task_id}": {
       "get": {
         "tags": ["task"],
         "summary": "Get task result by task ID",
@@ -1522,7 +1522,7 @@
         }
       }
     },
-    "/api/parameter": {
+    "/parameter": {
       "get": {
         "tags": ["parameter"],
         "summary": "Fetch all parameters",
@@ -1542,7 +1542,7 @@
         }
       }
     },
-    "/api/tag": {
+    "/tag": {
       "get": {
         "tags": ["tag"],
         "summary": "list all tag",
@@ -1562,7 +1562,7 @@
         }
       }
     },
-    "/api/device_topology": {
+    "/device_topology": {
       "post": {
         "tags": ["device_topology"],
         "summary": "Get the device topology",
@@ -1602,7 +1602,7 @@
         }
       }
     },
-    "/api/device_topology/plot": {
+    "/device_topology/plot": {
       "post": {
         "tags": ["device_topology"],
         "summary": "Get the device topology plot",
@@ -1635,7 +1635,7 @@
         }
       }
     },
-    "/api/backend": {
+    "/backend": {
       "get": {
         "tags": ["backend"],
         "summary": "Get all backends",
@@ -1664,7 +1664,7 @@
         ]
       }
     },
-    "/api/flow": {
+    "/flow": {
       "get": {
         "tags": ["flow"],
         "summary": "List Flows",
@@ -1722,7 +1722,7 @@
         }
       }
     },
-    "/api/flow/{name}": {
+    "/flow/{name}": {
       "get": {
         "tags": ["flow"],
         "summary": "Get Flow details",
@@ -1806,7 +1806,7 @@
         }
       }
     },
-    "/api/flow/{name}/execute": {
+    "/flow/{name}/execute": {
       "post": {
         "tags": ["flow"],
         "summary": "Execute a Flow",
@@ -1857,7 +1857,7 @@
         }
       }
     },
-    "/api/flow-templates": {
+    "/flow-templates": {
       "get": {
         "tags": ["flow"],
         "summary": "List Flow Templates",
@@ -1881,7 +1881,7 @@
         }
       }
     },
-    "/api/flow-templates/{template_id}": {
+    "/flow-templates/{template_id}": {
       "get": {
         "tags": ["flow"],
         "summary": "Get Flow Template",
@@ -1922,7 +1922,7 @@
         }
       }
     },
-    "/api/flow/{name}/schedule": {
+    "/flow/{name}/schedule": {
       "post": {
         "tags": ["flow_schedule"],
         "summary": "Schedule a Flow execution (cron or one-time)",
@@ -1973,7 +1973,7 @@
         }
       }
     },
-    "/api/flow/{name}/schedules": {
+    "/flow/{name}/schedules": {
       "get": {
         "tags": ["flow_schedule"],
         "summary": "List schedules for a specific Flow",
@@ -2034,7 +2034,7 @@
         }
       }
     },
-    "/api/flow-schedules": {
+    "/flow-schedules": {
       "get": {
         "tags": ["flow_schedule"],
         "summary": "List all Flow schedules for current user",
@@ -2086,7 +2086,7 @@
         }
       }
     },
-    "/api/flow-schedule/{schedule_id}": {
+    "/flow-schedule/{schedule_id}": {
       "delete": {
         "tags": ["flow_schedule"],
         "summary": "Delete a Flow schedule",
@@ -2176,7 +2176,7 @@
         }
       }
     },
-    "/api/config": {
+    "/config": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Metrics Config",
@@ -2198,7 +2198,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/metrics": {
+    "/chip/{chip_id}/metrics": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Chip Metrics",
@@ -2275,7 +2275,7 @@
         }
       }
     },
-    "/api/chips": {
+    "/chips": {
       "get": {
         "tags": ["metrics"],
         "summary": "List Chips",
@@ -2326,7 +2326,7 @@
         }
       }
     },
-    "/api/chip/current": {
+    "/chip/current": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Current Chip",
@@ -2379,7 +2379,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/qubit/{qid}/metric-history": {
+    "/chip/{chip_id}/qubit/{qid}/metric-history": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Qubit Metric History",
@@ -2484,7 +2484,7 @@
         }
       }
     },
-    "/api/chip/{chip_id}/coupling/{coupling_id}/metric-history": {
+    "/chip/{chip_id}/coupling/{coupling_id}/metric-history": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Coupling Metric History",

--- a/src/qdash/api/main.py
+++ b/src/qdash/api/main.py
@@ -68,23 +68,23 @@ app.add_middleware(
     allow_headers=["*"],
 )
 # Auth router without global auth dependency (login/register/logout need to be public)
-app.include_router(auth.router, prefix="/api", tags=["auth"])
+app.include_router(auth.router, tags=["auth"])
 
 # Routers without auth (for direct browser access like images, file downloads)
 # These routers handle their own auth for write operations
-app.include_router(execution.router, prefix="/api", tags=["execution"])
-app.include_router(file.router, prefix="/api", tags=["file"])
+app.include_router(execution.router, tags=["execution"])
+app.include_router(file.router, tags=["file"])
 
 # All other routers with global auth dependency
 auth_dependency = [Depends(get_current_active_user)]
-app.include_router(calibration.router, prefix="/api", tags=["calibration"], dependencies=auth_dependency)
-app.include_router(settings.router, prefix="/api", tags=["settings"], dependencies=auth_dependency)
-app.include_router(chip.router, prefix="/api", tags=["chip"], dependencies=auth_dependency)
-app.include_router(task.router, prefix="/api", tags=["task"], dependencies=auth_dependency)
-app.include_router(parameter.router, prefix="/api", tags=["parameter"], dependencies=auth_dependency)
-app.include_router(tag.router, prefix="/api", tags=["tag"], dependencies=auth_dependency)
-app.include_router(device_topology.router, prefix="/api", tags=["device_topology"], dependencies=auth_dependency)
-app.include_router(backend.router, prefix="/api", tags=["backend"], dependencies=auth_dependency)
-app.include_router(flow.router, prefix="/api", tags=["flow"], dependencies=auth_dependency)
-app.include_router(flow_schedule.router, prefix="/api", tags=["flow_schedule"], dependencies=auth_dependency)
-app.include_router(metrics.router, prefix="/api", tags=["metrics"], dependencies=auth_dependency)
+app.include_router(calibration.router, tags=["calibration"], dependencies=auth_dependency)
+app.include_router(settings.router, tags=["settings"], dependencies=auth_dependency)
+app.include_router(chip.router, tags=["chip"], dependencies=auth_dependency)
+app.include_router(task.router, tags=["task"], dependencies=auth_dependency)
+app.include_router(parameter.router, tags=["parameter"], dependencies=auth_dependency)
+app.include_router(tag.router, tags=["tag"], dependencies=auth_dependency)
+app.include_router(device_topology.router, tags=["device_topology"], dependencies=auth_dependency)
+app.include_router(backend.router, tags=["backend"], dependencies=auth_dependency)
+app.include_router(flow.router, tags=["flow"], dependencies=auth_dependency)
+app.include_router(flow_schedule.router, tags=["flow_schedule"], dependencies=auth_dependency)
+app.include_router(metrics.router, tags=["metrics"], dependencies=auth_dependency)

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,15 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  rewrites: async () => {
-    return [
-      {
-        source: "/api/:path*",
-        destination:
-          (process.env.NEXT_PUBLIC_API_URL || "http://localhost:5715") +
-          "/api/:path*",
-      },
-    ];
-  },
   transpilePackages: ["react-plotly.js", "plotly.js"],
   images: {
     remotePatterns: [

--- a/ui/src/app/chip/[chipId]/qubit/[qubitsId]/components/TaskHistoryViewer.tsx
+++ b/ui/src/app/chip/[chipId]/qubit/[qubitsId]/components/TaskHistoryViewer.tsx
@@ -552,7 +552,7 @@ export function TaskHistoryViewer({
                           className="w-full h-full"
                           fullPath={`${
                             process.env.NEXT_PUBLIC_API_URL
-                          }/api/executions/figure?path=${encodeURIComponent(
+                          }/executions/figure?path=${encodeURIComponent(
                             selectedTask.json_figure_path?.[
                               expandedFigureIdx
                             ] || "",

--- a/ui/src/app/chip/components/CouplingTaskHistoryModal.tsx
+++ b/ui/src/app/chip/components/CouplingTaskHistoryModal.tsx
@@ -263,7 +263,7 @@ export function CouplingTaskHistoryModal({
                         className="w-full h-full"
                         fullPath={`${
                           process.env.NEXT_PUBLIC_API_URL
-                        }/api/executions/figure?path=${encodeURIComponent(
+                        }/executions/figure?path=${encodeURIComponent(
                           currentJsonFigure,
                         )}`}
                       />

--- a/ui/src/app/components/TaskFigure.tsx
+++ b/ui/src/app/components/TaskFigure.tsx
@@ -59,7 +59,7 @@ export function TaskFigure({
         {figurePaths.map((p, i) => (
           <img
             key={i}
-            src={`${apiUrl}/api/executions/figure?path=${encodeURIComponent(
+            src={`${apiUrl}/executions/figure?path=${encodeURIComponent(
               p,
             )}`}
             alt={`Result for QID ${qid}`}
@@ -73,7 +73,7 @@ export function TaskFigure({
   if (typeof figurePaths === "string") {
     return (
       <img
-        src={`${apiUrl}/api/executions/figure?path=${encodeURIComponent(figurePaths)}`}
+        src={`${apiUrl}/executions/figure?path=${encodeURIComponent(figurePaths)}`}
         alt={`Result for QID ${qid}`}
         className={className}
       />

--- a/ui/src/app/execution/[chip_id]/[execute_id]/client.tsx
+++ b/ui/src/app/execution/[chip_id]/[execute_id]/client.tsx
@@ -710,7 +710,7 @@ export default function ExecutionDetailClient({
                                           : `/${path}`;
                                         const apiUrl =
                                           process.env.NEXT_PUBLIC_API_URL;
-                                        link.href = `${apiUrl}/api/file/raw_data?path=${encodeURIComponent(
+                                        link.href = `${apiUrl}/file/raw_data?path=${encodeURIComponent(
                                           normalizedPath,
                                         )}`;
                                         const filename =

--- a/ui/src/app/setting/page.tsx
+++ b/ui/src/app/setting/page.tsx
@@ -61,7 +61,7 @@ export default function SettingsPage() {
 
   const handleCopyCurl = async () => {
     const token = accessToken || "<your-token>";
-    const curlCommand = `curl -H "Authorization: Bearer ${token}" ${apiUrl}/api/auth/me`;
+    const curlCommand = `curl -H "Authorization: Bearer ${token}" ${apiUrl}/auth/me`;
     await navigator.clipboard.writeText(curlCommand);
     setCopiedCurl(true);
     setTimeout(() => setCopiedCurl(false), 2000);
@@ -326,7 +326,7 @@ export default function SettingsPage() {
                           </code>
                         </pre>
                         <pre>
-                          <code> {apiUrl}/api/auth/me</code>
+                          <code> {apiUrl}/auth/me</code>
                         </pre>
                       </div>
                       <button

--- a/ui/src/client/auth/auth.ts
+++ b/ui/src/client/auth/auth.ts
@@ -51,7 +51,7 @@ export const authLogin = (
 
   return customInstance<TokenResponse>(
     {
-      url: `/api/auth/login`,
+      url: `/auth/login`,
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       data: formUrlEncoded,
@@ -143,7 +143,7 @@ export const authRegisterUser = (
 ) => {
   return customInstance<UserWithToken>(
     {
-      url: `/api/auth/register`,
+      url: `/auth/register`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: userCreate,
@@ -234,13 +234,13 @@ export const authReadUsersMe = (
   signal?: AbortSignal,
 ) => {
   return customInstance<User>(
-    { url: `/api/auth/me`, method: "GET", signal },
+    { url: `/auth/me`, method: "GET", signal },
     options,
   );
 };
 
 export const getAuthReadUsersMeQueryKey = () => {
-  return [`/api/auth/me`] as const;
+  return [`/auth/me`] as const;
 };
 
 export const getAuthReadUsersMeQueryOptions = <
@@ -382,7 +382,7 @@ export const authLogout = (
   signal?: AbortSignal,
 ) => {
   return customInstance<AuthLogout200>(
-    { url: `/api/auth/logout`, method: "POST", signal },
+    { url: `/auth/logout`, method: "POST", signal },
     options,
   );
 };

--- a/ui/src/client/backend/backend.ts
+++ b/ui/src/client/backend/backend.ts
@@ -34,13 +34,13 @@ export const fetchAllBackends = (
   signal?: AbortSignal,
 ) => {
   return customInstance<BackendResponseModel[]>(
-    { url: `/api/backend`, method: "GET", signal },
+    { url: `/backend`, method: "GET", signal },
     options,
   );
 };
 
 export const getFetchAllBackendsQueryKey = () => {
-  return [`/api/backend`] as const;
+  return [`/backend`] as const;
 };
 
 export const getFetchAllBackendsQueryOptions = <

--- a/ui/src/client/calibration/calibration.ts
+++ b/ui/src/client/calibration/calibration.ts
@@ -34,13 +34,13 @@ export const listCronSchedules = (
   signal?: AbortSignal,
 ) => {
   return customInstance<CalibrationNoteResponse>(
-    { url: `/api/calibration/note`, method: "GET", signal },
+    { url: `/calibration/note`, method: "GET", signal },
     options,
   );
 };
 
 export const getListCronSchedulesQueryKey = () => {
-  return [`/api/calibration/note`] as const;
+  return [`/calibration/note`] as const;
 };
 
 export const getListCronSchedulesQueryOptions = <

--- a/ui/src/client/chip/chip.ts
+++ b/ui/src/client/chip/chip.ts
@@ -62,13 +62,13 @@ export const listChips = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ChipResponse[]>(
-    { url: `/api/chip`, method: "GET", signal },
+    { url: `/chip`, method: "GET", signal },
     options,
   );
 };
 
 export const getListChipsQueryKey = () => {
-  return [`/api/chip`] as const;
+  return [`/chip`] as const;
 };
 
 export const getListChipsQueryOptions = <
@@ -210,7 +210,7 @@ export const createChip = (
 ) => {
   return customInstance<ChipResponse>(
     {
-      url: `/api/chip`,
+      url: `/chip`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: createChipRequest,
@@ -313,13 +313,13 @@ export const fetchChipDates = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ChipDatesResponse>(
-    { url: `/api/chip/${chipId}/dates`, method: "GET", signal },
+    { url: `/chip/${chipId}/dates`, method: "GET", signal },
     options,
   );
 };
 
 export const getFetchChipDatesQueryKey = (chipId?: string) => {
-  return [`/api/chip/${chipId}/dates`] as const;
+  return [`/chip/${chipId}/dates`] as const;
 };
 
 export const getFetchChipDatesQueryOptions = <
@@ -472,13 +472,13 @@ export const fetchChip = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ChipResponse>(
-    { url: `/api/chip/${chipId}`, method: "GET", signal },
+    { url: `/chip/${chipId}`, method: "GET", signal },
     options,
   );
 };
 
 export const getFetchChipQueryKey = (chipId?: string) => {
-  return [`/api/chip/${chipId}`] as const;
+  return [`/chip/${chipId}`] as const;
 };
 
 export const getFetchChipQueryOptions = <
@@ -629,7 +629,7 @@ export const listExecutionsByChipId = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ExecutionResponseSummary[]>(
-    { url: `/api/chip/${chipId}/execution`, method: "GET", params, signal },
+    { url: `/chip/${chipId}/execution`, method: "GET", params, signal },
     options,
   );
 };
@@ -638,10 +638,7 @@ export const getListExecutionsByChipIdQueryKey = (
   chipId?: string,
   params?: ListExecutionsByChipIdParams,
 ) => {
-  return [
-    `/api/chip/${chipId}/execution`,
-    ...(params ? [params] : []),
-  ] as const;
+  return [`/chip/${chipId}/execution`, ...(params ? [params] : [])] as const;
 };
 
 export const getListExecutionsByChipIdQueryOptions = <
@@ -823,11 +820,7 @@ export const fetchExecutionByChipId = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ExecutionResponseDetail>(
-    {
-      url: `/api/chip/${chipId}/execution/${executionId}`,
-      method: "GET",
-      signal,
-    },
+    { url: `/chip/${chipId}/execution/${executionId}`, method: "GET", signal },
     options,
   );
 };
@@ -836,7 +829,7 @@ export const getFetchExecutionByChipIdQueryKey = (
   chipId?: string,
   executionId?: string,
 ) => {
-  return [`/api/chip/${chipId}/execution/${executionId}`] as const;
+  return [`/chip/${chipId}/execution/${executionId}`] as const;
 };
 
 export const getFetchExecutionByChipIdQueryOptions = <
@@ -1019,13 +1012,13 @@ export const fetchMuxDetails = (
   signal?: AbortSignal,
 ) => {
   return customInstance<MuxDetailResponse>(
-    { url: `/api/chip/${chipId}/mux/${muxId}`, method: "GET", signal },
+    { url: `/chip/${chipId}/mux/${muxId}`, method: "GET", signal },
     options,
   );
 };
 
 export const getFetchMuxDetailsQueryKey = (chipId?: string, muxId?: number) => {
-  return [`/api/chip/${chipId}/mux/${muxId}`] as const;
+  return [`/chip/${chipId}/mux/${muxId}`] as const;
 };
 
 export const getFetchMuxDetailsQueryOptions = <
@@ -1199,13 +1192,13 @@ export const listMuxes = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ListMuxResponse>(
-    { url: `/api/chip/${chipId}/mux`, method: "GET", signal },
+    { url: `/chip/${chipId}/mux`, method: "GET", signal },
     options,
   );
 };
 
 export const getListMuxesQueryKey = (chipId?: string) => {
-  return [`/api/chip/${chipId}/mux`] as const;
+  return [`/chip/${chipId}/mux`] as const;
 };
 
 export const getListMuxesQueryOptions = <
@@ -1358,7 +1351,7 @@ export const fetchHistoricalQubitTaskGroupedByChip = (
 ) => {
   return customInstance<LatestTaskGroupedByChipResponse>(
     {
-      url: `/api/chip/${chipId}/task/qubit/${taskName}/history/${recordedDate}`,
+      url: `/chip/${chipId}/task/qubit/${taskName}/history/${recordedDate}`,
       method: "GET",
       signal,
     },
@@ -1372,7 +1365,7 @@ export const getFetchHistoricalQubitTaskGroupedByChipQueryKey = (
   recordedDate?: string,
 ) => {
   return [
-    `/api/chip/${chipId}/task/qubit/${taskName}/history/${recordedDate}`,
+    `/chip/${chipId}/task/qubit/${taskName}/history/${recordedDate}`,
   ] as const;
 };
 
@@ -1560,7 +1553,7 @@ export const fetchLatestQubitTaskGroupedByChip = (
 ) => {
   return customInstance<LatestTaskGroupedByChipResponse>(
     {
-      url: `/api/chip/${chipId}/task/qubit/${taskName}/latest`,
+      url: `/chip/${chipId}/task/qubit/${taskName}/latest`,
       method: "GET",
       signal,
     },
@@ -1572,7 +1565,7 @@ export const getFetchLatestQubitTaskGroupedByChipQueryKey = (
   chipId?: string,
   taskName?: string,
 ) => {
-  return [`/api/chip/${chipId}/task/qubit/${taskName}/latest`] as const;
+  return [`/chip/${chipId}/task/qubit/${taskName}/latest`] as const;
 };
 
 export const getFetchLatestQubitTaskGroupedByChipQueryOptions = <
@@ -1744,7 +1737,7 @@ export const fetchQubitTaskHistory = (
 ) => {
   return customInstance<TaskHistoryResponse>(
     {
-      url: `/api/chip/${chipId}/task/qubit/${qid}/task/${taskName}`,
+      url: `/chip/${chipId}/task/qubit/${qid}/task/${taskName}`,
       method: "GET",
       signal,
     },
@@ -1757,7 +1750,7 @@ export const getFetchQubitTaskHistoryQueryKey = (
   qid?: string,
   taskName?: string,
 ) => {
-  return [`/api/chip/${chipId}/task/qubit/${qid}/task/${taskName}`] as const;
+  return [`/chip/${chipId}/task/qubit/${qid}/task/${taskName}`] as const;
 };
 
 export const getFetchQubitTaskHistoryQueryOptions = <
@@ -1934,7 +1927,7 @@ export const fetchCouplingTaskHistory = (
 ) => {
   return customInstance<TaskHistoryResponse>(
     {
-      url: `/api/chip/${chipId}/task/coupling/${couplingId}/task/${taskName}`,
+      url: `/chip/${chipId}/task/coupling/${couplingId}/task/${taskName}`,
       method: "GET",
       signal,
     },
@@ -1948,7 +1941,7 @@ export const getFetchCouplingTaskHistoryQueryKey = (
   taskName?: string,
 ) => {
   return [
-    `/api/chip/${chipId}/task/coupling/${couplingId}/task/${taskName}`,
+    `/chip/${chipId}/task/coupling/${couplingId}/task/${taskName}`,
   ] as const;
 };
 
@@ -2148,7 +2141,7 @@ export const fetchHistoricalCouplingTaskGroupedByChip = (
 ) => {
   return customInstance<LatestTaskGroupedByChipResponse>(
     {
-      url: `/api/chip/${chipId}/task/coupling/${taskName}/history/${recordedDate}`,
+      url: `/chip/${chipId}/task/coupling/${taskName}/history/${recordedDate}`,
       method: "GET",
       signal,
     },
@@ -2162,7 +2155,7 @@ export const getFetchHistoricalCouplingTaskGroupedByChipQueryKey = (
   recordedDate?: string,
 ) => {
   return [
-    `/api/chip/${chipId}/task/coupling/${taskName}/history/${recordedDate}`,
+    `/chip/${chipId}/task/coupling/${taskName}/history/${recordedDate}`,
   ] as const;
 };
 
@@ -2350,7 +2343,7 @@ export const fetchLatestCouplingTaskGroupedByChip = (
 ) => {
   return customInstance<LatestTaskGroupedByChipResponse>(
     {
-      url: `/api/chip/${chipId}/task/coupling/${taskName}/latest`,
+      url: `/chip/${chipId}/task/coupling/${taskName}/latest`,
       method: "GET",
       signal,
     },
@@ -2362,7 +2355,7 @@ export const getFetchLatestCouplingTaskGroupedByChipQueryKey = (
   chipId?: string,
   taskName?: string,
 ) => {
-  return [`/api/chip/${chipId}/task/coupling/${taskName}/latest`] as const;
+  return [`/chip/${chipId}/task/coupling/${taskName}/latest`] as const;
 };
 
 export const getFetchLatestCouplingTaskGroupedByChipQueryOptions = <
@@ -2544,7 +2537,7 @@ export const fetchTimeseriesTaskResultByTagAndParameterAndQid = (
 ) => {
   return customInstance<TimeSeriesData>(
     {
-      url: `/api/chip/${chipId}/parameter/${parameter}/qid/${qid}`,
+      url: `/chip/${chipId}/parameter/${parameter}/qid/${qid}`,
       method: "GET",
       params,
       signal,
@@ -2560,7 +2553,7 @@ export const getFetchTimeseriesTaskResultByTagAndParameterAndQidQueryKey = (
   params?: FetchTimeseriesTaskResultByTagAndParameterAndQidParams,
 ) => {
   return [
-    `/api/chip/${chipId}/parameter/${parameter}/qid/${qid}`,
+    `/chip/${chipId}/parameter/${parameter}/qid/${qid}`,
     ...(params ? [params] : []),
   ] as const;
 };
@@ -2794,7 +2787,7 @@ export const fetchTimeseriesTaskResultByTagAndParameter = (
 ) => {
   return customInstance<TimeSeriesData>(
     {
-      url: `/api/chip/${chipId}/parameter/${parameter}`,
+      url: `/chip/${chipId}/parameter/${parameter}`,
       method: "GET",
       params,
       signal,
@@ -2809,7 +2802,7 @@ export const getFetchTimeseriesTaskResultByTagAndParameterQueryKey = (
   params?: FetchTimeseriesTaskResultByTagAndParameterParams,
 ) => {
   return [
-    `/api/chip/${chipId}/parameter/${parameter}`,
+    `/chip/${chipId}/parameter/${parameter}`,
     ...(params ? [params] : []),
   ] as const;
 };

--- a/ui/src/client/device-topology/device-topology.ts
+++ b/ui/src/client/device-topology/device-topology.ts
@@ -35,7 +35,7 @@ export const getDeviceTopology = (
 ) => {
   return customInstance<Device>(
     {
-      url: `/api/device_topology`,
+      url: `/device_topology`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: deviceTopologyRequest,
@@ -127,7 +127,7 @@ export const getDeviceTopologyPlot = (
 ) => {
   return customInstance<void>(
     {
-      url: `/api/device_topology/plot`,
+      url: `/device_topology/plot`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: device,

--- a/ui/src/client/execution/execution.ts
+++ b/ui/src/client/execution/execution.ts
@@ -40,7 +40,7 @@ export const fetchFigureByPath = (
   signal?: AbortSignal,
 ) => {
   return customInstance<void>(
-    { url: `/api/executions/figure`, method: "GET", params, signal },
+    { url: `/executions/figure`, method: "GET", params, signal },
     options,
   );
 };
@@ -48,7 +48,7 @@ export const fetchFigureByPath = (
 export const getFetchFigureByPathQueryKey = (
   params?: FetchFigureByPathParams,
 ) => {
-  return [`/api/executions/figure`, ...(params ? [params] : [])] as const;
+  return [`/executions/figure`, ...(params ? [params] : [])] as const;
 };
 
 export const getFetchFigureByPathQueryOptions = <
@@ -201,13 +201,13 @@ export const fetchExecutionLockStatus = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ExecutionLockStatusResponse>(
-    { url: `/api/executions/lock_status`, method: "GET", signal },
+    { url: `/executions/lock_status`, method: "GET", signal },
     options,
   );
 };
 
 export const getFetchExecutionLockStatusQueryKey = () => {
-  return [`/api/executions/lock_status`] as const;
+  return [`/executions/lock_status`] as const;
 };
 
 export const getFetchExecutionLockStatusQueryOptions = <

--- a/ui/src/client/file/file.ts
+++ b/ui/src/client/file/file.ts
@@ -53,13 +53,13 @@ export const downloadFile = (
   signal?: AbortSignal,
 ) => {
   return customInstance<void>(
-    { url: `/api/file/raw_data`, method: "GET", params, signal },
+    { url: `/file/raw_data`, method: "GET", params, signal },
     options,
   );
 };
 
 export const getDownloadFileQueryKey = (params?: DownloadFileParams) => {
-  return [`/api/file/raw_data`, ...(params ? [params] : [])] as const;
+  return [`/file/raw_data`, ...(params ? [params] : [])] as const;
 };
 
 export const getDownloadFileQueryOptions = <
@@ -190,13 +190,13 @@ export const downloadZipFile = (
   signal?: AbortSignal,
 ) => {
   return customInstance<void>(
-    { url: `/api/file/zip`, method: "GET", params, signal },
+    { url: `/file/zip`, method: "GET", params, signal },
     options,
   );
 };
 
 export const getDownloadZipFileQueryKey = (params?: DownloadZipFileParams) => {
-  return [`/api/file/zip`, ...(params ? [params] : [])] as const;
+  return [`/file/zip`, ...(params ? [params] : [])] as const;
 };
 
 export const getDownloadZipFileQueryOptions = <
@@ -350,13 +350,13 @@ export const getFileTree = (
   signal?: AbortSignal,
 ) => {
   return customInstance<FileTreeNode[]>(
-    { url: `/api/file/tree`, method: "GET", signal },
+    { url: `/file/tree`, method: "GET", signal },
     options,
   );
 };
 
 export const getGetFileTreeQueryKey = () => {
-  return [`/api/file/tree`] as const;
+  return [`/file/tree`] as const;
 };
 
 export const getGetFileTreeQueryOptions = <
@@ -488,13 +488,13 @@ export const getFileContent = (
   signal?: AbortSignal,
 ) => {
   return customInstance<GetFileContent200>(
-    { url: `/api/file/content`, method: "GET", params, signal },
+    { url: `/file/content`, method: "GET", params, signal },
     options,
   );
 };
 
 export const getGetFileContentQueryKey = (params?: GetFileContentParams) => {
-  return [`/api/file/content`, ...(params ? [params] : [])] as const;
+  return [`/file/content`, ...(params ? [params] : [])] as const;
 };
 
 export const getGetFileContentQueryOptions = <
@@ -633,7 +633,7 @@ export const saveFileContent = (
 ) => {
   return customInstance<SaveFileContent200>(
     {
-      url: `/api/file/content`,
+      url: `/file/content`,
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       data: saveFileRequest,
@@ -732,7 +732,7 @@ export const validateFileContent = (
 ) => {
   return customInstance<ValidateFileContent200>(
     {
-      url: `/api/file/validate`,
+      url: `/file/validate`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: validateFileRequest,
@@ -826,13 +826,13 @@ export const getGitStatus = (
   signal?: AbortSignal,
 ) => {
   return customInstance<GetGitStatus200>(
-    { url: `/api/file/git/status`, method: "GET", signal },
+    { url: `/file/git/status`, method: "GET", signal },
     options,
   );
 };
 
 export const getGetGitStatusQueryKey = () => {
-  return [`/api/file/git/status`] as const;
+  return [`/file/git/status`] as const;
 };
 
 export const getGetGitStatusQueryOptions = <
@@ -959,7 +959,7 @@ export const gitPullConfig = (
   signal?: AbortSignal,
 ) => {
   return customInstance<GitPullConfig200>(
-    { url: `/api/file/git/pull`, method: "POST", signal },
+    { url: `/file/git/pull`, method: "POST", signal },
     options,
   );
 };
@@ -1052,7 +1052,7 @@ export const gitPushConfig = (
 ) => {
   return customInstance<GitPushConfig200>(
     {
-      url: `/api/file/git/push`,
+      url: `/file/git/push`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: gitPushRequest,

--- a/ui/src/client/flow-schedule/flow-schedule.ts
+++ b/ui/src/client/flow-schedule/flow-schedule.ts
@@ -60,7 +60,7 @@ export const scheduleFlow = (
 ) => {
   return customInstance<ScheduleFlowResponse>(
     {
-      url: `/api/flow/${name}/schedule`,
+      url: `/flow/${name}/schedule`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: scheduleFlowRequest,
@@ -163,7 +163,7 @@ export const listFlowSchedules = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ListFlowSchedulesResponse>(
-    { url: `/api/flow/${name}/schedules`, method: "GET", params, signal },
+    { url: `/flow/${name}/schedules`, method: "GET", params, signal },
     options,
   );
 };
@@ -172,7 +172,7 @@ export const getListFlowSchedulesQueryKey = (
   name?: string,
   params?: ListFlowSchedulesParams,
 ) => {
-  return [`/api/flow/${name}/schedules`, ...(params ? [params] : [])] as const;
+  return [`/flow/${name}/schedules`, ...(params ? [params] : [])] as const;
 };
 
 export const getListFlowSchedulesQueryOptions = <
@@ -344,7 +344,7 @@ export const listAllFlowSchedules = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ListFlowSchedulesResponse>(
-    { url: `/api/flow-schedules`, method: "GET", params, signal },
+    { url: `/flow-schedules`, method: "GET", params, signal },
     options,
   );
 };
@@ -352,7 +352,7 @@ export const listAllFlowSchedules = (
 export const getListAllFlowSchedulesQueryKey = (
   params?: ListAllFlowSchedulesParams,
 ) => {
-  return [`/api/flow-schedules`, ...(params ? [params] : [])] as const;
+  return [`/flow-schedules`, ...(params ? [params] : [])] as const;
 };
 
 export const getListAllFlowSchedulesQueryOptions = <
@@ -520,7 +520,7 @@ export const deleteFlowSchedule = (
   options?: SecondParameter<typeof customInstance>,
 ) => {
   return customInstance<DeleteScheduleResponse>(
-    { url: `/api/flow-schedule/${scheduleId}`, method: "DELETE" },
+    { url: `/flow-schedule/${scheduleId}`, method: "DELETE" },
     options,
   );
 };
@@ -619,7 +619,7 @@ export const updateFlowSchedule = (
 ) => {
   return customInstance<UpdateScheduleResponse>(
     {
-      url: `/api/flow-schedule/${scheduleId}`,
+      url: `/flow-schedule/${scheduleId}`,
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       data: updateScheduleRequest,

--- a/ui/src/client/flow/flow.ts
+++ b/ui/src/client/flow/flow.ts
@@ -50,13 +50,13 @@ export const listFlows = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ListFlowsResponse>(
-    { url: `/api/flow`, method: "GET", signal },
+    { url: `/flow`, method: "GET", signal },
     options,
   );
 };
 
 export const getListFlowsQueryKey = () => {
-  return [`/api/flow`] as const;
+  return [`/flow`] as const;
 };
 
 export const getListFlowsQueryOptions = <
@@ -189,7 +189,7 @@ export const saveFlow = (
 ) => {
   return customInstance<SaveFlowResponse>(
     {
-      url: `/api/flow`,
+      url: `/flow`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: saveFlowRequest,
@@ -285,13 +285,13 @@ export const getFlow = (
   signal?: AbortSignal,
 ) => {
   return customInstance<GetFlowResponse>(
-    { url: `/api/flow/${name}`, method: "GET", signal },
+    { url: `/flow/${name}`, method: "GET", signal },
     options,
   );
 };
 
 export const getGetFlowQueryKey = (name?: string) => {
-  return [`/api/flow/${name}`] as const;
+  return [`/flow/${name}`] as const;
 };
 
 export const getGetFlowQueryOptions = <
@@ -428,7 +428,7 @@ export const deleteFlow = (
   options?: SecondParameter<typeof customInstance>,
 ) => {
   return customInstance<DeleteFlow200>(
-    { url: `/api/flow/${name}`, method: "DELETE" },
+    { url: `/flow/${name}`, method: "DELETE" },
     options,
   );
 };
@@ -522,7 +522,7 @@ export const executeFlow = (
 ) => {
   return customInstance<ExecuteFlowResponse>(
     {
-      url: `/api/flow/${name}/execute`,
+      url: `/flow/${name}/execute`,
       method: "POST",
       headers: { "Content-Type": "application/json" },
       data: executeFlowRequest,
@@ -614,13 +614,13 @@ export const listFlowTemplates = (
   signal?: AbortSignal,
 ) => {
   return customInstance<FlowTemplate[]>(
-    { url: `/api/flow-templates`, method: "GET", signal },
+    { url: `/flow-templates`, method: "GET", signal },
     options,
   );
 };
 
 export const getListFlowTemplatesQueryKey = () => {
-  return [`/api/flow-templates`] as const;
+  return [`/flow-templates`] as const;
 };
 
 export const getListFlowTemplatesQueryOptions = <
@@ -769,13 +769,13 @@ export const getFlowTemplate = (
   signal?: AbortSignal,
 ) => {
   return customInstance<FlowTemplateWithCode>(
-    { url: `/api/flow-templates/${templateId}`, method: "GET", signal },
+    { url: `/flow-templates/${templateId}`, method: "GET", signal },
     options,
   );
 };
 
 export const getGetFlowTemplateQueryKey = (templateId?: string) => {
-  return [`/api/flow-templates/${templateId}`] as const;
+  return [`/flow-templates/${templateId}`] as const;
 };
 
 export const getGetFlowTemplateQueryOptions = <

--- a/ui/src/client/metrics/metrics.ts
+++ b/ui/src/client/metrics/metrics.ts
@@ -56,13 +56,13 @@ export const metricsGetMetricsConfig = (
   signal?: AbortSignal,
 ) => {
   return customInstance<MetricsGetMetricsConfig200>(
-    { url: `/api/config`, method: "GET", signal },
+    { url: `/config`, method: "GET", signal },
     options,
   );
 };
 
 export const getMetricsGetMetricsConfigQueryKey = () => {
-  return [`/api/config`] as const;
+  return [`/config`] as const;
 };
 
 export const getMetricsGetMetricsConfigQueryOptions = <
@@ -224,7 +224,7 @@ export const metricsGetChipMetrics = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ChipMetricsResponse>(
-    { url: `/api/chip/${chipId}/metrics`, method: "GET", params, signal },
+    { url: `/chip/${chipId}/metrics`, method: "GET", params, signal },
     options,
   );
 };
@@ -233,7 +233,7 @@ export const getMetricsGetChipMetricsQueryKey = (
   chipId?: string,
   params?: MetricsGetChipMetricsParams,
 ) => {
-  return [`/api/chip/${chipId}/metrics`, ...(params ? [params] : [])] as const;
+  return [`/chip/${chipId}/metrics`, ...(params ? [params] : [])] as const;
 };
 
 export const getMetricsGetChipMetricsQueryOptions = <
@@ -409,7 +409,7 @@ export const metricsListChips = (
   signal?: AbortSignal,
 ) => {
   return customInstance<MetricsListChips200>(
-    { url: `/api/chips`, method: "GET", params, signal },
+    { url: `/chips`, method: "GET", params, signal },
     options,
   );
 };
@@ -417,7 +417,7 @@ export const metricsListChips = (
 export const getMetricsListChipsQueryKey = (
   params?: MetricsListChipsParams,
 ) => {
-  return [`/api/chips`, ...(params ? [params] : [])] as const;
+  return [`/chips`, ...(params ? [params] : [])] as const;
 };
 
 export const getMetricsListChipsQueryOptions = <
@@ -578,7 +578,7 @@ export const metricsGetCurrentChip = (
   signal?: AbortSignal,
 ) => {
   return customInstance<MetricsGetCurrentChip200>(
-    { url: `/api/chip/current`, method: "GET", params, signal },
+    { url: `/chip/current`, method: "GET", params, signal },
     options,
   );
 };
@@ -586,7 +586,7 @@ export const metricsGetCurrentChip = (
 export const getMetricsGetCurrentChipQueryKey = (
   params?: MetricsGetCurrentChipParams,
 ) => {
-  return [`/api/chip/current`, ...(params ? [params] : [])] as const;
+  return [`/chip/current`, ...(params ? [params] : [])] as const;
 };
 
 export const getMetricsGetCurrentChipQueryOptions = <
@@ -758,7 +758,7 @@ export const metricsGetQubitMetricHistory = (
 ) => {
   return customInstance<QubitMetricHistoryResponse>(
     {
-      url: `/api/chip/${chipId}/qubit/${qid}/metric-history`,
+      url: `/chip/${chipId}/qubit/${qid}/metric-history`,
       method: "GET",
       params,
       signal,
@@ -773,7 +773,7 @@ export const getMetricsGetQubitMetricHistoryQueryKey = (
   params?: MetricsGetQubitMetricHistoryParams,
 ) => {
   return [
-    `/api/chip/${chipId}/qubit/${qid}/metric-history`,
+    `/chip/${chipId}/qubit/${qid}/metric-history`,
     ...(params ? [params] : []),
   ] as const;
 };
@@ -971,7 +971,7 @@ export const metricsGetCouplingMetricHistory = (
 ) => {
   return customInstance<QubitMetricHistoryResponse>(
     {
-      url: `/api/chip/${chipId}/coupling/${couplingId}/metric-history`,
+      url: `/chip/${chipId}/coupling/${couplingId}/metric-history`,
       method: "GET",
       params,
       signal,
@@ -986,7 +986,7 @@ export const getMetricsGetCouplingMetricHistoryQueryKey = (
   params?: MetricsGetCouplingMetricHistoryParams,
 ) => {
   return [
-    `/api/chip/${chipId}/coupling/${couplingId}/metric-history`,
+    `/chip/${chipId}/coupling/${couplingId}/metric-history`,
     ...(params ? [params] : []),
   ] as const;
 };

--- a/ui/src/client/parameter/parameter.ts
+++ b/ui/src/client/parameter/parameter.ts
@@ -41,13 +41,13 @@ export const fetchAllParameters = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ListParameterResponse>(
-    { url: `/api/parameter`, method: "GET", signal },
+    { url: `/parameter`, method: "GET", signal },
     options,
   );
 };
 
 export const getFetchAllParametersQueryKey = () => {
-  return [`/api/parameter`] as const;
+  return [`/parameter`] as const;
 };
 
 export const getFetchAllParametersQueryOptions = <

--- a/ui/src/client/settings/settings.ts
+++ b/ui/src/client/settings/settings.ts
@@ -34,13 +34,13 @@ export const fetchConfig = (
   signal?: AbortSignal,
 ) => {
   return customInstance<Settings>(
-    { url: `/api/settings`, method: "GET", signal },
+    { url: `/settings`, method: "GET", signal },
     options,
   );
 };
 
 export const getFetchConfigQueryKey = () => {
-  return [`/api/settings`] as const;
+  return [`/settings`] as const;
 };
 
 export const getFetchConfigQueryOptions = <

--- a/ui/src/client/tag/tag.ts
+++ b/ui/src/client/tag/tag.ts
@@ -42,13 +42,13 @@ export const listAllTag = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ListTagResponse>(
-    { url: `/api/tag`, method: "GET", signal },
+    { url: `/tag`, method: "GET", signal },
     options,
   );
 };
 
 export const getListAllTagQueryKey = () => {
-  return [`/api/tag`] as const;
+  return [`/tag`] as const;
 };
 
 export const getListAllTagQueryOptions = <

--- a/ui/src/client/task/task.ts
+++ b/ui/src/client/task/task.ts
@@ -49,13 +49,13 @@ export const fetchAllTasks = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ListTaskResponse>(
-    { url: `/api/tasks`, method: "GET", params, signal },
+    { url: `/tasks`, method: "GET", params, signal },
     options,
   );
 };
 
 export const getFetchAllTasksQueryKey = (params?: FetchAllTasksParams) => {
-  return [`/api/tasks`, ...(params ? [params] : [])] as const;
+  return [`/tasks`, ...(params ? [params] : [])] as const;
 };
 
 export const getFetchAllTasksQueryOptions = <
@@ -195,13 +195,13 @@ export const getTaskResultByTaskId = (
   signal?: AbortSignal,
 ) => {
   return customInstance<TaskResultResponse>(
-    { url: `/api/task/${taskId}`, method: "GET", signal },
+    { url: `/task/${taskId}`, method: "GET", signal },
     options,
   );
 };
 
 export const getGetTaskResultByTaskIdQueryKey = (taskId?: string) => {
-  return [`/api/task/${taskId}`] as const;
+  return [`/task/${taskId}`] as const;
 };
 
 export const getGetTaskResultByTaskIdQueryOptions = <

--- a/ui/src/lib/custom-instance.ts
+++ b/ui/src/lib/custom-instance.ts
@@ -2,7 +2,9 @@ import Axios, { AxiosHeaders } from "axios";
 
 import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 
-export const AXIOS_INSTANCE = Axios.create();
+export const AXIOS_INSTANCE = Axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || "http://localhost:5715",
+});
 
 // リクエストインターセプターを追加
 AXIOS_INSTANCE.interceptors.request.use((config) => {

--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -5,14 +5,8 @@ export function middleware(request: NextRequest) {
   const token = request.cookies.get("access_token");
   const isLoginPage = request.nextUrl.pathname === "/login";
   const isSignupPage = request.nextUrl.pathname === "/signup";
-  const isApiRequest = request.nextUrl.pathname.startsWith("/api/");
 
-  // 1. APIリクエストはスキップ
-  if (isApiRequest) {
-    return NextResponse.next();
-  }
-
-  // 2. 認証不要なページの処理
+  // 1. 認証不要なページの処理
   if (isLoginPage || isSignupPage) {
     // ログインページで認証済みの場合はexecutionにリダイレクト
     if (isLoginPage && token) {
@@ -21,7 +15,7 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 3. その他のページは認証が必要
+  // 2. その他のページは認証が必要
   if (!token) {
     return NextResponse.redirect(new URL("/login", request.url));
   }
@@ -32,11 +26,10 @@ export function middleware(request: NextRequest) {
 // 認証が必要なパスを指定
 export const config = {
   matcher: [
-    /*
+/*
      * 以下のパスに対してミドルウェアを適用:
      * - すべてのパス（/:path*）
      * - ルートパス（/）
-     * - /api/* (APIリクエストをスキップするため)
      */
     "/((?!_next/static|favicon.ico).*)",
   ],

--- a/ui/src/shared/components/InteractiveFigureContent.tsx
+++ b/ui/src/shared/components/InteractiveFigureContent.tsx
@@ -35,7 +35,7 @@ export function InteractiveFigureContent({
         <PlotlyRenderer
           fullPath={`${
             process.env.NEXT_PUBLIC_API_URL
-          }/api/executions/figure?path=${encodeURIComponent(figureJsonPath)}`}
+          }/executions/figure?path=${encodeURIComponent(figureJsonPath)}`}
         />
       </div>
       {showNavigation && (


### PR DESCRIPTION
Remove the /api prefix from all API endpoint paths across the OpenAPI
specification and generated client code. This simplifies the routing
structure by changing endpoints like /api/auth/login to /auth/login,
/api/flow to /flow, etc.
