### PR TITLE
fix(topology): derive qubit positions from topology config

### DIFF
--- a/src/qdash/api/services/chip_initializer.py
+++ b/src/qdash/api/services/chip_initializer.py
@@ -3,8 +3,8 @@
 import logging
 
 from qdash.api.lib.topology_config import load_topology
-from qdash.datamodel.coupling import CouplingModel, EdgeInfoModel
-from qdash.datamodel.qubit import NodeInfoModel, PositionModel, QubitModel
+from qdash.datamodel.coupling import CouplingModel
+from qdash.datamodel.qubit import QubitModel
 from qdash.dbmodel.chip import ChipDocument
 from qdash.dbmodel.coupling import CouplingDocument
 from qdash.dbmodel.qubit import QubitDocument
@@ -56,19 +56,13 @@ class ChipInitializer:
 
         """
         qubits = {}
-        for qid, pos in topology_qubits.items():
+        for qid in topology_qubits:
             qubits[f"{qid}"] = QubitModel(
                 project_id=project_id,
                 username=username,
                 chip_id=chip_id,
                 qid=f"{qid}",
                 status="pending",
-                node_info=NodeInfoModel(
-                    position=PositionModel(
-                        x=float(pos.col * 50),  # Simple grid spacing
-                        y=float(pos.row * 50),
-                    ),
-                ),
                 data={},
                 best_data={},
             )
@@ -105,7 +99,6 @@ class ChipInitializer:
                 chip_id=chip_id,
                 data={},
                 best_data={},
-                edge_info=EdgeInfoModel(size=4, fill="", source=f"{edge[0]}", target=f"{edge[1]}"),
             )
         return couplings
 
@@ -131,19 +124,13 @@ class ChipInitializer:
 
         """
         documents = []
-        for qid, pos in topology_qubits.items():
+        for qid in topology_qubits:
             qubit_doc = QubitDocument(
                 project_id=project_id,
                 username=username,
                 chip_id=chip_id,
                 qid=f"{qid}",
                 status="pending",
-                node_info=NodeInfoModel(
-                    position=PositionModel(
-                        x=float(pos.col * 50),
-                        y=float(pos.row * 50),
-                    ),
-                ),
                 data={},
                 best_data={},
                 system_info={},
@@ -182,7 +169,6 @@ class ChipInitializer:
                 chip_id=chip_id,
                 data={},
                 best_data={},
-                edge_info=EdgeInfoModel(size=4, fill="", source=f"{edge[0]}", target=f"{edge[1]}"),
                 system_info={},
             )
             documents.append(coupling_doc)

--- a/src/qdash/datamodel/coupling.py
+++ b/src/qdash/datamodel/coupling.py
@@ -30,7 +30,9 @@ class CouplingModel(BaseModel):
     """
 
     project_id: str | None = Field(None, description="Owning project identifier")
-    username: str | None = Field(None, description="The username of the user who created the coupling")
+    username: str | None = Field(
+        None, description="The username of the user who created the coupling"
+    )
     qid: str = Field(..., description="The coupling ID")
     status: str = Field("pending", description="The status of the coupling")
     chip_id: str | None = Field(None, description="The chip ID")
@@ -39,4 +41,6 @@ class CouplingModel(BaseModel):
         default_factory=dict,
         description="The best calibration results, focusing on fidelity metrics",
     )
-    edge_info: EdgeInfoModel = Field(..., description="The edge information")
+    edge_info: EdgeInfoModel | None = Field(
+        default=None, description="The edge information (deprecated)"
+    )

--- a/src/qdash/datamodel/qubit.py
+++ b/src/qdash/datamodel/qubit.py
@@ -52,7 +52,9 @@ class QubitModel(BaseModel):
         default_factory=dict,
         description="The best calibration results, focusing on fidelity metrics",
     )
-    node_info: NodeInfoModel = Field(..., description="The node information")
+    node_info: NodeInfoModel | None = Field(
+        default=None, description="The node information (deprecated)"
+    )
 
     @field_validator("data", mode="before")
     @classmethod

--- a/src/qdash/db/init/chip.py
+++ b/src/qdash/db/init/chip.py
@@ -1,7 +1,7 @@
 """Chip initialization module."""
 
-from qdash.datamodel.coupling import CouplingModel, EdgeInfoModel
-from qdash.datamodel.qubit import NodeInfoModel, PositionModel, QubitModel
+from qdash.datamodel.coupling import CouplingModel
+from qdash.datamodel.qubit import QubitModel
 from qdash.db.init.coupling import bi_direction, generate_coupling
 from qdash.db.init.qubit import (
     generate_dummy_data,  # qubit_lattice
@@ -22,7 +22,7 @@ def generate_qubit_data(num_qubits: int, pos: dict, chip_id: str, username: str)
     Args:
     ----
         num_qubits (int): Number of qubits.
-        pos (dict): Dictionary of positions for each qubit.
+        pos (dict): Dictionary of positions for each qubit (deprecated, kept for compatibility).
         chip_id (str): Chip ID.
         username (str): Username of the user creating the qubits.
 
@@ -38,12 +38,6 @@ def generate_qubit_data(num_qubits: int, pos: dict, chip_id: str, username: str)
             chip_id=chip_id,
             qid=f"{i}",
             status="pending",
-            node_info=NodeInfoModel(
-                position=PositionModel(
-                    x=pos[i][0],
-                    y=pos[i][1],
-                ),
-            ),
             data={},
             best_data={},
         )
@@ -74,7 +68,6 @@ def generate_coupling_data(edges: list[tuple[int, int]], chip_id: str, username:
             chip_id=chip_id,
             data={},
             best_data={},
-            edge_info=EdgeInfoModel(size=4, fill="", source=f"{edge[0]}", target=f"{edge[1]}"),
         )
     return coupling
 

--- a/src/qdash/db/init/coupling.py
+++ b/src/qdash/db/init/coupling.py
@@ -1,6 +1,5 @@
 """Coupling initialization module."""
 
-from qdash.datamodel.coupling import EdgeInfoModel
 from qdash.dbmodel.coupling import CouplingDocument
 
 
@@ -31,7 +30,6 @@ def generate_coupling(edges: list, username: str, chip_id: str) -> list:
             chip_id=chip_id,
             data={},
             best_data={},
-            edge_info=EdgeInfoModel(size=4, fill="", source=f"{edge[0]}", target=f"{edge[1]}"),
             system_info={},
         )
         for edge in edges

--- a/src/qdash/db/init/qubit.py
+++ b/src/qdash/db/init/qubit.py
@@ -1,6 +1,5 @@
 """Qubit initialization module."""
 
-from qdash.datamodel.qubit import NodeInfoModel, PositionModel
 from qdash.dbmodel.qubit import QubitDocument
 
 
@@ -67,7 +66,7 @@ def generate_dummy_data(num_qubits: int, pos: dict, username: str, chip_id: str)
     Args:
     ----
         num_qubits (int): Number of qubits
-        pos (dict): Position dictionary
+        pos (dict): Position dictionary (deprecated, kept for compatibility)
         username (str): Username
         chip_id (str): Chip ID
 
@@ -83,12 +82,6 @@ def generate_dummy_data(num_qubits: int, pos: dict, username: str, chip_id: str)
             chip_id=chip_id,
             qid=f"{i}",
             status="pending",
-            node_info=NodeInfoModel(
-                position=PositionModel(
-                    x=pos[i][0],
-                    y=pos[i][1],
-                ),
-            ),
             data={},
             best_data={},
             system_info={},

--- a/src/qdash/dbmodel/coupling_history.py
+++ b/src/qdash/dbmodel/coupling_history.py
@@ -34,7 +34,9 @@ class CouplingHistoryDocument(Document):
         default_factory=dict,
         description="The best calibration results, focusing on fidelity metrics",
     )
-    edge_info: EdgeInfoModel = Field(..., description="The edge information")
+    edge_info: EdgeInfoModel | None = Field(
+        default=None, description="The edge information (deprecated)"
+    )
     system_info: SystemInfoModel = Field(..., description="The system information")
     recorded_date: str = Field(
         default_factory=lambda: pendulum.now(tz="Asia/Tokyo").format("YYYYMMDD"),
@@ -60,7 +62,9 @@ class CouplingHistoryDocument(Document):
                 ],
                 unique=True,
             ),
-            IndexModel([("project_id", ASCENDING), ("chip_id", ASCENDING), ("recorded_date", DESCENDING)]),
+            IndexModel(
+                [("project_id", ASCENDING), ("chip_id", ASCENDING), ("recorded_date", DESCENDING)]
+            ),
         ]
 
     @classmethod

--- a/src/qdash/dbmodel/qubit.py
+++ b/src/qdash/dbmodel/qubit.py
@@ -33,7 +33,9 @@ class QubitDocument(Document):
         default_factory=dict,
         description="The best calibration results, focusing on fidelity metrics",
     )
-    node_info: NodeInfoModel = Field(..., description="The node information")
+    node_info: NodeInfoModel | None = Field(
+        default=None, description="The node information (deprecated)"
+    )
 
     system_info: SystemInfoModel = Field(..., description="The system information")
 
@@ -47,7 +49,12 @@ class QubitDocument(Document):
         name = "qubit"
         indexes: ClassVar = [
             IndexModel(
-                [("project_id", ASCENDING), ("chip_id", ASCENDING), ("qid", ASCENDING), ("username", ASCENDING)],
+                [
+                    ("project_id", ASCENDING),
+                    ("chip_id", ASCENDING),
+                    ("qid", ASCENDING),
+                    ("username", ASCENDING),
+                ],
                 unique=True,
             ),
             IndexModel([("project_id", ASCENDING), ("chip_id", ASCENDING)]),
@@ -86,7 +93,9 @@ class QubitDocument(Document):
                 new_param = new_data[metric]
                 new_value = new_param.value if hasattr(new_param, "value") else 0.0
                 # Initialize if metric doesn't exist in best_data or new value is better
-                current_value = current_best[metric].get("value", 0.0) if metric in current_best else 0.0
+                current_value = (
+                    current_best[metric].get("value", 0.0) if metric in current_best else 0.0
+                )
                 if metric not in current_best or new_value > current_value:
                     # Convert OutputParameterModel to dict for storage
                     current_best[metric] = {
@@ -131,7 +140,6 @@ class QubitDocument(Document):
             chip_id=chip_id,
             data=qubit_doc.data,
             best_data=qubit_doc.best_data,
-            node_info=qubit_doc.node_info,
             username=username,
         )
         chip_doc.update_qubit(qid, qubit_model)

--- a/src/qdash/dbmodel/qubit_history.py
+++ b/src/qdash/dbmodel/qubit_history.py
@@ -34,7 +34,9 @@ class QubitHistoryDocument(Document):
         default_factory=dict,
         description="The best calibration results, focusing on fidelity metrics",
     )
-    node_info: NodeInfoModel = Field(..., description="The node information")
+    node_info: NodeInfoModel | None = Field(
+        default=None, description="The node information (deprecated)"
+    )
     system_info: SystemInfoModel = Field(..., description="The system information")
     recorded_date: str = Field(
         default_factory=lambda: pendulum.now(tz="Asia/Tokyo").format("YYYYMMDD"),
@@ -60,7 +62,9 @@ class QubitHistoryDocument(Document):
                 ],
                 unique=True,
             ),
-            IndexModel([("project_id", ASCENDING), ("chip_id", ASCENDING), ("recorded_date", DESCENDING)]),
+            IndexModel(
+                [("project_id", ASCENDING), ("chip_id", ASCENDING), ("recorded_date", DESCENDING)]
+            ),
         ]
 
     @classmethod


### PR DESCRIPTION
Load the topology via `load_topology(chip_docs.topology_id)` and compute
qubit `Position` from config row/col using shared scaling constants,
instead of using stored `chip_docs` node positions for more consistent
layout generation.
