### PR TITLE
feat(ui): add QuantumLoader and replace analysis spinners

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -1615,3 +1615,116 @@ html[data-theme="dev-dark"],
   text-transform: uppercase !important;
   opacity: 0.7 !important;
 }
+
+/* ========================================
+   Quantum Loader Animation
+   ======================================== */
+
+@keyframes quantum-orbit {
+  0% {
+    transform: rotate(0deg) translateX(20px) rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg) translateX(20px) rotate(-360deg);
+  }
+}
+
+@keyframes quantum-orbit-reverse {
+  0% {
+    transform: rotate(0deg) translateX(16px) rotate(0deg);
+  }
+  100% {
+    transform: rotate(-360deg) translateX(16px) rotate(360deg);
+  }
+}
+
+@keyframes quantum-core-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow:
+      0 0 10px var(--color-primary),
+      0 0 20px color-mix(in oklch, var(--color-primary) 50%, transparent);
+  }
+  50% {
+    transform: scale(1.1);
+    box-shadow:
+      0 0 15px var(--color-primary),
+      0 0 30px color-mix(in oklch, var(--color-primary) 60%, transparent),
+      0 0 40px color-mix(in oklch, var(--color-secondary) 30%, transparent);
+  }
+}
+
+.quantum-loader {
+  position: relative;
+  width: 60px;
+  height: 60px;
+}
+
+.quantum-loader-core {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  margin: -8px 0 0 -8px;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-secondary)
+  );
+  border-radius: 50%;
+  animation: quantum-core-pulse 2s ease-in-out infinite;
+}
+
+.quantum-loader-orbit {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  margin: -4px 0 0 -4px;
+  border-radius: 50%;
+}
+
+.quantum-loader-orbit-1 {
+  background: var(--color-primary);
+  animation: quantum-orbit 1.5s linear infinite;
+  box-shadow: 0 0 8px var(--color-primary);
+}
+
+.quantum-loader-orbit-2 {
+  background: var(--color-secondary);
+  animation: quantum-orbit-reverse 2s linear infinite;
+  box-shadow: 0 0 8px var(--color-secondary);
+}
+
+.quantum-loader-orbit-3 {
+  background: var(--color-accent);
+  animation: quantum-orbit 2.5s linear infinite;
+  animation-delay: 0.5s;
+  box-shadow: 0 0 8px var(--color-accent);
+}
+
+/* Quantum trail effect */
+.quantum-loader-ring {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 2px solid transparent;
+  border-top-color: color-mix(in oklch, var(--color-primary) 40%, transparent);
+  border-radius: 50%;
+  animation: quantum-orbit 3s linear infinite;
+}
+
+.quantum-loader-ring:nth-child(2) {
+  border-top-color: color-mix(
+    in oklch,
+    var(--color-secondary) 30%,
+    transparent
+  );
+  animation-duration: 2.5s;
+  animation-direction: reverse;
+}

--- a/ui/src/components/features/analysis/CDFView.tsx
+++ b/ui/src/components/features/analysis/CDFView.tsx
@@ -10,6 +10,7 @@ import { PlotCard } from "@/components/charts/PlotCard";
 import { ChipSelector } from "@/components/selectors/ChipSelector";
 import { DataTable } from "@/components/ui/DataTable";
 import { ErrorCard } from "@/components/ui/ErrorCard";
+import { QuantumLoader } from "@/components/ui/QuantumLoader";
 import { useCSVExport } from "@/hooks/useCSVExport";
 import { useMetricsConfig, type MetricConfig } from "@/hooks/useMetricsConfig";
 import { useCDFUrlState } from "@/hooks/useUrlState";
@@ -693,7 +694,7 @@ export function CDFView() {
   if (!isInitialized || isConfigLoading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <span className="loading loading-spinner loading-lg"></span>
+        <QuantumLoader size="lg" />
       </div>
     );
   }

--- a/ui/src/components/features/analysis/CorrelationView/index.tsx
+++ b/ui/src/components/features/analysis/CorrelationView/index.tsx
@@ -10,6 +10,7 @@ import { PlotCard } from "@/components/charts/PlotCard";
 import { ChipSelector } from "@/components/selectors/ChipSelector";
 import { DataTable } from "@/components/ui/DataTable";
 import { ErrorCard } from "@/components/ui/ErrorCard";
+import { QuantumLoader } from "@/components/ui/QuantumLoader";
 import { useCSVExport } from "@/hooks/useCSVExport";
 import { useMetricsConfig } from "@/hooks/useMetricsConfig";
 import { useCorrelationUrlState } from "@/hooks/useUrlState";
@@ -549,7 +550,7 @@ export function CorrelationView() {
   if (!isInitialized || isConfigLoading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <span className="loading loading-spinner loading-lg"></span>
+        <QuantumLoader size="lg" />
       </div>
     );
   }

--- a/ui/src/components/features/analysis/HistogramView.tsx
+++ b/ui/src/components/features/analysis/HistogramView.tsx
@@ -10,6 +10,7 @@ import { PlotCard } from "@/components/charts/PlotCard";
 import { ChipSelector } from "@/components/selectors/ChipSelector";
 import { DataTable } from "@/components/ui/DataTable";
 import { ErrorCard } from "@/components/ui/ErrorCard";
+import { QuantumLoader } from "@/components/ui/QuantumLoader";
 import { useCSVExport } from "@/hooks/useCSVExport";
 import { useMetricsConfig } from "@/hooks/useMetricsConfig";
 import { useHistogramUrlState } from "@/hooks/useUrlState";
@@ -731,7 +732,7 @@ export function HistogramView() {
   if (!isInitialized || isConfigLoading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <span className="loading loading-spinner loading-lg"></span>
+        <QuantumLoader size="lg" />
       </div>
     );
   }

--- a/ui/src/components/features/analysis/TimeSeriesView/index.tsx
+++ b/ui/src/components/features/analysis/TimeSeriesView/index.tsx
@@ -16,6 +16,7 @@ import { TagSelector } from "@/components/selectors/TagSelector";
 import { DataTable } from "@/components/ui/DataTable";
 import { DateTimePicker } from "@/components/ui/DateTimePicker";
 import { ErrorCard } from "@/components/ui/ErrorCard";
+import { QuantumLoader } from "@/components/ui/QuantumLoader";
 import { useCSVExport } from "@/hooks/useCSVExport";
 import { useMetricsConfig } from "@/hooks/useMetricsConfig";
 import { useTimeRange } from "@/hooks/useTimeRange";
@@ -649,7 +650,7 @@ export function TimeSeriesView() {
   if (isConfigLoading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <span className="loading loading-spinner loading-lg"></span>
+        <QuantumLoader size="lg" />
       </div>
     );
   }

--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -23,6 +23,7 @@ import { DateSelector } from "@/components/selectors/DateSelector";
 import { TaskSelector } from "@/components/selectors/TaskSelector";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
+import { QuantumLoader } from "@/components/ui/QuantumLoader";
 import { ChipPageSkeleton } from "@/components/ui/Skeleton/PageSkeletons";
 import { useProject } from "@/contexts/ProjectContext";
 import { useDateNavigation } from "@/hooks/useDateNavigation";
@@ -433,7 +434,7 @@ export function ChipPageContent() {
         <div className="pt-4">
           {isLoadingMux ? (
             <div className="w-full flex justify-center py-12">
-              <span className="loading loading-spinner loading-lg"></span>
+              <QuantumLoader size="lg" />
             </div>
           ) : isMuxError ? (
             <div className="alert alert-error">

--- a/ui/src/components/features/metrics/MetricsPageContent.tsx
+++ b/ui/src/components/features/metrics/MetricsPageContent.tsx
@@ -13,6 +13,7 @@ import { MetricsStatsCards } from "./MetricsStatsCards";
 import { QubitMetricsGrid } from "./QubitMetricsGrid";
 
 import { useListChips, useGetChip } from "@/client/chip/chip";
+import { QuantumLoader } from "@/components/ui/QuantumLoader";
 import { useGetChipMetrics } from "@/client/metrics/metrics";
 import { ChipSelector } from "@/components/selectors/ChipSelector";
 import { PageContainer } from "@/components/ui/PageContainer";
@@ -365,12 +366,19 @@ export function MetricsPageContent() {
           </div>
         ) : isLoading ? (
           <div className="flex items-center justify-center h-96">
-            <span className="loading loading-spinner loading-lg"></span>
+            <QuantumLoader
+              size="lg"
+              showLabel
+              label="Loading metrics data..."
+            />
           </div>
         ) : isConfigLoading ? (
           <div className="flex items-center justify-center h-96">
-            <span className="loading loading-spinner loading-lg"></span>
-            <span className="ml-2">Loading metrics configuration...</span>
+            <QuantumLoader
+              size="lg"
+              showLabel
+              label="Loading metrics configuration..."
+            />
           </div>
         ) : isConfigError ? (
           <div className="alert alert-error">

--- a/ui/src/components/ui/QuantumLoader/index.tsx
+++ b/ui/src/components/ui/QuantumLoader/index.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+type QuantumLoaderProps = {
+  size?: "sm" | "md" | "lg";
+  showLabel?: boolean;
+  label?: string;
+};
+
+/**
+ * Quantum-themed loading spinner that visualizes quantum superposition
+ * with orbiting particles around a pulsing core.
+ */
+export function QuantumLoader({
+  size = "md",
+  showLabel = false,
+  label = "Loading...",
+}: QuantumLoaderProps) {
+  const sizeClasses = {
+    sm: "w-10 h-10",
+    md: "w-16 h-16",
+    lg: "w-24 h-24",
+  };
+
+  const coreSize = {
+    sm: "w-3 h-3 -ml-1.5 -mt-1.5",
+    md: "w-4 h-4 -ml-2 -mt-2",
+    lg: "w-6 h-6 -ml-3 -mt-3",
+  };
+
+  const orbitSize = {
+    sm: "w-1.5 h-1.5 -ml-[3px] -mt-[3px]",
+    md: "w-2 h-2 -ml-1 -mt-1",
+    lg: "w-3 h-3 -ml-1.5 -mt-1.5",
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-3">
+      <div className={`quantum-loader ${sizeClasses[size]}`}>
+        {/* Outer rings */}
+        <div className="quantum-loader-ring" />
+        <div className="quantum-loader-ring" />
+
+        {/* Central core with pulse */}
+        <div className={`quantum-loader-core ${coreSize[size]}`} />
+
+        {/* Orbiting particles */}
+        <div
+          className={`quantum-loader-orbit quantum-loader-orbit-1 ${orbitSize[size]}`}
+        />
+        <div
+          className={`quantum-loader-orbit quantum-loader-orbit-2 ${orbitSize[size]}`}
+        />
+        <div
+          className={`quantum-loader-orbit quantum-loader-orbit-3 ${orbitSize[size]}`}
+        />
+      </div>
+
+      {showLabel && (
+        <span className="text-sm text-base-content/70 animate-pulse">
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Full page quantum loader with centered positioning
+ */
+export function QuantumLoaderPage({
+  label = "Initializing quantum state...",
+}: {
+  label?: string;
+}) {
+  return (
+    <div className="flex justify-center items-center h-full min-h-[200px]">
+      <QuantumLoader size="lg" showLabel label={label} />
+    </div>
+  );
+}
+
+/**
+ * Inline quantum loader for smaller spaces
+ */
+export function QuantumLoaderInline() {
+  return <QuantumLoader size="sm" />;
+}


### PR DESCRIPTION
- Add global CSS keyframes and styles for the new “quantum” loader animation
- Use the QuantumLoader component in analysis views during config/init loading
- Improve loading-state consistency and provide a more distinctive UI indicator
