### PR TITLE
refactor(flow): extract typed sort_order and remove type ignore

### DIFF
--- a/src/qdash/dbmodel/flow.py
+++ b/src/qdash/dbmodel/flow.py
@@ -99,11 +99,13 @@ class FlowDocument(Document):
             List of FlowDocument objects
 
         """
+        sort_order: list = [("updated_at", DESCENDING)]
         return list(
             cls.find(
-                {"project_id": project_id, "username": username}, sort=[("updated_at", DESCENDING)]
+                {"project_id": project_id, "username": username},
+                sort=sort_order,
             ).run()
-        )  # type: ignore[list-item]
+        )
 
     @classmethod
     def delete_by_user_and_name(cls, username: str, name: str, project_id: str) -> bool:


### PR DESCRIPTION
- Define local sort_order with a type annotation for updated_at DESC
- Pass sort_order to find(), eliminating type: ignore[list-item]
- Improves readability and typing clarity; no behavior change
