### PR TITLE
fix(topology): invert qubit row coord for correct y-axis

### DIFF
--- a/src/qdash/api/routers/device_topology.py
+++ b/src/qdash/api/routers/device_topology.py
@@ -245,7 +245,7 @@ def get_device_topology(
                 physical_id=int(qid),
                 position=Position(
                     x=qubit_pos.col * POSITION_SCALE / POSITION_DIVISOR,
-                    y=qubit_pos.row * POSITION_SCALE / POSITION_DIVISOR,
+                    y=-1 * qubit_pos.row * POSITION_SCALE / POSITION_DIVISOR,
                 ),
                 fidelity=x90_gate_fidelity,
                 meas_error=MeasError(


### PR DESCRIPTION
Negate the computed y position from the device topology grid so rendered qubit coordinates align with the expected coordinate system.
