### PR TITLE
Ui/fix-grid

### DIFF
--- a/ui/src/hooks/useGridLayout.ts
+++ b/ui/src/hooks/useGridLayout.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type RefObject,
+} from "react";
+
+import {
+  calculateCellSize,
+  calculateGridContainerWidth,
+  calculateGridDimension,
+  checkIsMobile,
+  getGridGap,
+  getGridPadding,
+} from "@/utils/gridLayout";
+
+interface UseGridLayoutParams {
+  /** Number of columns in the grid */
+  cols: number;
+  /** Number of rows in the grid */
+  rows: number;
+  /** Custom minimum cell size (optional) */
+  minCellSize?: number;
+  /** Height to reserve for header/controls (default: 300 mobile, 350 desktop) */
+  reservedHeight?: { mobile: number; desktop: number };
+  /** Additional dependencies that should trigger recalculation */
+  deps?: unknown[];
+}
+
+interface UseGridLayoutResult {
+  /** Reference to attach to the container element */
+  containerRef: RefObject<HTMLDivElement>;
+  /** Calculated cell size in pixels */
+  cellSize: number;
+  /** Whether the viewport is mobile width */
+  isMobile: boolean;
+  /** Gap between cells in pixels */
+  gap: number;
+  /** Padding for grid container in pixels */
+  padding: number;
+  /** Calculate grid dimension (width or height) without padding */
+  getGridDimension: (count: number) => number;
+  /** Calculate grid container width with padding */
+  getContainerWidth: (cols: number) => number;
+  /** Force recalculation of sizes */
+  updateSize: () => void;
+}
+
+/**
+ * Custom hook for managing responsive grid layout
+ * Handles cell size calculation, resize events, and provides utility functions
+ */
+export function useGridLayout({
+  cols,
+  rows,
+  minCellSize,
+  reservedHeight = { mobile: 300, desktop: 350 },
+  deps = [],
+}: UseGridLayoutParams): UseGridLayoutResult {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [cellSize, setCellSize] = useState(60);
+  const [isMobile, setIsMobile] = useState(false);
+
+  const updateSize = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const viewportWidth = window.innerWidth;
+    const mobile = checkIsMobile(viewportWidth);
+    setIsMobile(mobile);
+
+    const containerPadding = mobile ? 16 : 32;
+    const containerWidth =
+      Math.min(container.offsetWidth, viewportWidth) - containerPadding * 2;
+    const viewportHeight = window.innerHeight;
+    const availableHeight =
+      viewportHeight -
+      (mobile ? reservedHeight.mobile : reservedHeight.desktop);
+
+    const newCellSize = calculateCellSize({
+      containerWidth,
+      availableHeight,
+      cols,
+      rows,
+      isMobile: mobile,
+      minCellSize,
+    });
+
+    setCellSize(newCellSize);
+  }, [cols, rows, minCellSize, reservedHeight.mobile, reservedHeight.desktop]);
+
+  // Initial calculation and resize listener
+  useEffect(() => {
+    const timeoutId = setTimeout(updateSize, 0);
+    window.addEventListener("resize", updateSize);
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener("resize", updateSize);
+    };
+  }, [updateSize]);
+
+  // Recalculate when dependencies change
+  useEffect(() => {
+    updateSize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updateSize, ...deps]);
+
+  const gap = getGridGap(isMobile);
+  const padding = getGridPadding(isMobile);
+
+  const getGridDimension = useCallback(
+    (count: number) => calculateGridDimension(count, cellSize, isMobile),
+    [cellSize, isMobile],
+  );
+
+  const getContainerWidth = useCallback(
+    (colCount: number) =>
+      calculateGridContainerWidth(colCount, cellSize, isMobile),
+    [cellSize, isMobile],
+  );
+
+  return {
+    containerRef,
+    cellSize,
+    isMobile,
+    gap,
+    padding,
+    getGridDimension,
+    getContainerWidth,
+    updateSize,
+  };
+}

--- a/ui/src/utils/gridLayout.ts
+++ b/ui/src/utils/gridLayout.ts
@@ -1,0 +1,114 @@
+/**
+ * Grid layout utilities for consistent grid sizing across components
+ */
+
+/** Grid gap in pixels based on mobile/desktop */
+export const GRID_GAP = {
+  mobile: 4,
+  desktop: 8,
+} as const;
+
+/** Grid padding in pixels based on mobile/desktop */
+export const GRID_PADDING = {
+  mobile: 16,
+  desktop: 32,
+} as const;
+
+/** Minimum cell size in pixels based on mobile/desktop */
+export const MIN_CELL_SIZE = {
+  mobile: 28,
+  desktop: 40,
+} as const;
+
+/** Mobile breakpoint in pixels */
+export const MOBILE_BREAKPOINT = 768;
+
+/**
+ * Get the gap size based on mobile state
+ */
+export function getGridGap(isMobile: boolean): number {
+  return isMobile ? GRID_GAP.mobile : GRID_GAP.desktop;
+}
+
+/**
+ * Get the padding size based on mobile state
+ */
+export function getGridPadding(isMobile: boolean): number {
+  return isMobile ? GRID_PADDING.mobile : GRID_PADDING.desktop;
+}
+
+/**
+ * Get the minimum cell size based on mobile state
+ */
+export function getMinCellSize(isMobile: boolean): number {
+  return isMobile ? MIN_CELL_SIZE.mobile : MIN_CELL_SIZE.desktop;
+}
+
+/**
+ * Calculate the total grid width/height
+ * Formula: n * cellSize + (n - 1) * gap
+ */
+export function calculateGridDimension(
+  count: number,
+  cellSize: number,
+  isMobile: boolean,
+): number {
+  const gap = getGridGap(isMobile);
+  return count * cellSize + (count - 1) * gap;
+}
+
+/**
+ * Calculate the total grid container width including padding
+ * Formula: n * cellSize + (n - 1) * gap + 2 * padding
+ */
+export function calculateGridContainerWidth(
+  cols: number,
+  cellSize: number,
+  isMobile: boolean,
+): number {
+  const gap = getGridGap(isMobile);
+  const padding = getGridPadding(isMobile);
+  return cols * cellSize + (cols - 1) * gap + padding;
+}
+
+/**
+ * Check if viewport is mobile width
+ */
+export function checkIsMobile(viewportWidth: number): boolean {
+  return viewportWidth < MOBILE_BREAKPOINT;
+}
+
+/**
+ * Calculate optimal cell size to fit grid in available space
+ */
+export function calculateCellSize(params: {
+  containerWidth: number;
+  availableHeight: number;
+  cols: number;
+  rows: number;
+  isMobile: boolean;
+  minCellSize?: number;
+}): number {
+  const {
+    containerWidth,
+    availableHeight,
+    cols,
+    rows,
+    isMobile,
+    minCellSize: customMinSize,
+  } = params;
+
+  const gap = getGridGap(isMobile);
+  const minSize = customMinSize ?? getMinCellSize(isMobile);
+
+  const totalGapX = gap * (cols - 1);
+  const totalGapY = gap * (rows - 1);
+
+  // Calculate max cell size that fits both dimensions
+  const maxCellByWidth = Math.floor((containerWidth - totalGapX) / cols);
+  const maxCellByHeight = Math.floor((availableHeight - totalGapY) / rows);
+
+  // Use smaller dimension, with min size constraint
+  const calculatedSize = Math.min(maxCellByWidth, maxCellByHeight);
+  return Math.max(minSize, calculatedSize);
+}


### PR DESCRIPTION
- Replace duplicated resize/effect-based cell size logic in CouplingGrid and QubitMetricsGrid with the shared `useGridLayout` hook
- Use new grid layout utilities (e.g., `calculateGridDimension`/`calculateGridContainerWidth`) to compute responsive dimensions consistently
- Simplifies components and ensures consistent mobile detection, spacing, and sizing behavior across grids
