### PR TITLE
fix(ui): center chip and metrics grids in scroll containers

### DIFF
--- a/ui/src/components/features/chip/CouplingGrid/index.tsx
+++ b/ui/src/components/features/chip/CouplingGrid/index.tsx
@@ -214,7 +214,7 @@ export function CouplingGrid({
       )}
 
       {/* Grid Container - scrollable for non-square or large grids */}
-      <div className="relative overflow-x-auto p-1 md:p-4">
+      <div className="relative overflow-x-auto p-1 md:p-4 flex justify-center">
         <div
           className="relative flex-shrink-0 mx-auto"
           style={{

--- a/ui/src/components/features/chip/TaskResultGrid/index.tsx
+++ b/ui/src/components/features/chip/TaskResultGrid/index.tsx
@@ -186,7 +186,10 @@ export function TaskResultGrid({
       )}
 
       {/* Grid Container - scrollable for non-square or large grids */}
-      <div className="relative overflow-x-auto p-1 md:p-4" ref={containerRef}>
+      <div
+        className="relative overflow-x-auto p-1 md:p-4 flex justify-center"
+        ref={containerRef}
+      >
         <div
           className="grid gap-1 md:gap-2 p-2 md:p-4 bg-base-200/50 rounded-xl relative"
           style={{

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -277,7 +277,7 @@ export function QubitMetricsGrid({
 
       {/* Grid display */}
       <div
-        className="flex-1 p-1 md:p-4 relative overflow-x-auto"
+        className="flex-1 p-1 md:p-4 relative overflow-x-auto flex justify-center"
         ref={containerRef}
       >
         <div


### PR DESCRIPTION
Add `flex justify-center` to CouplingGrid, TaskResultGrid, and QubitMetricsGrid container wrappers to keep grids horizontally centered while preserving overflow scrolling for wide/non-square layouts.
