### PR TITLE
feat(ui): refine chip grid card styles and selection highlight

### DIFF
--- a/ui/src/components/features/chip/CouplingGrid/index.tsx
+++ b/ui/src/components/features/chip/CouplingGrid/index.tsx
@@ -381,18 +381,20 @@ export function CouplingGrid({
                     width: displayCellSize * 0.6,
                     height: displayCellSize * 0.6,
                   }}
-                  className={`rounded-lg bg-base-100 shadow-sm overflow-hidden transition-all duration-200 hover:shadow-xl hover:scale-105 -translate-x-1/2 -translate-y-1/2 ${
+                  className={`rounded-xl bg-white shadow-md border border-base-300/60 overflow-hidden transition-all duration-200 hover:shadow-xl hover:scale-105 hover:border-primary/40 -translate-x-1/2 -translate-y-1/2 ${
                     task.over_threshold
-                      ? "border-2 border-primary animate-pulse-light"
+                      ? "ring-2 ring-primary ring-offset-1 animate-pulse-light"
                       : ""
                   }`}
                 >
                   {figurePath && (
-                    <TaskFigure
-                      path={figurePath}
-                      qid={String(task.couplingId)}
-                      className="w-full h-full object-contain"
-                    />
+                    <div className="absolute inset-1">
+                      <TaskFigure
+                        path={figurePath}
+                        qid={String(task.couplingId)}
+                        className="w-full h-full object-contain"
+                      />
+                    </div>
                   )}
                 </button>
               );

--- a/ui/src/components/features/chip/TaskResultGrid/index.tsx
+++ b/ui/src/components/features/chip/TaskResultGrid/index.tsx
@@ -262,14 +262,14 @@ export function TaskResultGrid({
                 onClick={() => {
                   setSelectedTaskInfo({ qid, taskName: selectedTask });
                 }}
-                className={`aspect-square rounded-lg bg-base-100 shadow-sm overflow-hidden transition-all duration-200 hover:shadow-xl hover:scale-105 relative w-full ${
+                className={`aspect-square rounded-xl bg-white shadow-md border border-base-300/60 overflow-hidden transition-all duration-200 hover:shadow-xl hover:scale-105 hover:border-primary/40 relative w-full ${
                   task.over_threshold
-                    ? "border-2 border-primary animate-pulse-light"
+                    ? "ring-2 ring-primary ring-offset-1 animate-pulse-light"
                     : ""
                 } ${muxBgClass}`}
               >
                 {task.figure_path && figurePath && (
-                  <div className="absolute inset-0">
+                  <div className="absolute inset-1">
                     <TaskFigure
                       path={figurePath}
                       qid={qid}


### PR DESCRIPTION
Update CouplingGrid and TaskResultGrid buttons to use rounded-xl white cards with borders and stronger shadows, switch over-threshold highlight from border to ring for clearer emphasis, and inset TaskFigure by 1px to avoid edge clipping.
