### PR TITLE
docs(api): add HTTPBearer security to API endpoints in OpenAPI spec

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -121,7 +121,12 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/auth/logout": {
@@ -354,6 +359,11 @@
         "summary": "Save file content",
         "description": "Save file content.\n\nArgs:\n----\n    request: Save file request with path and content\n\nReturns:\n-------\n    Success message",
         "operationId": "saveFileContent",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -475,7 +485,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/file/git/push": {
@@ -517,7 +532,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/calibration/note": {
@@ -537,7 +557,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/settings": {
@@ -557,7 +582,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/chip": {
@@ -624,7 +654,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/chip/{chip_id}/dates": {
@@ -633,6 +668,11 @@
         "summary": "Fetch available dates for a chip",
         "description": "Fetch available dates for a chip from execution counter.\n\nParameters\n----------\nchip_id : str\n    ID of the chip\ncurrent_user : User\n    Current authenticated user\n\nReturns\n-------\nlist[str]\n    List of available dates in ISO format",
         "operationId": "fetchChipDates",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -674,6 +714,11 @@
         "summary": "Fetch a chip",
         "description": "Fetch a chip by its ID.\n\nParameters\n----------\nchip_id : str\n    ID of the chip to fetch\ncurrent_user : User\n    Current authenticated user\n\nReturns\n-------\nChipResponse\n    Chip information\n\nRaises\n------\nHTTPException\n    If chip is not found",
         "operationId": "fetchChip",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -715,6 +760,11 @@
         "summary": "Fetch executions",
         "description": "Fetch executions for a given chip with pagination.\n\nParameters\n----------\nchip_id : str\n    ID of the chip to fetch executions for\ncurrent_user : str\n    Current user ID from authentication\nskip : int\n    Number of items to skip (default: 0)\nlimit : int\n    Number of items to return (default: 20, max: 100)\n\nReturns\n-------\nlist[ExecutionResponseSummary]\n    List of executions for the chip",
         "operationId": "listExecutionsByChipId",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -787,6 +837,11 @@
         "summary": "Fetch an execution by its ID",
         "description": "Return the execution detail by its ID.\n\nParameters\n----------\nchip_id : str\n    ID of the chip\nexecution_id : str\n    ID of the execution to fetch\ncurrent_user : User\n    Current authenticated user\n\nReturns\n-------\nExecutionResponseDetail\n    Detailed execution information",
         "operationId": "fetchExecutionByChipId",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -837,6 +892,11 @@
         "summary": "Fetch the multiplexer details",
         "description": "Fetch the multiplexer details.\n\nParameters\n----------\nchip_id : str\n    ID of the chip\nmux_id : int\n    ID of the multiplexer\ncurrent_user : User\n    Current authenticated user\n\nReturns\n-------\nMuxDetailResponse\n    Multiplexer details",
         "operationId": "fetchMuxDetails",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -887,6 +947,11 @@
         "summary": "Fetch the multiplexers",
         "description": "Fetch the multiplexers.\n\nParameters\n----------\nchip_id : str\n    ID of the chip\ncurrent_user : User\n    Current authenticated user\n\nReturns\n-------\nListMuxResponse\n    Multiplexdetails",
         "operationId": "listMuxes",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -928,6 +993,11 @@
         "summary": "Fetch historical task results",
         "description": "Fetch historical task results for a specific date.\n\nParameters\n----------\nchip_id : str\n    ID of the chip\ntask_name : str\n    Name of the task to fetch\nrecorded_date : str\n    Date to fetch history for (ISO format YYYY-MM-DD)\ncurrent_user : User\n    Current authenticated user\n\nReturns\n-------\nLatestTaskGroupedByChipResponse\n    Historical task results for all qubits on the specified date",
         "operationId": "fetchHistoricalQubitTaskGroupedByChip",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -987,6 +1057,11 @@
         "summary": "Fetch latest qubit task results with optional outlier filtering",
         "description": "Fetch latest qubit task results with optional defensive outlier filtering.",
         "operationId": "fetchLatestQubitTaskGroupedByChip",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -1165,6 +1240,11 @@
         "summary": "Fetch historical task results",
         "description": "Fetch historical task results for a specific date.\n\nParameters\n----------\nchip_id : str\n    ID of the chip\ntask_name : str\n    Name of the task to fetch\nrecorded_date : str\n    Date to fetch history for (ISO format YYYY-MM-DD)\ncurrent_user : User\n    Current authenticated user\n\nReturns\n-------\nLatestTaskGroupedByChipResponse\n    Historical task results for all qubits on the specified date",
         "operationId": "fetchHistoricalCouplingTaskGroupedByChip",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -1224,6 +1304,11 @@
         "summary": "Fetch the multiplexers",
         "description": "Fetch the multiplexers.",
         "operationId": "fetchLatestCouplingTaskGroupedByChip",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -1274,6 +1359,11 @@
         "summary": "Fetch the timeseries task result by tag and parameter for a specific qid",
         "description": "Fetch the timeseries task result by tag and parameter for a specific qid.\n\nReturns\n-------\n    TimeSeriesData: Time series data for the specified qid.",
         "operationId": "fetchTimeseriesTaskResultByTagAndParameterAndQid",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -1360,6 +1450,11 @@
         "summary": "Fetch the timeseries task result by tag and parameter for all qids",
         "description": "Fetch the timeseries task result by tag and parameter for all qids.\n\nReturns\n-------\n    TimeSeriesData: Time series data for all qids.",
         "operationId": "fetchTimeseriesTaskResultByTagAndParameter",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "chip_id",
@@ -1437,6 +1532,11 @@
         "summary": "Fetch all tasks",
         "description": "Fetch all tasks.\n\nArgs:\n----\n    current_user (User): The current user.\n    backend (Optional[str]): Optional backend name to filter tasks by.\n\nReturns:\n-------\n    list[TaskResponse]: The list of tasks.",
         "operationId": "fetch_all_tasks",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "backend",
@@ -1487,6 +1587,11 @@
         "summary": "Get task result by task ID",
         "description": "Get task result by task_id.\n\nArgs:\n----\n    task_id: The task ID to search for.\n    current_user: The current authenticated user.\n\nReturns:\n-------\n    TaskResultResponse: The task result information including figure paths.",
         "operationId": "get_task_result_by_task_id",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "task_id",
@@ -1539,7 +1644,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/tag": {
@@ -1559,7 +1669,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/device_topology": {
@@ -1599,7 +1714,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/device_topology/plot": {
@@ -1632,7 +1752,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/backend": {
@@ -1681,7 +1806,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       },
       "post": {
         "tags": ["flow"],
@@ -1719,7 +1849,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/flow/{name}": {
@@ -1728,6 +1863,11 @@
         "summary": "Get Flow details",
         "description": "Get Flow details including code content.\n\nSteps:\n1. Find metadata in MongoDB\n2. Read code from file\n3. Return combined data",
         "operationId": "get_flow",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "name",
@@ -1767,6 +1907,11 @@
         "summary": "Delete a Flow",
         "description": "Delete a Flow.\n\nSteps:\n1. Delete file from user_flows/{username}/{name}.py\n2. Delete metadata from MongoDB",
         "operationId": "delete_flow",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "name",
@@ -1812,6 +1957,11 @@
         "summary": "Execute a Flow",
         "description": "Execute a Flow via Prefect deployment.\n\nSteps:\n1. Find flow metadata in MongoDB\n2. Merge request parameters with default_parameters\n3. Create flow run via Prefect Client\n4. Return execution_id and URLs",
         "operationId": "execute_flow",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "name",
@@ -1878,7 +2028,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
     "/flow-templates/{template_id}": {
@@ -1887,6 +2042,11 @@
         "summary": "Get Flow Template",
         "description": "Get flow template details including code content.\n\nSteps:\n1. Find template metadata\n2. Read Python file content\n3. Return combined data",
         "operationId": "get_flow_template",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "template_id",
@@ -1928,6 +2088,11 @@
         "summary": "Schedule a Flow execution (cron or one-time)",
         "description": "Schedule a Flow execution with cron or one-time schedule.\n\nArgs:\n----\n    name: Flow name\n    request: Schedule request (must provide either cron or scheduled_time)\n    current_user: Current authenticated user\n\nReturns:\n-------\n    Schedule response with schedule_id and details",
         "operationId": "schedule_flow",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "name",
@@ -1979,6 +2144,11 @@
         "summary": "List schedules for a specific Flow",
         "description": "List all schedules (cron and one-time) for a specific Flow.\n\nArgs:\n----\n    name: Flow name\n    current_user: Current authenticated user\n    limit: Maximum number of schedules to return (max 100)\n    offset: Number of schedules to skip\n\nReturns:\n-------\n    List of schedules for the flow",
         "operationId": "list_flow_schedules",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "name",
@@ -2040,6 +2210,11 @@
         "summary": "List all Flow schedules for current user",
         "description": "List all Flow schedules (cron and one-time) for the current user.\n\nArgs:\n----\n    current_user: Current authenticated user\n    limit: Maximum number of schedules to return (max 100)\n    offset: Number of schedules to skip\n\nReturns:\n-------\n    List of all flow schedules",
         "operationId": "list_all_flow_schedules",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -2092,6 +2267,11 @@
         "summary": "Delete a Flow schedule",
         "description": "Delete a Flow schedule (cron or one-time).\n\nSchedule ID Types:\n- **Cron schedules**: schedule_id is the deployment_id (UUID format)\n- **One-time schedules**: schedule_id is the flow_run_id (UUID format)\n\nThe API automatically determines the type and handles accordingly:\n- Cron: Removes the schedule from the deployment (schedule=None)\n- One-time: Deletes the scheduled flow run\n\nArgs:\n----\n    schedule_id: Schedule ID (deployment_id for cron, flow_run_id for one-time)\n    current_user: Current authenticated user\n\nReturns:\n-------\n    Standardized response with schedule type information",
         "operationId": "delete_flow_schedule",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "schedule_id",
@@ -2131,6 +2311,11 @@
         "summary": "Update a Flow schedule",
         "description": "Update a Flow schedule (cron schedules only).\n\nCan update: active status, cron expression, parameters.\n\nArgs:\n----\n    schedule_id: Schedule ID (deployment_id)\n    request: Update request\n    current_user: Current authenticated user\n\nReturns:\n-------\n    Success message",
         "operationId": "update_flow_schedule",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "parameters": [
           {
             "name": "schedule_id",
@@ -2176,7 +2361,7 @@
         }
       }
     },
-    "/config": {
+    "/metrics/config": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Metrics Config",
@@ -2195,10 +2380,15 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
       }
     },
-    "/chip/{chip_id}/metrics": {
+    "/metrics/chip/{chip_id}/metrics": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Chip Metrics",
@@ -2275,7 +2465,7 @@
         }
       }
     },
-    "/chips": {
+    "/metrics/chips": {
       "get": {
         "tags": ["metrics"],
         "summary": "List Chips",
@@ -2326,7 +2516,7 @@
         }
       }
     },
-    "/chip/current": {
+    "/metrics/chip/current": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Current Chip",
@@ -2379,7 +2569,7 @@
         }
       }
     },
-    "/chip/{chip_id}/qubit/{qid}/metric-history": {
+    "/metrics/chip/{chip_id}/qubit/{qid}/metric-history": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Qubit Metric History",
@@ -2484,7 +2674,7 @@
         }
       }
     },
-    "/chip/{chip_id}/coupling/{coupling_id}/metric-history": {
+    "/metrics/chip/{chip_id}/coupling/{coupling_id}/metric-history": {
       "get": {
         "tags": ["metrics"],
         "summary": "Get Coupling Metric History",

--- a/src/qdash/api/main.py
+++ b/src/qdash/api/main.py
@@ -87,4 +87,4 @@ app.include_router(device_topology.router, tags=["device_topology"], dependencie
 app.include_router(backend.router, tags=["backend"], dependencies=auth_dependency)
 app.include_router(flow.router, tags=["flow"], dependencies=auth_dependency)
 app.include_router(flow_schedule.router, tags=["flow_schedule"], dependencies=auth_dependency)
-app.include_router(metrics.router, tags=["metrics"], dependencies=auth_dependency)
+app.include_router(metrics.router, prefix="/metrics", tags=["metrics"], dependencies=auth_dependency)

--- a/ui/src/app/components/TaskFigure.tsx
+++ b/ui/src/app/components/TaskFigure.tsx
@@ -59,9 +59,7 @@ export function TaskFigure({
         {figurePaths.map((p, i) => (
           <img
             key={i}
-            src={`${apiUrl}/executions/figure?path=${encodeURIComponent(
-              p,
-            )}`}
+            src={`${apiUrl}/executions/figure?path=${encodeURIComponent(p)}`}
             alt={`Result for QID ${qid}`}
             className={className}
           />

--- a/ui/src/client/metrics/metrics.ts
+++ b/ui/src/client/metrics/metrics.ts
@@ -56,13 +56,13 @@ export const metricsGetMetricsConfig = (
   signal?: AbortSignal,
 ) => {
   return customInstance<MetricsGetMetricsConfig200>(
-    { url: `/config`, method: "GET", signal },
+    { url: `/metrics/config`, method: "GET", signal },
     options,
   );
 };
 
 export const getMetricsGetMetricsConfigQueryKey = () => {
-  return [`/config`] as const;
+  return [`/metrics/config`] as const;
 };
 
 export const getMetricsGetMetricsConfigQueryOptions = <
@@ -224,7 +224,7 @@ export const metricsGetChipMetrics = (
   signal?: AbortSignal,
 ) => {
   return customInstance<ChipMetricsResponse>(
-    { url: `/chip/${chipId}/metrics`, method: "GET", params, signal },
+    { url: `/metrics/chip/${chipId}/metrics`, method: "GET", params, signal },
     options,
   );
 };
@@ -233,7 +233,10 @@ export const getMetricsGetChipMetricsQueryKey = (
   chipId?: string,
   params?: MetricsGetChipMetricsParams,
 ) => {
-  return [`/chip/${chipId}/metrics`, ...(params ? [params] : [])] as const;
+  return [
+    `/metrics/chip/${chipId}/metrics`,
+    ...(params ? [params] : []),
+  ] as const;
 };
 
 export const getMetricsGetChipMetricsQueryOptions = <
@@ -409,7 +412,7 @@ export const metricsListChips = (
   signal?: AbortSignal,
 ) => {
   return customInstance<MetricsListChips200>(
-    { url: `/chips`, method: "GET", params, signal },
+    { url: `/metrics/chips`, method: "GET", params, signal },
     options,
   );
 };
@@ -417,7 +420,7 @@ export const metricsListChips = (
 export const getMetricsListChipsQueryKey = (
   params?: MetricsListChipsParams,
 ) => {
-  return [`/chips`, ...(params ? [params] : [])] as const;
+  return [`/metrics/chips`, ...(params ? [params] : [])] as const;
 };
 
 export const getMetricsListChipsQueryOptions = <
@@ -578,7 +581,7 @@ export const metricsGetCurrentChip = (
   signal?: AbortSignal,
 ) => {
   return customInstance<MetricsGetCurrentChip200>(
-    { url: `/chip/current`, method: "GET", params, signal },
+    { url: `/metrics/chip/current`, method: "GET", params, signal },
     options,
   );
 };
@@ -586,7 +589,7 @@ export const metricsGetCurrentChip = (
 export const getMetricsGetCurrentChipQueryKey = (
   params?: MetricsGetCurrentChipParams,
 ) => {
-  return [`/chip/current`, ...(params ? [params] : [])] as const;
+  return [`/metrics/chip/current`, ...(params ? [params] : [])] as const;
 };
 
 export const getMetricsGetCurrentChipQueryOptions = <
@@ -758,7 +761,7 @@ export const metricsGetQubitMetricHistory = (
 ) => {
   return customInstance<QubitMetricHistoryResponse>(
     {
-      url: `/chip/${chipId}/qubit/${qid}/metric-history`,
+      url: `/metrics/chip/${chipId}/qubit/${qid}/metric-history`,
       method: "GET",
       params,
       signal,
@@ -773,7 +776,7 @@ export const getMetricsGetQubitMetricHistoryQueryKey = (
   params?: MetricsGetQubitMetricHistoryParams,
 ) => {
   return [
-    `/chip/${chipId}/qubit/${qid}/metric-history`,
+    `/metrics/chip/${chipId}/qubit/${qid}/metric-history`,
     ...(params ? [params] : []),
   ] as const;
 };
@@ -971,7 +974,7 @@ export const metricsGetCouplingMetricHistory = (
 ) => {
   return customInstance<QubitMetricHistoryResponse>(
     {
-      url: `/chip/${chipId}/coupling/${couplingId}/metric-history`,
+      url: `/metrics/chip/${chipId}/coupling/${couplingId}/metric-history`,
       method: "GET",
       params,
       signal,
@@ -986,7 +989,7 @@ export const getMetricsGetCouplingMetricHistoryQueryKey = (
   params?: MetricsGetCouplingMetricHistoryParams,
 ) => {
   return [
-    `/chip/${chipId}/coupling/${couplingId}/metric-history`,
+    `/metrics/chip/${chipId}/coupling/${couplingId}/metric-history`,
     ...(params ? [params] : []),
   ] as const;
 };

--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -26,7 +26,7 @@ export function middleware(request: NextRequest) {
 // 認証が必要なパスを指定
 export const config = {
   matcher: [
-/*
+    /*
      * 以下のパスに対してミドルウェアを適用:
      * - すべてのパス（/:path*）
      * - ルートパス（/）


### PR DESCRIPTION
Add HTTPBearer authentication requirement to multiple API endpoints
including auth, file operations, flow management, calibration, and
chip endpoints. This ensures proper authentication documentation in
the OpenAPI specification.

