### PR TITLE
chore(vscode): migrate to ruff.configuration in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,7 @@
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
   "ruff.path": ["${workspaceFolder}/.venv/bin/ruff"],
-  "ruff.lint.args": ["--config=${workspaceFolder}/pyproject.toml"],
+  "ruff.configuration": "${workspaceFolder}/pyproject.toml",
   "markdownlint.config": {
     "MD024": false,
     "MD033": false,


### PR DESCRIPTION
Replace deprecated ruff.lint.args (--config=...) with ruff.configuration
pointing to ${workspaceFolder}/pyproject.toml. Aligns with the latest
Ruff VS Code extension settings, removes deprecation warnings, and
ensures the extension reads config from pyproject.toml.
