### PR TITLE
refactor(ui): simplify chip/qubit controls and date navigation

### DIFF
--- a/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitsId]/page.tsx
+++ b/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitsId]/page.tsx
@@ -71,13 +71,11 @@ function QubitDetailPageContent() {
     }
   }, [isInitialized, chipId, selectedChip, setSelectedChip]);
 
-  const {
-    navigateToPreviousDay,
-    navigateToNextDay,
-    canNavigatePrevious,
-    canNavigateNext,
-    formatDate,
-  } = useDateNavigation(chipId, selectedDate, setSelectedDate);
+  const { formatDate } = useDateNavigation(
+    chipId,
+    selectedDate,
+    setSelectedDate,
+  );
 
   // Get filtered tasks for qubit type
   const filteredTasks = (taskInfoData?.data?.tasks || []).filter(
@@ -218,61 +216,29 @@ function QubitDetailPageContent() {
 
           {/* Controls */}
           <div className="flex gap-4">
-            <div className="flex flex-col gap-1">
-              <div className="flex justify-center gap-1 opacity-0">
-                <button className="btn btn-xs btn-ghost invisible">←</button>
-                <button className="btn btn-xs btn-ghost invisible">→</button>
-              </div>
-              <ChipSelector
-                selectedChip={chipId}
-                onChipSelect={(newChipId) => {
-                  // Navigate to the new chip's qubit detail page
-                  window.location.href = `/chip/${newChipId}/qubit/${qubitId}`;
-                }}
-              />
-            </div>
+            <ChipSelector
+              selectedChip={chipId}
+              onChipSelect={(newChipId) => {
+                // Navigate to the new chip's qubit detail page
+                window.location.href = `/chip/${newChipId}/qubit/${qubitId}`;
+              }}
+            />
 
             {viewMode !== "history" && (
-              <div className="flex flex-col gap-1">
-                <div className="flex justify-center gap-1">
-                  <button
-                    onClick={navigateToPreviousDay}
-                    disabled={!canNavigatePrevious}
-                    className="btn btn-xs btn-ghost"
-                    title="Previous Day"
-                  >
-                    ←
-                  </button>
-                  <button
-                    onClick={navigateToNextDay}
-                    disabled={!canNavigateNext}
-                    className="btn btn-xs btn-ghost"
-                    title="Next Day"
-                  >
-                    →
-                  </button>
-                </div>
-                <DateSelector
-                  chipId={chipId}
-                  selectedDate={selectedDate}
-                  onDateSelect={setSelectedDate}
-                  disabled={!chipId}
-                />
-              </div>
+              <DateSelector
+                chipId={chipId}
+                selectedDate={selectedDate}
+                onDateSelect={setSelectedDate}
+                disabled={!chipId}
+              />
             )}
 
-            <div className="flex flex-col gap-1">
-              <div className="flex justify-center gap-1 opacity-0">
-                <button className="btn btn-xs btn-ghost invisible">←</button>
-                <button className="btn btn-xs btn-ghost invisible">→</button>
-              </div>
-              <TaskSelector
-                tasks={filteredTasks}
-                selectedTask={selectedTask}
-                onTaskSelect={setSelectedTask}
-                disabled={false}
-              />
-            </div>
+            <TaskSelector
+              tasks={filteredTasks}
+              selectedTask={selectedTask}
+              onTaskSelect={setSelectedTask}
+              disabled={false}
+            />
           </div>
         </div>
 

--- a/ui/src/components/features/analysis/TimeSeriesView/index.tsx
+++ b/ui/src/components/features/analysis/TimeSeriesView/index.tsx
@@ -700,10 +700,7 @@ export function TimeSeriesView() {
           </button>
         </div>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
-          <div className="space-y-1">
-            <label className="text-sm font-medium text-base-content/70">
-              Chip
-            </label>
+          <div>
             <ChipSelector
               selectedChip={selectedChip}
               onChipSelect={setSelectedChip}
@@ -755,10 +752,7 @@ export function TimeSeriesView() {
               }}
             />
           </div>
-          <div className="space-y-1">
-            <label className="text-sm font-medium text-base-content/70">
-              Tag
-            </label>
+          <div>
             <TagSelector
               tags={tags}
               selectedTag={selectedTag}

--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -402,40 +402,14 @@ export function ChipPageContent() {
           {/* Selection Controls */}
           <div className="flex flex-col md:flex-row md:justify-between md:items-end gap-4">
             <div className="flex flex-col sm:flex-row gap-4 flex-shrink-0">
-              <div className="flex flex-col gap-1 w-full sm:w-auto">
-                <label className="text-xs text-base-content/60 font-medium">
-                  Chip
-                </label>
+              <div className="w-full sm:w-auto">
                 <ChipSelector
                   selectedChip={selectedChip}
                   onChipSelect={setSelectedChip}
                 />
               </div>
 
-              <div className="flex flex-col gap-1 w-full sm:w-auto">
-                <div className="flex items-center justify-between">
-                  <label className="text-xs text-base-content/60 font-medium">
-                    Date
-                  </label>
-                  <div className="flex gap-1">
-                    <button
-                      onClick={navigateToPreviousDay}
-                      disabled={!canNavigatePrevious}
-                      className="btn btn-xs btn-ghost px-1"
-                      title="Previous Day"
-                    >
-                      ←
-                    </button>
-                    <button
-                      onClick={navigateToNextDay}
-                      disabled={!canNavigateNext}
-                      className="btn btn-xs btn-ghost px-1"
-                      title="Next Day"
-                    >
-                      →
-                    </button>
-                  </div>
-                </div>
+              <div className="w-full sm:w-auto">
                 <DateSelector
                   chipId={selectedChip}
                   selectedDate={selectedDate}
@@ -444,10 +418,7 @@ export function ChipPageContent() {
                 />
               </div>
 
-              <div className="flex flex-col gap-1 w-full sm:w-auto">
-                <label className="text-xs text-base-content/60 font-medium">
-                  Task
-                </label>
+              <div className="w-full sm:w-auto">
                 <TaskSelector
                   tasks={filteredTasks}
                   selectedTask={selectedTask}

--- a/ui/src/components/features/chip/CouplingGrid/index.tsx
+++ b/ui/src/components/features/chip/CouplingGrid/index.tsx
@@ -6,6 +6,7 @@ import type { Task } from "@/schemas";
 
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { CouplingTaskHistoryModal } from "@/components/features/chip/modals/CouplingTaskHistoryModal";
+import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { useCouplingTaskResults } from "@/hooks/useCouplingTaskResults";
 import { useTopologyConfig } from "@/hooks/useTopologyConfig";
 import {
@@ -232,19 +233,11 @@ export function CouplingGrid({
     <div ref={containerRef} className="space-y-4 px-4">
       {/* Zoom mode toggle - only show in full view mode for square grids */}
       {zoomMode === "full" && gridRows === gridCols && (
-        <div className="flex items-center gap-2 px-4">
-          <label className="text-sm font-medium">Region Zoom:</label>
-          <input
-            type="checkbox"
-            checked={regionSelectionEnabled}
-            onChange={(e) => setRegionSelectionEnabled(e.target.checked)}
-            className="toggle toggle-sm toggle-primary"
+        <div className="px-4">
+          <RegionZoomToggle
+            enabled={regionSelectionEnabled}
+            onToggle={setRegionSelectionEnabled}
           />
-          <span className="text-xs text-base-content/70">
-            {regionSelectionEnabled
-              ? "Enabled - Click a region to zoom"
-              : "Disabled"}
-          </span>
         </div>
       )}
 

--- a/ui/src/components/features/chip/TaskResultGrid/index.tsx
+++ b/ui/src/components/features/chip/TaskResultGrid/index.tsx
@@ -6,6 +6,7 @@ import type { Task } from "@/schemas";
 
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { TaskHistoryModal } from "@/components/features/chip/modals/TaskHistoryModal";
+import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { useQubitTaskResults } from "@/hooks/useQubitTaskResults";
 import { useTopologyConfig } from "@/hooks/useTopologyConfig";
 import {
@@ -195,19 +196,11 @@ export function TaskResultGrid({
     <div className="space-y-4">
       {/* Zoom mode toggle - only show in full view mode for square grids */}
       {zoomMode === "full" && gridRows === gridCols && (
-        <div className="flex items-center gap-2 px-4">
-          <label className="text-sm font-medium">Region Zoom:</label>
-          <input
-            type="checkbox"
-            checked={regionSelectionEnabled}
-            onChange={(e) => setRegionSelectionEnabled(e.target.checked)}
-            className="toggle toggle-sm toggle-primary"
+        <div className="px-4">
+          <RegionZoomToggle
+            enabled={regionSelectionEnabled}
+            onToggle={setRegionSelectionEnabled}
           />
-          <span className="text-xs text-base-content/70">
-            {regionSelectionEnabled
-              ? "Enabled - Click a region to zoom"
-              : "Disabled"}
-          </span>
         </div>
       )}
 

--- a/ui/src/components/features/execution/ExecutionPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionPageContent.tsx
@@ -45,13 +45,8 @@ export function ExecutionPageContent() {
   // Track if we've already set the default chip to prevent race conditions
   const hasSetDefaultChip = useRef(false);
 
-  // Use custom hook for date navigation
-  const {
-    navigateToPreviousDay,
-    navigateToNextDay,
-    canNavigatePrevious,
-    canNavigateNext,
-  } = useDateNavigation(selectedChip || "", selectedDate, setSelectedDate);
+  // Use custom hook for date navigation (unused but kept for potential future use)
+  useDateNavigation(selectedChip || "", selectedDate, setSelectedDate);
 
   // Get list of chips to set default
   const { data: chipsData } = useListChips();
@@ -226,43 +221,16 @@ export function ExecutionPageContent() {
         </p>
       </div>
       <div className="px-3 sm:px-10 pb-4 sm:pb-6 flex flex-col sm:flex-row gap-3 sm:gap-4">
-        <div className="flex flex-col gap-1">
-          <div className="flex justify-center gap-1 opacity-0">
-            <button className="btn btn-xs btn-ghost invisible">←</button>
-            <button className="btn btn-xs btn-ghost invisible">→</button>
-          </div>
-          <ChipSelector
-            selectedChip={selectedChip || ""}
-            onChipSelect={handleChipChange}
-          />
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <div className="flex justify-center gap-1">
-            <button
-              onClick={navigateToPreviousDay}
-              disabled={!canNavigatePrevious}
-              className="btn btn-xs btn-ghost"
-              title="Previous Day"
-            >
-              ←
-            </button>
-            <button
-              onClick={navigateToNextDay}
-              disabled={!canNavigateNext}
-              className="btn btn-xs btn-ghost"
-              title="Next Day"
-            >
-              →
-            </button>
-          </div>
-          <DateSelector
-            chipId={selectedChip || ""}
-            selectedDate={selectedDate}
-            onDateSelect={setSelectedDate}
-            disabled={!selectedChip}
-          />
-        </div>
+        <ChipSelector
+          selectedChip={selectedChip || ""}
+          onChipSelect={handleChipChange}
+        />
+        <DateSelector
+          chipId={selectedChip || ""}
+          selectedDate={selectedDate}
+          onDateSelect={setSelectedDate}
+          disabled={!selectedChip}
+        />
       </div>
       {/* Statistics display */}
       <ExecutionStats

--- a/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from "react";
 
+import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { useTopologyConfig } from "@/hooks/useTopologyConfig";
 import {
   getQubitGridPosition,
@@ -328,61 +329,10 @@ export function CouplingMetricsGrid({
     <div className="flex flex-col h-full space-y-4" ref={containerRef}>
       {/* Zoom mode toggle - only show in full view mode for square grids */}
       {zoomMode === "full" && isSquareGrid && (
-        <div
-          className={`flex items-center gap-3 p-3 rounded-lg border-2 transition-all duration-200 cursor-pointer select-none ${
-            regionSelectionEnabled
-              ? "bg-primary/10 border-primary"
-              : "bg-base-200/50 border-base-300 hover:border-primary/50"
-          }`}
-          onClick={() => setRegionSelectionEnabled(!regionSelectionEnabled)}
-        >
-          <div
-            className={`p-2 rounded-lg ${
-              regionSelectionEnabled
-                ? "bg-primary text-primary-content"
-                : "bg-base-300"
-            }`}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <circle cx="11" cy="11" r="8" />
-              <path d="m21 21-4.3-4.3" />
-              <path d="M11 8v6" />
-              <path d="M8 11h6" />
-            </svg>
-          </div>
-          <div className="flex-1">
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-sm">Region Zoom</span>
-              {regionSelectionEnabled && (
-                <span className="badge badge-primary badge-xs">Active</span>
-              )}
-            </div>
-            <p className="text-xs text-base-content/60">
-              {regionSelectionEnabled
-                ? "Click any 2×2 region on the grid to zoom in"
-                : "Enable to zoom into specific regions"}
-            </p>
-          </div>
-          <input
-            type="checkbox"
-            checked={regionSelectionEnabled}
-            onChange={(e) => {
-              e.stopPropagation();
-              setRegionSelectionEnabled(e.target.checked);
-            }}
-            className="toggle toggle-primary"
-          />
-        </div>
+        <RegionZoomToggle
+          enabled={regionSelectionEnabled}
+          onToggle={setRegionSelectionEnabled}
+        />
       )}
 
       {/* Back button when in region mode */}

--- a/ui/src/components/features/metrics/MetricsPageContent.tsx
+++ b/ui/src/components/features/metrics/MetricsPageContent.tsx
@@ -318,20 +318,14 @@ export function MetricsPageContent() {
               </div>
             </div>
 
-            <div className="flex flex-col gap-1 w-full sm:w-auto">
-              <label className="text-xs text-base-content/60 font-medium">
-                Chip
-              </label>
+            <div className="w-full sm:w-auto">
               <ChipSelector
                 selectedChip={selectedChip}
                 onChipSelect={setSelectedChip}
               />
             </div>
 
-            <div className="flex flex-col gap-1 w-full sm:w-auto">
-              <label className="text-xs text-base-content/60 font-medium">
-                Metric
-              </label>
+            <div className="w-full sm:w-auto">
               <Select<MetricOption, false, GroupBase<MetricOption>>
                 className="w-full sm:w-64 text-base-content"
                 classNamePrefix="react-select"

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -8,6 +8,7 @@ import React, {
   useCallback,
 } from "react";
 
+import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { useTopologyConfig } from "@/hooks/useTopologyConfig";
 import {
   getQubitGridPosition,
@@ -298,61 +299,10 @@ export function QubitMetricsGrid({
     <div className="flex flex-col h-full space-y-4">
       {/* Zoom mode toggle - only show in full view mode for square grids */}
       {zoomMode === "full" && isSquareGrid && (
-        <div
-          className={`flex items-center gap-3 p-3 rounded-lg border-2 transition-all duration-200 cursor-pointer select-none ${
-            regionSelectionEnabled
-              ? "bg-primary/10 border-primary"
-              : "bg-base-200/50 border-base-300 hover:border-primary/50"
-          }`}
-          onClick={() => setRegionSelectionEnabled(!regionSelectionEnabled)}
-        >
-          <div
-            className={`p-2 rounded-lg ${
-              regionSelectionEnabled
-                ? "bg-primary text-primary-content"
-                : "bg-base-300"
-            }`}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <circle cx="11" cy="11" r="8" />
-              <path d="m21 21-4.3-4.3" />
-              <path d="M11 8v6" />
-              <path d="M8 11h6" />
-            </svg>
-          </div>
-          <div className="flex-1">
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-sm">Region Zoom</span>
-              {regionSelectionEnabled && (
-                <span className="badge badge-primary badge-xs">Active</span>
-              )}
-            </div>
-            <p className="text-xs text-base-content/60">
-              {regionSelectionEnabled
-                ? "Click any 2×2 region on the grid to zoom in"
-                : "Enable to zoom into specific regions"}
-            </p>
-          </div>
-          <input
-            type="checkbox"
-            checked={regionSelectionEnabled}
-            onChange={(e) => {
-              e.stopPropagation();
-              setRegionSelectionEnabled(e.target.checked);
-            }}
-            className="toggle toggle-primary"
-          />
-        </div>
+        <RegionZoomToggle
+          enabled={regionSelectionEnabled}
+          onToggle={setRegionSelectionEnabled}
+        />
       )}
 
       {/* Back button when in region mode */}

--- a/ui/src/components/selectors/ChipSelector/index.tsx
+++ b/ui/src/components/selectors/ChipSelector/index.tsx
@@ -7,6 +7,7 @@ import Select from "react-select";
 import type { SingleValue } from "react-select";
 
 import { useListChips } from "@/client/chip/chip";
+import { useSelectStyles } from "@/hooks/useSelectStyles";
 
 interface ChipOption {
   value: string;
@@ -18,6 +19,8 @@ interface ChipSelectorProps {
   selectedChip: string;
   onChipSelect: (chipId: string) => void;
 }
+
+const PLACEHOLDER = "Select a chip";
 
 export function ChipSelector({
   selectedChip,
@@ -45,10 +48,15 @@ export function ChipSelector({
       }));
   }, [chips]);
 
+  const { minWidth, styles } = useSelectStyles<ChipOption>({
+    labels: sortedOptions.map((opt) => opt.label),
+    placeholder: PLACEHOLDER,
+  });
+
   if (isLoading) {
     return (
-      <div className="w-full animate-pulse">
-        <div className="h-9 bg-base-300 rounded"></div>
+      <div className="animate-pulse" style={{ minWidth }}>
+        <div className="h-[38px] bg-base-300 rounded"></div>
       </div>
     );
   }
@@ -68,8 +76,9 @@ export function ChipSelector({
       options={sortedOptions}
       value={sortedOptions.find((option) => option.value === selectedChip)}
       onChange={handleChange}
-      placeholder="Select a chip"
-      className="text-base-content w-full"
+      placeholder={PLACEHOLDER}
+      className="text-base-content"
+      styles={styles}
     />
   );
 }

--- a/ui/src/components/selectors/DateSelector/index.tsx
+++ b/ui/src/components/selectors/DateSelector/index.tsx
@@ -7,6 +7,7 @@ import Select from "react-select";
 import type { SingleValue } from "react-select";
 
 import { useGetChipDates } from "@/client/chip/chip";
+import { useSelectStyles } from "@/hooks/useSelectStyles";
 
 interface DateOption {
   value: string;
@@ -19,6 +20,8 @@ interface DateSelectorProps {
   onDateSelect: (date: string) => void;
   disabled?: boolean;
 }
+
+const PLACEHOLDER = "Select a date";
 
 /**
  * Component for selecting a date from available dates
@@ -69,11 +72,16 @@ export function DateSelector({
     }));
   }, [datesResponse]);
 
+  const { minWidth, styles } = useSelectStyles<DateOption>({
+    labels: dateOptions.map((opt) => opt.label),
+    placeholder: PLACEHOLDER,
+  });
+
   // Show loading state but keep the current selection visible
   if (isLoading) {
     return (
-      <div className="w-full animate-pulse">
-        <div className="h-9 bg-base-300 rounded"></div>
+      <div className="animate-pulse" style={{ minWidth }}>
+        <div className="h-[38px] bg-base-300 rounded"></div>
       </div>
     );
   }
@@ -86,7 +94,8 @@ export function DateSelector({
         value={{ value: "latest", label: "Latest" }}
         onChange={handleChange}
         isDisabled={disabled}
-        className="text-base-content w-full"
+        className="text-base-content"
+        styles={styles}
       />
     );
   }
@@ -96,9 +105,10 @@ export function DateSelector({
       options={dateOptions}
       value={dateOptions.find((option) => option.value === selectedDate)}
       onChange={handleChange}
-      placeholder="Select a date"
-      className="text-base-content w-full"
+      placeholder={PLACEHOLDER}
+      className="text-base-content"
       isDisabled={disabled}
+      styles={styles}
     />
   );
 }

--- a/ui/src/components/selectors/TaskSelector/index.tsx
+++ b/ui/src/components/selectors/TaskSelector/index.tsx
@@ -4,6 +4,8 @@ import Select from "react-select";
 
 import type { SingleValue } from "react-select";
 
+import { useSelectStyles } from "@/hooks/useSelectStyles";
+
 interface TaskOption {
   value: string;
   label: string;
@@ -21,6 +23,8 @@ interface TaskSelectorProps {
   disabled?: boolean;
 }
 
+const PLACEHOLDER = "Select a task";
+
 export function TaskSelector({
   tasks,
   selectedTask,
@@ -31,6 +35,11 @@ export function TaskSelector({
     value: task.name,
     label: task.name,
   }));
+
+  const { styles } = useSelectStyles<TaskOption>({
+    labels: options.map((opt) => opt.label),
+    placeholder: PLACEHOLDER,
+  });
 
   const handleChange = (option: SingleValue<TaskOption>) => {
     if (option) {
@@ -43,9 +52,10 @@ export function TaskSelector({
       options={options}
       value={options.find((option) => option.value === selectedTask)}
       onChange={handleChange}
-      placeholder="Select a task"
-      className="text-base-content w-full"
+      placeholder={PLACEHOLDER}
+      className="text-base-content"
       isDisabled={disabled}
+      styles={styles}
     />
   );
 }

--- a/ui/src/components/ui/RegionZoomToggle.tsx
+++ b/ui/src/components/ui/RegionZoomToggle.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+interface RegionZoomToggleProps {
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+}
+
+export function RegionZoomToggle({ enabled, onToggle }: RegionZoomToggleProps) {
+  return (
+    <div
+      className={`flex items-center gap-3 p-3 rounded-lg border-2 transition-all duration-200 cursor-pointer select-none ${
+        enabled
+          ? "bg-primary/10 border-primary"
+          : "bg-base-200/50 border-base-300 hover:border-primary/50"
+      }`}
+      onClick={() => onToggle(!enabled)}
+    >
+      <div
+        className={`p-2 rounded-lg ${
+          enabled ? "bg-primary text-primary-content" : "bg-base-300"
+        }`}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.3-4.3" />
+          <path d="M11 8v6" />
+          <path d="M8 11h6" />
+        </svg>
+      </div>
+      <div className="flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-sm">Region Zoom</span>
+          {enabled && (
+            <span className="badge badge-primary badge-xs">Active</span>
+          )}
+        </div>
+        <p className="text-xs text-base-content/60">
+          {enabled
+            ? "Click any region on the grid to zoom in"
+            : "Enable to zoom into specific regions"}
+        </p>
+      </div>
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={(e) => {
+          e.stopPropagation();
+          onToggle(e.target.checked);
+        }}
+        className="toggle toggle-primary"
+      />
+    </div>
+  );
+}

--- a/ui/src/hooks/useSelectStyles.ts
+++ b/ui/src/hooks/useSelectStyles.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+
+import type { StylesConfig } from "react-select";
+
+interface UseSelectStylesOptions {
+  labels: string[];
+  placeholder: string;
+  charWidth?: number;
+  padding?: number;
+}
+
+export function useSelectStyles<T>({
+  labels,
+  placeholder,
+  charWidth = 8,
+  padding = 60,
+}: UseSelectStylesOptions) {
+  const minWidth = useMemo(() => {
+    const maxLength = Math.max(
+      ...labels.map((l) => l.length),
+      placeholder.length,
+    );
+    return maxLength * charWidth + padding;
+  }, [labels, placeholder, charWidth, padding]);
+
+  const styles = useMemo<StylesConfig<T, false>>(
+    () => ({
+      container: (provided) => ({
+        ...provided,
+        minWidth,
+      }),
+      control: (provided) => ({
+        ...provided,
+        minHeight: 38,
+      }),
+      menu: (provided) => ({
+        ...provided,
+        zIndex: 20,
+        minWidth,
+      }),
+    }),
+    [minWidth],
+  );
+
+  return { minWidth, styles };
+}


### PR DESCRIPTION
- Remove previous/next day arrow buttons and related layout wrappers
- Only use `formatDate` from `useDateNavigation` to avoid unused hook values
- Rely on `DateSelector`/`ChipSelector`/`TaskSelector` directly for a cleaner UI and less duplicated markup
