### PR TITLE
feat(admin,settings): move system settings to Admin; add System tab

### DIFF
--- a/ui/src/app/(auth)/admin/page.tsx
+++ b/ui/src/app/(auth)/admin/page.tsx
@@ -25,12 +25,15 @@ import {
   useCreateProjectForUser,
 } from "@/client/admin/admin";
 import { useRegisterUser, useResetPassword } from "@/client/auth/auth";
+import { SettingsCard } from "@/components/features/setting/SettingsCard";
 import { useAuth } from "@/contexts/AuthContext";
 
 export default function AdminPage() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState<"users" | "projects">("users");
+  const [activeTab, setActiveTab] = useState<"users" | "projects" | "system">(
+    "users",
+  );
   const [selectedUser, setSelectedUser] = useState<UserListItem | null>(null);
   const [selectedProject, setSelectedProject] =
     useState<ProjectListItem | null>(null);
@@ -234,6 +237,12 @@ export default function AdminPage() {
           onClick={() => setActiveTab("projects")}
         >
           Projects ({projectsData?.data?.total || 0})
+        </button>
+        <button
+          className={`tab ${activeTab === "system" ? "tab-active" : ""}`}
+          onClick={() => setActiveTab("system")}
+        >
+          System
         </button>
       </div>
 
@@ -567,6 +576,9 @@ export default function AdminPage() {
           </div>
         </div>
       )}
+
+      {/* System Tab */}
+      {activeTab === "system" && <SettingsCard />}
 
       {/* Edit Modal */}
       {isEditModalOpen && selectedUser && (

--- a/ui/src/app/(auth)/setting/page.tsx
+++ b/ui/src/app/(auth)/setting/page.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 
 import { useTheme } from "@/app/providers/theme-provider";
 import { PasswordChangeCard } from "@/components/features/setting/PasswordChangeCard";
-import { SettingsCard } from "@/components/features/setting/SettingsCard";
 import { useAuth } from "@/contexts/AuthContext";
 
 const themes = [
@@ -45,7 +44,7 @@ const themes = [
   "silk",
 ];
 
-type Tab = "appearance" | "account" | "api" | "system";
+type Tab = "appearance" | "account" | "api";
 
 export default function SettingsPage() {
   const { theme, setTheme } = useTheme();
@@ -96,12 +95,6 @@ export default function SettingsPage() {
             onClick={() => setActiveTab("api")}
           >
             API Token
-          </a>
-          <a
-            className={`tab ${activeTab === "system" ? "tab-active" : ""}`}
-            onClick={() => setActiveTab("system")}
-          >
-            System
           </a>
         </div>
         <div className="w-full h-full space-y-6">
@@ -211,7 +204,7 @@ export default function SettingsPage() {
             </div>
           ) : activeTab === "account" ? (
             <PasswordChangeCard key="account" />
-          ) : activeTab === "api" ? (
+          ) : (
             <div className="card bg-base-200 shadow-lg" key="api">
               <div className="card-body">
                 <h2 className="card-title text-xl mb-4">API Access Token</h2>
@@ -414,8 +407,6 @@ export default function SettingsPage() {
                 </div>
               </div>
             </div>
-          ) : (
-            <SettingsCard key="system" />
           )}
         </div>
       </div>


### PR DESCRIPTION
- Add System tab to Admin page and render SettingsCard
- Remove System tab and SettingsCard from user Settings page
- Update tab state/types and conditionals accordingly

Centralizes system-wide configuration under Admin for clearer ownership and access control, and simplifies the user Settings UI.
