### PR TITLE
perf(ui): make modals close instantly and cache history

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -328,25 +328,45 @@ a.card:hover {
 
 .modal-box {
   border-radius: 1.5rem;
-  box-shadow:
-    0 25px 50px -12px rgb(0 0 0 / 0.3),
-    0 0 0 1px rgb(0 0 0 / 0.05);
+  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
   border: 1px solid
     color-mix(in oklch, var(--color-base-content) 10%, transparent);
+  will-change: transform, opacity;
+  contain: layout style paint;
 }
 
-/* Modal backdrop with blur */
+/* Disable all default modal transitions for instant close */
+.modal {
+  transition: none !important;
+}
+
+.modal-box {
+  transition: none !important;
+}
+
+/* Modal backdrop - no transition */
 .modal-backdrop,
 .modal::backdrop {
-  background-color: rgb(0 0 0 / 0.5);
-  backdrop-filter: blur(4px);
+  background-color: rgb(0 0 0 / 0.4);
+  transition: none !important;
 }
 
-/* Modal animation - mobile only (slide up from bottom) */
+/* Modal animation - instant/snappy */
+@keyframes modal-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 @keyframes modal-slide-up {
   from {
     opacity: 0;
-    transform: translateY(100%);
+    transform: translateY(8px);
   }
   to {
     opacity: 1;
@@ -354,23 +374,27 @@ a.card:hover {
   }
 }
 
-@keyframes modal-backdrop-fade {
-  from {
-    opacity: 0;
+/* Desktop: instant pop animation */
+@media (min-width: 640px) {
+  .modal[open] .modal-box {
+    animation: modal-pop 50ms ease-out;
   }
-  to {
+
+  .modal[open]::backdrop {
+    animation: none;
     opacity: 1;
   }
 }
 
-/* Apply slide-up animation only on mobile for modal-bottom */
+/* Mobile: very fast slide-up animation */
 @media (max-width: 639px) {
   .modal-bottom[open] .modal-box {
-    animation: modal-slide-up 0.2s ease-out;
+    animation: modal-slide-up 60ms ease-out;
   }
 
   .modal-bottom[open]::backdrop {
-    animation: modal-backdrop-fade 0.2s ease-out;
+    animation: none;
+    opacity: 1;
   }
 }
 

--- a/ui/src/components/features/chip/modals/CouplingTaskHistoryModal.tsx
+++ b/ui/src/components/features/chip/modals/CouplingTaskHistoryModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useLayoutEffect } from "react";
 
 import type { Task } from "@/schemas";
 
@@ -39,7 +39,8 @@ export function CouplingTaskHistoryModal({
   const [viewMode, setViewMode] = useState<"static" | "interactive">("static");
   const [showParams, setShowParams] = useState(false);
 
-  useEffect(() => {
+  // Use useLayoutEffect for immediate modal open/close (before paint)
+  useLayoutEffect(() => {
     const modal = modalRef.current;
     if (!modal) return;
 
@@ -56,6 +57,8 @@ export function CouplingTaskHistoryModal({
     {
       query: {
         enabled: isOpen && !!chipId && !!couplingId && !!taskName,
+        staleTime: 30000, // Cache for 30 seconds
+        gcTime: 60000, // Keep in cache for 1 minute
       },
     },
   );

--- a/ui/src/components/features/chip/modals/TaskHistoryModal.tsx
+++ b/ui/src/components/features/chip/modals/TaskHistoryModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useLayoutEffect } from "react";
 
 import type { Task } from "@/schemas";
 
@@ -27,7 +27,8 @@ export function TaskHistoryModal({
   const [subIndex, setSubIndex] = useState(0);
   const [showParams, setShowParams] = useState(false);
 
-  useEffect(() => {
+  // Use useLayoutEffect for immediate modal open/close (before paint)
+  useLayoutEffect(() => {
     const modal = modalRef.current;
     if (!modal) return;
 
@@ -44,6 +45,8 @@ export function TaskHistoryModal({
     {
       query: {
         enabled: isOpen && !!chipId && !!qid && !!taskName,
+        staleTime: 30000, // Cache for 30 seconds
+        gcTime: 60000, // Keep in cache for 1 minute
       },
     },
   );

--- a/ui/src/components/features/metrics/CouplingMetricHistoryModal.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricHistoryModal.tsx
@@ -44,6 +44,12 @@ export function CouplingMetricHistoryModal({
     chipId,
     couplingId,
     { metric: metricName, limit: 20, within_days: 30 },
+    {
+      query: {
+        staleTime: 30000, // Cache for 30 seconds
+        gcTime: 60000, // Keep in cache for 1 minute
+      },
+    },
   );
 
   const history = (data?.data?.history || []) as MetricHistoryItem[];

--- a/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { useGridLayout } from "@/hooks/useGridLayout";
@@ -111,9 +111,9 @@ export function CouplingMetricsGrid({
     useState<SelectedCouplingInfo | null>(null);
   const modalRef = useRef<HTMLDialogElement>(null);
 
-  // Control modal with native dialog API
+  // Control modal with native dialog API (useLayoutEffect for instant response)
   const isModalOpen = selectedCouplingInfo !== null;
-  useEffect(() => {
+  useLayoutEffect(() => {
     const modal = modalRef.current;
     if (!modal) return;
 

--- a/ui/src/components/features/metrics/QubitMetricHistoryModal.tsx
+++ b/ui/src/components/features/metrics/QubitMetricHistoryModal.tsx
@@ -40,11 +40,17 @@ export function QubitMetricHistoryModal({
 }: QubitMetricHistoryModalProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  const { data, isLoading, isError } = useGetQubitMetricHistory(chipId, qid, {
-    metric: metricName,
-    limit: 20,
-    within_days: 30,
-  });
+  const { data, isLoading, isError } = useGetQubitMetricHistory(
+    chipId,
+    qid,
+    { metric: metricName, limit: 20, within_days: 30 },
+    {
+      query: {
+        staleTime: 30000, // Cache for 30 seconds
+        gcTime: 60000, // Keep in cache for 1 minute
+      },
+    },
+  );
 
   const history = (data?.data?.history || []) as MetricHistoryItem[];
 

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState, useRef, useEffect } from "react";
+import React, { useMemo, useState, useRef, useLayoutEffect } from "react";
 
 import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { useGridLayout } from "@/hooks/useGridLayout";
@@ -119,9 +119,9 @@ export function QubitMetricsGrid({
     deps: [metricData],
   });
 
-  // Control modal with native dialog API
+  // Control modal with native dialog API (useLayoutEffect for instant response)
   const isModalOpen = selectedQubitInfo !== null;
-  useEffect(() => {
+  useLayoutEffect(() => {
     const modal = modalRef.current;
     if (!modal) return;
 


### PR DESCRIPTION
- Remove default modal transitions and tweak backdrop/shadow for snappier UX
- Add fast open animations (desktop pop, mobile slide-up) and disable close animation
- Switch modals to useLayoutEffect to apply open/close state before paint
- Cache task/metric history queries with staleTime/gcTime to reduce refetching

