### PR TITLE
feat(copilot): split languages and enforce topology fetch

### DIFF
--- a/config/copilot.yaml
+++ b/config/copilot.yaml
@@ -5,8 +5,10 @@
 enabled: true
 
 # Language configuration
-# Supported: "ja" (Japanese), "en" (English)
-language: ja
+# thinking_language: Language for internal reasoning (en recommended for technical accuracy)
+# response_language: Language for user-facing responses (ja or en)
+thinking_language: en
+response_language: ja
 
 # Model configuration
 model:
@@ -108,7 +110,7 @@ system_prompt: |
   - **Chip health readable**: total devices, average multi-metric score, distribution across Excellent/Good/Poor, and aggregate readiness label.
   - **Problem list readable**: up to 10 worst qubits with issues arrayed by metric plus textual issues derived from thresholds.
   - **Thresholds readable**: "good"/"excellent" limits and whether higher values are better for each metric.
-  - **Topology readable**: chip layout including qubit grid positions (row, col), coupling pairs, and a neighbor_map that lists adjacent qubits for each qubit. Use this for spatial correlation analysis, identifying crosstalk candidates, and reasoning about frequency crowding among neighbors.
+  - **Topology** (via `getChipTopology` tool): chip layout including qubit grid positions (row, col), coupling pairs, and a neighbor_map that lists adjacent qubits for each qubit. **You MUST call the `getChipTopology` tool to fetch this data before performing spatial correlation analysis.** Use this for identifying crosstalk candidates and reasoning about frequency crowding among neighbors.
   - Treat a readable with availability `disabled` as missing data: acknowledge the gap and, if needed, ask the user to load the requisite dashboard context.
 
   ## Mission
@@ -124,17 +126,19 @@ system_prompt: |
   - Mention the number/percentage of qubits or couplers in each quality bucket.
 
   ## Workflow for every reply
+  **IMPORTANT: When analyzing a chip, you MUST call BOTH `getChipMetricsData` AND `getChipTopology` tools to get complete information. Always fetch topology data for spatial analysis.**
+
   1. **Chip overview** – one paragraph summarizing global health, score, and whether the device is production-ready.
   2. **Metric comparison** – tabular or bullet summary comparing coherence, gate, readout, coupling, and spectral metrics (bare frequency, anharmonicity) with mean, spread, notable extremes, and units.
   3. **Key findings** – list qubits/couplers with correlated issues first; explicitly cite metric values and thresh­olds.
   4. **Recommendations** – explain the most impactful mitigation or follow-up experiments plus assumptions/risks.
   5. **Tool usage** – whenever insight requires a different metric or time range, call the `changeMetric` or `changeTimeRange` action before answering; narrate that you changed context and incorporate the new data. If an action is unavailable, state that limitation.
-  6. **Spatial analysis** – use the topology readable (qubit positions, coupling pairs, neighbor_map) to identify spatially correlated issues. When analyzing crosstalk or frequency crowding, reference specific qubit coordinates and their coupled neighbors. If topology data is unavailable, note this limitation.
+  6. **Spatial analysis** – call the `getChipTopology` tool to fetch qubit positions, coupling pairs, and neighbor_map. Use this data to identify spatially correlated issues. When analyzing crosstalk or frequency crowding, reference specific qubit coordinates and their coupled neighbors.
 
   ## Reporting rules
-  - Use actual numeric values with units and cite data provenance (e.g., “Q3 T1 = 42 μs vs 100 μs target”).
+  - Use actual numeric values with units and cite data provenance (e.g., "Q3 T1 = 42 μs vs 100 μs target").
   - If data for a metric is missing, say so and discuss how it limits confidence.
-  - Respond in the same language as the user (Japanese or English).
+  - **Language**: Think and reason internally in English for technical precision, but ALWAYS respond to the user in Japanese (日本語). Use technical terms in English where appropriate (e.g., T1, T2, fidelity, crosstalk).
   - Keep the tone professional, concise, and technically specific—write for experienced experimentalists.
   - If chip health or problematic-qubit readables disagree with your manual analysis, reconcile them explicitly or explain why you deviate.
 

--- a/src/qdash/api/lib/project_service.py
+++ b/src/qdash/api/lib/project_service.py
@@ -74,7 +74,9 @@ class ProjectService:
         invited_by: str | None = None,
     ) -> ProjectMembershipDocument:
         """Insert or update a membership entry."""
-        membership = ProjectMembershipDocument.find_one({"project_id": project_id, "username": username}).run()
+        membership = ProjectMembershipDocument.find_one(
+            {"project_id": project_id, "username": username}
+        ).run()
         if membership:
             membership.role = role
             membership.status = status
@@ -93,7 +95,9 @@ class ProjectService:
         membership.insert()
         return membership
 
-    def invite_viewer(self, project_id: str, username: str, invited_by: str) -> ProjectMembershipDocument:
+    def invite_viewer(
+        self, project_id: str, username: str, invited_by: str
+    ) -> ProjectMembershipDocument:
         """Create/update a pending viewer membership invitation."""
         return self._ensure_membership(
             project_id=project_id,

--- a/src/qdash/api/routers/backend.py
+++ b/src/qdash/api/routers/backend.py
@@ -45,4 +45,6 @@ def list_backends(
     """
     logger.info(f"User {ctx.user.username} is listing backends for project {ctx.project_id}.")
     backends = BackendDocument.find({"project_id": ctx.project_id}).to_list()
-    return ListBackendsResponse(backends=[BackendResponseModel(**backend.dict()) for backend in backends])
+    return ListBackendsResponse(
+        backends=[BackendResponseModel(**backend.dict()) for backend in backends]
+    )

--- a/src/qdash/api/routers/calibration.py
+++ b/src/qdash/api/routers/calibration.py
@@ -31,7 +31,9 @@ def generate_execution_id(username: str, chip_id: str, project_id: str | None = 
 
     """
     date_str = pendulum.now(tz="Asia/Tokyo").date().strftime("%Y%m%d")
-    execution_index = ExecutionCounterDocument.get_next_index(date_str, username, chip_id, project_id)
+    execution_index = ExecutionCounterDocument.get_next_index(
+        date_str, username, chip_id, project_id
+    )
     return f"{date_str}-{execution_index:03d}"
 
 

--- a/src/qdash/api/routers/file.py
+++ b/src/qdash/api/routers/file.py
@@ -204,7 +204,9 @@ def download_zip_file(path: str) -> FileResponse:
         if source_path.is_dir():
             # If it's a directory, zip its contents
             # make_archive returns the path to the created zip file
-            actual_zip_path = Path(shutil.make_archive(str(temp_dir_path / source_path.name), "zip", source_path))
+            actual_zip_path = Path(
+                shutil.make_archive(str(temp_dir_path / source_path.name), "zip", source_path)
+            )
         else:
             # If it's a file, create a zip containing just that file
             actual_zip_path = temp_dir_path / zip_filename
@@ -255,7 +257,9 @@ def get_file_tree() -> list[FileTreeNode]:
 
     """
     if not CONFIG_BASE_PATH.exists():
-        raise HTTPException(status_code=404, detail=f"Config directory not found: {CONFIG_BASE_PATH}")
+        raise HTTPException(
+            status_code=404, detail=f"Config directory not found: {CONFIG_BASE_PATH}"
+        )
 
     return build_file_tree(CONFIG_BASE_PATH, CONFIG_BASE_PATH)
 
@@ -292,7 +296,9 @@ def get_file_content(path: str) -> dict[str, Any]:
             "path": path,
             "name": file_path.name,
             "size": file_path.stat().st_size,
-            "modified": datetime.fromtimestamp(file_path.stat().st_mtime, tz=timezone.utc).isoformat(),
+            "modified": datetime.fromtimestamp(
+                file_path.stat().st_mtime, tz=timezone.utc
+            ).isoformat(),
         }
     except UnicodeDecodeError:
         raise HTTPException(status_code=400, detail="File is not a text file")
@@ -369,7 +375,9 @@ def validate_file_content(request: ValidateFileRequest) -> dict[str, Any]:
             json.loads(request.content)
             return {"valid": True, "message": "Valid JSON"}
         else:
-            raise HTTPException(status_code=400, detail="Unsupported file type. Use 'yaml' or 'json'")
+            raise HTTPException(
+                status_code=400, detail="Unsupported file type. Use 'yaml' or 'json'"
+            )
     except yaml.YAMLError as e:
         return {
             "valid": False,
@@ -402,7 +410,9 @@ def get_git_status() -> dict[str, Any]:
     """
     try:
         if not CONFIG_BASE_PATH.exists():
-            raise HTTPException(status_code=404, detail=f"Config directory not found: {CONFIG_BASE_PATH}")
+            raise HTTPException(
+                status_code=404, detail=f"Config directory not found: {CONFIG_BASE_PATH}"
+            )
 
         # Check if directory is a Git repository
         git_dir = CONFIG_BASE_PATH / ".git"
@@ -488,7 +498,8 @@ def git_pull_config(
             # Create backup of current config if it exists
             if CONFIG_BASE_PATH.exists():
                 backup_dir = (
-                    CONFIG_BASE_PATH.parent / f"config_backup_{datetime.now(tz=timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+                    CONFIG_BASE_PATH.parent
+                    / f"config_backup_{datetime.now(tz=timezone.utc).strftime('%Y%m%d_%H%M%S')}"
                 )
                 shutil.copytree(CONFIG_BASE_PATH, backup_dir)
                 logger.info(f"Created backup at: {backup_dir}")

--- a/src/qdash/api/routers/flow.py
+++ b/src/qdash/api/routers/flow.py
@@ -146,7 +146,10 @@ def validate_flow_code(code: str, expected_function_name: str) -> None:
 
 
 async def register_flow_deployment(
-    file_path: str, flow_function_name: str, deployment_name: str, old_deployment_id: str | None = None
+    file_path: str,
+    flow_function_name: str,
+    deployment_name: str,
+    old_deployment_id: str | None = None,
 ) -> str:
     """Register a flow as a Prefect deployment via Workflow service.
 
@@ -184,7 +187,9 @@ async def register_flow_deployment(
             logger.info(f"Successfully registered deployment: {data['deployment_id']}")
             return data["deployment_id"]
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error during deployment registration: {e.response.status_code} - {e.response.text}")
+        logger.error(
+            f"HTTP error during deployment registration: {e.response.status_code} - {e.response.text}"
+        )
         raise HTTPException(
             status_code=500,
             detail=f"Failed to register deployment: {e.response.status_code}: {e.response.text}",
@@ -602,7 +607,9 @@ async def list_all_flow_schedules(
             try:
                 state_filter = FlowRunFilterStateType(any_=[StateType.SCHEDULED])
                 flow_runs = await client.read_flow_runs(
-                    deployment_filter=DeploymentFilter(id={"any_": [uuid.UUID(flow.deployment_id)]}),
+                    deployment_filter=DeploymentFilter(
+                        id={"any_": [uuid.UUID(flow.deployment_id)]}
+                    ),
                     flow_run_filter=FlowRunFilter(state=FlowRunFilterState(type=state_filter)),
                     limit=limit,  # Use pagination limit
                 )
@@ -610,7 +617,10 @@ async def list_all_flow_schedules(
                 now = datetime.now(timezone.utc)
                 for flow_run in flow_runs:
                     # Only show future scheduled runs
-                    if flow_run.next_scheduled_start_time and flow_run.next_scheduled_start_time > now:
+                    if (
+                        flow_run.next_scheduled_start_time
+                        and flow_run.next_scheduled_start_time > now
+                    ):
                         all_schedules.append(
                             FlowScheduleSummary(
                                 schedule_id=str(flow_run.id),
@@ -712,7 +722,11 @@ async def delete_flow_schedule(
             # Verify ownership through deployment
             if flow_run.deployment_id:
                 flow = FlowDocument.find_one(
-                    {"project_id": project_id, "deployment_id": str(flow_run.deployment_id), "username": username}
+                    {
+                        "project_id": project_id,
+                        "deployment_id": str(flow_run.deployment_id),
+                        "username": username,
+                    }
                 ).run()
                 if not flow:
                     raise HTTPException(
@@ -915,7 +929,9 @@ async def execute_flow(
         "project_id": project_id,  # Add project_id for multi-tenancy
     }
 
-    logger.info(f"Executing flow '{name}' (deployment={flow.deployment_id}) with parameters: {parameters}")
+    logger.info(
+        f"Executing flow '{name}' (deployment={flow.deployment_id}) with parameters: {parameters}"
+    )
 
     # Create flow run via Prefect Client
     try:
@@ -927,7 +943,9 @@ async def execute_flow(
 
             execution_id = str(flow_run.id)
             # Construct URLs
-            flow_run_url = f"http://localhost:{settings.prefect_port}/flow-runs/flow-run/{execution_id}"
+            flow_run_url = (
+                f"http://localhost:{settings.prefect_port}/flow-runs/flow-run/{execution_id}"
+            )
             qdash_ui_url = f"http://localhost:{settings.ui_port}/execution/{execution_id}"
 
             logger.info(f"Flow run created: {execution_id}")
@@ -1114,7 +1132,9 @@ async def schedule_flow(
                     except (httpx.TimeoutException, httpx.ConnectError) as e:
                         if attempt < max_retries - 1:
                             wait_time = 2**attempt  # Exponential backoff: 1s, 2s, 4s
-                            logger.warning(f"Attempt {attempt + 1} failed, retrying in {wait_time}s: {e}")
+                            logger.warning(
+                                f"Attempt {attempt + 1} failed, retrying in {wait_time}s: {e}"
+                            )
                             await asyncio.sleep(wait_time)
                         else:
                             raise  # Final attempt failed
@@ -1172,7 +1192,8 @@ async def schedule_flow(
             # Formats with timezone: 2025-11-26T10:00:00+09:00, 2025-11-26T01:00:00Z
             # Formats without timezone: 2025-11-26T10:00, 2025-11-26T10:00:00
             has_timezone = "Z" in scheduled_time_str or (
-                "+" in scheduled_time_str[10:] or (scheduled_time_str.count("-") > 2 and "-" in scheduled_time_str[19:])
+                "+" in scheduled_time_str[10:]
+                or (scheduled_time_str.count("-") > 2 and "-" in scheduled_time_str[19:])
             )
 
             if not has_timezone:
@@ -1222,7 +1243,9 @@ async def schedule_flow(
                     except (httpx.TimeoutException, httpx.ConnectError) as e:
                         if attempt < max_retries - 1:
                             wait_time = 2**attempt
-                            logger.warning(f"Attempt {attempt + 1} failed, retrying in {wait_time}s: {e}")
+                            logger.warning(
+                                f"Attempt {attempt + 1} failed, retrying in {wait_time}s: {e}"
+                            )
                             await asyncio.sleep(wait_time)
                         else:
                             raise
@@ -1230,7 +1253,9 @@ async def schedule_flow(
                         raise
 
                 flow_run_id = data["flow_run_id"]
-                logger.info(f"Created one-time schedule for flow '{name}': {request.scheduled_time}")
+                logger.info(
+                    f"Created one-time schedule for flow '{name}': {request.scheduled_time}"
+                )
 
                 return ScheduleFlowResponse(
                     schedule_id=flow_run_id,

--- a/src/qdash/api/routers/project.py
+++ b/src/qdash/api/routers/project.py
@@ -110,7 +110,11 @@ def list_projects(
     logger.debug(f"Listing projects for user {current_user.username}")
 
     # Find all active memberships for this user
-    memberships = list(ProjectMembershipDocument.find({"username": current_user.username, "status": "active"}).run())
+    memberships = list(
+        ProjectMembershipDocument.find(
+            {"username": current_user.username, "status": "active"}
+        ).run()
+    )
 
     project_ids = [m.project_id for m in memberships]
     projects = list(ProjectDocument.find({"project_id": {"$in": project_ids}}).run())
@@ -235,7 +239,9 @@ def invite_member(
         )
 
     # Check if already a member
-    existing = ProjectMembershipDocument.find_one({"project_id": project_id, "username": invite_data.username}).run()
+    existing = ProjectMembershipDocument.find_one(
+        {"project_id": project_id, "username": invite_data.username}
+    ).run()
 
     if existing:
         if existing.status == "active":
@@ -264,7 +270,9 @@ def invite_member(
     )
     membership.insert()
 
-    logger.info(f"Admin {admin.username} invited {invite_data.username} to project {project_id} as {invite_data.role}")
+    logger.info(
+        f"Admin {admin.username} invited {invite_data.username} to project {project_id} as {invite_data.role}"
+    )
 
     return _to_member_response(membership)
 
@@ -295,7 +303,9 @@ def update_member(
             detail="Cannot change the owner's role",
         )
 
-    membership = ProjectMembershipDocument.find_one({"project_id": project_id, "username": username}).run()
+    membership = ProjectMembershipDocument.find_one(
+        {"project_id": project_id, "username": username}
+    ).run()
 
     if not membership:
         raise HTTPException(
@@ -335,7 +345,9 @@ def remove_member(
             detail="Cannot remove the project owner",
         )
 
-    membership = ProjectMembershipDocument.find_one({"project_id": project_id, "username": username}).run()
+    membership = ProjectMembershipDocument.find_one(
+        {"project_id": project_id, "username": username}
+    ).run()
 
     if not membership:
         raise HTTPException(
@@ -423,6 +435,8 @@ def transfer_ownership(
     project.system_info.update_time()
     project.save()
 
-    logger.warning(f"Admin {admin.username} transferred project {project_id} ownership to {new_owner.username}")
+    logger.warning(
+        f"Admin {admin.username} transferred project {project_id} ownership to {new_owner.username}"
+    )
 
     return _to_project_response(project)

--- a/src/qdash/api/routers/task.py
+++ b/src/qdash/api/routers/task.py
@@ -60,9 +60,13 @@ def list_tasks(
                 description=task.description,
                 task_type=task.task_type,
                 backend=task.backend,
-                input_parameters={name: InputParameterModel(**param) for name, param in task.input_parameters.items()},
+                input_parameters={
+                    name: InputParameterModel(**param)
+                    for name, param in task.input_parameters.items()
+                },
                 output_parameters={
-                    name: InputParameterModel(**param) for name, param in task.output_parameters.items()
+                    name: InputParameterModel(**param)
+                    for name, param in task.output_parameters.items()
                 },
             )
             for task in tasks
@@ -93,7 +97,9 @@ def get_task_result(
 
     """
     # Find task result by task_id (scoped to project)
-    task_result = TaskResultHistoryDocument.find_one({"project_id": ctx.project_id, "task_id": task_id}).run()
+    task_result = TaskResultHistoryDocument.find_one(
+        {"project_id": ctx.project_id, "task_id": task_id}
+    ).run()
 
     if not task_result:
         raise HTTPException(status_code=404, detail=f"Task result with task_id {task_id} not found")

--- a/src/qdash/api/routers/task_file.py
+++ b/src/qdash/api/routers/task_file.py
@@ -180,7 +180,9 @@ def list_task_file_backends() -> ListTaskFileBackendsResponse:
 
     """
     if not CALTASKS_BASE_PATH.exists():
-        raise HTTPException(status_code=404, detail=f"Caltasks directory not found: {CALTASKS_BASE_PATH}")
+        raise HTTPException(
+            status_code=404, detail=f"Caltasks directory not found: {CALTASKS_BASE_PATH}"
+        )
 
     backends = []
     try:
@@ -260,7 +262,9 @@ def get_task_file_content(path: str) -> dict[str, Any]:
             "path": path,
             "name": file_path.name,
             "size": file_path.stat().st_size,
-            "modified": datetime.fromtimestamp(file_path.stat().st_mtime, tz=timezone.utc).isoformat(),
+            "modified": datetime.fromtimestamp(
+                file_path.stat().st_mtime, tz=timezone.utc
+            ).isoformat(),
         }
     except UnicodeDecodeError:
         raise HTTPException(status_code=400, detail="File is not a text file")

--- a/src/qdash/api/schemas/flow.py
+++ b/src/qdash/api/schemas/flow.py
@@ -15,7 +15,9 @@ class SaveFlowRequest(BaseModel):
         None, description="Entry point function name (defaults to same as name if not provided)"
     )
     chip_id: str = Field(..., description="Target chip ID")
-    default_parameters: dict[str, Any] = Field(default_factory=dict, description="Default execution parameters")
+    default_parameters: dict[str, Any] = Field(
+        default_factory=dict, description="Default execution parameters"
+    )
     tags: list[str] = Field(default_factory=list, description="Tags for categorization")
 
     model_config: ClassVar[dict] = {
@@ -84,7 +86,9 @@ class ExecuteFlowRequest(BaseModel):
     )
 
     model_config: ClassVar[dict] = {
-        "json_schema_extra": {"examples": [{"parameters": {"qids": ["32", "38"], "max_iterations": 5}}]}
+        "json_schema_extra": {
+            "examples": [{"parameters": {"qids": ["32", "38"], "max_iterations": 5}}]
+        }
     }
 
 
@@ -100,8 +104,12 @@ class ExecuteFlowResponse(BaseModel):
 class ScheduleFlowRequest(BaseModel):
     """Request to schedule a Flow execution."""
 
-    cron: str | None = Field(None, description="Cron expression (e.g., '0 2 * * *' for daily at 2am JST)")
-    scheduled_time: str | None = Field(None, description="One-time execution time (ISO format, JST)")
+    cron: str | None = Field(
+        None, description="Cron expression (e.g., '0 2 * * *' for daily at 2am JST)"
+    )
+    scheduled_time: str | None = Field(
+        None, description="One-time execution time (ISO format, JST)"
+    )
     parameters: dict[str, Any] = Field(
         default_factory=dict, description="Execution parameters (overrides default_parameters)"
     )
@@ -130,7 +138,9 @@ class ScheduleFlowRequest(BaseModel):
 class ScheduleFlowResponse(BaseModel):
     """Response after scheduling a flow."""
 
-    schedule_id: str = Field(..., description="Schedule ID (deployment ID for cron, flow_run_id for one-time)")
+    schedule_id: str = Field(
+        ..., description="Schedule ID (deployment ID for cron, flow_run_id for one-time)"
+    )
     flow_name: str = Field(..., description="Flow name")
     schedule_type: str = Field(..., description="Schedule type: 'cron' or 'one-time'")
     cron: str | None = Field(None, description="Cron expression (for cron schedules)")
@@ -228,7 +238,9 @@ class ImportableModule(BaseModel):
     name: str = Field(..., description="Module category name")
     description: str = Field(..., description="Module category description")
     import_path: str = Field(..., description="Python import path")
-    functions: list[ImportableFunction] = Field(default_factory=list, description="Available functions")
+    functions: list[ImportableFunction] = Field(
+        default_factory=list, description="Available functions"
+    )
     classes: list[ImportableClass] = Field(default_factory=list, description="Available classes")
 
 

--- a/src/qdash/cli/download_task_figures.py
+++ b/src/qdash/cli/download_task_figures.py
@@ -41,7 +41,9 @@ def download_task_figures(
     }
 
     # Fetch ALL matching documents, sorted by most recent first
-    all_docs = list(TaskResultHistoryDocument.find(query).sort([("system_info.updated_at", -1)]).run())
+    all_docs = list(
+        TaskResultHistoryDocument.find(query).sort([("system_info.updated_at", -1)]).run()
+    )
 
     if not all_docs:
         query_str = ", ".join(f"{k}={v}" for k, v in query.items())
@@ -163,4 +165,6 @@ def download_task_figures(
     typer.echo(f"{'='*60}")
     typer.echo(f"📁 Files saved to: {output_path.absolute()}")
     typer.echo(f"📄 Metadata saved to: {meta_path.absolute()}")
-    typer.echo(f"📊 Total JSON figures downloaded: {sum(len(t['json_figures']) for t in metadata_list)}")
+    typer.echo(
+        f"📊 Total JSON figures downloaded: {sum(len(t['json_figures']) for t in metadata_list)}"
+    )

--- a/src/qdash/cli/main.py
+++ b/src/qdash/cli/main.py
@@ -38,7 +38,9 @@ def add_new_chip(
         from qdash.db.init.chip import init_chip_document
 
         init_chip_document(username=username, chip_id=chip_id, size=size)
-        typer.echo(f"New chip added successfully (username: {username}, chip_id: {chip_id}, size: {size})")
+        typer.echo(
+            f"New chip added successfully (username: {username}, chip_id: {chip_id}, size: {size})"
+        )
     except Exception as e:
         typer.echo(f"Error adding new chip: {e}", err=True)
         raise typer.Exit(1)
@@ -69,7 +71,9 @@ def update_active_tasks(
 def init_all_data(
     username: str = typer.Option(..., "--username", "-u", help="Username for initialization"),
     chip_id: str = typer.Option(..., "--chip-id", "-c", help="Chip ID for initialization"),
-    chip_size: int = typer.Option(..., "--chip-size", "-s", help="Size of the chip (e.g., 64, 144)"),
+    chip_size: int = typer.Option(
+        ..., "--chip-size", "-s", help="Size of the chip (e.g., 64, 144)"
+    ),
     backend: str = typer.Option(..., "--backend", "-b", help="Backend (e.g., qubex)"),
 ) -> None:
     """Initialize all data with confirmation."""
@@ -100,7 +104,9 @@ def init_all_data(
 
 @app.command()
 def export_note(
-    execution_id: str = typer.Option(..., "--execution-id", "-e", help="Execution ID (e.g., 20250130-001)"),
+    execution_id: str = typer.Option(
+        ..., "--execution-id", "-e", help="Execution ID (e.g., 20250130-001)"
+    ),
     task_id: str = typer.Option("master", "--task-id", "-t", help="Task ID (default: master)"),
     output: str = typer.Option(None, "--output", "-o", help="Output file path"),
     username: str = typer.Option(None, "--username", "-u", help="Username filter (optional)"),
@@ -147,7 +153,9 @@ def download_figures(
     task_name: str = typer.Option(..., "--task-name", "-t", help="Task name to search for"),
     chip_id: str = typer.Option(..., "--chip-id", "-c", help="Chip ID to filter by"),
     username: str = typer.Option(..., "--username", "-u", help="Username to filter by"),
-    output_dir: str = typer.Option(None, "--output-dir", "-o", help="Output directory for downloaded files"),
+    output_dir: str = typer.Option(
+        None, "--output-dir", "-o", help="Output directory for downloaded files"
+    ),
 ) -> None:
     """Download JSON figures from completed calibration tasks.
 

--- a/src/qdash/datamodel/project.py
+++ b/src/qdash/datamodel/project.py
@@ -32,7 +32,9 @@ class ProjectMembershipModel(BaseModel):
 
     project_id: str = Field(..., description="Project identifier")
     username: str = Field(..., description="Member username")
-    role: ProjectRole = Field(default=ProjectRole.VIEWER, description="Member role within the project")
+    role: ProjectRole = Field(
+        default=ProjectRole.VIEWER, description="Member role within the project"
+    )
     invited_by: str | None = Field(default=None, description="User who invited this member")
     status: str = Field(default="pending", description="Invitation status")
     system_info: SystemInfoModel = Field(default_factory=SystemInfoModel)

--- a/src/qdash/db/init/task.py
+++ b/src/qdash/db/init/task.py
@@ -32,8 +32,12 @@ def update_active_tasks(username: str, backend: str) -> list[TaskModel]:
             description=cls.__doc__,
             backend=cls.backend,
             task_type=cls.task_type,
-            input_parameters={name: param.model_dump() for name, param in cls.input_parameters.items()},
-            output_parameters={name: param.model_dump() for name, param in cls.output_parameters.items()},
+            input_parameters={
+                name: param.model_dump() for name, param in cls.input_parameters.items()
+            },
+            output_parameters={
+                name: param.model_dump() for name, param in cls.output_parameters.items()
+            },
         )
         for cls in task_cls.values()
     ]

--- a/src/qdash/dbmodel/backend.py
+++ b/src/qdash/dbmodel/backend.py
@@ -24,7 +24,9 @@ class BackendDocument(Document):
     project_id: str = Field(..., description="Owning project identifier")
     username: str = Field(..., description="The username of the user who created the task")
     name: str = Field(..., description="The name of backend")
-    system_info: SystemInfoModel = Field(default_factory=SystemInfoModel, description="The system information")
+    system_info: SystemInfoModel = Field(
+        default_factory=SystemInfoModel, description="The system information"
+    )
 
     model_config = ConfigDict(
         from_attributes=True,
@@ -35,7 +37,10 @@ class BackendDocument(Document):
 
         name = "backend"
         indexes: ClassVar = [
-            IndexModel([("project_id", ASCENDING), ("name", ASCENDING), ("username", ASCENDING)], unique=True),
+            IndexModel(
+                [("project_id", ASCENDING), ("name", ASCENDING), ("username", ASCENDING)],
+                unique=True,
+            ),
             IndexModel([("project_id", ASCENDING), ("username", ASCENDING)]),
         ]
 

--- a/src/qdash/dbmodel/calibration_note.py
+++ b/src/qdash/dbmodel/calibration_note.py
@@ -33,7 +33,9 @@ class CalibrationNoteDocument(Document):
         default_factory=lambda: pendulum.now(tz="Asia/Tokyo").to_iso8601_string(),
         description="The time when the note was last updated",
     )
-    system_info: SystemInfoModel = Field(default_factory=SystemInfoModel, description="The system information")
+    system_info: SystemInfoModel = Field(
+        default_factory=SystemInfoModel, description="The system information"
+    )
 
     class Settings:
         """Settings for the document."""

--- a/src/qdash/dbmodel/execution_counter.py
+++ b/src/qdash/dbmodel/execution_counter.py
@@ -14,7 +14,9 @@ class ExecutionCounterDocument(Document):
     username: str
     chip_id: str
     index: int
-    system_info: SystemInfoModel = Field(default_factory=SystemInfoModel, description="The system information")
+    system_info: SystemInfoModel = Field(
+        default_factory=SystemInfoModel, description="The system information"
+    )
 
     class Settings:
         """Settings for the document."""
@@ -22,7 +24,12 @@ class ExecutionCounterDocument(Document):
         name = "execution_counter"
         indexes: ClassVar = [
             IndexModel(
-                [("project_id", ASCENDING), ("date", ASCENDING), ("username", ASCENDING), ("chip_id", ASCENDING)],
+                [
+                    ("project_id", ASCENDING),
+                    ("date", ASCENDING),
+                    ("username", ASCENDING),
+                    ("chip_id", ASCENDING),
+                ],
                 unique=True,
             )
         ]
@@ -58,12 +65,20 @@ class ExecutionCounterDocument(Document):
         max_retries = 5
         for attempt in range(max_retries):
             # First, try to find existing document
-            doc = cls.find_one({"project_id": project_id, "date": date, "username": username, "chip_id": chip_id}).run()
+            doc = cls.find_one(
+                {"project_id": project_id, "date": date, "username": username, "chip_id": chip_id}
+            ).run()
 
             if doc is None:
                 # Try to create initial document with index 0
                 try:
-                    doc = cls(project_id=project_id, date=date, username=username, chip_id=chip_id, index=0)
+                    doc = cls(
+                        project_id=project_id,
+                        date=date,
+                        username=username,
+                        chip_id=chip_id,
+                        index=0,
+                    )
                     doc.insert()
                     return 0
                 except DuplicateKeyError:

--- a/src/qdash/dbmodel/execution_history.py
+++ b/src/qdash/dbmodel/execution_history.py
@@ -55,9 +55,13 @@ class ExecutionHistoryDocument(Document):
         name = "execution_history"
         indexes: ClassVar = [
             IndexModel([("project_id", ASCENDING), ("execution_id", ASCENDING)], unique=True),
-            IndexModel([("project_id", ASCENDING), ("chip_id", ASCENDING), ("start_at", DESCENDING)]),
+            IndexModel(
+                [("project_id", ASCENDING), ("chip_id", ASCENDING), ("start_at", DESCENDING)]
+            ),
             IndexModel([("project_id", ASCENDING), ("chip_id", ASCENDING)]),
-            IndexModel([("project_id", ASCENDING), ("username", ASCENDING), ("start_at", DESCENDING)]),
+            IndexModel(
+                [("project_id", ASCENDING), ("username", ASCENDING), ("start_at", DESCENDING)]
+            ),
         ]
 
     @classmethod

--- a/src/qdash/dbmodel/execution_lock.py
+++ b/src/qdash/dbmodel/execution_lock.py
@@ -11,7 +11,9 @@ class ExecutionLockDocument(Document):
 
     project_id: str = Field(..., description="Owning project identifier")
     locked: bool = Field(default=False, description="Whether the execution is locked")
-    system_info: SystemInfoModel = Field(default_factory=SystemInfoModel, description="The system information")
+    system_info: SystemInfoModel = Field(
+        default_factory=SystemInfoModel, description="The system information"
+    )
 
     class Settings:
         """Settings for the document."""

--- a/src/qdash/dbmodel/project.py
+++ b/src/qdash/dbmodel/project.py
@@ -13,13 +13,19 @@ from qdash.datamodel.system_info import SystemInfoModel
 class ProjectDocument(Document):
     """Mongo document representing a collaborative project."""
 
-    project_id: str = Field(default_factory=lambda: str(uuid.uuid4()), description="Project identifier")
+    project_id: str = Field(
+        default_factory=lambda: str(uuid.uuid4()), description="Project identifier"
+    )
     owner_username: str = Field(..., description="Project owner username")
     name: str = Field(..., description="Project display name")
     description: str | None = Field(default=None, description="Project description")
     tags: list[str] = Field(default_factory=list, description="Project tags")
-    default_role: ProjectRole = Field(default=ProjectRole.VIEWER, description="Default role for invite links")
-    system_info: SystemInfoModel = Field(default_factory=SystemInfoModel, description="System info timestamps")
+    default_role: ProjectRole = Field(
+        default=ProjectRole.VIEWER, description="Default role for invite links"
+    )
+    system_info: SystemInfoModel = Field(
+        default_factory=SystemInfoModel, description="System info timestamps"
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/qdash/dbmodel/project_membership.py
+++ b/src/qdash/dbmodel/project_membership.py
@@ -18,7 +18,9 @@ class ProjectMembershipDocument(Document):
     status: str = Field(default="pending", description="Invitation status")
     invited_by: str | None = Field(default=None, description="Inviter username")
     last_accessed_at: str | None = Field(default=None, description="Last access timestamp ISO8601")
-    system_info: SystemInfoModel = Field(default_factory=SystemInfoModel, description="System info timestamps")
+    system_info: SystemInfoModel = Field(
+        default_factory=SystemInfoModel, description="System info timestamps"
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -32,6 +34,10 @@ class ProjectMembershipDocument(Document):
         ]
 
     @classmethod
-    def get_active_membership(cls, project_id: str, username: str) -> ProjectMembershipDocument | None:
+    def get_active_membership(
+        cls, project_id: str, username: str
+    ) -> ProjectMembershipDocument | None:
         """Fetch active membership for the user/project pair."""
-        return cls.find_one({"project_id": project_id, "username": username, "status": "active"}).run()
+        return cls.find_one(
+            {"project_id": project_id, "username": username, "status": "active"}
+        ).run()

--- a/src/qdash/dbmodel/tag.py
+++ b/src/qdash/dbmodel/tag.py
@@ -29,7 +29,10 @@ class TagDocument(Document):
 
         name = "tag"
         indexes: ClassVar = [
-            IndexModel([("project_id", ASCENDING), ("name", ASCENDING), ("username", ASCENDING)], unique=True),
+            IndexModel(
+                [("project_id", ASCENDING), ("name", ASCENDING), ("username", ASCENDING)],
+                unique=True,
+            ),
             IndexModel([("project_id", ASCENDING), ("username", ASCENDING)]),
         ]
 

--- a/src/qdash/dbmodel/task.py
+++ b/src/qdash/dbmodel/task.py
@@ -39,7 +39,10 @@ class TaskDocument(Document):
 
         name = "task"
         indexes: ClassVar = [
-            IndexModel([("project_id", ASCENDING), ("name", ASCENDING), ("username", ASCENDING)], unique=True),
+            IndexModel(
+                [("project_id", ASCENDING), ("name", ASCENDING), ("username", ASCENDING)],
+                unique=True,
+            ),
             IndexModel([("project_id", ASCENDING), ("username", ASCENDING)]),
         ]
 
@@ -74,7 +77,9 @@ class TaskDocument(Document):
         inserted_documents = []
         for task in tasks:
             logger.debug(f"Inserting task: {task}")
-            doc = cls.find_one({"project_id": task.project_id, "name": task.name, "username": task.username}).run()
+            doc = cls.find_one(
+                {"project_id": task.project_id, "name": task.name, "username": task.username}
+            ).run()
             if doc is None:
                 logger.debug(f"Task {task.name} not found. Inserting new task.")
                 doc = cls.from_task_model(task)

--- a/src/qdash/dbmodel/task_result_history.py
+++ b/src/qdash/dbmodel/task_result_history.py
@@ -66,11 +66,15 @@ class TaskResultHistoryDocument(Document):
         indexes: ClassVar = [
             IndexModel([("project_id", ASCENDING), ("task_id", ASCENDING)], unique=True),
             IndexModel([("project_id", ASCENDING), ("execution_id", ASCENDING)]),
-            IndexModel([("project_id", ASCENDING), ("chip_id", ASCENDING), ("start_at", DESCENDING)]),
+            IndexModel(
+                [("project_id", ASCENDING), ("chip_id", ASCENDING), ("start_at", DESCENDING)]
+            ),
         ]
 
     @classmethod
-    def from_datamodel(cls, task: BaseTaskResultModel, execution_model: ExecutionModel) -> "TaskResultHistoryDocument":
+    def from_datamodel(
+        cls, task: BaseTaskResultModel, execution_model: ExecutionModel
+    ) -> "TaskResultHistoryDocument":
         return cls(
             project_id=execution_model.project_id,
             username=execution_model.username,
@@ -98,8 +102,12 @@ class TaskResultHistoryDocument(Document):
         )
 
     @classmethod
-    def upsert_document(cls, task: BaseTaskResultModel, execution_model: ExecutionModel) -> "TaskResultHistoryDocument":
-        doc = cls.find_one({"project_id": execution_model.project_id, "task_id": task.task_id}).run()
+    def upsert_document(
+        cls, task: BaseTaskResultModel, execution_model: ExecutionModel
+    ) -> "TaskResultHistoryDocument":
+        doc = cls.find_one(
+            {"project_id": execution_model.project_id, "task_id": task.task_id}
+        ).run()
         if doc is None:
             doc = cls.from_datamodel(task=task, execution_model=execution_model)
             doc.save()

--- a/src/qdash/workflow/_internal/merge_notes.py
+++ b/src/qdash/workflow/_internal/merge_notes.py
@@ -3,7 +3,9 @@ from typing import Any
 import pendulum
 
 
-def merge_notes_by_timestamp(master_note: dict[str, Any], task_note: dict[str, Any]) -> dict[str, Any]:
+def merge_notes_by_timestamp(
+    master_note: dict[str, Any], task_note: dict[str, Any]
+) -> dict[str, Any]:
     """Merge master note and task note based on timestamp for each parameter type and qubit.
 
     Args:
@@ -25,7 +27,9 @@ def merge_notes_by_timestamp(master_note: dict[str, Any], task_note: dict[str, A
         merged[param_type] = {}
 
         # Get all qubits for this parameter type
-        all_qubits = set(master_note.get(param_type, {}).keys()) | set(task_note.get(param_type, {}).keys())
+        all_qubits = set(master_note.get(param_type, {}).keys()) | set(
+            task_note.get(param_type, {}).keys()
+        )
 
         for qubit in all_qubits:
             master_data = master_note.get(param_type, {}).get(qubit)

--- a/src/qdash/workflow/_internal/slack.py
+++ b/src/qdash/workflow/_internal/slack.py
@@ -127,7 +127,9 @@ class SlackContents:
                     channel=self.channel,
                     text=self.header,
                     thread_ts=self.ts if self.ts != "" else None,
-                    reply_broadcast=self.broadcast if self.ts != "" else False,  # スレッド内の返信時のみ有効
+                    reply_broadcast=self.broadcast
+                    if self.ts != ""
+                    else False,  # スレッド内の返信時のみ有効
                     attachments=attachments,
                 )
                 return str(resp["ts"])
@@ -144,7 +146,9 @@ class SlackContents:
                 channel=self.channel,
                 text=self.header,
                 thread_ts=self.ts if self.ts != "" else None,
-                reply_broadcast=self.broadcast if self.ts != "" else False,  # スレッド内の返信時のみ有効
+                reply_broadcast=self.broadcast
+                if self.ts != ""
+                else False,  # スレッド内の返信時のみ有効
                 attachments=attachments,
             )
             message_ts = str(resp["ts"])

--- a/src/qdash/workflow/caltasks/base.py
+++ b/src/qdash/workflow/caltasks/base.py
@@ -125,7 +125,9 @@ class BaseTask(ABC):
                     # Parameter already exists in class definition - update its value
                     value = param_data.get("value")
                     if value is not None:
-                        value_type = param_data.get("value_type", self.input_parameters[name].value_type)
+                        value_type = param_data.get(
+                            "value_type", self.input_parameters[name].value_type
+                        )
                         converted_value = self._convert_value_to_type(value, value_type)
                         self.input_parameters[name].value = converted_value
                 else:

--- a/src/qdash/workflow/caltasks/fake/base.py
+++ b/src/qdash/workflow/caltasks/fake/base.py
@@ -35,7 +35,9 @@ class FakeTask(BaseTask):
             NotImplementedError: Always raised for tasks that don't support batch execution
 
         """
-        raise NotImplementedError(f"Batch run is not implemented for {self.name} task. Use run method instead.")
+        raise NotImplementedError(
+            f"Batch run is not implemented for {self.name} task. Use run method instead."
+        )
 
     def get_label(self, qid: str) -> str:
         """Convert qubit ID to label.

--- a/src/qdash/workflow/caltasks/fake/fake_rabi.py
+++ b/src/qdash/workflow/caltasks/fake/fake_rabi.py
@@ -58,7 +58,9 @@ class CustomSimulationResult(SimulationResult):
                 populations[f"|{basis}〉"].append(prob)
 
         sampled_times = self.get_times(n_samples=n_samples)
-        sampled_populations = {key: downsample(np.asarray(value), n_samples) for key, value in populations.items()}
+        sampled_populations = {
+            key: downsample(np.asarray(value), n_samples) for key, value in populations.items()
+        }
 
         fig = go.Figure()
         for key, value in sampled_populations.items():

--- a/src/qdash/workflow/caltasks/qubex/__init__.py
+++ b/src/qdash/workflow/caltasks/qubex/__init__.py
@@ -23,7 +23,9 @@ from qdash.workflow.caltasks.qubex.cw.check_reflection_coefficient import CheckR
 from qdash.workflow.caltasks.qubex.cw.check_resonator_frequencies import CheckResonatorFrequencies
 from qdash.workflow.caltasks.qubex.cw.check_resonator_spectroscopy import CheckResonatorSpectroscopy
 from qdash.workflow.caltasks.qubex.measurement.readout_classification import ReadoutClassification
-from qdash.workflow.caltasks.qubex.one_qubit_coarse.check_dispersive_shift import CheckDispersiveShift
+from qdash.workflow.caltasks.qubex.one_qubit_coarse.check_dispersive_shift import (
+    CheckDispersiveShift,
+)
 from qdash.workflow.caltasks.qubex.one_qubit_coarse.check_hpi_pulse import CheckHPIPulse
 from qdash.workflow.caltasks.qubex.one_qubit_coarse.check_optimal_readout_amplitude import (
     CheckOptimalReadoutAmplitude,

--- a/src/qdash/workflow/caltasks/qubex/base.py
+++ b/src/qdash/workflow/caltasks/qubex/base.py
@@ -156,7 +156,9 @@ class QubexTask(BaseTask):
             NotImplementedError: Always raised for tasks that don't support batch execution
 
         """
-        raise NotImplementedError(f"Batch run is not implemented for {self.name} task. Use run method instead.")
+        raise NotImplementedError(
+            f"Batch run is not implemented for {self.name} task. Use run method instead."
+        )
 
     def get_experiment(self, backend: "QubexBackend"):
         """Get the experiment session from QubexBackend.

--- a/src/qdash/workflow/caltasks/qubex/benchmark/randomized_benchmarking.py
+++ b/src/qdash/workflow/caltasks/qubex/benchmark/randomized_benchmarking.py
@@ -54,7 +54,9 @@ class RandomizedBenchmarking(QubexTask):
         label = self.get_qubit_label(backend, qid)
         result = run_result.raw_result
         self.output_parameters["average_gate_fidelity"].value = result[label]["avg_gate_fidelity"]
-        self.output_parameters["average_gate_fidelity"].error = result[label]["avg_gate_fidelity_err"]
+        self.output_parameters["average_gate_fidelity"].error = result[label][
+            "avg_gate_fidelity_err"
+        ]
         self.output_parameters["depolarizing_rate"].value = result[label]["depolarizing_rate"]
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result[label]["fig"]]

--- a/src/qdash/workflow/caltasks/qubex/benchmark/x180_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/caltasks/qubex/benchmark/x180_interleaved_randoized_benchmarking.py
@@ -56,7 +56,9 @@ class X180InterleavedRandomizedBenchmarking(QubexTask):
         result = run_result.raw_result
         self.output_parameters["x180_gate_fidelity"].value = result[label]["gate_fidelity"]
         self.output_parameters["x180_gate_fidelity"].error = result[label]["gate_fidelity_err"]
-        self.output_parameters["x180_depolarizing_rate"].value = result[label]["rb_fit_result"]["depolarizing_rate"]
+        self.output_parameters["x180_depolarizing_rate"].value = result[label]["rb_fit_result"][
+            "depolarizing_rate"
+        ]
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result[label]["fig"]]
         return PostProcessResult(output_parameters=output_parameters, figures=figures)

--- a/src/qdash/workflow/caltasks/qubex/benchmark/x90_interleaved_randomized_benchmarking.py
+++ b/src/qdash/workflow/caltasks/qubex/benchmark/x90_interleaved_randomized_benchmarking.py
@@ -56,7 +56,9 @@ class X90InterleavedRandomizedBenchmarking(QubexTask):
         result = run_result.raw_result
         self.output_parameters["x90_gate_fidelity"].value = result[label]["gate_fidelity"]
         self.output_parameters["x90_gate_fidelity"].error = result[label]["gate_fidelity_err"]
-        self.output_parameters["x90_depolarizing_rate"].value = result[label]["rb_fit_result"]["depolarizing_rate"]
+        self.output_parameters["x90_depolarizing_rate"].value = result[label]["rb_fit_result"][
+            "depolarizing_rate"
+        ]
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result[label]["fig"]]
         return PostProcessResult(output_parameters=output_parameters, figures=figures)

--- a/src/qdash/workflow/caltasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/caltasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
@@ -54,18 +54,24 @@ class ZX90InterleavedRandomizedBenchmarking(QubexTask):
         self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
     ) -> PostProcessResult:
         exp = self.get_experiment(backend)
-        label = "-".join([exp.get_qubit_label(int(q)) for q in qid.split("-")])  # e.g., "0-1" → "Q00-Q01"
+        label = "-".join(
+            [exp.get_qubit_label(int(q)) for q in qid.split("-")]
+        )  # e.g., "0-1" → "Q00-Q01"
         result = run_result.raw_result
         self.output_parameters["zx90_gate_fidelity"].value = result[label]["gate_fidelity"]
         self.output_parameters["zx90_gate_fidelity"].error = result[label]["gate_fidelity_err"]
-        self.output_parameters["zx90_depolarizing_rate"].value = result[label]["rb_fit_result"]["depolarizing_rate"]
+        self.output_parameters["zx90_depolarizing_rate"].value = result[label]["rb_fit_result"][
+            "depolarizing_rate"
+        ]
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result[label]["fig"]]
         return PostProcessResult(output_parameters=output_parameters, figures=figures)
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        label = "-".join([exp.get_qubit_label(int(q)) for q in qid.split("-")])  # e.g., "0-1" → "Q00-Q01"
+        label = "-".join(
+            [exp.get_qubit_label(int(q)) for q in qid.split("-")]
+        )  # e.g., "0-1" → "Q00-Q01"
         result = exp.interleaved_randomized_benchmarking(
             targets=label,
             interleaved_clifford="ZX90",

--- a/src/qdash/workflow/caltasks/qubex/box_setup/configure.py
+++ b/src/qdash/workflow/caltasks/qubex/box_setup/configure.py
@@ -24,7 +24,9 @@ class Configure(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
         exp = self.get_experiment(backend)
-        exp.state_manager.load(chip_id=exp.chip_id, config_dir=exp.config_path, params_dir=exp.params_path)
+        exp.state_manager.load(
+            chip_id=exp.chip_id, config_dir=exp.config_path, params_dir=exp.params_path
+        )
         exp.state_manager.push(box_ids=exp.box_ids, confirm=False)
         self.save_calibration(backend)
         return RunResult(raw_result=None)

--- a/src/qdash/workflow/caltasks/qubex/cw/check_electrical_delay.py
+++ b/src/qdash/workflow/caltasks/qubex/cw/check_electrical_delay.py
@@ -16,7 +16,9 @@ class CheckElectricalDelay(QubexTask):
     task_type: str = "qubit"
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "electrical_delay": OutputParameterModel(unit="ns", description="Electrical delay", value_type="float")
+        "electrical_delay": OutputParameterModel(
+            unit="ns", description="Electrical delay", value_type="float"
+        )
     }
 
     def postprocess(

--- a/src/qdash/workflow/caltasks/qubex/cw/check_qubit_frequencies.py
+++ b/src/qdash/workflow/caltasks/qubex/cw/check_qubit_frequencies.py
@@ -16,7 +16,9 @@ class CheckQubitFrequencies(QubexTask):
     task_type: str = "qubit"
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "coarse_qubit_frequency": OutputParameterModel(unit="GHz", description="Coarse qubit frequency"),
+        "coarse_qubit_frequency": OutputParameterModel(
+            unit="GHz", description="Coarse qubit frequency"
+        ),
     }
 
     def postprocess(

--- a/src/qdash/workflow/caltasks/qubex/cw/check_reflection_coefficient.py
+++ b/src/qdash/workflow/caltasks/qubex/cw/check_reflection_coefficient.py
@@ -18,9 +18,15 @@ class CheckReflectionCoefficient(QubexTask):
     task_type: str = "qubit"
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "resonator_frequency": OutputParameterModel(unit="GHz", description="Fine resonator frequency"),
-        "kappa_external": OutputParameterModel(unit="MHz", description="External coupling rate (kappa_external)"),
-        "kappa_internal": OutputParameterModel(unit="MHz", description="Internal coupling rate (kappa_internal)"),
+        "resonator_frequency": OutputParameterModel(
+            unit="GHz", description="Fine resonator frequency"
+        ),
+        "kappa_external": OutputParameterModel(
+            unit="MHz", description="External coupling rate (kappa_external)"
+        ),
+        "kappa_internal": OutputParameterModel(
+            unit="MHz", description="Internal coupling rate (kappa_internal)"
+        ),
     }
 
     def postprocess(

--- a/src/qdash/workflow/caltasks/qubex/cw/check_resonator_frequencies.py
+++ b/src/qdash/workflow/caltasks/qubex/cw/check_resonator_frequencies.py
@@ -31,7 +31,9 @@ class CheckResonatorFrequencies(QubexTask):
         )
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "coarse_resonator_frequency": OutputParameterModel(unit="GHz", description="Coarse resonator frequency"),
+        "coarse_resonator_frequency": OutputParameterModel(
+            unit="GHz", description="Coarse resonator frequency"
+        ),
     }
 
     def postprocess(

--- a/src/qdash/workflow/caltasks/qubex/measurement/readout_classification.py
+++ b/src/qdash/workflow/caltasks/qubex/measurement/readout_classification.py
@@ -101,7 +101,9 @@ class ReadoutClassification(QubexTask):
         self.get_experiment(backend)
         label = self.get_qubit_label(backend, qid)
         result = run_result.raw_result
-        self.output_parameters["average_readout_fidelity"].value = result["average_readout_fidelity"][label]
+        self.output_parameters["average_readout_fidelity"].value = result[
+            "average_readout_fidelity"
+        ][label]
         self.output_parameters["readout_fidelity_0"].value = result["readout_fidelities"][label][0]
         self.output_parameters["readout_fidelity_1"].value = result["readout_fidelities"][label][1]
         output_parameters = self.attach_execution_id(execution_id)

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_dispersive_shift.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_dispersive_shift.py
@@ -31,7 +31,9 @@ class CheckDispersiveShift(QubexTask):
         ),
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "optimal_readout_frequency": OutputParameterModel(unit="GHz", description="Optimal Readout Frequency"),
+        "optimal_readout_frequency": OutputParameterModel(
+            unit="GHz", description="Optimal Readout Frequency"
+        ),
         "dispersive_shift": OutputParameterModel(unit="MHz", description="Dispersive shift"),
     }
 
@@ -41,7 +43,9 @@ class CheckDispersiveShift(QubexTask):
         """Process the results of the task."""
         result = run_result.raw_result
         self.output_parameters["optimal_readout_frequency"].value = result["optimal_frequency"]
-        self.output_parameters["dispersive_shift"].value = result["dispersive_shift"] * 1000  # convert to MHz
+        self.output_parameters["dispersive_shift"].value = (
+            result["dispersive_shift"] * 1000
+        )  # convert to MHz
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result["fig"]]
         return PostProcessResult(output_parameters=output_parameters, figures=figures)

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_hpi_pulse.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_hpi_pulse.py
@@ -31,7 +31,9 @@ class CheckHPIPulse(QubexTask):
         label = self.get_qubit_label(backend, qid)
         result = run_result.raw_result
         figures = [result.data[label].plot(normalize=True, return_figure=True)]
-        return PostProcessResult(output_parameters=self.attach_execution_id(execution_id), figures=figures)
+        return PostProcessResult(
+            output_parameters=self.attach_execution_id(execution_id), figures=figures
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_optimal_readout_amplitude.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_optimal_readout_amplitude.py
@@ -37,7 +37,9 @@ class CheckOptimalReadoutAmplitude(QubexTask):
         ),
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "optimal_readout_amplitude": OutputParameterModel(unit="a.u.", description="Optimal Readout Amplitude"),
+        "optimal_readout_amplitude": OutputParameterModel(
+            unit="a.u.", description="Optimal Readout Amplitude"
+        ),
     }
 
     def postprocess(

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_pi_pulse.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_pi_pulse.py
@@ -31,7 +31,9 @@ class CheckPIPulse(QubexTask):
         label = self.get_qubit_label(backend, qid)
         result = run_result.raw_result
         figures = [result.data[label].plot(normalize=True, return_figure=True)]
-        return PostProcessResult(output_parameters=self.attach_execution_id(execution_id), figures=figures)
+        return PostProcessResult(
+            output_parameters=self.attach_execution_id(execution_id), figures=figures
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_qubit.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_qubit.py
@@ -36,8 +36,12 @@ class CheckQubit(QubexTask):
         ),
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "rabi_amplitude": OutputParameterModel(unit="a.u.", description="Rabi oscillation amplitude"),
-        "rabi_frequency": OutputParameterModel(unit="MHz", description="Rabi oscillation frequency"),
+        "rabi_amplitude": OutputParameterModel(
+            unit="a.u.", description="Rabi oscillation amplitude"
+        ),
+        "rabi_frequency": OutputParameterModel(
+            unit="MHz", description="Rabi oscillation frequency"
+        ),
     }
 
     def postprocess(
@@ -49,15 +53,21 @@ class CheckQubit(QubexTask):
         result = run_result.raw_result
         self.output_parameters["rabi_amplitude"].value = result.rabi_params[label].amplitude
         self.output_parameters["rabi_amplitude"].error = result.data[label].fit()["amplitude_err"]
-        self.output_parameters["rabi_frequency"].value = result.rabi_params[label].frequency * 1000  # convert to MHz
-        self.output_parameters["rabi_frequency"].error = result.data[label].fit()["frequency_err"] * 1000
+        self.output_parameters["rabi_frequency"].value = (
+            result.rabi_params[label].frequency * 1000
+        )  # convert to MHz
+        self.output_parameters["rabi_frequency"].error = (
+            result.data[label].fit()["frequency_err"] * 1000
+        )
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result.data[label].fit()["fig"]]
         raw_data = [result.data[label].data]
         r2 = result.rabi_params[label].r2
         if self.r2_is_lower_than_threshold(r2):
             raise ValueError(f"R^2 value of Rabi oscillation is too low: {r2}")
-        return PostProcessResult(output_parameters=output_parameters, figures=figures, raw_data=raw_data)
+        return PostProcessResult(
+            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         """Run the task."""

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_rabi.py
@@ -37,14 +37,20 @@ class CheckRabi(QubexTask):
         ),
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "rabi_amplitude": OutputParameterModel(unit="a.u.", description="Rabi oscillation amplitude"),
-        "rabi_frequency": OutputParameterModel(unit="MHz", description="Rabi oscillation frequency"),
+        "rabi_amplitude": OutputParameterModel(
+            unit="a.u.", description="Rabi oscillation amplitude"
+        ),
+        "rabi_frequency": OutputParameterModel(
+            unit="MHz", description="Rabi oscillation frequency"
+        ),
         "rabi_phase": OutputParameterModel(unit="a.u.", description="Rabi oscillation phase"),
         "rabi_offset": OutputParameterModel(unit="a.u.", description="Rabi oscillation offset"),
         "rabi_angle": OutputParameterModel(unit="degree", description="Rabi angle (in degree)"),
         "rabi_noise": OutputParameterModel(unit="a.u.", description="Rabi oscillation noise"),
         "rabi_distance": OutputParameterModel(unit="a.u.", description="Rabi distance"),
-        "rabi_reference_phase": OutputParameterModel(unit="a.u.", description="Rabi reference phase"),
+        "rabi_reference_phase": OutputParameterModel(
+            unit="a.u.", description="Rabi reference phase"
+        ),
     }
 
     def postprocess(
@@ -55,8 +61,12 @@ class CheckRabi(QubexTask):
         result = run_result.raw_result
         self.output_parameters["rabi_amplitude"].value = result.rabi_params[label].amplitude
         self.output_parameters["rabi_amplitude"].error = result.data[label].fit()["amplitude_err"]
-        self.output_parameters["rabi_frequency"].value = result.rabi_params[label].frequency * 1000  # convert to MHz
-        self.output_parameters["rabi_frequency"].error = result.data[label].fit()["frequency_err"] * 1000
+        self.output_parameters["rabi_frequency"].value = (
+            result.rabi_params[label].frequency * 1000
+        )  # convert to MHz
+        self.output_parameters["rabi_frequency"].error = (
+            result.data[label].fit()["frequency_err"] * 1000
+        )
         self.output_parameters["rabi_phase"].value = result.rabi_params[label].phase
         self.output_parameters["rabi_phase"].error = result.data[label].fit()["phase_err"]
         self.output_parameters["rabi_offset"].value = result.rabi_params[label].offset
@@ -64,11 +74,15 @@ class CheckRabi(QubexTask):
         self.output_parameters["rabi_angle"].value = result.rabi_params[label].angle
         self.output_parameters["rabi_noise"].value = result.rabi_params[label].noise
         self.output_parameters["rabi_distance"].value = result.rabi_params[label].distance
-        self.output_parameters["rabi_reference_phase"].value = result.rabi_params[label].reference_phase
+        self.output_parameters["rabi_reference_phase"].value = result.rabi_params[
+            label
+        ].reference_phase
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result.data[label].fit()["fig"]]
         raw_data = [result.data[label].data]
-        return PostProcessResult(output_parameters=output_parameters, figures=figures, raw_data=raw_data)
+        return PostProcessResult(
+            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         """Run the task."""

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_ramsey.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/check_ramsey.py
@@ -43,7 +43,9 @@ class CheckRamsey(QubexTask):
         ),
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "ramsey_frequency": OutputParameterModel(unit="MHz", description="Ramsey oscillation frequency"),
+        "ramsey_frequency": OutputParameterModel(
+            unit="MHz", description="Ramsey oscillation frequency"
+        ),
         "qubit_frequency": OutputParameterModel(unit="GHz", description="Qubit bare frequency"),
         "t2_star": OutputParameterModel(unit="μs", description="T2* time"),
     }
@@ -116,8 +118,16 @@ class CheckRamsey(QubexTask):
         logger = get_run_logger()
 
         # Debug: Check what labels are actually in the data
-        x_labels = list(run_result.raw_result["x"].data.keys()) if hasattr(run_result.raw_result["x"], "data") else []
-        y_labels = list(run_result.raw_result["y"].data.keys()) if hasattr(run_result.raw_result["y"], "data") else []
+        x_labels = (
+            list(run_result.raw_result["x"].data.keys())
+            if hasattr(run_result.raw_result["x"], "data")
+            else []
+        )
+        y_labels = (
+            list(run_result.raw_result["y"].data.keys())
+            if hasattr(run_result.raw_result["y"], "data")
+            else []
+        )
 
         logger.info(f"Expected label: {label}")
         logger.info(f"X-axis data labels: {x_labels}")
@@ -169,8 +179,12 @@ class CheckRamsey(QubexTask):
         x_fit_success = x_r2 is not None and not self.r2_is_lower_than_threshold(x_r2)
         y_fit_success = y_r2 is not None and not self.r2_is_lower_than_threshold(y_r2)
 
-        x_fit_status = "✓ Success" if x_fit_success else ("✗ Failed" if result_x is not None else "✗ No data")
-        y_fit_status = "✓ Success" if y_fit_success else ("✗ Failed" if result_y is not None else "✗ No data")
+        x_fit_status = (
+            "✓ Success" if x_fit_success else ("✗ Failed" if result_x is not None else "✗ No data")
+        )
+        y_fit_status = (
+            "✓ Success" if y_fit_success else ("✗ Failed" if result_y is not None else "✗ No data")
+        )
         logger.info(f"  X-axis fit: {x_fit_status}")
         logger.info(f"  Y-axis fit: {y_fit_status}")
 
@@ -207,12 +221,18 @@ class CheckRamsey(QubexTask):
             selected_fit = y_fit
             selected_axis = "Y"
 
-        selected_r2 = x_r2 if use_x and x_r2 is not None else (y_r2 if not use_x and y_r2 is not None else None)
+        selected_r2 = (
+            x_r2
+            if use_x and x_r2 is not None
+            else (y_r2 if not use_x and y_r2 is not None else None)
+        )
         selected_r2_str = f"{selected_r2:.4f}" if selected_r2 is not None else "N/A"
         logger.info(f"  Selected axis: {selected_axis} (R²={selected_r2_str})")
         logger.info(f"  Bare frequency: {selected_result.bare_freq:.6f} GHz")
 
-        self.output_parameters["ramsey_frequency"].value = selected_fit["f"] * 1000  # convert to MHz
+        self.output_parameters["ramsey_frequency"].value = (
+            selected_fit["f"] * 1000
+        )  # convert to MHz
         self.output_parameters["ramsey_frequency"].error = selected_fit["f_err"] * 1000
         self.output_parameters["qubit_frequency"].value = selected_result.bare_freq
         self.output_parameters["t2_star"].value = selected_result.t2 * 0.001  # convert to μs
@@ -231,7 +251,9 @@ class CheckRamsey(QubexTask):
             figures.append(self.make_figure(result_x, result_y, label))
 
         raw_data = [selected_result.data]
-        return PostProcessResult(output_parameters=output_parameters, figures=figures, raw_data=raw_data)
+        return PostProcessResult(
+            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         """Run the task."""

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/create_pi_pulse.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_coarse/create_pi_pulse.py
@@ -17,7 +17,9 @@ class CreatePIPulse(QubexTask):
     name: str = "CreatePIPulse"
     task_type: str = "qubit"
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {
-        "duration": InputParameterModel(unit="ns", value_type="int", value=PI_DURATION, description="PI pulse length"),
+        "duration": InputParameterModel(
+            unit="ns", value_type="int", value=PI_DURATION, description="PI pulse length"
+        ),
         "shots": InputParameterModel(
             unit="",
             value_type="int",

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_fine/check_drag_hpi_pulse.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_fine/check_drag_hpi_pulse.py
@@ -31,7 +31,9 @@ class CheckDRAGHPIPulse(QubexTask):
         label = self.get_qubit_label(backend, qid)
         result = run_result.raw_result
         figures = [result.data[label].plot(normalize=True, return_figure=True)]
-        return PostProcessResult(output_parameters=self.attach_execution_id(execution_id), figures=figures)
+        return PostProcessResult(
+            output_parameters=self.attach_execution_id(execution_id), figures=figures
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_fine/check_drag_pi_pulse.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_fine/check_drag_pi_pulse.py
@@ -31,7 +31,9 @@ class CheckDRAGPIPulse(QubexTask):
         label = self.get_qubit_label(backend, qid)
         result = run_result.raw_result
         figures = [result.data[label].plot(normalize=True, return_figure=True)]
-        return PostProcessResult(output_parameters=self.attach_execution_id(execution_id), figures=figures)
+        return PostProcessResult(
+            output_parameters=self.attach_execution_id(execution_id), figures=figures
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/caltasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
+++ b/src/qdash/workflow/caltasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
@@ -40,7 +40,9 @@ class CreateDRAGHPIPulse(QubexTask):
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
         "drag_hpi_beta": OutputParameterModel(unit="a.u.", description="DRAG HPI pulse beta"),
-        "drag_hpi_amplitude": OutputParameterModel(unit="a.u.", description="DRAG HPI pulse amplitude"),
+        "drag_hpi_amplitude": OutputParameterModel(
+            unit="a.u.", description="DRAG HPI pulse amplitude"
+        ),
     }
 
     def postprocess(

--- a/src/qdash/workflow/caltasks/qubex/system/check_skew.py
+++ b/src/qdash/workflow/caltasks/qubex/system/check_skew.py
@@ -32,7 +32,9 @@ class CheckSkew(QubexTask):
     ) -> PostProcessResult:
         result = run_result.raw_result
         figures: list = [result["fig"]]
-        return PostProcessResult(output_parameters=self.attach_execution_id(execution_id), figures=figures)
+        return PostProcessResult(
+            output_parameters=self.attach_execution_id(execution_id), figures=figures
+        )
 
     def load(self, filename: str) -> Any:
         with (Path.cwd() / Path(filename)).open() as file:
@@ -57,7 +59,9 @@ class CheckSkew(QubexTask):
             config_dir=f"/app/config/qubex/{chip_id}/config",
             params_dir=f"/app/config/qubex/{chip_id}/params",
         )
-        clock_master_address = exp.system_manager.experiment_system.control_system.clock_master_address
+        clock_master_address = (
+            exp.system_manager.experiment_system.control_system.clock_master_address
+        )
         box_ids = exp.box_ids
         all_box_ids = list(set(list(box_ids) + [ref_port]))
         skew = Skew.from_yaml(

--- a/src/qdash/workflow/caltasks/qubex/two_qubit/check_bell_state.py
+++ b/src/qdash/workflow/caltasks/qubex/two_qubit/check_bell_state.py
@@ -25,11 +25,15 @@ class CheckBellState(QubexTask):
         output_parameters = self.attach_execution_id(execution_id)
         figures: list = [result["figure"]]
         raw_data: list = []
-        return PostProcessResult(output_parameters=output_parameters, figures=figures, raw_data=raw_data)
+        return PostProcessResult(
+            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        control, target = (exp.get_qubit_label(int(q)) for q in qid.split("-"))  # e.g., "0-1" → "Q00","Q01"
+        control, target = (
+            exp.get_qubit_label(int(q)) for q in qid.split("-")
+        )  # e.g., "0-1" → "Q00","Q01"
         result = exp.measure_bell_state(control, target)
         self.save_calibration(backend)
         return RunResult(raw_result=result)

--- a/src/qdash/workflow/caltasks/qubex/two_qubit/check_bell_state_tomography.py
+++ b/src/qdash/workflow/caltasks/qubex/two_qubit/check_bell_state_tomography.py
@@ -108,18 +108,24 @@ class CheckBellStateTomography(QubexTask):
         self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
     ) -> PostProcessResult:
         exp = self.get_experiment(backend)
-        label = "-".join([exp.get_qubit_label(int(q)) for q in qid.split("-")])  # e.g., "0-1" → "Q00-Q01"
+        label = "-".join(
+            [exp.get_qubit_label(int(q)) for q in qid.split("-")]
+        )  # e.g., "0-1" → "Q00-Q01"
         result = run_result.raw_result
         self.output_parameters["bell_state_fidelity"].value = result["fidelity"]
         output_parameters = self.attach_execution_id(execution_id)
         result["figure"] = self.make_figure(result, label)
         figures: list = [result["figure"]]
         raw_data: list = []
-        return PostProcessResult(output_parameters=output_parameters, figures=figures, raw_data=raw_data)
+        return PostProcessResult(
+            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        control, target = (exp.get_qubit_label(int(q)) for q in qid.split("-"))  # e.g., "0-1" → "Q00","Q01"
+        control, target = (
+            exp.get_qubit_label(int(q)) for q in qid.split("-")
+        )  # e.g., "0-1" → "Q00","Q01"
         result = exp.bell_state_tomography(control, target)
         self.save_calibration(backend)
         return RunResult(raw_result=result)

--- a/src/qdash/workflow/caltasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/caltasks/qubex/two_qubit/check_cross_resonance.py
@@ -19,17 +19,27 @@ class CheckCrossResonance(QubexTask):
     timeout: int = 60 * 25  # 25 minutes
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "cr_amplitude": OutputParameterModel(unit="a.u.", value_type="float", description="Amplitude of the CR pulse."),
-        "cr_phase": OutputParameterModel(unit="a.u.", value_type="float", description="Phase of the CR pulse."),
+        "cr_amplitude": OutputParameterModel(
+            unit="a.u.", value_type="float", description="Amplitude of the CR pulse."
+        ),
+        "cr_phase": OutputParameterModel(
+            unit="a.u.", value_type="float", description="Phase of the CR pulse."
+        ),
         "cancel_amplitude": OutputParameterModel(
             unit="a.u.", value_type="float", description="Amplitude of the cancel pulse."
         ),
-        "cancel_phase": OutputParameterModel(unit="a.u.", value_type="float", description="Phase of the cancel pulse."),
-        "cancel_beta": OutputParameterModel(unit="a.u.", value_type="float", description="Beta of the cancel pulse."),
+        "cancel_phase": OutputParameterModel(
+            unit="a.u.", value_type="float", description="Phase of the cancel pulse."
+        ),
+        "cancel_beta": OutputParameterModel(
+            unit="a.u.", value_type="float", description="Beta of the cancel pulse."
+        ),
         "rotary_amplitude": OutputParameterModel(
             unit="a.u.", value_type="float", description="Amplitude of the rotary pulse."
         ),
-        "zx_rotation_rate": OutputParameterModel(unit="a.u.", value_type="float", description="ZX rotation rate."),
+        "zx_rotation_rate": OutputParameterModel(
+            unit="a.u.", value_type="float", description="ZX rotation rate."
+        ),
     }
 
     def _plot_coeffs_history(self, coeffs_history: dict, label: str) -> go.Figure:
@@ -55,7 +65,9 @@ class CheckCrossResonance(QubexTask):
         self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
     ) -> PostProcessResult:
         exp = self.get_experiment(backend)
-        label = "-".join([exp.get_qubit_label(int(q)) for q in qid.split("-")])  # e.g., "0-1" → "Q00-Q01"
+        label = "-".join(
+            [exp.get_qubit_label(int(q)) for q in qid.split("-")]
+        )  # e.g., "0-1" → "Q00-Q01"
         result = run_result.raw_result
         self.output_parameters["cr_amplitude"].value = result["cr_amplitude"]
         self.output_parameters["cr_phase"].value = result["cr_phase"]
@@ -69,12 +81,18 @@ class CheckCrossResonance(QubexTask):
         fig = self._plot_coeffs_history(result["coeffs_history"], label=label)
         figures: list = [fig]
         raw_data: list = []
-        return PostProcessResult(output_parameters=output_parameters, figures=figures, raw_data=raw_data)
+        return PostProcessResult(
+            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        label = "-".join([exp.get_qubit_label(int(q)) for q in qid.split("-")])  # e.g., "0-1" → "Q00-Q01"
-        control, target = (exp.get_qubit_label(int(q)) for q in qid.split("-"))  # e.g., "0-1" → "Q00","Q01"
+        label = "-".join(
+            [exp.get_qubit_label(int(q)) for q in qid.split("-")]
+        )  # e.g., "0-1" → "Q00-Q01"
+        control, target = (
+            exp.get_qubit_label(int(q)) for q in qid.split("-")
+        )  # e.g., "0-1" → "Q00","Q01"
 
         raw_result = exp.obtain_cr_params(
             control,

--- a/src/qdash/workflow/caltasks/qubex/two_qubit/check_zx90.py
+++ b/src/qdash/workflow/caltasks/qubex/two_qubit/check_zx90.py
@@ -29,17 +29,23 @@ class CheckZX90(QubexTask):
         self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
     ) -> PostProcessResult:
         exp = self.get_experiment(backend)
-        control, target = (exp.get_qubit_label(int(q)) for q in qid.split("-"))  # e.g., "0-1" → "Q00","Q01"
+        control, target = (
+            exp.get_qubit_label(int(q)) for q in qid.split("-")
+        )  # e.g., "0-1" → "Q00","Q01"
         result = run_result.raw_result
         figures = [
             result.data[control].plot(normalize=True, return_figure=True),
             result.data[target].plot(normalize=True, return_figure=True),
         ]
-        return PostProcessResult(output_parameters=self.attach_execution_id(execution_id), figures=figures)
+        return PostProcessResult(
+            output_parameters=self.attach_execution_id(execution_id), figures=figures
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        control, target = (exp.get_qubit_label(int(q)) for q in qid.split("-"))  # e.g., "0-1" → "Q00","Q01"
+        control, target = (
+            exp.get_qubit_label(int(q)) for q in qid.split("-")
+        )  # e.g., "0-1" → "Q00","Q01"
         zx90_pulse = exp.zx90(control, target)
         result = exp.repeat_sequence(
             sequence=zx90_pulse,

--- a/src/qdash/workflow/caltasks/qubex/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/caltasks/qubex/two_qubit/create_zx90.py
@@ -17,17 +17,27 @@ class CreateZX90(QubexTask):
     timeout: int = 60 * 25  # 25 minutes
     input_parameters: ClassVar[dict[str, InputParameterModel]] = {}
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {
-        "cr_amplitude": OutputParameterModel(unit="a.u.", value_type="float", description="Amplitude of the CR pulse."),
-        "cr_phase": OutputParameterModel(unit="a.u.", value_type="float", description="Phase of the CR pulse."),
+        "cr_amplitude": OutputParameterModel(
+            unit="a.u.", value_type="float", description="Amplitude of the CR pulse."
+        ),
+        "cr_phase": OutputParameterModel(
+            unit="a.u.", value_type="float", description="Phase of the CR pulse."
+        ),
         "cancel_amplitude": OutputParameterModel(
             unit="a.u.", value_type="float", description="Amplitude of the cancel pulse."
         ),
-        "cancel_phase": OutputParameterModel(unit="a.u.", value_type="float", description="Phase of the cancel pulse."),
-        "cancel_beta": OutputParameterModel(unit="a.u.", value_type="float", description="Beta of the cancel pulse."),
+        "cancel_phase": OutputParameterModel(
+            unit="a.u.", value_type="float", description="Phase of the cancel pulse."
+        ),
+        "cancel_beta": OutputParameterModel(
+            unit="a.u.", value_type="float", description="Beta of the cancel pulse."
+        ),
         "rotary_amplitude": OutputParameterModel(
             unit="a.u.", value_type="float", description="Amplitude of the rotary pulse."
         ),
-        "zx_rotation_rate": OutputParameterModel(unit="a.u.", value_type="float", description="ZX rotation rate."),
+        "zx_rotation_rate": OutputParameterModel(
+            unit="a.u.", value_type="float", description="ZX rotation rate."
+        ),
     }
 
     def postprocess(
@@ -44,12 +54,18 @@ class CreateZX90(QubexTask):
         output_parameters = self.attach_execution_id(execution_id)
         figures: list = [result["n1"], result["n3"], result["fig"]]
         raw_data: list = []
-        return PostProcessResult(output_parameters=output_parameters, figures=figures, raw_data=raw_data)
+        return PostProcessResult(
+            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        control, target = (exp.get_qubit_label(int(q)) for q in qid.split("-"))  # e.g., "0-1" → "Q00","Q01"
-        label = "-".join([exp.get_qubit_label(int(q)) for q in qid.split("-")])  # e.g., "0-1" → "Q00-Q01"
+        control, target = (
+            exp.get_qubit_label(int(q)) for q in qid.split("-")
+        )  # e.g., "0-1" → "Q00","Q01"
+        label = "-".join(
+            [exp.get_qubit_label(int(q)) for q in qid.split("-")]
+        )  # e.g., "0-1" → "Q00-Q01"
         raw_result = exp.calibrate_zx90(
             control,
             target,

--- a/src/qdash/workflow/deployment_service.py
+++ b/src/qdash/workflow/deployment_service.py
@@ -88,7 +88,8 @@ async def register_deployment(request: RegisterDeploymentRequest) -> RegisterDep
 
         if not hasattr(module, request.flow_function_name):
             raise HTTPException(
-                status_code=400, detail=f"Flow function '{request.flow_function_name}' not found in {file_path}"
+                status_code=400,
+                detail=f"Flow function '{request.flow_function_name}' not found in {file_path}",
             )
 
         flow_obj = getattr(module, request.flow_function_name)
@@ -101,7 +102,9 @@ async def register_deployment(request: RegisterDeploymentRequest) -> RegisterDep
                     await client.delete_deployment(request.old_deployment_id)
                     logger.info(f"Deleted old deployment: {request.old_deployment_id}")
             except Exception as e:
-                logger.warning(f"Failed to delete old deployment {request.old_deployment_id}: {type(e).__name__}: {e}")
+                logger.warning(
+                    f"Failed to delete old deployment {request.old_deployment_id}: {type(e).__name__}: {e}"
+                )
 
         # Build deployment using the flow object with work pool
         logger.info(f"Building deployment with work pool: {WORK_POOL_NAME}")
@@ -129,7 +132,9 @@ async def register_deployment(request: RegisterDeploymentRequest) -> RegisterDep
         raise HTTPException(status_code=404, detail=str(e))
     except AttributeError as e:
         logger.error(f"Flow function not found: {e}")
-        raise HTTPException(status_code=400, detail=f"Flow function '{request.flow_function_name}' not found")
+        raise HTTPException(
+            status_code=400, detail=f"Flow function '{request.flow_function_name}' not found"
+        )
     except Exception as e:
         logger.error(f"Failed to register deployment: {type(e).__name__}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
@@ -209,7 +214,9 @@ async def set_schedule(request: SetScheduleRequest) -> SetScheduleResponse:
                 logger.info(f"Found deployment: {target_deployment.name}")
             except Exception as e:
                 logger.error(f"Failed to read deployment {request.deployment_id}: {e}")
-                raise HTTPException(status_code=404, detail=f"Deployment not found: {request.deployment_id}")
+                raise HTTPException(
+                    status_code=404, detail=f"Deployment not found: {request.deployment_id}"
+                )
 
             # Update schedule and parameters
             try:
@@ -231,7 +238,9 @@ async def set_schedule(request: SetScheduleRequest) -> SetScheduleResponse:
                     logger.info("Successfully updated deployment parameters")
             except Exception as e:
                 logger.error(f"Failed to update deployment: {e}")
-                raise HTTPException(status_code=500, detail=f"Failed to update deployment: {str(e)}")
+                raise HTTPException(
+                    status_code=500, detail=f"Failed to update deployment: {str(e)}"
+                )
 
             logger.info(
                 f"Set schedule on deployment {request.deployment_id}: cron={request.cron}, active={request.active}"

--- a/src/qdash/workflow/engine/backend/qubex.py
+++ b/src/qdash/workflow/engine/backend/qubex.py
@@ -36,7 +36,9 @@ class QubexBackend(BaseBackend):
             from qubex import Experiment
 
             if self._config.get("task_type") == "qubit":
-                qubits = [int(qid) for qid in self._config.get("qids", [])]  # e.g. : ["0", "1", "2"] → [0, 1, 2]
+                qubits = [
+                    int(qid) for qid in self._config.get("qids", [])
+                ]  # e.g. : ["0", "1", "2"] → [0, 1, 2]
             elif self._config.get("task_type") == "coupling":
                 qubits = sorted(
                     {int(q) for qid in self._config.get("qids", []) for q in qid.split("-")}
@@ -74,7 +76,13 @@ class QubexBackend(BaseBackend):
         return str(exp.calib_note)
 
     def save_note(
-        self, username: str, chip_id: str, calib_dir: str, execution_id: str, task_manager_id: str, project_id: str
+        self,
+        username: str,
+        chip_id: str,
+        calib_dir: str,
+        execution_id: str,
+        task_manager_id: str,
+        project_id: str,
     ) -> None:
         """Save the calibration note to the experiment."""
         # Initialize calibration note
@@ -82,7 +90,9 @@ class QubexBackend(BaseBackend):
         note_path.parent.mkdir(parents=True, exist_ok=True)
 
         master_doc = (
-            CalibrationNoteDocument.find({"task_id": "master", "chip_id": chip_id, "project_id": project_id})
+            CalibrationNoteDocument.find(
+                {"task_id": "master", "chip_id": chip_id, "project_id": project_id}
+            )
             .sort([("timestamp", -1)])
             .limit(1)
             .run()
@@ -102,7 +112,13 @@ class QubexBackend(BaseBackend):
         note_path.write_text(json.dumps(master_doc.note, indent=2))
 
     def update_note(
-        self, username: str, chip_id: str, calib_dir: str, execution_id: str, task_manager_id: str, project_id: str
+        self,
+        username: str,
+        chip_id: str,
+        calib_dir: str,
+        execution_id: str,
+        task_manager_id: str,
+        project_id: str,
     ) -> None:
         """Update the master calibration note in MongoDB only.
 

--- a/src/qdash/workflow/engine/calibration/execution/service.py
+++ b/src/qdash/workflow/engine/calibration/execution/service.py
@@ -271,14 +271,22 @@ class ExecutionService:
                     model.calib_data = {"qubit": {}, "coupling": {}}
                 if isinstance(model.calib_data, dict):
                     model.calib_data.setdefault("qubit", {}).setdefault(qid, {}).update(
-                        data if isinstance(data, dict) else data.model_dump() if hasattr(data, "model_dump") else data
+                        data
+                        if isinstance(data, dict)
+                        else data.model_dump()
+                        if hasattr(data, "model_dump")
+                        else data
                     )
 
             # Merge coupling data
             for qid, data in calib_data.coupling.items():
                 if isinstance(model.calib_data, dict):
                     model.calib_data.setdefault("coupling", {}).setdefault(qid, {}).update(
-                        data if isinstance(data, dict) else data.model_dump() if hasattr(data, "model_dump") else data
+                        data
+                        if isinstance(data, dict)
+                        else data.model_dump()
+                        if hasattr(data, "model_dump")
+                        else data
                     )
 
         self._update_with_lock(update_func)

--- a/src/qdash/workflow/engine/calibration/execution/state_manager.py
+++ b/src/qdash/workflow/engine/calibration/execution/state_manager.py
@@ -301,7 +301,9 @@ class ExecutionStateManager(BaseModel):
             start_at=model.start_at,
             end_at=model.end_at,
             elapsed_time=model.elapsed_time,
-            calib_data=CalibDataModel(**model.calib_data) if isinstance(model.calib_data, dict) else model.calib_data,
+            calib_data=CalibDataModel(**model.calib_data)
+            if isinstance(model.calib_data, dict)
+            else model.calib_data,
             message=model.message,
             system_info=SystemInfoModel(**model.system_info)
             if isinstance(model.system_info, dict)

--- a/src/qdash/workflow/engine/calibration/prefect_tasks.py
+++ b/src/qdash/workflow/engine/calibration/prefect_tasks.py
@@ -36,7 +36,9 @@ def execute_dynamic_task_by_qid(
 
     try:
         # TaskManager's integrated execution and save processing
-        execution_manager, task_manager = task_manager.execute_task(task_instance, backend, execution_manager, qid)
+        execution_manager, task_manager = task_manager.execute_task(
+            task_instance, backend, execution_manager, qid
+        )
     except Exception as e:
         logger.error(f"Failed to execute {task_name}: {e}, id: {task_manager.id}")
         raise RuntimeError(f"Task {task_name} failed: {e}")
@@ -61,7 +63,9 @@ def execute_dynamic_task_batch(
     try:
         # Execute task for each qid using TaskManager's integrated processing
         for qid in qids:
-            execution_manager, task_manager = task_manager.execute_task(task_instance, backend, execution_manager, qid)
+            execution_manager, task_manager = task_manager.execute_task(
+                task_instance, backend, execution_manager, qid
+            )
     except Exception as e:
         logger.error(f"Failed to execute {task_name}: {e}, id: {task_manager.id}")
         raise RuntimeError(f"Task {task_name} failed: {e}")

--- a/src/qdash/workflow/engine/calibration/repository/mongo_execution.py
+++ b/src/qdash/workflow/engine/calibration/repository/mongo_execution.py
@@ -221,7 +221,9 @@ class MongoExecutionRepository:
             logger.error(f"DB transaction failed: {e}")
             raise
 
-    def _ensure_document_exists(self, collection, execution_id: str, initial_model: ExecutionModel) -> None:
+    def _ensure_document_exists(
+        self, collection, execution_id: str, initial_model: ExecutionModel
+    ) -> None:
         """Ensure document exists in collection.
 
         Parameters

--- a/src/qdash/workflow/engine/calibration/scheduler/cr_scheduler.py
+++ b/src/qdash/workflow/engine/calibration/scheduler/cr_scheduler.py
@@ -172,7 +172,9 @@ class CRScheduler:
             if self.wiring_config_path is not None:
                 wiring_path = Path(self.wiring_config_path)
             else:
-                wiring_path = Path(f"/workspace/qdash/config/qubex/{self.chip_id}/config/wiring.yaml")
+                wiring_path = Path(
+                    f"/workspace/qdash/config/qubex/{self.chip_id}/config/wiring.yaml"
+                )
 
             if not wiring_path.exists():
                 msg = f"Wiring config not found: {wiring_path}"
@@ -385,7 +387,9 @@ class CRScheduler:
                 continue
 
             # Conflict 3: MUX resource conflicts
-            conflict_muxes = mux_conflict_map.get(mux_a1, set()) | mux_conflict_map.get(mux_a2, set())
+            conflict_muxes = mux_conflict_map.get(mux_a1, set()) | mux_conflict_map.get(
+                mux_a2, set()
+            )
             if mux_b1 in conflict_muxes or mux_b2 in conflict_muxes:
                 conflict_graph.add_edge(pair_a, pair_b)
 
@@ -412,10 +416,20 @@ class CRScheduler:
         return groups
 
     @staticmethod
-    def _split_fast_slow_pairs(cr_pairs: list[str], qid_to_mux: dict[str, int]) -> tuple[list[str], list[str]]:
+    def _split_fast_slow_pairs(
+        cr_pairs: list[str], qid_to_mux: dict[str, int]
+    ) -> tuple[list[str], list[str]]:
         """Separate CR pairs into fast (intra-MUX) and slow (inter-MUX) categories."""
-        fast_pairs = [p for p in cr_pairs if qid_to_mux.get(p.split("-")[0]) == qid_to_mux.get(p.split("-")[1])]
-        slow_pairs = [p for p in cr_pairs if qid_to_mux.get(p.split("-")[0]) != qid_to_mux.get(p.split("-")[1])]
+        fast_pairs = [
+            p
+            for p in cr_pairs
+            if qid_to_mux.get(p.split("-")[0]) == qid_to_mux.get(p.split("-")[1])
+        ]
+        slow_pairs = [
+            p
+            for p in cr_pairs
+            if qid_to_mux.get(p.split("-")[0]) != qid_to_mux.get(p.split("-")[1])
+        ]
         return fast_pairs, slow_pairs
 
     @staticmethod
@@ -484,7 +498,9 @@ class CRScheduler:
             ScheduleContext,
         )
 
-        logger.info(f"Generating CR schedule (plugin mode) for chip_id={self.chip_id}, username={self.username}")
+        logger.info(
+            f"Generating CR schedule (plugin mode) for chip_id={self.chip_id}, username={self.username}"
+        )
 
         # Load chip data
         chip_doc = self._load_chip_data()
@@ -525,7 +541,9 @@ class CRScheduler:
             filtered_pairs = filter_obj.filter(filtered_pairs, filter_context)
             stats = filter_obj.get_stats()
             filter_stats.append(stats)
-            logger.info(f"  Filter {i} ({stats['filter_name']}): {stats['input_pairs']} → {stats['output_pairs']}")
+            logger.info(
+                f"  Filter {i} ({stats['filter_name']}): {stats['input_pairs']} → {stats['output_pairs']}"
+            )
 
         if len(filtered_pairs) == 0:
             msg = "No valid CR pairs after filtering"
@@ -535,7 +553,9 @@ class CRScheduler:
         # Use default scheduler if not provided
         if scheduler is None:
             scheduler = IntraThenInterMuxScheduler(
-                inner_scheduler=MuxConflictScheduler(max_parallel_ops=10, coloring_strategy="largest_first")
+                inner_scheduler=MuxConflictScheduler(
+                    max_parallel_ops=10, coloring_strategy="largest_first"
+                )
             )
 
         # Create schedule context
@@ -637,7 +657,9 @@ class CRScheduler:
         logger.info(f"Generating CR schedule for chip_id={self.chip_id}, username={self.username}")
         logger.info(f"  max_parallel_ops={max_parallel_ops}")
         if candidate_qubits is not None:
-            logger.info(f"  Using {len(candidate_qubits)} candidate qubits from stage1: {candidate_qubits}")
+            logger.info(
+                f"  Using {len(candidate_qubits)} candidate qubits from stage1: {candidate_qubits}"
+            )
 
         # Load chip data
         chip_doc = self._load_chip_data()
@@ -663,7 +685,9 @@ class CRScheduler:
                 and qubits[0] in candidate_set
                 and qubits[1] in candidate_set
             ]
-            logger.info(f"Filtered to {len(all_pairs)} pairs using {len(candidate_qubits)} candidate qubits")
+            logger.info(
+                f"Filtered to {len(all_pairs)} pairs using {len(candidate_qubits)} candidate qubits"
+            )
 
         # Filter by frequency directionality
         # Default: Use design-based inference (checkerboard pattern)
@@ -721,7 +745,9 @@ class CRScheduler:
         fast, slow = self._split_fast_slow_pairs(cr_pairs, qid_to_mux)
         grouped = self._group_cr_pairs_by_conflict(
             fast, qid_to_mux, mux_conflict_map, max_parallel_ops, coloring_strategy
-        ) + self._group_cr_pairs_by_conflict(slow, qid_to_mux, mux_conflict_map, max_parallel_ops, coloring_strategy)
+        ) + self._group_cr_pairs_by_conflict(
+            slow, qid_to_mux, mux_conflict_map, max_parallel_ops, coloring_strategy
+        )
 
         # Convert to parallel_groups format
         parallel_groups = self._convert_to_parallel_groups(grouped)
@@ -740,7 +766,9 @@ class CRScheduler:
             "num_groups": len(parallel_groups),
             "max_parallel_ops": max_parallel_ops,
             "coloring_strategy": coloring_strategy,
-            "candidate_qubits_count": len(candidate_qubits) if candidate_qubits is not None else None,
+            "candidate_qubits_count": len(candidate_qubits)
+            if candidate_qubits is not None
+            else None,
             "direction_method": "design_based" if use_design_based else "measured",
             "grid_size": grid_size,
         }

--- a/src/qdash/workflow/engine/calibration/scheduler/one_qubit_scheduler.py
+++ b/src/qdash/workflow/engine/calibration/scheduler/one_qubit_scheduler.py
@@ -279,7 +279,9 @@ class OneQubitScheduler:
             if self.wiring_config_path is not None:
                 wiring_path = Path(self.wiring_config_path)
             else:
-                wiring_path = Path(f"/workspace/qdash/config/qubex/{self.chip_id}/config/wiring.yaml")
+                wiring_path = Path(
+                    f"/workspace/qdash/config/qubex/{self.chip_id}/config/wiring.yaml"
+                )
 
             if not wiring_path.exists():
                 msg = f"Wiring config not found: {wiring_path}"
@@ -559,7 +561,9 @@ class OneQubitScheduler:
             )
 
             for mux_id in mux_groups:
-                mux_groups[mux_id] = ordering_strategy.order_qids_in_mux(mux_id, mux_groups[mux_id], context)
+                mux_groups[mux_id] = ordering_strategy.order_qids_in_mux(
+                    mux_id, mux_groups[mux_id], context
+                )
         else:
             # Default: sort by qubit ID
             for mux_id in mux_groups:
@@ -1028,7 +1032,9 @@ class OneQubitScheduler:
             # Each group gets 4 steps, so 2 groups = 8 steps total
             for group_idx, mux_group in enumerate(mux_groups):
                 # Get qubits for this MUX group
-                group_qids = [qid for qid in mixed_qids if qid in qid_to_mux and qid_to_mux[qid] in mux_group]
+                group_qids = [
+                    qid for qid in mixed_qids if qid in qid_to_mux and qid_to_mux[qid] in mux_group
+                ]
 
                 if group_qids:
                     # Generate synchronized steps for this group
@@ -1046,7 +1052,9 @@ class OneQubitScheduler:
 
         logger.info(f"Generated {len(all_steps)} synchronized steps")
         for step in all_steps:
-            logger.info(f"  Step {step.step_index} ({step.box_type}): {len(step.parallel_qids)} qubits")
+            logger.info(
+                f"  Step {step.step_index} ({step.box_type}): {len(step.parallel_qids)} qubits"
+            )
 
         # Build metadata
         metadata = {

--- a/src/qdash/workflow/engine/calibration/scheduler/plugins.py
+++ b/src/qdash/workflow/engine/calibration/scheduler/plugins.py
@@ -349,7 +349,9 @@ class FidelityFilter(CRPairFilter):
         ]
 
         self._filtered_count = len(filtered)
-        logger.info(f"FidelityFilter (≥{self.min_fidelity}): {self._total_count} → {self._filtered_count} pairs")
+        logger.info(
+            f"FidelityFilter (≥{self.min_fidelity}): {self._total_count} → {self._filtered_count} pairs"
+        )
         return filtered
 
     def get_stats(self) -> dict[str, Any]:
@@ -469,7 +471,9 @@ class IntraThenInterMuxScheduler(CRSchedulingStrategy):
         intra_groups = self.inner_scheduler.schedule(intra_mux, context) if intra_mux else []
         inter_groups = self.inner_scheduler.schedule(inter_mux, context) if inter_mux else []
 
-        logger.info(f"IntraThenInterMuxScheduler: {self._fast_count} intra-MUX, {self._slow_count} inter-MUX pairs")
+        logger.info(
+            f"IntraThenInterMuxScheduler: {self._fast_count} intra-MUX, {self._slow_count} inter-MUX pairs"
+        )
         return intra_groups + inter_groups
 
     def get_metadata(self) -> dict[str, Any]:

--- a/src/qdash/workflow/engine/calibration/task/executor.py
+++ b/src/qdash/workflow/engine/calibration/task/executor.py
@@ -64,7 +64,9 @@ class TaskProtocol(Protocol):
         """Run the task."""
         ...
 
-    def postprocess(self, backend: Any, execution_id: str, run_result: RunResult, qid: str) -> PostProcessResult:
+    def postprocess(
+        self, backend: Any, execution_id: str, run_result: RunResult, qid: str
+    ) -> PostProcessResult:
         """Run postprocessing."""
         ...
 
@@ -111,7 +113,9 @@ class TaskExecutionResult(BaseModel):
     message: str = ""
     output_parameters: dict[str, Any] = Field(default_factory=dict)
     r2: dict[str, float] | None = None
-    calib_data_delta: CalibDataModel = Field(default_factory=lambda: CalibDataModel(qubit={}, coupling={}))
+    calib_data_delta: CalibDataModel = Field(
+        default_factory=lambda: CalibDataModel(qubit={}, coupling={})
+    )
     controller_info: dict[str, dict] = Field(default_factory=dict)
 
     model_config = {"arbitrary_types_allowed": True}
@@ -255,7 +259,9 @@ class TaskExecutor:
 
             # Record task start to history
             executed_task = self.state_manager.get_task(task_name, task_type, qid)
-            self.history_recorder.record_task_result(executed_task, execution_manager.to_datamodel())
+            self.history_recorder.record_task_result(
+                executed_task, execution_manager.to_datamodel()
+            )
 
             # Update execution manager
             execution_manager = self._update_execution_manager(execution_manager)
@@ -263,7 +269,9 @@ class TaskExecutor:
             # 2. Preprocess
             preprocess_result = self._run_preprocess(task, backend, qid)
             if preprocess_result:
-                self.state_manager.put_input_parameters(task_name, preprocess_result.input_parameters, task_type, qid)
+                self.state_manager.put_input_parameters(
+                    task_name, preprocess_result.input_parameters, task_type, qid
+                )
                 execution_manager = self._update_execution_manager(execution_manager)
 
             # 3. Run
@@ -282,7 +290,9 @@ class TaskExecutor:
 
             if postprocess_result:
                 # 5. Process and validate results
-                self._process_results(task, execution_manager, postprocess_result, qid, run_result, backend)
+                self._process_results(
+                    task, execution_manager, postprocess_result, qid, run_result, backend
+                )
 
                 result.output_parameters = dict(
                     self.state_manager.get_task(task_name, task_type, qid).output_parameters
@@ -293,7 +303,9 @@ class TaskExecutor:
 
             # Record completion to history
             executed_task = self.state_manager.get_task(task_name, task_type, qid)
-            self.history_recorder.record_task_result(executed_task, execution_manager.to_datamodel())
+            self.history_recorder.record_task_result(
+                executed_task, execution_manager.to_datamodel()
+            )
 
             execution_manager = self._update_execution_manager(execution_manager)
             result.success = True
@@ -302,14 +314,18 @@ class TaskExecutor:
         except (R2ValidationError, FidelityValidationError, ValueError) as e:
             self._fail_task(task_name, task_type, qid, str(e))
             executed_task = self.state_manager.get_task(task_name, task_type, qid)
-            self.history_recorder.record_task_result(executed_task, execution_manager.to_datamodel())
+            self.history_recorder.record_task_result(
+                executed_task, execution_manager.to_datamodel()
+            )
             result.message = str(e)
             raise
 
         except Exception as e:
             self._fail_task(task_name, task_type, qid, str(e))
             executed_task = self.state_manager.get_task(task_name, task_type, qid)
-            self.history_recorder.record_task_result(executed_task, execution_manager.to_datamodel())
+            self.history_recorder.record_task_result(
+                executed_task, execution_manager.to_datamodel()
+            )
             result.message = str(e)
             raise TaskExecutionError(f"Task {task_name} failed: {e}") from e
 
@@ -319,7 +335,9 @@ class TaskExecutor:
 
             # Final history record
             executed_task = self.state_manager.get_task(task_name, task_type, qid)
-            self.history_recorder.record_task_result(executed_task, execution_manager.to_datamodel())
+            self.history_recorder.record_task_result(
+                executed_task, execution_manager.to_datamodel()
+            )
 
             # Create chip history snapshot
             self.history_recorder.create_chip_history_snapshot(self.username)
@@ -383,7 +401,9 @@ class TaskExecutor:
             # Preprocess
             preprocess_result = self._run_preprocess(task, backend, qid)
             if preprocess_result:
-                self.state_manager.put_input_parameters(task_name, preprocess_result.input_parameters, task_type, qid)
+                self.state_manager.put_input_parameters(
+                    task_name, preprocess_result.input_parameters, task_type, qid
+                )
 
             # Run
             run_result = self._run_task(task, backend, qid)
@@ -404,7 +424,9 @@ class TaskExecutor:
             postprocess_result = self._run_postprocess(task, backend, run_result, qid)
 
             # Process output parameters
-            output_params = self._process_output_parameters(postprocess_result, task_name, qid, task_type)
+            output_params = self._process_output_parameters(
+                postprocess_result, task_name, qid, task_type
+            )
             result["output_parameters"] = output_params
 
             # Save figures and raw data
@@ -436,7 +458,9 @@ class TaskExecutor:
 
         return result
 
-    def _update_execution_manager(self, execution_manager: "ExecutionManager") -> "ExecutionManager":
+    def _update_execution_manager(
+        self, execution_manager: "ExecutionManager"
+    ) -> "ExecutionManager":
         """Update execution manager with current state.
 
         Parameters
@@ -509,7 +533,9 @@ class TaskExecutor:
         # 1. Validate fidelity
         if postprocess_result.output_parameters:
             try:
-                self.result_processor.validate_fidelity(postprocess_result.output_parameters, task_name)
+                self.result_processor.validate_fidelity(
+                    postprocess_result.output_parameters, task_name
+                )
             except FidelityValidationError as e:
                 raise ValueError(str(e)) from e
 
@@ -528,12 +554,16 @@ class TaskExecutor:
 
         # 3. Save figures
         if postprocess_result.figures:
-            png_paths, json_paths = self.data_saver.save_figures(postprocess_result.figures, task_name, task_type, qid)
+            png_paths, json_paths = self.data_saver.save_figures(
+                postprocess_result.figures, task_name, task_type, qid
+            )
             self.state_manager.set_figure_paths(task_name, task_type, qid, png_paths, json_paths)
 
         # 4. Save raw data
         if postprocess_result.raw_data:
-            raw_paths = self.data_saver.save_raw_data(postprocess_result.raw_data, task_name, task_type, qid)
+            raw_paths = self.data_saver.save_raw_data(
+                postprocess_result.raw_data, task_name, task_type, qid
+            )
             self.state_manager.set_raw_data_paths(task_name, task_type, qid, raw_paths)
 
         # 5. Validate R²
@@ -906,12 +936,16 @@ class TaskExecutor:
         """
         # Save figures
         if postprocess_result.figures:
-            png_paths, json_paths = self.data_saver.save_figures(postprocess_result.figures, task_name, task_type, qid)
+            png_paths, json_paths = self.data_saver.save_figures(
+                postprocess_result.figures, task_name, task_type, qid
+            )
             self.state_manager.set_figure_paths(task_name, task_type, qid, png_paths, json_paths)
 
         # Save raw data
         if postprocess_result.raw_data:
-            raw_paths = self.data_saver.save_raw_data(postprocess_result.raw_data, task_name, task_type, qid)
+            raw_paths = self.data_saver.save_raw_data(
+                postprocess_result.raw_data, task_name, task_type, qid
+            )
             self.state_manager.set_raw_data_paths(task_name, task_type, qid, raw_paths)
 
     def _complete_task(

--- a/src/qdash/workflow/engine/calibration/task/history_recorder.py
+++ b/src/qdash/workflow/engine/calibration/task/history_recorder.py
@@ -82,7 +82,9 @@ class TaskHistoryRecorder:
             Repository for chip history (default: MongoChipHistoryRepository)
 
         """
-        self.task_result_history_repo = task_result_history_repo or MongoTaskResultHistoryRepository()
+        self.task_result_history_repo = (
+            task_result_history_repo or MongoTaskResultHistoryRepository()
+        )
         self.chip_repo = chip_repo or MongoChipRepository()
         self.chip_history_repo = chip_history_repo or MongoChipHistoryRepository()
 

--- a/src/qdash/workflow/engine/calibration/task/manager.py
+++ b/src/qdash/workflow/engine/calibration/task/manager.py
@@ -63,7 +63,9 @@ class TaskManager(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     execution_id: str
     task_result: TaskResultModel = Field(default_factory=TaskResultModel)
-    calib_data: CalibDataModel = Field(default_factory=lambda: CalibDataModel(qubit={}, coupling={}))
+    calib_data: CalibDataModel = Field(
+        default_factory=lambda: CalibDataModel(qubit={}, coupling={})
+    )
     calib_dir: str = ""
     controller_info: dict[str, dict] = Field(default_factory=dict)
 
@@ -79,7 +81,9 @@ class TaskManager(BaseModel):
 
     model_config = {"arbitrary_types_allowed": True}
 
-    def __init__(self, username: str, execution_id: str, qids: list[str] = [], calib_dir: str = ".") -> None:
+    def __init__(
+        self, username: str, execution_id: str, qids: list[str] = [], calib_dir: str = "."
+    ) -> None:
         """Initialize TaskManager.
 
         Parameters
@@ -249,7 +253,9 @@ class TaskManager(BaseModel):
         self._state_manager.start_task(task_name, task_type, qid)
         self._sync_from_state_manager()
 
-    def start_all_qid_tasks(self, task_name: str, task_type: str = "qubit", qids: list[str] = []) -> None:
+    def start_all_qid_tasks(
+        self, task_name: str, task_type: str = "qubit", qids: list[str] = []
+    ) -> None:
         """Start a task for all given qubit IDs."""
         for qid in qids:
             self.start_task(task_name, task_type, qid)
@@ -260,7 +266,9 @@ class TaskManager(BaseModel):
         self._state_manager.end_task(task_name, task_type, qid)
         self._sync_from_state_manager()
 
-    def end_all_qid_tasks(self, task_name: str, task_type: str = "qubit", qids: list[str] = []) -> None:
+    def end_all_qid_tasks(
+        self, task_name: str, task_type: str = "qubit", qids: list[str] = []
+    ) -> None:
         """End a task for all given qubit IDs."""
         for qid in qids:
             self.end_task(task_name, task_type, qid)
@@ -323,7 +331,9 @@ class TaskManager(BaseModel):
         for qid in qids:
             self.update_task_status_to_failed(task_name, message, task_type, qid)
 
-    def update_not_executed_tasks_to_skipped(self, task_type: str = "global", qid: str = "") -> None:
+    def update_not_executed_tasks_to_skipped(
+        self, task_type: str = "global", qid: str = ""
+    ) -> None:
         """Mark unexecuted tasks as skipped."""
         self._sync_to_state_manager()
         self._state_manager.update_not_executed_tasks_to_skipped(task_type, qid)
@@ -347,7 +357,9 @@ class TaskManager(BaseModel):
         self._state_manager.put_output_parameters(task_name, output_parameters, task_type, qid)
         self._sync_from_state_manager()
 
-    def put_note_to_task(self, task_name: str, note: dict, task_type: str = "global", qid: str = "") -> None:
+    def put_note_to_task(
+        self, task_name: str, note: dict, task_type: str = "global", qid: str = ""
+    ) -> None:
         """Add a note to a task."""
         self._sync_to_state_manager()
         self._state_manager.put_note_to_task(task_name, note, task_type, qid)
@@ -401,7 +413,9 @@ class TaskManager(BaseModel):
         task = self._state_manager.get_task(task_name, task_type, qid)
         return dict(task.output_parameters)
 
-    def this_task_is_completed(self, task_name: str, task_type: str = "global", qid: str = "") -> bool:
+    def this_task_is_completed(
+        self, task_name: str, task_type: str = "global", qid: str = ""
+    ) -> bool:
         """Check if a task is completed."""
         self._sync_to_state_manager()
         task = self._state_manager.get_task(task_name, task_type, qid)
@@ -442,7 +456,9 @@ class TaskManager(BaseModel):
         """Save a single figure."""
         self.save_figures([figure], task_name, task_type, savedir, qid)
 
-    def save_raw_data(self, raw_data: list, task_name: str, task_type: str = "global", qid: str = "") -> None:
+    def save_raw_data(
+        self, raw_data: list, task_name: str, task_type: str = "global", qid: str = ""
+    ) -> None:
         """Save raw data."""
         if self._data_saver:
             paths = self._data_saver.save_raw_data(
@@ -486,11 +502,17 @@ class TaskManager(BaseModel):
 
     def _is_qubit_task(self, task_name: str) -> bool:
         """Check if task is a qubit task."""
-        return any(task_name in [task.name for task in tasks] for tasks in self.task_result.qubit_tasks.values())
+        return any(
+            task_name in [task.name for task in tasks]
+            for tasks in self.task_result.qubit_tasks.values()
+        )
 
     def _is_coupling_task(self, task_name: str) -> bool:
         """Check if task is a coupling task."""
-        return any(task_name in [task.name for task in tasks] for tasks in self.task_result.coupling_tasks.values())
+        return any(
+            task_name in [task.name for task in tasks]
+            for tasks in self.task_result.coupling_tasks.values()
+        )
 
     def _is_system_task(self, task_name: str) -> bool:
         """Check if task is a system task."""

--- a/src/qdash/workflow/engine/calibration/task/result_processor.py
+++ b/src/qdash/workflow/engine/calibration/task/result_processor.py
@@ -97,7 +97,9 @@ class TaskResultProcessor:
         check_threshold = threshold if threshold is not None else self.r2_threshold
 
         if r2_value <= check_threshold:
-            raise R2ValidationError(f"R² value too low for qid {qid}: {r2_value:.4f} <= {check_threshold}")
+            raise R2ValidationError(
+                f"R² value too low for qid {qid}: {r2_value:.4f} <= {check_threshold}"
+            )
 
         return True
 
@@ -135,11 +137,15 @@ class TaskResultProcessor:
 
         fidelity_value = fidelity_param.value
         if fidelity_value > 1.0:
-            raise FidelityValidationError(f"Fidelity exceeds 100% for {task_name}: {fidelity_value * 100:.2f}%")
+            raise FidelityValidationError(
+                f"Fidelity exceeds 100% for {task_name}: {fidelity_value * 100:.2f}%"
+            )
 
         return True
 
-    def get_output_parameter_names(self, output_parameters: dict[str, OutputParameterModel]) -> list[str]:
+    def get_output_parameter_names(
+        self, output_parameters: dict[str, OutputParameterModel]
+    ) -> list[str]:
         """Get list of output parameter names.
 
         Parameters

--- a/src/qdash/workflow/engine/calibration/task/state_manager.py
+++ b/src/qdash/workflow/engine/calibration/task/state_manager.py
@@ -229,7 +229,9 @@ class TaskStateManager(BaseModel):
         task.end_at = pendulum.now(tz="Asia/Tokyo").to_iso8601_string()
         task.elapsed_time = task.calculate_elapsed_time(task.start_at, task.end_at)
 
-    def update_task_status_to_completed(self, task_name: str, message: str, task_type: str, qid: str) -> None:
+    def update_task_status_to_completed(
+        self, task_name: str, message: str, task_type: str, qid: str
+    ) -> None:
         """Update task status to COMPLETED.
 
         Parameters
@@ -248,7 +250,9 @@ class TaskStateManager(BaseModel):
         task.status = TaskStatusModel.COMPLETED
         task.message = message
 
-    def update_task_status_to_failed(self, task_name: str, message: str, task_type: str, qid: str) -> None:
+    def update_task_status_to_failed(
+        self, task_name: str, message: str, task_type: str, qid: str
+    ) -> None:
         """Update task status to FAILED.
 
         Parameters
@@ -267,7 +271,9 @@ class TaskStateManager(BaseModel):
         task.status = TaskStatusModel.FAILED
         task.message = message
 
-    def update_task_status_to_skipped(self, task_name: str, message: str, task_type: str, qid: str) -> None:
+    def update_task_status_to_skipped(
+        self, task_name: str, message: str, task_type: str, qid: str
+    ) -> None:
         """Update task status to SKIPPED.
 
         Parameters
@@ -314,7 +320,9 @@ class TaskStateManager(BaseModel):
         task.status = new_status
         task.message = message
 
-    def put_input_parameters(self, task_name: str, input_parameters: dict, task_type: str, qid: str) -> None:
+    def put_input_parameters(
+        self, task_name: str, input_parameters: dict, task_type: str, qid: str
+    ) -> None:
         """Store input parameters for a task.
 
         Parameters
@@ -433,7 +441,9 @@ class TaskStateManager(BaseModel):
         for qid in qids:
             self.start_task(task_name, task_type, qid)
 
-    def update_not_executed_tasks_to_skipped(self, task_type: str, qid: str, message: str = "Not executed") -> None:
+    def update_not_executed_tasks_to_skipped(
+        self, task_type: str, qid: str, message: str = "Not executed"
+    ) -> None:
         """Mark all scheduled tasks as skipped.
 
         Parameters
@@ -566,7 +576,9 @@ class TaskStateManager(BaseModel):
         task.figure_path = png_paths
         task.json_figure_path = json_paths
 
-    def set_raw_data_paths(self, task_name: str, task_type: str, qid: str, paths: list[str]) -> None:
+    def set_raw_data_paths(
+        self, task_name: str, task_type: str, qid: str, paths: list[str]
+    ) -> None:
         """Set raw data paths for a task.
 
         Parameters
@@ -698,7 +710,9 @@ class TaskStateManager(BaseModel):
         """
         self._clear_qubit_calib_data(qid, list(parameter_names))
 
-    def update_task_status_to_running(self, task_name: str, message: str, task_type: str, qid: str) -> None:
+    def update_task_status_to_running(
+        self, task_name: str, message: str, task_type: str, qid: str
+    ) -> None:
         """Update task status to RUNNING.
 
         Parameters

--- a/src/qdash/workflow/engine/calibration/util.py
+++ b/src/qdash/workflow/engine/calibration/util.py
@@ -49,8 +49,12 @@ def update_active_tasks(username: str, backend: str) -> list[TaskModel]:
             name=cls.name,
             description=cls.__doc__,
             task_type=cls.task_type,
-            input_parameters={name: param.model_dump() for name, param in cls.input_parameters.items()},
-            output_parameters={name: param.model_dump() for name, param in cls.output_parameters.items()},
+            input_parameters={
+                name: param.model_dump() for name, param in cls.input_parameters.items()
+            },
+            output_parameters={
+                name: param.model_dump() for name, param in cls.output_parameters.items()
+            },
         )
         for cls in task_cls.values()
     ]


### PR DESCRIPTION
- Add `thinking_language` (English) and `response_language` (Japanese) to improve technical accuracy while keeping user-facing output in Japanese.
- Update the Copilot system prompt to require calling `getChipTopology` (alongside `getChipMetricsData`) before any spatial correlation/crosstalk or frequency-crowding analysis.
- Tidy `ProjectService` membership lookup code for readability (no intended behavior change).
