### PR TITLE
feat(ui)!: add dev-only themes, DOM lock; rename deploy tasks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-ENV="oqtopus-dev"
+ENV="oqtopus"
 
 SUBNET=""
 GATEWAY=""

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -136,12 +136,12 @@ tasks:
       - task export-workflow
       - docker compose build --no-cache workflow
 
-  deploy-dev:
+  deploy-local:
     cmds:
       - docker compose up -d --build
     desc: Deploy the application with Docker Compose in dev mode
 
-  deploy-prod:
+  deploy:
     cmds:
       - docker compose --profile tunnel up -d --build
     desc: Deploy the application with Docker Compose

--- a/ui/src/app/(auth)/files/page.tsx
+++ b/ui/src/app/(auth)/files/page.tsx
@@ -437,6 +437,7 @@ export default function FilesEditorPage() {
                       cursorStyle: "line",
                       cursorBlinking: "blink",
                       readOnly: isEditorLocked,
+                      domReadOnly: isEditorLocked,
                     }}
                   />
                 )}

--- a/ui/src/app/(auth)/setting/page.tsx
+++ b/ui/src/app/(auth)/setting/page.tsx
@@ -6,7 +6,10 @@ import { useTheme } from "@/app/providers/theme-provider";
 import { PasswordChangeCard } from "@/components/features/setting/PasswordChangeCard";
 import { useAuth } from "@/contexts/AuthContext";
 
-const themes = [
+// In dev environment, only light/dark available (auto-converted to dev-light/dev-dark)
+const devThemes = ["light", "dark"];
+
+const allThemes = [
   "light",
   "dark",
   "cupcake",
@@ -47,9 +50,12 @@ const themes = [
 type Tab = "appearance" | "account" | "api";
 
 export default function SettingsPage() {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, isDevEnv } = useTheme();
   const { accessToken } = useAuth();
   const [activeTab, setActiveTab] = useState<Tab>("appearance");
+
+  // Limit theme options in dev environment
+  const themes = isDevEnv ? devThemes : allThemes;
   const [copied, setCopied] = useState(false);
   const [copiedCurl, setCopiedCurl] = useState(false);
   const [showToken, setShowToken] = useState(false);
@@ -102,6 +108,26 @@ export default function SettingsPage() {
             <div className="card bg-base-200 shadow-lg" key="appearance">
               <div className="card-body">
                 <h2 className="card-title text-xl mb-4">Theme Settings</h2>
+                {isDevEnv && (
+                  <div className="alert alert-warning mb-4">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="stroke-current shrink-0 h-6 w-6"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                      />
+                    </svg>
+                    <span>
+                      Dev environment: Using purple theme for visual distinction
+                    </span>
+                  </div>
+                )}
                 <div className="flex flex-col gap-6">
                   <div className="flex flex-col gap-3">
                     <label className="text-sm font-medium">Select Theme</label>
@@ -118,26 +144,28 @@ export default function SettingsPage() {
                         </button>
                       ))}
                     </div>
-                    <details className="collapse collapse-arrow bg-base-100">
-                      <summary className="collapse-title text-sm font-medium">
-                        More themes
-                      </summary>
-                      <div className="collapse-content">
-                        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 pt-2">
-                          {themes.slice(8).map((t) => (
-                            <button
-                              key={t}
-                              className={`btn btn-sm w-full ${
-                                theme === t ? "btn-primary" : "btn-ghost"
-                              }`}
-                              onClick={() => setTheme(t)}
-                            >
-                              {t.charAt(0).toUpperCase() + t.slice(1)}
-                            </button>
-                          ))}
+                    {!isDevEnv && themes.length > 8 && (
+                      <details className="collapse collapse-arrow bg-base-100">
+                        <summary className="collapse-title text-sm font-medium">
+                          More themes
+                        </summary>
+                        <div className="collapse-content">
+                          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3 pt-2">
+                            {themes.slice(8).map((t) => (
+                              <button
+                                key={t}
+                                className={`btn btn-sm w-full ${
+                                  theme === t ? "btn-primary" : "btn-ghost"
+                                }`}
+                                onClick={() => setTheme(t)}
+                              >
+                                {t.charAt(0).toUpperCase() + t.slice(1)}
+                              </button>
+                            ))}
+                          </div>
                         </div>
-                      </div>
-                    </details>
+                      </details>
+                    )}
                   </div>
 
                   {/* Color palette */}

--- a/ui/src/app/(auth)/tasks/page.tsx
+++ b/ui/src/app/(auth)/tasks/page.tsx
@@ -623,6 +623,7 @@ export default function TasksPage() {
                       cursorStyle: "line",
                       cursorBlinking: "blink",
                       readOnly: isEditorLocked,
+                      domReadOnly: isEditorLocked,
                     }}
                   />
                 )}

--- a/ui/src/app/(auth)/workflow/[name]/page.tsx
+++ b/ui/src/app/(auth)/workflow/[name]/page.tsx
@@ -423,6 +423,7 @@ export default function EditFlowPage() {
                   cursorStyle: "line",
                   cursorBlinking: "blink",
                   readOnly: isEditorLocked,
+                  domReadOnly: isEditorLocked,
                 }}
               />
             ) : (

--- a/ui/src/app/(public)/login/page.tsx
+++ b/ui/src/app/(public)/login/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useCallback, useState, useEffect } from "react";
 
-import { Book, Github } from "lucide-react";
+import { Book, Github, Moon, Sun } from "lucide-react";
 
+import { useTheme } from "@/app/providers/theme-provider";
 import { EnvironmentBadge } from "@/components/ui/EnvironmentBadge";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { useAuth } from "@/contexts/AuthContext";
@@ -15,6 +16,13 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const router = useRouter();
   const { login: authLogin, loading } = useAuth();
+  const { theme, setTheme } = useTheme();
+
+  const isDarkTheme = theme === "dark";
+
+  const toggleTheme = useCallback(() => {
+    setTheme(isDarkTheme ? "light" : "dark");
+  }, [isDarkTheme, setTheme]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -69,7 +77,7 @@ export default function LoginPage() {
             <span className="badge badge-outline badge-lg">Monitoring</span>
             <span className="badge badge-outline badge-lg">Workflow</span>
           </div>
-          <div className="flex gap-4 mt-6 justify-center lg:justify-start">
+          <div className="flex gap-2 sm:gap-4 mt-6 justify-center lg:justify-start flex-wrap">
             <a
               href="https://oqtopus-team.github.io/qdash/"
               target="_blank"
@@ -88,6 +96,14 @@ export default function LoginPage() {
               <Github size={18} />
               GitHub
             </a>
+            <button
+              onClick={toggleTheme}
+              className="btn btn-ghost btn-sm gap-2"
+              aria-label="Toggle theme"
+            >
+              {isDarkTheme ? <Sun size={18} /> : <Moon size={18} />}
+              Theme
+            </button>
           </div>
         </div>
 

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -528,13 +528,13 @@ a.card:hover {
 html[data-theme="light"],
 :root[data-theme="light"],
 [data-theme="light"] {
-  /* ベース色 - VitePress light mode */
+  /* Base colors - VitePress light mode */
   --color-base-100: #ffffff !important;
   --color-base-200: #f6f6f7 !important;
   --color-base-300: #e2e2e3 !important;
   --color-base-content: #3c3c43 !important;
 
-  /* プライマリカラー - OQTOPUS brand */
+  /* Primary colors - OQTOPUS brand */
   --color-primary: #1f1fdd !important;
   --color-primary-content: #ffffff !important;
   --color-secondary: #e21331 !important;
@@ -544,7 +544,7 @@ html[data-theme="light"],
   --color-neutral: #dddde3 !important;
   --color-neutral-content: #3c3c43 !important;
 
-  /* ステータスカラー - VitePress palette */
+  /* Status colors - VitePress palette */
   --color-info: #3a5ccc !important;
   --color-info-content: #ffffff !important;
   --color-success: #18794e !important;
@@ -562,13 +562,13 @@ html[data-theme="light"],
 html[data-theme="dark"],
 :root[data-theme="dark"],
 [data-theme="dark"] {
-  /* ベース色 - VitePress dark mode */
+  /* Base colors - VitePress dark mode */
   --color-base-100: #1b1b1f !important;
   --color-base-200: #161618 !important;
   --color-base-300: #2e2e32 !important;
   --color-base-content: rgba(255, 255, 255, 0.87) !important;
 
-  /* プライマリカラー - OQTOPUS brand (dark variants) */
+  /* Primary colors - OQTOPUS brand (dark variants) */
   --color-primary: #5555f0 !important;
   --color-primary-content: #ffffff !important;
   --color-secondary: #e21331 !important;
@@ -578,7 +578,7 @@ html[data-theme="dark"],
   --color-neutral: #515c67 !important;
   --color-neutral-content: rgba(255, 255, 255, 0.87) !important;
 
-  /* ステータスカラー - VitePress palette (dark variants) */
+  /* Status colors - VitePress palette (dark variants) */
   --color-info: #5c73e7 !important;
   --color-info-content: #ffffff !important;
   --color-success: #3dd68c !important;
@@ -587,6 +587,74 @@ html[data-theme="dark"],
   --color-warning-content: #1b1b1f !important;
   --color-error: #f66f81 !important;
   --color-error-content: #1b1b1f !important;
+}
+
+/* ----------------------------------------
+   Dev Environment Light Theme
+   Vivid purple/magenta for clear visual distinction
+   ---------------------------------------- */
+html[data-theme="dev-light"],
+:root[data-theme="dev-light"],
+[data-theme="dev-light"] {
+  /* Base colors - noticeably purple-tinted */
+  --color-base-100: #f5f0ff !important;
+  --color-base-200: #ebe0ff !important;
+  --color-base-300: #d8c8f5 !important;
+  --color-base-content: #2d1f4e !important;
+
+  /* Primary colors - Vivid Purple */
+  --color-primary: #7c3aed !important;
+  --color-primary-content: #ffffff !important;
+  --color-secondary: #db2777 !important;
+  --color-secondary-content: #ffffff !important;
+  --color-accent: #c026d3 !important;
+  --color-accent-content: #ffffff !important;
+  --color-neutral: #c4b5fd !important;
+  --color-neutral-content: #2d1f4e !important;
+
+  /* Status colors */
+  --color-info: #8b5cf6 !important;
+  --color-info-content: #ffffff !important;
+  --color-success: #059669 !important;
+  --color-success-content: #ffffff !important;
+  --color-warning: #d97706 !important;
+  --color-warning-content: #ffffff !important;
+  --color-error: #dc2626 !important;
+  --color-error-content: #ffffff !important;
+}
+
+/* ----------------------------------------
+   Dev Environment Dark Theme
+   Vivid purple/magenta for clear visual distinction
+   ---------------------------------------- */
+html[data-theme="dev-dark"],
+:root[data-theme="dev-dark"],
+[data-theme="dev-dark"] {
+  /* Base colors - deep purple-tinted dark */
+  --color-base-100: #1e1033 !important;
+  --color-base-200: #150a24 !important;
+  --color-base-300: #2d1b4e !important;
+  --color-base-content: rgba(255, 255, 255, 0.92) !important;
+
+  /* Primary colors - Vivid Purple (dark variants) */
+  --color-primary: #a78bfa !important;
+  --color-primary-content: #1e1033 !important;
+  --color-secondary: #f472b6 !important;
+  --color-secondary-content: #1e1033 !important;
+  --color-accent: #e879f9 !important;
+  --color-accent-content: #1e1033 !important;
+  --color-neutral: #5b4380 !important;
+  --color-neutral-content: rgba(255, 255, 255, 0.92) !important;
+
+  /* Status colors */
+  --color-info: #a78bfa !important;
+  --color-info-content: #1e1033 !important;
+  --color-success: #34d399 !important;
+  --color-success-content: #1e1033 !important;
+  --color-warning: #fbbf24 !important;
+  --color-warning-content: #1e1033 !important;
+  --color-error: #fb7185 !important;
+  --color-error-content: #1e1033 !important;
 }
 
 /* Import other DaisyUI themes that users can select */
@@ -702,6 +770,72 @@ html[data-theme="dark"],
   background-clip: text;
 }
 
+/* Login page background gradient - Dev Light mode */
+[data-theme="dev-light"] .login-page-bg {
+  background: linear-gradient(
+    135deg,
+    #f5f0ff 0%,
+    #ebe0ff 25%,
+    #fce7f3 75%,
+    #f5f0ff 100%
+  );
+}
+
+[data-theme="dev-light"] .login-page-bg::before {
+  background:
+    radial-gradient(
+      ellipse at 20% 30%,
+      rgba(124, 58, 237, 0.15) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      ellipse at 80% 70%,
+      rgba(219, 39, 119, 0.12) 0%,
+      transparent 50%
+    );
+}
+
+/* Login title gradient text - Dev Light mode */
+[data-theme="dev-light"] .login-title-gradient {
+  background: linear-gradient(120deg, #7c3aed 30%, #db2777 70%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Login page background gradient - Dev Dark mode */
+[data-theme="dev-dark"] .login-page-bg {
+  background: linear-gradient(
+    135deg,
+    #1e1033 0%,
+    #2d1b4e 25%,
+    #2a1f3d 75%,
+    #1e1033 100%
+  );
+}
+
+[data-theme="dev-dark"] .login-page-bg::before {
+  background:
+    radial-gradient(
+      ellipse at 20% 30%,
+      rgba(167, 139, 250, 0.2) 0%,
+      transparent 50%
+    ),
+    radial-gradient(
+      ellipse at 80% 70%,
+      rgba(244, 114, 182, 0.15) 0%,
+      transparent 50%
+    );
+}
+
+/* Login title gradient text - Dev Dark mode */
+[data-theme="dev-dark"] .login-title-gradient {
+  background: linear-gradient(120deg, #a78bfa 30%, #f472b6 70%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
 /* ----------------------------------------
    Page Title Gradient (Generic)
    ---------------------------------------- */
@@ -779,6 +913,50 @@ html[data-theme="dark"],
 [data-theme="dark"] .btn-glow:active:not(:disabled) {
   box-shadow:
     0 2px 10px rgba(85, 85, 240, 0.4),
+    0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Glow button effect - Dev Light mode */
+[data-theme="dev-light"] .btn-glow {
+  background: linear-gradient(135deg, #7c3aed 0%, #a855f7 100%);
+  box-shadow:
+    0 4px 15px rgba(124, 58, 237, 0.4),
+    0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dev-light"] .btn-glow:hover:not(:disabled) {
+  background: linear-gradient(135deg, #a855f7 0%, #c084fc 100%);
+  box-shadow:
+    0 6px 20px rgba(124, 58, 237, 0.5),
+    0 0 30px rgba(124, 58, 237, 0.3),
+    0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dev-light"] .btn-glow:active:not(:disabled) {
+  box-shadow:
+    0 2px 10px rgba(124, 58, 237, 0.4),
+    0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* Glow button effect - Dev Dark mode */
+[data-theme="dev-dark"] .btn-glow {
+  background: linear-gradient(135deg, #a78bfa 0%, #c4b5fd 100%);
+  box-shadow:
+    0 4px 15px rgba(167, 139, 250, 0.5),
+    0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dev-dark"] .btn-glow:hover:not(:disabled) {
+  background: linear-gradient(135deg, #c4b5fd 0%, #ddd6fe 100%);
+  box-shadow:
+    0 6px 20px rgba(167, 139, 250, 0.6),
+    0 0 30px rgba(167, 139, 250, 0.4),
+    0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dev-dark"] .btn-glow:active:not(:disabled) {
+  box-shadow:
+    0 2px 10px rgba(167, 139, 250, 0.5),
     0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
@@ -1075,6 +1253,28 @@ html[data-theme="dark"],
   }
 }
 
+@keyframes glow-dev-light {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 8px rgba(124, 58, 237, 0.4));
+  }
+  50% {
+    filter: drop-shadow(0 0 15px rgba(124, 58, 237, 0.5))
+      drop-shadow(0 0 25px rgba(219, 39, 119, 0.3));
+  }
+}
+
+@keyframes glow-dev-dark {
+  0%,
+  100% {
+    filter: drop-shadow(0 0 10px rgba(167, 139, 250, 0.5));
+  }
+  50% {
+    filter: drop-shadow(0 0 18px rgba(167, 139, 250, 0.6))
+      drop-shadow(0 0 30px rgba(244, 114, 182, 0.4));
+  }
+}
+
 .floating-logo {
   animation:
     float 4s ease-in-out infinite,
@@ -1085,6 +1285,18 @@ html[data-theme="dark"],
   animation:
     float 4s ease-in-out infinite,
     glow-dark 3s ease-in-out infinite;
+}
+
+[data-theme="dev-light"] .floating-logo {
+  animation:
+    float 4s ease-in-out infinite,
+    glow-dev-light 3s ease-in-out infinite;
+}
+
+[data-theme="dev-dark"] .floating-logo {
+  animation:
+    float 4s ease-in-out infinite,
+    glow-dev-dark 3s ease-in-out infinite;
 }
 
 /* 404 Page - Lost logo animation */

--- a/ui/src/app/providers/theme-provider.tsx
+++ b/ui/src/app/providers/theme-provider.tsx
@@ -11,46 +11,93 @@ import {
 
 import { themeChange } from "theme-change";
 
-type Theme = string; // daisyUIのすべてのテーマを許可
+type Theme = string; // Allow all daisyUI themes
 
 interface ThemeContextProps {
   theme: Theme;
   setTheme: (theme: Theme) => void;
+  isDevEnv: boolean;
 }
 
 const ThemeContext = createContext<ThemeContextProps | undefined>(undefined);
 
+// Check if current environment is dev
+function isDevEnvironment(): boolean {
+  const env = process.env.NEXT_PUBLIC_ENV?.toLowerCase() ?? "";
+  return env.includes("dev");
+}
+
+// Theme mapping for dev environment
+const DEV_THEME_MAP: Record<string, string> = {
+  light: "dev-light",
+  dark: "dev-dark",
+};
+
+// Get actual theme to apply (converts based on environment)
+function getActualTheme(baseTheme: string, isDev: boolean): string {
+  if (isDev && DEV_THEME_MAP[baseTheme]) {
+    return DEV_THEME_MAP[baseTheme];
+  }
+  return baseTheme;
+}
+
+// Get base theme name from dev-specific theme
+function getBaseTheme(actualTheme: string): string {
+  for (const [base, dev] of Object.entries(DEV_THEME_MAP)) {
+    if (actualTheme === dev) {
+      return base;
+    }
+  }
+  return actualTheme;
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = useState<Theme>("light");
+  const isDevEnv = isDevEnvironment();
 
   useEffect(() => {
     // Get theme from localStorage on client-side only
     const savedTheme = localStorage.getItem("theme");
     if (savedTheme) {
-      setThemeState(savedTheme);
-      document.documentElement.setAttribute("data-theme", savedTheme);
+      // Saved theme is base theme name, convert to actual theme based on env
+      const baseTheme = getBaseTheme(savedTheme);
+      setThemeState(baseTheme);
+      const actualTheme = getActualTheme(baseTheme, isDevEnv);
+      document.documentElement.setAttribute("data-theme", actualTheme);
+    } else {
+      // Apply default theme
+      const actualTheme = getActualTheme("light", isDevEnv);
+      document.documentElement.setAttribute("data-theme", actualTheme);
     }
     themeChange(false);
-  }, []);
+  }, [isDevEnv]);
 
   useEffect(() => {
-    document.documentElement.setAttribute("data-theme", theme);
-  }, [theme]);
+    const actualTheme = getActualTheme(theme, isDevEnv);
+    document.documentElement.setAttribute("data-theme", actualTheme);
+  }, [theme, isDevEnv]);
 
-  const setTheme = useCallback((newTheme: Theme) => {
-    setThemeState(newTheme);
-    if (typeof window !== "undefined") {
-      localStorage.setItem("theme", newTheme);
-      document.documentElement.setAttribute("data-theme", newTheme);
-    }
-  }, []);
+  const setTheme = useCallback(
+    (newTheme: Theme) => {
+      // Save base theme name (light, dark, etc.)
+      const baseTheme = getBaseTheme(newTheme);
+      setThemeState(baseTheme);
+      if (typeof window !== "undefined") {
+        localStorage.setItem("theme", baseTheme);
+        const actualTheme = getActualTheme(baseTheme, isDevEnv);
+        document.documentElement.setAttribute("data-theme", actualTheme);
+      }
+    },
+    [isDevEnv],
+  );
 
   const value = useMemo(
     () => ({
       theme,
       setTheme,
+      isDevEnv,
     }),
-    [theme, setTheme],
+    [theme, setTheme, isDevEnv],
   );
 
   return (

--- a/ui/src/components/features/execution/ExecutionDAG.tsx
+++ b/ui/src/components/features/execution/ExecutionDAG.tsx
@@ -89,7 +89,7 @@ const CustomNode = ({ data }: NodeProps) => {
         borderWidth: "2px",
         minWidth: "150px",
         maxWidth: "300px",
-        height: "60px", // 固定の高さ
+        height: "60px", // Fixed height
         display: "flex",
         flexDirection: "column",
         justifyContent: "center",

--- a/ui/src/components/features/execution/ExecutionStats.tsx
+++ b/ui/src/components/features/execution/ExecutionStats.tsx
@@ -58,7 +58,7 @@ export function ExecutionStats({
         try {
           const start = new Date(exec.start_at).getTime();
           const end = new Date(exec.end_at).getTime();
-          const duration = (end - start) / 1000; // 秒単位
+          const duration = (end - start) / 1000; // In seconds
           return duration > 0 ? duration : 0;
         } catch (error) {
           console.error("Error calculating duration:", error);

--- a/ui/src/lib/api/custom-instance.ts
+++ b/ui/src/lib/api/custom-instance.ts
@@ -8,18 +8,18 @@ export const AXIOS_INSTANCE = Axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL || "/api",
 });
 
-// リクエストインターセプターを追加
+// Add request interceptor
 AXIOS_INSTANCE.interceptors.request.use((config) => {
-  // クッキーからトークンを取得
+  // Get token from cookie
   const token = document.cookie
     .split("; ")
     .find((row) => row.startsWith("access_token="))
     ?.split("=")[1];
 
   if (token) {
-    // トークンをデコード
+    // Decode token
     const decodedToken = decodeURIComponent(token);
-    // Authorization: Bearer ヘッダーを設定
+    // Set Authorization: Bearer header
     if (!config.headers) {
       config.headers = new AxiosHeaders();
     }

--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -13,16 +13,16 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 1. 認証不要なページの処理
+  // 1. Handle pages that don't require authentication
   if (isLoginPage || isSignupPage) {
-    // ログインページで認証済みの場合はexecutionにリダイレクト
+    // Redirect to execution if already authenticated on login page
     if (isLoginPage && token) {
       return NextResponse.redirect(new URL("/execution", request.url));
     }
     return NextResponse.next();
   }
 
-  // 2. その他のページは認証が必要
+  // 2. Other pages require authentication
   if (!token) {
     return NextResponse.redirect(new URL("/login", request.url));
   }
@@ -30,14 +30,14 @@ export function middleware(request: NextRequest) {
   return NextResponse.next();
 }
 
-// 認証が必要なパスを指定
+// Specify paths that require authentication
 export const config = {
   matcher: [
     /*
-     * 以下のパスに対してミドルウェアを適用:
-     * - すべてのパス（/:path*）
-     * - ルートパス（/）
-     * 除外: _next/static, _next/image, favicon, 静的ファイル（画像等）
+     * Apply middleware to the following paths:
+     * - All paths (/:path*)
+     * - Root path (/)
+     * Exclude: _next/static, _next/image, favicon, static files (images, etc.)
      */
     "/((?!_next/static|_next/image|favicon.ico|.*\\.png$|.*\\.svg$|.*\\.jpg$|.*\\.jpeg$|.*\\.gif$|.*\\.ico$).*)",
   ],


### PR DESCRIPTION
- Add dev-light/dev-dark themes with purple accents for clear dev/prod distinction
- In dev, restrict selectable themes to light/dark (mapped to dev variants) and show a warning
- Add domReadOnly to Monaco editor to fully honor lock state
- Rename Taskfile tasks: deploy-dev -> deploy-local, deploy-prod -> deploy
- Set .env.example ENV default to "oqtopus" to align naming

BREAKING CHANGE:
- Taskfile task names changed: use `task deploy-local` (was deploy-dev) and `task deploy` (was deploy-prod)
- If you relied on ENV="oqtopus-dev" by default, set it explicitly in your .env for local dev
