### PR TITLE
refactor: improve error handling and add backend validation

### DIFF
--- a/src/qdash/db/init/task.py
+++ b/src/qdash/db/init/task.py
@@ -7,8 +7,24 @@ from qdash.workflow.caltasks.base import BaseTask
 
 
 def update_active_tasks(username: str, backend: str) -> list[TaskModel]:
-    """Update the active tasks in the registry and return a list of TaskModel instances."""
+    """Update the active tasks in the registry and return a list of TaskModel instances.
+
+    Args:
+        username: The username to associate with the tasks
+        backend: The backend type (e.g., 'qubex', 'fake')
+
+    Returns:
+        List of TaskModel instances for the specified backend
+
+    Raises:
+        ValueError: If the backend is not registered in the task registry
+
+    """
     task_cls = BaseTask.registry.get(backend)
+    if task_cls is None:
+        supported_backends = list(BaseTask.registry.keys())
+        msg = f"Unknown backend '{backend}'. Supported backends: {supported_backends}"
+        raise ValueError(msg)
     return [
         TaskModel(
             username=username,

--- a/src/qdash/dbmodel/chip.py
+++ b/src/qdash/dbmodel/chip.py
@@ -67,3 +67,20 @@ class ChipDocument(Document):
         if chip is None:
             raise ValueError(f"Chip not found for user {username}")
         return chip
+
+    @classmethod
+    def get_chip_by_id(cls, username: str, chip_id: str) -> "ChipDocument | None":
+        """Get a specific chip by chip_id and username.
+
+        Unlike get_current_chip which returns the most recently installed chip,
+        this method returns the chip with the specified chip_id.
+
+        Args:
+            username: The username of the chip owner
+            chip_id: The specific chip ID to retrieve
+
+        Returns:
+            ChipDocument if found, None otherwise
+
+        """
+        return cls.find_one({"username": username, "chip_id": chip_id}).run()

--- a/src/qdash/workflow/flow/__init__.py
+++ b/src/qdash/workflow/flow/__init__.py
@@ -13,13 +13,6 @@ from qdash.workflow.flow.context import (
     set_current_session,
 )
 from qdash.workflow.flow.factory import (
-    BackendFactory,
-    DefaultBackendFactory,
-    DefaultExecutionManagerFactory,
-    DefaultTaskManagerFactory,
-    ExecutionManagerFactory,
-    FlowSessionDependencies,
-    TaskManagerFactory,
     create_flow_session,
 )
 from qdash.workflow.flow.github import (
@@ -47,13 +40,6 @@ __all__ = [
     "CalibrationPaths",
     # === Factory ===
     "create_flow_session",
-    "FlowSessionDependencies",
-    "BackendFactory",
-    "ExecutionManagerFactory",
-    "TaskManagerFactory",
-    "DefaultBackendFactory",
-    "DefaultExecutionManagerFactory",
-    "DefaultTaskManagerFactory",
     # === GitHub Integration ===
     "GitHubIntegration",
     "GitHubPushConfig",

--- a/src/qdash/workflow/flow/factory.py
+++ b/src/qdash/workflow/flow/factory.py
@@ -1,255 +1,27 @@
-"""FlowSession factory for dependency injection.
+"""FlowSession factory module.
 
-This module provides factory functions and classes for creating FlowSession
-instances with proper dependency injection, enabling both production and
-test configurations.
+This module provides factory functions for creating FlowSession instances
+with sensible defaults.
 """
 
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING
 
-from qdash.workflow.engine.backend.factory import create_backend
-from qdash.workflow.engine.calibration.execution.manager import ExecutionManager
-from qdash.workflow.engine.calibration.task.manager import TaskManager
 from qdash.workflow.flow.config import FlowSessionConfig
 
 if TYPE_CHECKING:
     from qdash.workflow.flow.session import FlowSession
 
 
-@runtime_checkable
-class BackendFactory(Protocol):
-    """Protocol for backend factory."""
-
-    def create(self, config: dict) -> Any:
-        """Create a backend instance.
-
-        Args:
-            config: Backend configuration dictionary
-
-        Returns:
-            Backend instance
-        """
-        ...
-
-
-@runtime_checkable
-class ExecutionManagerFactory(Protocol):
-    """Protocol for ExecutionManager factory."""
-
-    def create(
-        self,
-        username: str,
-        execution_id: str,
-        calib_data_path: str,
-        chip_id: str,
-        name: str,
-        tags: list[str],
-        note: dict,
-    ) -> ExecutionManager:
-        """Create an ExecutionManager instance.
-
-        Args:
-            username: Username for the session
-            execution_id: Execution identifier
-            calib_data_path: Path for calibration data
-            chip_id: Target chip ID
-            name: Human-readable execution name
-            tags: Tags for categorization
-            note: Additional notes
-
-        Returns:
-            ExecutionManager instance
-        """
-        ...
-
-
-@runtime_checkable
-class TaskManagerFactory(Protocol):
-    """Protocol for TaskManager factory."""
-
-    def create(
-        self,
-        username: str,
-        execution_id: str,
-        qids: list[str],
-        calib_dir: str,
-    ) -> TaskManager:
-        """Create a TaskManager instance.
-
-        Args:
-            username: Username for the session
-            execution_id: Execution identifier
-            qids: List of qubit IDs
-            calib_dir: Calibration directory path
-
-        Returns:
-            TaskManager instance
-        """
-        ...
-
-
-class DefaultBackendFactory:
-    """Default implementation of BackendFactory using create_backend."""
-
-    def __init__(self, backend_name: str = "qubex"):
-        """Initialize factory with backend type.
-
-        Args:
-            backend_name: Backend type ('qubex' or 'fake')
-        """
-        self.backend_name = backend_name
-
-    def create(self, config: dict) -> Any:
-        """Create a backend instance using the standard factory.
-
-        Args:
-            config: Backend configuration dictionary
-
-        Returns:
-            Backend instance
-        """
-        return create_backend(backend=self.backend_name, config=config)
-
-
-class DefaultExecutionManagerFactory:
-    """Default implementation of ExecutionManagerFactory."""
-
-    def create(
-        self,
-        username: str,
-        execution_id: str,
-        calib_data_path: str,
-        chip_id: str,
-        name: str,
-        tags: list[str],
-        note: dict,
-    ) -> ExecutionManager:
-        """Create an ExecutionManager with default repositories.
-
-        Args:
-            username: Username for the session
-            execution_id: Execution identifier
-            calib_data_path: Path for calibration data
-            chip_id: Target chip ID
-            name: Human-readable execution name
-            tags: Tags for categorization
-            note: Additional notes
-
-        Returns:
-            ExecutionManager instance with default MongoDB repositories
-        """
-        return ExecutionManager(
-            username=username,
-            execution_id=execution_id,
-            calib_data_path=calib_data_path,
-            chip_id=chip_id,
-            name=name,
-            tags=tags,
-            note=note,
-        )
-
-
-class DefaultTaskManagerFactory:
-    """Default implementation of TaskManagerFactory."""
-
-    def create(
-        self,
-        username: str,
-        execution_id: str,
-        qids: list[str],
-        calib_dir: str,
-    ) -> TaskManager:
-        """Create a TaskManager instance.
-
-        Args:
-            username: Username for the session
-            execution_id: Execution identifier
-            qids: List of qubit IDs
-            calib_dir: Calibration directory path
-
-        Returns:
-            TaskManager instance
-        """
-        return TaskManager(
-            username=username,
-            execution_id=execution_id,
-            qids=qids,
-            calib_dir=calib_dir,
-        )
-
-
-class FlowSessionDependencies:
-    """Container for FlowSession dependencies.
-
-    This class holds all the factory instances needed to create a FlowSession,
-    enabling easy swapping for testing.
-
-    Attributes:
-        backend_factory: Factory for backend instances
-        execution_manager_factory: Factory for ExecutionManager
-        task_manager_factory: Factory for TaskManager
-    """
-
-    def __init__(
-        self,
-        backend_factory: BackendFactory | None = None,
-        execution_manager_factory: ExecutionManagerFactory | None = None,
-        task_manager_factory: TaskManagerFactory | None = None,
-    ):
-        """Initialize with optional custom factories.
-
-        Args:
-            backend_factory: Custom backend factory (defaults to DefaultBackendFactory)
-            execution_manager_factory: Custom execution manager factory
-            task_manager_factory: Custom task manager factory
-        """
-        self.backend_factory = backend_factory
-        self.execution_manager_factory = execution_manager_factory or DefaultExecutionManagerFactory()
-        self.task_manager_factory = task_manager_factory or DefaultTaskManagerFactory()
-
-    @classmethod
-    def production(cls, backend_name: str = "qubex") -> "FlowSessionDependencies":
-        """Create production dependencies.
-
-        Args:
-            backend_name: Backend type ('qubex' or 'fake')
-
-        Returns:
-            FlowSessionDependencies configured for production
-        """
-        return cls(
-            backend_factory=DefaultBackendFactory(backend_name=backend_name),
-            execution_manager_factory=DefaultExecutionManagerFactory(),
-            task_manager_factory=DefaultTaskManagerFactory(),
-        )
-
-    @classmethod
-    def fake(cls) -> "FlowSessionDependencies":
-        """Create dependencies for fake/test backend.
-
-        Returns:
-            FlowSessionDependencies configured for fake backend
-        """
-        return cls(
-            backend_factory=DefaultBackendFactory(backend_name="fake"),
-            execution_manager_factory=DefaultExecutionManagerFactory(),
-            task_manager_factory=DefaultTaskManagerFactory(),
-        )
-
-
 def create_flow_session(
     config: FlowSessionConfig,
-    dependencies: FlowSessionDependencies | None = None,
 ) -> "FlowSession":
-    """Create a FlowSession with the given configuration and dependencies.
+    """Create a FlowSession with the given configuration.
 
     This is the primary factory function for creating FlowSession instances.
-    It handles dependency injection and provides sensible defaults for
-    production use.
+    It provides a clean way to create sessions from immutable config objects.
 
     Args:
         config: FlowSession configuration
-        dependencies: Optional custom dependencies (defaults to production)
 
     Returns:
         Configured FlowSession instance
@@ -262,21 +34,11 @@ def create_flow_session(
             qids=["0", "1", "2"],
         )
 
-        # Production use
         session = create_flow_session(config)
-
-        # Test use with fake backend
-        test_deps = FlowSessionDependencies.fake()
-        test_session = create_flow_session(config, dependencies=test_deps)
         ```
     """
     from qdash.workflow.flow.session import FlowSession
 
-    # Use production dependencies if not specified
-    if dependencies is None:
-        dependencies = FlowSessionDependencies.production(backend_name=config.backend_name)
-
-    # Convert config to kwargs for FlowSession.__init__
     return FlowSession(
         username=config.username,
         chip_id=config.chip_id,

--- a/tests/qdash/workflow/engine/calibration/task/test_executor.py
+++ b/tests/qdash/workflow/engine/calibration/task/test_executor.py
@@ -13,7 +13,7 @@ from qdash.workflow.engine.calibration.task.result_processor import (
     FidelityValidationError,
     R2ValidationError,
 )
-from qdash.workflow.tasks.base import PostProcessResult, PreProcessResult, RunResult
+from qdash.workflow.caltasks.base import PostProcessResult, PreProcessResult, RunResult
 
 
 class MockTask:

--- a/tests/qdash/workflow/engine/calibration/task/test_manager.py
+++ b/tests/qdash/workflow/engine/calibration/task/test_manager.py
@@ -24,7 +24,7 @@ from qdash.datamodel.task import (
     TaskStatusModel,
 )
 from qdash.workflow.engine.calibration.task.manager import TaskManager
-from qdash.workflow.tasks.base import PostProcessResult, PreProcessResult, RunResult
+from qdash.workflow.caltasks.base import PostProcessResult, PreProcessResult, RunResult
 
 
 class TestTaskStateManagement:
@@ -433,11 +433,11 @@ class TestExecuteTaskIntegration:
         return task
 
     @pytest.fixture
-    def mock_session(self):
-        """Create a mock session for testing."""
-        session = MagicMock()
-        session.name = "fake"
-        return session
+    def mock_backend(self):
+        """Create a mock backend for testing."""
+        backend = MagicMock()
+        backend.name = "fake"
+        return backend
 
     @pytest.fixture
     def mock_execution_manager(self):
@@ -480,7 +480,7 @@ class TestExecuteTaskIntegration:
             yield tmpdir
 
     def test_execute_task_without_run_result(
-        self, init_db, mock_task, mock_session, mock_execution_manager, calib_dir
+        self, init_db, mock_task, mock_backend, mock_execution_manager, calib_dir
     ):
         """Test execute_task when run returns None."""
         tm = TaskManager(
@@ -500,7 +500,7 @@ class TestExecuteTaskIntegration:
 
             em_result, tm_result = tm.execute_task(
                 task_instance=mock_task,
-                session=mock_session,
+                backend=mock_backend,
                 execution_manager=mock_execution_manager,
                 qid="0",
             )
@@ -510,7 +510,7 @@ class TestExecuteTaskIntegration:
         assert task.status == TaskStatusModel.COMPLETED
 
     def test_execute_task_with_output_parameters(
-        self, init_db, mock_task, mock_session, mock_execution_manager, calib_dir
+        self, init_db, mock_task, mock_backend, mock_execution_manager, calib_dir
     ):
         """Test execute_task with output parameters."""
         tm = TaskManager(
@@ -536,7 +536,7 @@ class TestExecuteTaskIntegration:
 
             em_result, tm_result = tm.execute_task(
                 task_instance=mock_task,
-                session=mock_session,
+                backend=mock_backend,
                 execution_manager=mock_execution_manager,
                 qid="0",
             )
@@ -547,7 +547,7 @@ class TestExecuteTaskIntegration:
         assert "qubit_frequency" in tm_result.calib_data.qubit["0"]
 
     def test_execute_task_with_r2_validation_pass(
-        self, init_db, mock_task, mock_session, mock_execution_manager, calib_dir
+        self, init_db, mock_task, mock_backend, mock_execution_manager, calib_dir
     ):
         """Test execute_task with passing R² validation."""
         tm = TaskManager(
@@ -573,7 +573,7 @@ class TestExecuteTaskIntegration:
 
             em_result, tm_result = tm.execute_task(
                 task_instance=mock_task,
-                session=mock_session,
+                backend=mock_backend,
                 execution_manager=mock_execution_manager,
                 qid="0",
             )
@@ -584,7 +584,7 @@ class TestExecuteTaskIntegration:
         assert "qubit_frequency" in tm_result.calib_data.qubit["0"]
 
     def test_execute_task_with_r2_validation_fail(
-        self, init_db, mock_task, mock_session, mock_execution_manager, calib_dir
+        self, init_db, mock_task, mock_backend, mock_execution_manager, calib_dir
     ):
         """Test execute_task with failing R² validation."""
         tm = TaskManager(
@@ -611,7 +611,7 @@ class TestExecuteTaskIntegration:
             with pytest.raises(ValueError, match="R² value too low"):
                 tm.execute_task(
                     task_instance=mock_task,
-                    session=mock_session,
+                    backend=mock_backend,
                     execution_manager=mock_execution_manager,
                     qid="0",
                 )
@@ -621,7 +621,7 @@ class TestExecuteTaskIntegration:
         assert task.status == TaskStatusModel.FAILED
 
     def test_execute_task_with_fidelity_over_100_fails(
-        self, init_db, mock_task, mock_session, mock_execution_manager, calib_dir
+        self, init_db, mock_task, mock_backend, mock_execution_manager, calib_dir
     ):
         """Test execute_task fails when fidelity > 100% for RB tasks."""
         tm = TaskManager(
@@ -652,13 +652,13 @@ class TestExecuteTaskIntegration:
             with pytest.raises(ValueError, match="exceeds 100%"):
                 tm.execute_task(
                     task_instance=mock_task,
-                    session=mock_session,
+                    backend=mock_backend,
                     execution_manager=mock_execution_manager,
                     qid="0",
                 )
 
     def test_execute_task_with_figures(
-        self, init_db, mock_task, mock_session, mock_execution_manager, calib_dir
+        self, init_db, mock_task, mock_backend, mock_execution_manager, calib_dir
     ):
         """Test execute_task saves figures correctly."""
         tm = TaskManager(
@@ -682,7 +682,7 @@ class TestExecuteTaskIntegration:
 
             em_result, tm_result = tm.execute_task(
                 task_instance=mock_task,
-                session=mock_session,
+                backend=mock_backend,
                 execution_manager=mock_execution_manager,
                 qid="0",
             )
@@ -692,7 +692,7 @@ class TestExecuteTaskIntegration:
         assert Path(task.figure_path[0]).exists()
 
     def test_execute_task_records_to_task_result_history(
-        self, init_db, mock_task, mock_session, mock_execution_manager, calib_dir
+        self, init_db, mock_task, mock_backend, mock_execution_manager, calib_dir
     ):
         """Test execute_task creates TaskResultHistoryDocument."""
         from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
@@ -712,7 +712,7 @@ class TestExecuteTaskIntegration:
 
             em_result, tm_result = tm.execute_task(
                 task_instance=mock_task,
-                session=mock_session,
+                backend=mock_backend,
                 execution_manager=mock_execution_manager,
                 qid="0",
             )

--- a/tests/qdash/workflow/flow/test_config.py
+++ b/tests/qdash/workflow/flow/test_config.py
@@ -22,7 +22,7 @@ class TestFlowSessionConfigCreation:
         assert config.chip_id == "chip_1"
         assert config.qids == ("0", "1", "2")
         assert config.execution_id is None
-        assert config.backend == "qubex"
+        assert config.backend_name == "qubex"
         assert config.name == "Python Flow Execution"
         assert config.tags is None
         assert config.use_lock is True
@@ -39,7 +39,7 @@ class TestFlowSessionConfigCreation:
             chip_id="chip_1",
             qids=("0", "1"),
             execution_id="20240101-001",
-            backend="fake",
+            backend_name="fake",
             name="Test Calibration",
             tags=("tag1", "tag2"),
             use_lock=False,
@@ -53,7 +53,7 @@ class TestFlowSessionConfigCreation:
         assert config.chip_id == "chip_1"
         assert config.qids == ("0", "1")
         assert config.execution_id == "20240101-001"
-        assert config.backend == "fake"
+        assert config.backend_name == "fake"
         assert config.name == "Test Calibration"
         assert config.tags == ("tag1", "tag2")
         assert config.use_lock is False

--- a/tests/qdash/workflow/flow/test_factory.py
+++ b/tests/qdash/workflow/flow/test_factory.py
@@ -1,113 +1,47 @@
 """Tests for FlowSession factory module."""
 
-import pytest
 from qdash.workflow.flow.config import FlowSessionConfig
-from qdash.workflow.flow.factory import (
-    DefaultExecutionManagerFactory,
-    DefaultSessionFactory,
-    DefaultTaskManagerFactory,
-    FlowSessionDependencies,
-)
+from qdash.workflow.flow.factory import create_flow_session
 
 
-class TestDefaultSessionFactory:
-    """Test DefaultSessionFactory."""
+class TestCreateFlowSession:
+    """Test create_flow_session factory function."""
 
-    def test_init_with_default_backend(self):
-        """Test initialization with default backend."""
-        factory = DefaultSessionFactory()
-        assert factory.backend == "qubex"
+    def test_create_flow_session_returns_correct_type(self, mocker):
+        """Test that create_flow_session returns a FlowSession instance."""
+        # Mock FlowSession to avoid database dependencies
+        mock_flow_session = mocker.patch("qdash.workflow.flow.session.FlowSession")
 
-    def test_init_with_custom_backend(self):
-        """Test initialization with custom backend."""
-        factory = DefaultSessionFactory(backend="fake")
-        assert factory.backend == "fake"
-
-
-class TestDefaultExecutionManagerFactory:
-    """Test DefaultExecutionManagerFactory."""
-
-    def test_create_returns_execution_manager(self):
-        """Test that create returns an ExecutionManager."""
-        factory = DefaultExecutionManagerFactory()
-
-        # Note: This will fail without DB connection, but we can test factory instantiation
-        assert factory is not None
-
-
-class TestDefaultTaskManagerFactory:
-    """Test DefaultTaskManagerFactory."""
-
-    def test_create_returns_task_manager(self):
-        """Test that create returns a TaskManager."""
-        factory = DefaultTaskManagerFactory()
-
-        # Note: This will fail without DB connection, but we can test factory instantiation
-        assert factory is not None
-
-
-class TestFlowSessionDependencies:
-    """Test FlowSessionDependencies container."""
-
-    def test_init_with_defaults(self):
-        """Test initialization with default factories."""
-        deps = FlowSessionDependencies()
-
-        assert deps.session_factory is None  # Not set until production()
-        assert isinstance(deps.execution_manager_factory, DefaultExecutionManagerFactory)
-        assert isinstance(deps.task_manager_factory, DefaultTaskManagerFactory)
-
-    def test_production_creates_all_factories(self):
-        """Test production() creates all factories."""
-        deps = FlowSessionDependencies.production()
-
-        assert isinstance(deps.session_factory, DefaultSessionFactory)
-        assert deps.session_factory.backend == "qubex"
-        assert isinstance(deps.execution_manager_factory, DefaultExecutionManagerFactory)
-        assert isinstance(deps.task_manager_factory, DefaultTaskManagerFactory)
-
-    def test_production_with_custom_backend(self):
-        """Test production() with custom backend."""
-        deps = FlowSessionDependencies.production(backend="fake")
-
-        assert isinstance(deps.session_factory, DefaultSessionFactory)
-        assert deps.session_factory.backend == "fake"
-
-    def test_fake_creates_fake_backend(self):
-        """Test fake() creates dependencies with fake backend."""
-        deps = FlowSessionDependencies.fake()
-
-        assert isinstance(deps.session_factory, DefaultSessionFactory)
-        assert deps.session_factory.backend == "fake"
-
-    def test_init_with_custom_factories(self):
-        """Test initialization with custom factories."""
-
-        class CustomSessionFactory:
-            def create(self, config: dict):
-                return None
-
-        class CustomExecutionManagerFactory:
-            def create(self, **kwargs):
-                return None
-
-        class CustomTaskManagerFactory:
-            def create(self, **kwargs):
-                return None
-
-        custom_session = CustomSessionFactory()
-        custom_execution = CustomExecutionManagerFactory()
-        custom_task = CustomTaskManagerFactory()
-
-        deps = FlowSessionDependencies(
-            session_factory=custom_session,
-            execution_manager_factory=custom_execution,
-            task_manager_factory=custom_task,
+        config = FlowSessionConfig.create(
+            username="test_user",
+            chip_id="chip_1",
+            qids=["0", "1", "2"],
+            execution_id="20240101-001",
+            backend_name="fake",
+            name="Test Calibration",
+            tags=["tag1", "tag2"],
+            use_lock=False,
+            note={"key": "value"},
+            muxes=[0, 1],
         )
 
-        assert deps.session_factory is custom_session
-        assert deps.execution_manager_factory is custom_execution
-        assert deps.task_manager_factory is custom_task
+        create_flow_session(config)
+
+        # Verify FlowSession was called with correct parameters
+        mock_flow_session.assert_called_once_with(
+            username="test_user",
+            chip_id="chip_1",
+            qids=["0", "1", "2"],
+            execution_id="20240101-001",
+            backend_name="fake",
+            name="Test Calibration",
+            tags=["tag1", "tag2"],
+            use_lock=False,
+            note={"key": "value"},
+            enable_github_pull=False,
+            github_push_config=None,
+            muxes=[0, 1],
+        )
 
 
 class TestFlowSessionConfigIntegration:
@@ -120,7 +54,7 @@ class TestFlowSessionConfigIntegration:
             chip_id="chip_1",
             qids=["0", "1", "2"],
             execution_id="20240101-001",
-            backend="fake",
+            backend_name="fake",
             name="Test Calibration",
             tags=["tag1", "tag2"],
             use_lock=False,
@@ -135,7 +69,7 @@ class TestFlowSessionConfigIntegration:
         assert "chip_id" in result
         assert "qids" in result
         assert "execution_id" in result
-        assert "backend" in result
+        assert "backend_name" in result
         assert "name" in result
         assert "tags" in result
         assert "use_lock" in result

--- a/tests/qdash/workflow/flow/test_session.py
+++ b/tests/qdash/workflow/flow/test_session.py
@@ -127,17 +127,17 @@ class TestFlowSessionInitialization:
             execution_id="20240101-001",
             chip_id="chip_1",
             qids=["0", "1"],
-            backend="fake",
+            backend_name="fake",
         )
 
         # Verify attributes
         assert session.username == "test_user"
         assert session.execution_id == "20240101-001"
         assert session.chip_id == "chip_1"
-        assert session.backend == "fake"
+        assert session.backend_name == "fake"
         assert session.qids == ["0", "1"]
         assert session.execution_manager is not None
-        assert session.session is not None
+        assert session.backend is not None
 
     def test_flow_session_default_tags(self, mock_flow_session_deps):
         """Test that default tags are set correctly."""


### PR DESCRIPTION
- Add backend validation in update_active_tasks with descriptive error messages
- Add get_chip_by_id method to ChipDocument for specific chip retrieval
- Enhance docstrings with detailed Args/Returns/Raises sections
- Replace silent error handling with proper logging for chip history updates
- Clean up public API by removing internal factory class exports
- Update test imports to use qdash.workflow.caltasks.base
