### PR TITLE
fix(scripts): default Mongo URI to root:example@mongo:27017

### DIFF
--- a/scripts/migrate_user_tokens.py
+++ b/scripts/migrate_user_tokens.py
@@ -15,7 +15,7 @@ def generate_access_token() -> str:
     return secrets.token_urlsafe(32)
 
 
-def migrate_users(mongo_uri: str = "mongodb://localhost:27017", db_name: str = "qubex") -> None:
+def migrate_users(mongo_uri: str = "mongodb://root:example@mongo:27017", db_name: str = "qubex") -> None:
     """Add access_token to all users without one."""
     client = MongoClient(mongo_uri)
     db = client[db_name]
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Migrate users to have access tokens")
-    parser.add_argument("--mongo-uri", default="mongodb://localhost:27017", help="MongoDB connection URI")
+    parser.add_argument("--mongo-uri", default="mongodb://root:example@mongo:27017", help="MongoDB connection URI")
     parser.add_argument("--db-name", default="qubex", help="Database name")
     args = parser.parse_args()
 


### PR DESCRIPTION
- Update migrate_users and argparse defaults from localhost to
  root:example@mongo:27017 to match containerized/Docker environments.
- Prevents connection failures when running the script in Docker and
  reduces need to pass --mongo-uri manually.
- Local setups can still override via the --mongo-uri flag.
