### PR TITLE
chore(gitignore): ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,4 @@ src/tools/schedule/*
 .serena/cache/*
 .mcp.json
 .tmp/*
+/.claude/settings.local.json


### PR DESCRIPTION
Add root-level .claude/settings.local.json to .gitignore to avoid committing developer-specific Claude configuration. This prevents accidental leaks of local settings and keeps diffs clean with no impact on runtime behavior.
