### PR TITLE
feat(config): add custom metrics template and override env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,9 @@ NEXT_PUBLIC_COPILOT_ENABLED=""
 OPENAI_API_KEY=""
 # Custom path to copilot.yaml config file (optional, defaults to config/copilot.yaml)
 COPILOT_CONFIG_PATH=""
+
+# Custom Metrics Configuration (optional)
+# Set a custom path to metrics.yaml for user-defined metric settings.
+# Priority: METRICS_CONFIG_PATH > config/custom/metrics.yaml > config/metrics.yaml
+# See config/custom/metrics.yaml.template for customization guide.
+METRICS_CONFIG_PATH=""

--- a/.gitignore
+++ b/.gitignore
@@ -228,7 +228,8 @@ src/qdash/workflow/*.json
 src/qdash/workflow/.calibration/*.json
 src/qdash/workflow/.classifier/*/*
 # Ignore all files in config directory except metrics.yaml
-/config/*
+config/qubex/*
+!config/custom/*.template
 !config/metrics.yaml
 !config/settings.yaml
 !config/copilot.yaml

--- a/config/custom/metrics.yaml.template
+++ b/config/custom/metrics.yaml.template
@@ -1,0 +1,283 @@
+# Custom Metrics Configuration Template
+# =====================================
+# Copy this file to `metrics.yaml` in this directory to customize metrics settings.
+# Or set METRICS_CONFIG_PATH environment variable to point to your custom config file.
+#
+# Priority order:
+#   1. METRICS_CONFIG_PATH environment variable (highest priority)
+#   2. config/custom/metrics.yaml
+#   3. /app/config/metrics.yaml (Docker)
+#   4. config/metrics.yaml (default)
+#
+# Example usage:
+#   cp config/custom/metrics.yaml.template config/custom/metrics.yaml
+#   # Edit config/custom/metrics.yaml as needed
+#
+# Or with environment variable:
+#   METRICS_CONFIG_PATH=/path/to/your/metrics.yaml
+
+# Qubit Metrics
+# -------------
+# Each metric requires:
+#   - title: Display name in UI
+#   - unit: Unit string (e.g., "GHz", "μs", "%")
+#   - scale: Multiplier for display (e.g., 1000 to convert GHz to MHz)
+#   - description: Tooltip text (optional)
+#   - evaluation.mode: "maximize", "minimize", or "none"
+#   - threshold: Default threshold with slider range (optional)
+
+qubit_metrics:
+  resonator_frequency:
+    title: Resonator Frequency
+    unit: GHz
+    scale: 1
+    description: Resonance frequency of the readout resonator
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 7.0
+      range:
+        min: 6.0
+        max: 8.0
+        step: 0.01
+
+  qubit_frequency:
+    title: Qubit Frequency
+    unit: GHz
+    scale: 1
+    description: Resonance frequency of the qubit
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 5.0
+      range:
+        min: 4.0
+        max: 6.0
+        step: 0.01
+
+  anharmonicity:
+    title: Qubit Anharmonicity
+    unit: MHz
+    scale: 1000 # Convert GHz to MHz
+    description: Anharmonicity of the qubit energy levels
+    evaluation:
+      mode: minimize
+    threshold:
+      value: -300
+      range:
+        min: -500
+        max: -200
+        step: 1
+
+  t1:
+    title: T1
+    unit: μs
+    scale: 1
+    description: Energy relaxation time
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 100
+      range:
+        min: 25
+        max: 200
+        step: 1
+
+  t2_echo:
+    title: T2 Echo
+    unit: μs
+    scale: 1
+    description: Dephasing time measured with echo sequence
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 200
+      range:
+        min: 50
+        max: 400
+        step: 1
+
+  t2_star:
+    title: T2 Star
+    unit: μs
+    scale: 1
+    description: Free induction decay time
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 50
+      range:
+        min: 15
+        max: 100
+        step: 1
+
+  average_readout_fidelity:
+    title: Average Readout Fidelity
+    unit: "%"
+    scale: 100
+    description: Average fidelity of readout operations
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 0.99 # Raw value (99%)
+      range:
+        min: 0.9
+        max: 0.999
+        step: 0.001
+
+  x90_gate_fidelity:
+    title: X90 Gate Fidelity
+    unit: "%"
+    scale: 100
+    description: Fidelity of X90 (π/2 rotation) gate
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 0.999 # Raw value (99.9%)
+      range:
+        min: 0.9
+        max: 0.9999
+        step: 0.0001
+
+  x180_gate_fidelity:
+    title: X180 Gate Fidelity
+    unit: "%"
+    scale: 100
+    description: Fidelity of X180 (π rotation) gate
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 0.999 # Raw value (99.9%)
+      range:
+        min: 0.9
+        max: 0.9999
+        step: 0.0001
+
+# Coupling Metrics
+# ----------------
+coupling_metrics:
+  zx90_gate_fidelity:
+    title: ZX90 Gate Fidelity
+    unit: "%"
+    scale: 100
+    description: Fidelity of two-qubit ZX90 gate
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 0.99 # Raw value (99%)
+      range:
+        min: 0.9
+        max: 0.999
+        step: 0.001
+
+  bell_state_fidelity:
+    title: Bell State Fidelity
+    unit: "%"
+    scale: 100
+    description: Fidelity of Bell state preparation
+    evaluation:
+      mode: maximize
+    threshold:
+      value: 0.95 # Raw value (95%)
+      range:
+        min: 0.8
+        max: 0.999
+        step: 0.001
+
+  static_zz_interaction:
+    title: Static ZZ Interaction
+    unit: MHz
+    scale: 1000 # Convert GHz to MHz
+    description: Static ZZ coupling strength between qubits
+    evaluation:
+      mode: minimize
+
+# CDF Chart Grouping
+# ------------------
+# Metrics in the same group will be displayed together in a single CDF chart.
+# You can customize groups to organize metrics according to your needs.
+cdf_groups:
+  qubit:
+    - id: resonator_frequency
+      title: Resonator Frequency
+      unit: GHz
+      metrics:
+        - resonator_frequency
+    - id: qubit_frequency
+      title: Qubit Frequency
+      unit: GHz
+      metrics:
+        - qubit_frequency
+    - id: coherence
+      title: Coherence Times
+      unit: μs
+      metrics:
+        - t1
+        - t2_echo
+        - t2_star
+    - id: fidelity
+      title: Fidelity
+      unit: "%"
+      metrics:
+        - x90_gate_fidelity
+        - x180_gate_fidelity
+    - id: readout
+      title: Readout Fidelity
+      unit: "%"
+      metrics:
+        - average_readout_fidelity
+  coupling:
+    - id: coupling_fidelity
+      title: Coupling Fidelity
+      unit: "%"
+      metrics:
+        - zx90_gate_fidelity
+        - bell_state_fidelity
+
+# Color Scale Configuration
+# -------------------------
+# Viridis palette for heatmap visualization.
+# Customize colors as needed for your visualization preferences.
+color_scale:
+  colors:
+    - "#440154" # 0 - Dark purple (lowest values)
+    - "#46085c" # 1
+    - "#481467" # 2
+    - "#482173" # 3
+    - "#472d7b" # 4
+    - "#453882" # 5
+    - "#424086" # 6
+    - "#3f4889" # 7
+    - "#3d4e8a" # 8
+    - "#3a538b" # 9
+    - "#37588c" # 10 - Blue (mid-low values)
+    - "#345d8d" # 11
+    - "#31688e" # 12
+    - "#2e6e8e" # 13
+    - "#2c728e" # 14
+    - "#2a788e" # 15
+    - "#287d8e" # 16
+    - "#25828e" # 17
+    - "#23878e" # 18
+    - "#218c8d" # 19
+    - "#21918c" # 20 - Teal (mid values)
+    - "#22968b" # 21
+    - "#239b89" # 22
+    - "#25a186" # 23
+    - "#29a783" # 24
+    - "#2fac80" # 25
+    - "#35b179" # 26
+    - "#3db771" # 27
+    - "#46bd6a" # 28
+    - "#51c362" # 29
+    - "#5ec962" # 30 - Green (mid-high values)
+    - "#6ed05b" # 31
+    - "#7ed655" # 32
+    - "#8fdc4f" # 33
+    - "#a0e249" # 34
+    - "#b1e745" # 35
+    - "#c2eb42" # 36
+    - "#d4ef40" # 37
+    - "#e5f03f" # 38
+    - "#f5ee3f" # 39
+    - "#fde724" # 40 - Yellow (highest values)

--- a/src/qdash/api/lib/metrics_config.py
+++ b/src/qdash/api/lib/metrics_config.py
@@ -84,17 +84,30 @@ def load_metrics_config() -> MetricsConfig:
         FileNotFoundError: If config file doesn't exist
         ValueError: If config file is invalid
 
+    Priority order for config file:
+        1. METRICS_CONFIG_PATH environment variable (highest priority)
+        2. /app/config/custom/metrics.yaml (Docker custom)
+        3. config/custom/metrics.yaml (local custom)
+        4. /app/config/metrics.yaml (Docker default)
+        5. config/metrics.yaml (local default)
+
     """
     import os
 
-    # Try multiple possible locations for the config file
+    project_root = Path(__file__).parent.parent.parent.parent.parent
+
+    # Try multiple possible locations for the config file (in priority order)
     possible_paths = [
-        # Docker environment: mounted at /app/config
-        Path("/app/config/metrics.yaml"),
-        # Local development: relative to project root
-        Path(__file__).parent.parent.parent.parent.parent / "config" / "metrics.yaml",
-        # Environment variable override
+        # 1. Environment variable override (highest priority)
         Path(os.getenv("METRICS_CONFIG_PATH", "")) if os.getenv("METRICS_CONFIG_PATH") else None,
+        # 2. Custom configuration in config/custom/ (Docker environment)
+        Path("/app/config/custom/metrics.yaml"),
+        # 3. Custom configuration in config/custom/ (local development)
+        project_root / "config" / "custom" / "metrics.yaml",
+        # 4. Docker environment: mounted at /app/config
+        Path("/app/config/metrics.yaml"),
+        # 5. Local development: default config
+        project_root / "config" / "metrics.yaml",
     ]
 
     config_path = None


### PR DESCRIPTION
Document `METRICS_CONFIG_PATH` in `.env.example` and add `config/custom/metrics.yaml.template` to guide user-defined metric settings. Update `.gitignore` to allow custom templates while ignoring `config/qubex/*`, keeping tracked default config files intact.
