### PR TITLE
refactor(caltasks): use qubex-provided chevron figure; bump qubex

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -533,7 +533,7 @@ qctrl-visualizer==8.0.2
     # via qubex
 qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@487227c1154aa087e55b9fee1eabda2a164d299c
     # via qubex
-qubex @ git+https://github.com/amachino/qubex.git@d20176016f4bf2f1e1dd18f24d0091e3fb8efd73
+qubex @ git+https://github.com/amachino/qubex.git@0e3a46804ad204537e5bdf1687870400ce5f3148
 quel-clock-master @ git+https://github.com/quel-inc/quelware.git@c839e8b1a6fde4b4ece3d5f415015829857e775e#subdirectory=quel_clock_master
     # via
     #   qubecalib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,4 +122,4 @@ dev = [
     "go-task-bin>=3.41.0",
 ]
 [tool.uv.sources]
-qubex = { git = "https://github.com/amachino/qubex.git", tag = "develop" }
+qubex = { git = "https://github.com/amachino/qubex.git", branch = "chore/chevron-fig" }

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/chevron_pattern.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/chevron_pattern.py
@@ -22,45 +22,6 @@ class ChevronPattern(QubexTask):
         "qubit_frequency": OutputParameterModel(unit="GHz", description="Qubit bare frequency"),
     }
 
-    def make_figure(self, result: Any, label: str) -> go.Figure:
-        """Create a figure for the results."""
-
-        detuning_range = result["detuning_range"]
-        time_range = result["time_range"]
-        frequencies = result["frequencies"]
-
-        result["rabi_rates"]
-        chevron_data = result["chevron_data"]
-
-        fig = go.Figure()
-        fig.add_trace(
-            go.Heatmap(
-                x=detuning_range + frequencies[label],
-                y=time_range,
-                z=chevron_data[label],
-                colorscale="Viridis",
-            )
-        )
-        fig.update_layout(
-            title=dict(
-                text=f"Chevron pattern : {label}",
-                subtitle=dict(
-                    text="control_amplitude=",
-                    font=dict(
-                        size=13,
-                        family="monospace",
-                    ),
-                ),
-            ),
-            xaxis_title="Drive frequency (GHz)",
-            yaxis_title="Time (ns)",
-            width=600,
-            height=400,
-            margin=dict(t=80),
-        )
-
-        return fig
-
     def postprocess(
         self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
     ) -> PostProcessResult:
@@ -69,7 +30,7 @@ class ChevronPattern(QubexTask):
         result = run_result.raw_result
         self.output_parameters["qubit_frequency"].value = result["resonant_frequencies"][label]
         output_parameters = self.attach_execution_id(execution_id)
-        figures = [self.make_figure(result, label)]
+        figures = [result["fig"][label]]
         return PostProcessResult(output_parameters=output_parameters, figures=figures)
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:

--- a/src/qdash/workflow/requirements.txt
+++ b/src/qdash/workflow/requirements.txt
@@ -471,7 +471,7 @@ qctrl-visualizer==8.0.2
     # via qubex
 qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@487227c1154aa087e55b9fee1eabda2a164d299c
     # via qubex
-qubex @ git+https://github.com/amachino/qubex.git@d20176016f4bf2f1e1dd18f24d0091e3fb8efd73
+qubex @ git+https://github.com/amachino/qubex.git@0e3a46804ad204537e5bdf1687870400ce5f3148
 quel-clock-master @ git+https://github.com/quel-inc/quelware.git@c839e8b1a6fde4b4ece3d5f415015829857e775e#subdirectory=quel_clock_master
     # via
     #   qubecalib

--- a/uv.lock
+++ b/uv.lock
@@ -2909,7 +2909,7 @@ workflow = [
     { name = "pymongo", specifier = "==4.8.0" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "pyyaml", specifier = "==6.0.1" },
-    { name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?tag=develop" },
+    { name = "qubex", extras = ["backend"], git = "https://github.com/amachino/qubex.git?branch=chore%2Fchevron-fig" },
     { name = "reportlab", specifier = ">=4.4.1" },
     { name = "slack-sdk", specifier = "==3.36.0" },
 ]
@@ -2936,8 +2936,8 @@ dependencies = [
 
 [[package]]
 name = "qubex"
-version = "1.4.3+d201760"
-source = { git = "https://github.com/amachino/qubex.git?tag=develop#d20176016f4bf2f1e1dd18f24d0091e3fb8efd73" }
+version = "1.4.3+0e3a468"
+source = { git = "https://github.com/amachino/qubex.git?branch=chore%2Fchevron-fig#0e3a46804ad204537e5bdf1687870400ce5f3148" }
 dependencies = [
     { name = "cma" },
     { name = "cvxopt" },


### PR DESCRIPTION
- Remove local make_figure in ChevronPattern; in postprocess use result["fig"][label] returned by qubex
- Update qubex source to branch chore/chevron-fig and pin to commit 0e3a468 in devcontainer/workflow requirements and uv.lock
- Adjust pyproject.toml [tool.uv.sources] to track the new branch

This aligns with upstream changes where qubex now generates the chevron plot, avoiding duplicate plotting logic, ensuring consistent visuals, and reducing maintenance.

