### PR TITLE
Fix/ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,17 +33,29 @@ packages = [
 [tool.ruff]
 line-length = 100
 exclude = ["tools", "scripts"]
+target-version = "py310"
 lint.unfixable = ["F401"]
-# Temporarily use minimal rule set to get CI passing
 lint.select = [
-    "E9",  # syntax errors only
-    "F63", # comparison issues
-    "F7",  # syntax errors
-    "F82", # undefined names
+    "E",   # pycodestyle errors
+    "F",   # Pyflakes
+    "W",   # pycodestyle warnings
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
 ]
-lint.ignore = []
+lint.ignore = [
+    "E501",  # line-too-long (handled by formatter)
+    "B904",  # raise-without-from-inside-except (TODO: fix in exception handling task)
+    "B008",  # function-call-in-default-argument (FastAPI Depends pattern)
+    "UP038", # non-pep604-isinstance (requires manual fix)
+    "B007",  # unused-loop-control-variable (minor style issue)
+    "B012",  # return-in-finally (intentional in specific cases)
+    "B027",  # empty-method-without-abstract-decorator (intentional default impl)
+]
 
 [tool.ruff.lint.per-file-ignores]
+"src/qdash/workflow/service/calib_service.py" = ["E402"]  # Circular import avoidance
+"src/qdash/workflow/paths.py" = ["F401"]  # Re-exports for backward compatibility
 "tests/**" = [
     "ANN201",
     "ANN205",
@@ -68,6 +80,12 @@ disable_error_code = ["misc", "override", "no-untyped-call", "redundant-cast"]
 # Use explicit package bases to avoid src.qdash vs qdash conflicts
 explicit_package_bases = true
 mypy_path = "src"
+plugins = ["pydantic.mypy"]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ lint.select = [
     "I",   # isort
     "B",   # flake8-bugbear
     "UP",  # pyupgrade
+    "SIM", # flake8-simplify
+    "C4",  # flake8-comprehensions
+    "RET", # flake8-return
 ]
 lint.ignore = [
     "E501",  # line-too-long (handled by formatter)
@@ -51,6 +54,10 @@ lint.ignore = [
     "B007",  # unused-loop-control-variable (minor style issue)
     "B012",  # return-in-finally (intentional in specific cases)
     "B027",  # empty-method-without-abstract-decorator (intentional default impl)
+    "RET505", # superfluous-else-return (style preference)
+    "RET506", # superfluous-else-raise (style preference)
+    "SIM102", # collapsible-if (readability preference)
+    "SIM108", # if-else-block-instead-of-if-exp (readability preference)
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,14 @@ lint.select = [
     "SIM", # flake8-simplify
     "C4",  # flake8-comprehensions
     "RET", # flake8-return
+    "TCH", # flake8-type-checking
+    "PIE", # flake8-pie
+    "PERF", # perflint
+    "PLC", # pylint convention
+    "PLE", # pylint error
+    "PLW", # pylint warning
+    "RUF", # ruff-specific rules
+    "S",   # flake8-bandit (security)
 ]
 lint.ignore = [
     "E501",  # line-too-long (handled by formatter)
@@ -58,11 +66,19 @@ lint.ignore = [
     "RET506", # superfluous-else-raise (style preference)
     "SIM102", # collapsible-if (readability preference)
     "SIM108", # if-else-block-instead-of-if-exp (readability preference)
+    "PERF401", # manual-list-comprehension (readability over micro-optimization)
+    "PLW0603", # global-statement (used for singletons/caching)
+    "RUF003",  # ambiguous-unicode-character-comment (Japanese comments)
+    "RUF012",  # mutable-class-default (Pydantic models)
+    "S101",    # assert (used for runtime checks)
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "src/qdash/workflow/service/calib_service.py" = ["E402"]  # Circular import avoidance
 "src/qdash/workflow/paths.py" = ["F401"]  # Re-exports for backward compatibility
+"src/qdash/api/routers/auth.py" = ["S106"]  # "bearer" is standard token type
+"src/qdash/api/routers/flow.py" = ["S603", "S607"]  # ruff format subprocess call
+"src/qdash/api/lib/topology_config.py" = ["S112"]  # Skip invalid config files
 "tests/**" = [
     "ANN201",
     "ANN205",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ lint.ignore = [
     "SIM102", # collapsible-if (readability preference)
     "SIM108", # if-else-block-instead-of-if-exp (readability preference)
     "PERF401", # manual-list-comprehension (readability over micro-optimization)
+    "PERF402", # manual-list-copy (readability over micro-optimization)
     "PLW0603", # global-statement (used for singletons/caching)
     "RUF003",  # ambiguous-unicode-character-comment (Japanese comments)
     "RUF012",  # mutable-class-default (Pydantic models)
@@ -89,6 +90,9 @@ lint.ignore = [
     "PLR2004",
     "PLR6301",
     "S101",
+    "S106",  # Test data passwords
+    "S108",  # /tmp usage in tests is acceptable
+    "RUF002", # Japanese in docstrings
 ]
 
 [tool.mypy]

--- a/src/qdash/api/lib/copilot_config.py
+++ b/src/qdash/api/lib/copilot_config.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 from functools import lru_cache
 
 from pydantic import BaseModel
-
 from qdash.api.lib.config_loader import ConfigLoader
 
 

--- a/src/qdash/api/lib/metrics_config.py
+++ b/src/qdash/api/lib/metrics_config.py
@@ -12,7 +12,6 @@ from functools import lru_cache
 from typing import Any, Literal
 
 from pydantic import BaseModel
-
 from qdash.api.lib.config_loader import ConfigLoader
 
 

--- a/src/qdash/api/lib/metrics_pdf.py
+++ b/src/qdash/api/lib/metrics_pdf.py
@@ -9,20 +9,19 @@ from __future__ import annotations
 import io
 import logging
 import math
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
 import numpy as np
 import plotly.graph_objects as go
 from PIL import Image
+from qdash.api.lib.metrics_config import load_metrics_config
+from qdash.api.lib.topology_config import TopologyDefinition, load_topology
+from qdash.api.schemas.metrics import ChipMetricsResponse
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfgen import canvas
-
-from qdash.api.lib.metrics_config import load_metrics_config
-from qdash.api.lib.topology_config import TopologyDefinition, load_topology
-from qdash.api.schemas.metrics import ChipMetricsResponse
 
 logger = logging.getLogger(__name__)
 

--- a/src/qdash/api/lib/metrics_pdf.py
+++ b/src/qdash/api/lib/metrics_pdf.py
@@ -10,18 +10,20 @@ import io
 import logging
 import math
 from datetime import datetime, timedelta, timezone
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import plotly.graph_objects as go
 from PIL import Image
 from qdash.api.lib.metrics_config import load_metrics_config
 from qdash.api.lib.topology_config import TopologyDefinition, load_topology
-from qdash.api.schemas.metrics import ChipMetricsResponse
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfgen import canvas
+
+if TYPE_CHECKING:
+    from qdash.api.schemas.metrics import ChipMetricsResponse
 
 logger = logging.getLogger(__name__)
 
@@ -517,7 +519,7 @@ class MetricsPDFGenerator:
     ) -> dict[str, Any]:
         """Calculate statistics for the metric values."""
         values = []
-        for key, metric_value in metric_data.items():
+        for metric_value in metric_data.values():
             if metric_value and metric_value.value is not None:
                 scaled_value = metric_value.value * metric_scale
                 values.append(scaled_value)
@@ -977,7 +979,7 @@ class MetricsPDFGenerator:
             schema_key = self._map_config_to_schema_key(metric_key, metric_type)
             metric_data = getattr(metrics_source, schema_key, None)
             if metric_data:
-                for key, metric_value in metric_data.items():
+                for metric_value in metric_data.values():
                     if metric_value and metric_value.value is not None:
                         return True
         return False
@@ -1110,7 +1112,7 @@ class MetricsPDFGenerator:
 
             # Extract and scale values
             values = []
-            for key, metric_value in metric_data.items():
+            for metric_value in metric_data.values():
                 if metric_value and metric_value.value is not None:
                     scaled_value = metric_value.value * metric_meta.scale
                     values.append(scaled_value)

--- a/src/qdash/api/lib/metrics_pdf.py
+++ b/src/qdash/api/lib/metrics_pdf.py
@@ -709,11 +709,11 @@ class MetricsPDFGenerator:
                 hovertext=text_matrix,
                 texttemplate="%{text}",
                 showscale=False,
-                textfont=dict(
-                    family="monospace",
-                    size=TEXT_SIZE,
-                    weight="bold",
-                ),
+                textfont={
+                    "family": "monospace",
+                    "size": TEXT_SIZE,
+                    "weight": "bold",
+                },
             )
         )
 
@@ -724,22 +724,22 @@ class MetricsPDFGenerator:
         fig.update_layout(
             title=None,  # Title is in PDF header
             showlegend=False,
-            margin=dict(b=20, l=20, r=20, t=20),
-            xaxis=dict(
-                ticks="",
-                linewidth=1,
-                showgrid=False,
-                zeroline=False,
-                showticklabels=False,
-            ),
-            yaxis=dict(
-                ticks="",
-                autorange="reversed",
-                linewidth=1,
-                showgrid=False,
-                zeroline=False,
-                showticklabels=False,
-            ),
+            margin={"b": 20, "l": 20, "r": 20, "t": 20},
+            xaxis={
+                "ticks": "",
+                "linewidth": 1,
+                "showgrid": False,
+                "zeroline": False,
+                "showticklabels": False,
+            },
+            yaxis={
+                "ticks": "",
+                "autorange": "reversed",
+                "linewidth": 1,
+                "showgrid": False,
+                "zeroline": False,
+                "showticklabels": False,
+            },
             width=width,
             height=height,
         )
@@ -762,21 +762,21 @@ class MetricsPDFGenerator:
             title=None,  # Title is in PDF header
             width=width,
             height=height,
-            margin=dict(b=20, l=20, r=20, t=20),
-            xaxis=dict(
-                ticks="",
-                showgrid=False,
-                zeroline=False,
-                showticklabels=False,
-                constrain="domain",
-            ),
-            yaxis=dict(
-                ticks="",
-                autorange="reversed",
-                showgrid=False,
-                zeroline=False,
-                showticklabels=False,
-            ),
+            margin={"b": 20, "l": 20, "r": 20, "t": 20},
+            xaxis={
+                "ticks": "",
+                "showgrid": False,
+                "zeroline": False,
+                "showticklabels": False,
+                "constrain": "domain",
+            },
+            yaxis={
+                "ticks": "",
+                "autorange": "reversed",
+                "showgrid": False,
+                "zeroline": False,
+                "showticklabels": False,
+            },
             plot_bgcolor="white",
             showlegend=False,
             hovermode="closest",
@@ -799,8 +799,7 @@ class MetricsPDFGenerator:
         node_traces = self._create_qubit_node_traces()
         data.extend(node_traces)
 
-        fig = go.Figure(data=data, layout=layout)
-        return fig
+        return go.Figure(data=data, layout=layout)
 
     def _create_mux_node_trace(self) -> go.Scatter:
         """Create trace for MUX boundary rectangles."""
@@ -826,7 +825,7 @@ class MetricsPDFGenerator:
             x=shapes_x,
             y=shapes_y,
             mode="lines",
-            line=dict(color="lightgray", width=2),
+            line={"color": "lightgray", "width": 2},
             hoverinfo="skip",
         )
 
@@ -846,14 +845,14 @@ class MetricsPDFGenerator:
             x=x_coords,
             y=y_coords,
             mode="markers+text",
-            marker=dict(
-                size=NODE_SIZE * 1.2,
-                color="lightblue",
-                line=dict(color="darkblue", width=2),
-            ),
+            marker={
+                "size": NODE_SIZE * 1.2,
+                "color": "lightblue",
+                "line": {"color": "darkblue", "width": 2},
+            },
             text=texts,
             textposition="middle center",
-            textfont=dict(size=12, color="black", weight="bold"),
+            textfont={"size": 12, "color": "black", "weight": "bold"},
             hoverinfo="text",
             hovertext=[f"Q{qid}" for qid in range(self.n_qubits)],
         )
@@ -911,7 +910,7 @@ class MetricsPDFGenerator:
                 x=[col1, col2],
                 y=[row1, row2],
                 mode="lines",
-                line=dict(color=color, width=3),
+                line={"color": color, "width": 3},
                 hoverinfo="skip",
             )
             traces.append(line_trace)
@@ -925,7 +924,7 @@ class MetricsPDFGenerator:
                 y=[mid_y],
                 mode="text",
                 text=[f"{value:.1f}"],
-                textfont=dict(size=11, color="black", weight="bold"),
+                textfont={"size": 11, "color": "black", "weight": "bold"},
                 hoverinfo="text",
                 hovertext=[f"{qid1}-{qid2}: {value:.2f}%"],
             )
@@ -1151,7 +1150,7 @@ class MetricsPDFGenerator:
                     y=cdf_y,
                     mode="lines",
                     name=f"{metric_meta.title} (n={n})",
-                    line=dict(color=color, width=2, shape="hv"),
+                    line={"color": color, "width": 2, "shape": "hv"},
                     hovertemplate=f"{metric_meta.title}: %{{x:.3f}}<br>Percentile: %{{y:.1f}}%<extra></extra>",
                 )
             )
@@ -1163,7 +1162,7 @@ class MetricsPDFGenerator:
                     y=[0, 50],
                     mode="lines",
                     name=f"{metric_meta.title} Median: {median:.2f}",
-                    line=dict(color=color, width=1, dash="dot"),
+                    line={"color": color, "width": 1, "dash": "dot"},
                     hoverinfo="skip",
                 )
             )
@@ -1173,28 +1172,28 @@ class MetricsPDFGenerator:
 
         fig.update_layout(
             title=None,
-            xaxis=dict(
-                title=dict(text=f"{cdf_group.title} ({cdf_group.unit})", font=dict(size=14)),
-                gridcolor="rgba(128,128,128,0.2)",
-                zeroline=False,
-            ),
-            yaxis=dict(
-                title=dict(text="Cumulative %", font=dict(size=14)),
-                range=[0, 100],
-                gridcolor="rgba(128,128,128,0.2)",
-                zeroline=False,
-            ),
+            xaxis={
+                "title": {"text": f"{cdf_group.title} ({cdf_group.unit})", "font": {"size": 14}},
+                "gridcolor": "rgba(128,128,128,0.2)",
+                "zeroline": False,
+            },
+            yaxis={
+                "title": {"text": "Cumulative %", "font": {"size": 14}},
+                "range": [0, 100],
+                "gridcolor": "rgba(128,128,128,0.2)",
+                "zeroline": False,
+            },
             showlegend=True,
-            legend=dict(
-                orientation="h",
-                yanchor="top",
-                y=-0.15,
-                xanchor="center",
-                x=0.5,
-                font=dict(size=11),
-                bgcolor="rgba(255,255,255,0.8)",
-            ),
-            margin=dict(l=70, r=40, t=30, b=100),
+            legend={
+                "orientation": "h",
+                "yanchor": "top",
+                "y": -0.15,
+                "xanchor": "center",
+                "x": 0.5,
+                "font": {"size": 11},
+                "bgcolor": "rgba(255,255,255,0.8)",
+            },
+            margin={"l": 70, "r": 40, "t": 30, "b": 100},
             width=500,
             height=450,
             plot_bgcolor="white",

--- a/src/qdash/api/lib/project_service.py
+++ b/src/qdash/api/lib/project_service.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Iterable, cast
+from collections.abc import Iterable
+from typing import cast
 
 from fastapi.logger import logger
 from qdash.datamodel.project import ProjectRole

--- a/src/qdash/api/lib/project_service.py
+++ b/src/qdash/api/lib/project_service.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from fastapi.logger import logger
 from qdash.datamodel.project import ProjectRole
 from qdash.dbmodel.project import ProjectDocument
 from qdash.dbmodel.project_membership import ProjectMembershipDocument
-from qdash.dbmodel.user import UserDocument
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from qdash.dbmodel.user import UserDocument
 
 
 class ProjectService:

--- a/src/qdash/api/lib/topology_config.py
+++ b/src/qdash/api/lib/topology_config.py
@@ -9,11 +9,14 @@ Uses ConfigLoader for unified configuration directory resolution.
 from __future__ import annotations
 
 from functools import lru_cache
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import yaml
 from pydantic import BaseModel, Field
 from qdash.api.lib.config_loader import ConfigLoader
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class QubitPosition(BaseModel):

--- a/src/qdash/api/lib/topology_config.py
+++ b/src/qdash/api/lib/topology_config.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import yaml
 from pydantic import BaseModel, Field
-
 from qdash.api.lib.config_loader import ConfigLoader
 
 

--- a/src/qdash/api/routers/chip.py
+++ b/src/qdash/api/routers/chip.py
@@ -10,7 +10,6 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-
 from qdash.api.dependencies import get_chip_service
 from qdash.api.lib.config_loader import ConfigLoader
 from qdash.api.lib.project import (

--- a/src/qdash/api/routers/chip.py
+++ b/src/qdash/api/routers/chip.py
@@ -7,16 +7,10 @@ Business logic is delegated to ChipService for better testability.
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
-from qdash.api.dependencies import get_chip_service
 from qdash.api.lib.config_loader import ConfigLoader
-from qdash.api.lib.project import (
-    ProjectContext,
-    get_project_context,
-    get_project_context_owner,
-)
 from qdash.api.routers.task_file import (
     CALIBTASKS_BASE_PATH,
     collect_tasks_from_directory,
@@ -30,7 +24,15 @@ from qdash.api.schemas.chip import (
     MuxDetailResponse,
 )
 from qdash.api.services.chip_initializer import ChipInitializer
-from qdash.api.services.chip_service import ChipService
+
+if TYPE_CHECKING:
+    from qdash.api.dependencies import get_chip_service
+    from qdash.api.lib.project import (
+        ProjectContext,
+        get_project_context,
+        get_project_context_owner,
+    )
+    from qdash.api.services.chip_service import ChipService
 
 router = APIRouter()
 
@@ -123,7 +125,7 @@ def create_chip(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.error(f"Error creating chip {request.chip_id}: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to create chip: {str(e)}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to create chip: {e!s}") from e
 
 
 @router.get(

--- a/src/qdash/api/routers/chip.py
+++ b/src/qdash/api/routers/chip.py
@@ -7,10 +7,16 @@ Business logic is delegated to ChipService for better testability.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
+from qdash.api.dependencies import get_chip_service  # noqa: TCH002
 from qdash.api.lib.config_loader import ConfigLoader
+from qdash.api.lib.project import (  # noqa: TCH002
+    ProjectContext,
+    get_project_context,
+    get_project_context_owner,
+)
 from qdash.api.routers.task_file import (
     CALIBTASKS_BASE_PATH,
     collect_tasks_from_directory,
@@ -24,15 +30,7 @@ from qdash.api.schemas.chip import (
     MuxDetailResponse,
 )
 from qdash.api.services.chip_initializer import ChipInitializer
-
-if TYPE_CHECKING:
-    from qdash.api.dependencies import get_chip_service
-    from qdash.api.lib.project import (
-        ProjectContext,
-        get_project_context,
-        get_project_context_owner,
-    )
-    from qdash.api.services.chip_service import ChipService
+from qdash.api.services.chip_service import ChipService  # noqa: TCH002
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/config.py
+++ b/src/qdash/api/routers/config.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
-
 from qdash.api.lib.config_loader import ConfigLoader
 
 router = APIRouter(tags=["config"])

--- a/src/qdash/api/routers/copilot.py
+++ b/src/qdash/api/routers/copilot.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter
-
 from qdash.api.lib.copilot_config import load_copilot_config
 
 router = APIRouter()

--- a/src/qdash/api/routers/execution.py
+++ b/src/qdash/api/routers/execution.py
@@ -8,12 +8,10 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse
-from starlette.exceptions import HTTPException
-
 from qdash.api.dependencies import get_execution_service
 from qdash.api.lib.project import ProjectContext, get_project_context
 from qdash.api.schemas.error import Detail
@@ -23,6 +21,7 @@ from qdash.api.schemas.execution import (
     ListExecutionsResponse,
 )
 from qdash.api.services.execution_service import ExecutionService
+from starlette.exceptions import HTTPException
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/execution.py
+++ b/src/qdash/api/routers/execution.py
@@ -8,20 +8,22 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse
-from qdash.api.dependencies import get_execution_service
-from qdash.api.lib.project import ProjectContext, get_project_context
 from qdash.api.schemas.error import Detail
 from qdash.api.schemas.execution import (
     ExecutionLockStatusResponse,
     ExecutionResponseDetail,
     ListExecutionsResponse,
 )
-from qdash.api.services.execution_service import ExecutionService
 from starlette.exceptions import HTTPException
+
+if TYPE_CHECKING:
+    from qdash.api.dependencies import get_execution_service
+    from qdash.api.lib.project import ProjectContext, get_project_context
+    from qdash.api.services.execution_service import ExecutionService
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/execution.py
+++ b/src/qdash/api/routers/execution.py
@@ -8,22 +8,23 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import FileResponse
+from qdash.api.dependencies import get_execution_service  # noqa: TCH002
+from qdash.api.lib.project import (  # noqa: TCH002
+    ProjectContext,
+    get_project_context,
+)
 from qdash.api.schemas.error import Detail
 from qdash.api.schemas.execution import (
     ExecutionLockStatusResponse,
     ExecutionResponseDetail,
     ListExecutionsResponse,
 )
+from qdash.api.services.execution_service import ExecutionService  # noqa: TCH002
 from starlette.exceptions import HTTPException
-
-if TYPE_CHECKING:
-    from qdash.api.dependencies import get_execution_service
-    from qdash.api.lib.project import ProjectContext, get_project_context
-    from qdash.api.services.execution_service import ExecutionService
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/file.py
+++ b/src/qdash/api/routers/file.py
@@ -7,7 +7,7 @@ import os
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import yaml
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -15,8 +15,6 @@ from fastapi.logger import logger
 from fastapi.responses import FileResponse
 from git import Repo
 from git.exc import GitCommandError
-from qdash.api.lib.auth import get_current_active_user
-from qdash.api.schemas.auth import User
 from qdash.api.schemas.file import (
     FileTreeNode,
     GitPushRequest,
@@ -24,6 +22,10 @@ from qdash.api.schemas.file import (
     ValidateFileRequest,
 )
 from qdash.common.paths import QUBEX_CONFIG_BASE
+
+if TYPE_CHECKING:
+    from qdash.api.lib.auth import get_current_active_user
+    from qdash.api.schemas.auth import User
 
 router = APIRouter()
 gunicorn_logger = logging.getLogger("gunicorn.error")

--- a/src/qdash/api/routers/file.py
+++ b/src/qdash/api/routers/file.py
@@ -7,7 +7,7 @@ import os
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import Annotated, Any
 
 import yaml
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -15,6 +15,8 @@ from fastapi.logger import logger
 from fastapi.responses import FileResponse
 from git import Repo
 from git.exc import GitCommandError
+from qdash.api.lib.auth import get_current_active_user  # noqa: TCH002
+from qdash.api.schemas.auth import User  # noqa: TCH002
 from qdash.api.schemas.file import (
     FileTreeNode,
     GitPushRequest,
@@ -22,10 +24,6 @@ from qdash.api.schemas.file import (
     ValidateFileRequest,
 )
 from qdash.common.paths import QUBEX_CONFIG_BASE
-
-if TYPE_CHECKING:
-    from qdash.api.lib.auth import get_current_active_user
-    from qdash.api.schemas.auth import User
 
 router = APIRouter()
 gunicorn_logger = logging.getLogger("gunicorn.error")

--- a/src/qdash/api/routers/flow.py
+++ b/src/qdash/api/routers/flow.py
@@ -122,9 +122,7 @@ def validate_flow_code(code: str, expected_function_name: str) -> None:
         if isinstance(node, ast.FunctionDef):
             # Check if function has @flow decorator
             for decorator in node.decorator_list:
-                if isinstance(decorator, ast.Name) and decorator.id == "flow":
-                    flow_functions.append(node.name)
-                elif (
+                if isinstance(decorator, ast.Name) and decorator.id == "flow" or (
                     isinstance(decorator, ast.Call)
                     and isinstance(decorator.func, ast.Name)
                     and decorator.func.id == "flow"

--- a/src/qdash/api/routers/flow.py
+++ b/src/qdash/api/routers/flow.py
@@ -262,7 +262,7 @@ async def save_flow(
             ["ruff", "format", str(file_path)],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=10, check=False,
         )
         if result.returncode == 0:
             logger.info(f"Auto-formatted flow code with ruff: {file_path}")
@@ -808,7 +808,7 @@ async def update_flow_schedule(
                 except ValueError as e:
                     raise HTTPException(
                         status_code=400,
-                        detail=f"Invalid cron expression '{request.cron}': {str(e)}",
+                        detail=f"Invalid cron expression '{request.cron}': {e!s}",
                     )
 
                 # Use timezone from request (defaults to Asia/Tokyo in schema)
@@ -1085,7 +1085,7 @@ async def schedule_flow(
         logger.error(f"Deployment {flow.deployment_id} not found in Prefect: {e}")
         raise HTTPException(
             status_code=400,
-            detail=f"Flow '{name}' deployment not found in Prefect. Please re-save the flow. Error: {str(e)}",
+            detail=f"Flow '{name}' deployment not found in Prefect. Please re-save the flow. Error: {e!s}",
         )
 
     # Merge parameters - include username, chip_id, and project_id from flow metadata
@@ -1108,7 +1108,7 @@ async def schedule_flow(
         except ValueError as e:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid cron expression '{request.cron}': {str(e)}",
+                detail=f"Invalid cron expression '{request.cron}': {e!s}",
             )
 
         try:
@@ -1225,7 +1225,7 @@ async def schedule_flow(
         except ValueError as e:
             raise HTTPException(
                 status_code=400,
-                detail=f"Invalid scheduled_time format: {str(e)}",
+                detail=f"Invalid scheduled_time format: {e!s}",
             )
 
         try:

--- a/src/qdash/api/routers/flow.py
+++ b/src/qdash/api/routers/flow.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from logging import getLogger
 from pathlib import Path
 from typing import Annotated, Any
+from zoneinfo import ZoneInfo
 
 import httpx
 from croniter import croniter
@@ -39,10 +40,9 @@ from qdash.api.schemas.flow import (
     UpdateScheduleRequest,
     UpdateScheduleResponse,
 )
+from qdash.common.paths import SERVICE_DIR, TEMPLATES_DIR, USER_FLOWS_DIR
 from qdash.config import get_settings
 from qdash.repository import MongoFlowRepository
-from qdash.common.paths import SERVICE_DIR, TEMPLATES_DIR, USER_FLOWS_DIR
-from zoneinfo import ZoneInfo
 
 router = APIRouter()
 logger = getLogger("uvicorn.app")

--- a/src/qdash/api/routers/flow.py
+++ b/src/qdash/api/routers/flow.py
@@ -122,10 +122,14 @@ def validate_flow_code(code: str, expected_function_name: str) -> None:
         if isinstance(node, ast.FunctionDef):
             # Check if function has @flow decorator
             for decorator in node.decorator_list:
-                if isinstance(decorator, ast.Name) and decorator.id == "flow" or (
-                    isinstance(decorator, ast.Call)
-                    and isinstance(decorator.func, ast.Name)
-                    and decorator.func.id == "flow"
+                if (
+                    isinstance(decorator, ast.Name)
+                    and decorator.id == "flow"
+                    or (
+                        isinstance(decorator, ast.Call)
+                        and isinstance(decorator.func, ast.Name)
+                        and decorator.func.id == "flow"
+                    )
                 ):
                     flow_functions.append(node.name)
 
@@ -262,7 +266,8 @@ async def save_flow(
             ["ruff", "format", str(file_path)],
             capture_output=True,
             text=True,
-            timeout=10, check=False,
+            timeout=10,
+            check=False,
         )
         if result.returncode == 0:
             logger.info(f"Auto-formatted flow code with ruff: {file_path}")

--- a/src/qdash/api/routers/metrics.py
+++ b/src/qdash/api/routers/metrics.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import pendulum
 from bunnet import SortDirection
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from qdash.api.lib.metrics_config import load_metrics_config
-from qdash.api.lib.project import ProjectContext, get_project_context
 from qdash.api.schemas.metrics import (
     ChipMetricsResponse,
     CouplingMetrics,
@@ -19,9 +18,12 @@ from qdash.api.schemas.metrics import (
     QubitMetricHistoryResponse,
     QubitMetrics,
 )
-from qdash.dbmodel.chip import ChipDocument
 from qdash.repository.chip import MongoChipRepository
 from qdash.repository.task_result_history import MongoTaskResultHistoryRepository
+
+if TYPE_CHECKING:
+    from qdash.api.lib.project import ProjectContext, get_project_context
+    from qdash.dbmodel.chip import ChipDocument
 
 router = APIRouter()
 logger = logging.getLogger(__name__)

--- a/src/qdash/api/routers/metrics.py
+++ b/src/qdash/api/routers/metrics.py
@@ -10,6 +10,10 @@ from bunnet import SortDirection
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from qdash.api.lib.metrics_config import load_metrics_config
+from qdash.api.lib.project import (  # noqa: TCH002
+    ProjectContext,
+    get_project_context,
+)
 from qdash.api.schemas.metrics import (
     ChipMetricsResponse,
     CouplingMetrics,
@@ -22,7 +26,6 @@ from qdash.repository.chip import MongoChipRepository
 from qdash.repository.task_result_history import MongoTaskResultHistoryRepository
 
 if TYPE_CHECKING:
-    from qdash.api.lib.project import ProjectContext, get_project_context
     from qdash.dbmodel.chip import ChipDocument
 
 router = APIRouter()

--- a/src/qdash/api/routers/project.py
+++ b/src/qdash/api/routers/project.py
@@ -27,8 +27,8 @@ from qdash.datamodel.user import SystemRole
 from qdash.dbmodel.project import ProjectDocument
 from qdash.dbmodel.project_membership import ProjectMembershipDocument
 from qdash.repository import (
-    MongoProjectRepository,
     MongoProjectMembershipRepository,
+    MongoProjectRepository,
     MongoUserRepository,
 )
 

--- a/src/qdash/api/routers/tag.py
+++ b/src/qdash/api/routers/tag.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from qdash.api.lib.project import (  # noqa: TCH002
+    ProjectContext,
+    get_project_context,
+)
 from qdash.api.schemas.tag import ListTagResponse, Tag
 from qdash.repository.tag import MongoTagRepository
-
-if TYPE_CHECKING:
-    from qdash.api.lib.project import ProjectContext, get_project_context
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/tag.py
+++ b/src/qdash/api/routers/tag.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, Depends
-from qdash.api.lib.project import ProjectContext, get_project_context
 from qdash.api.schemas.tag import ListTagResponse, Tag
 from qdash.repository.tag import MongoTagRepository
+
+if TYPE_CHECKING:
+    from qdash.api.lib.project import ProjectContext, get_project_context
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/task.py
+++ b/src/qdash/api/routers/task.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Annotated
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from qdash.api.lib.project import (  # noqa: TCH002
+    ProjectContext,
+    get_project_context,
+)
 from qdash.api.schemas.task import (
     InputParameterModel,
     ListTaskResponse,
@@ -14,9 +18,6 @@ from qdash.api.schemas.task import (
 )
 from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 from qdash.repository.task_definition import MongoTaskDefinitionRepository
-
-if TYPE_CHECKING:
-    from qdash.api.lib.project import ProjectContext, get_project_context
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/task.py
+++ b/src/qdash/api/routers/task.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from qdash.api.lib.project import ProjectContext, get_project_context
 from qdash.api.schemas.task import (
     InputParameterModel,
     ListTaskResponse,
@@ -15,6 +14,9 @@ from qdash.api.schemas.task import (
 )
 from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 from qdash.repository.task_definition import MongoTaskDefinitionRepository
+
+if TYPE_CHECKING:
+    from qdash.api.lib.project import ProjectContext, get_project_context
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/task_file.py
+++ b/src/qdash/api/routers/task_file.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import contextlib
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -494,10 +495,8 @@ def _get_directory_mtime_sum(directory: Path) -> float:
         for item in directory.rglob("*.py"):
             if item.name.startswith(".") or "__pycache__" in str(item):
                 continue
-            try:
+            with contextlib.suppress(OSError):
                 mtime_sum += item.stat().st_mtime
-            except OSError:
-                pass
     except PermissionError:
         pass
     return mtime_sum

--- a/src/qdash/api/routers/task_file.py
+++ b/src/qdash/api/routers/task_file.py
@@ -6,14 +6,11 @@ import ast
 import contextlib
 import logging
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.logger import logger
-from qdash.api.lib.auth import get_current_active_user
 from qdash.api.lib.config_loader import ConfigLoader
-from qdash.api.schemas.auth import User
 from qdash.api.schemas.task_file import (
     FileNodeType,
     ListTaskFileBackendsResponse,
@@ -25,6 +22,12 @@ from qdash.api.schemas.task_file import (
     TaskInfo,
 )
 from qdash.common.paths import CALIBTASKS_DIR
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from qdash.api.lib.auth import get_current_active_user
+    from qdash.api.schemas.auth import User
 
 router = APIRouter()
 gunicorn_logger = logging.getLogger("gunicorn.error")

--- a/src/qdash/api/routers/task_file.py
+++ b/src/qdash/api/routers/task_file.py
@@ -10,7 +10,9 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.logger import logger
+from qdash.api.lib.auth import get_current_active_user  # noqa: TCH002
 from qdash.api.lib.config_loader import ConfigLoader
+from qdash.api.schemas.auth import User  # noqa: TCH002
 from qdash.api.schemas.task_file import (
     FileNodeType,
     ListTaskFileBackendsResponse,
@@ -25,9 +27,6 @@ from qdash.common.paths import CALIBTASKS_DIR
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from qdash.api.lib.auth import get_current_active_user
-    from qdash.api.schemas.auth import User
 
 router = APIRouter()
 gunicorn_logger = logging.getLogger("gunicorn.error")

--- a/src/qdash/api/routers/task_result.py
+++ b/src/qdash/api/routers/task_result.py
@@ -6,13 +6,12 @@ import io
 import logging
 import zipfile
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 import pendulum
 from bunnet import SortDirection
 from fastapi import APIRouter, Body, Depends, Query
 from fastapi.responses import StreamingResponse
-from qdash.api.lib.project import ProjectContext, get_project_context
 from qdash.api.schemas.task_result import (
     LatestTaskResultResponse,
     TaskHistoryResponse,
@@ -22,11 +21,14 @@ from qdash.api.schemas.task_result import (
 )
 from qdash.api.services.response_processor import response_processor
 from qdash.datamodel.task import OutputParameterModel
-from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 from qdash.repository.chip import MongoChipRepository
 from qdash.repository.chip_history import MongoChipHistoryRepository
 from qdash.repository.task_result_history import MongoTaskResultHistoryRepository
 from starlette.exceptions import HTTPException
+
+if TYPE_CHECKING:
+    from qdash.api.lib.project import ProjectContext, get_project_context
+    from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/task_result.py
+++ b/src/qdash/api/routers/task_result.py
@@ -12,6 +12,10 @@ import pendulum
 from bunnet import SortDirection
 from fastapi import APIRouter, Body, Depends, Query
 from fastapi.responses import StreamingResponse
+from qdash.api.lib.project import (  # noqa: TCH002
+    ProjectContext,
+    get_project_context,
+)
 from qdash.api.schemas.task_result import (
     LatestTaskResultResponse,
     TaskHistoryResponse,
@@ -27,7 +31,6 @@ from qdash.repository.task_result_history import MongoTaskResultHistoryRepositor
 from starlette.exceptions import HTTPException
 
 if TYPE_CHECKING:
-    from qdash.api.lib.project import ProjectContext, get_project_context
     from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 
 router = APIRouter()

--- a/src/qdash/api/routers/task_result.py
+++ b/src/qdash/api/routers/task_result.py
@@ -12,8 +12,6 @@ import pendulum
 from bunnet import SortDirection
 from fastapi import APIRouter, Body, Depends, Query
 from fastapi.responses import StreamingResponse
-from starlette.exceptions import HTTPException
-
 from qdash.api.lib.project import ProjectContext, get_project_context
 from qdash.api.schemas.task_result import (
     LatestTaskResultResponse,
@@ -28,6 +26,7 @@ from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 from qdash.repository.chip import MongoChipRepository
 from qdash.repository.chip_history import MongoChipHistoryRepository
 from qdash.repository.task_result_history import MongoTaskResultHistoryRepository
+from starlette.exceptions import HTTPException
 
 router = APIRouter()
 

--- a/src/qdash/api/routers/topology.py
+++ b/src/qdash/api/routers/topology.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-
 from qdash.api.lib.topology_config import (
     list_topologies,
     load_topology,

--- a/src/qdash/api/schemas/error.py
+++ b/src/qdash/api/schemas/error.py
@@ -13,7 +13,6 @@ class ErrorResponse(JSONResponse):
     """Base class for error responses."""
 
 
-
 class InternalServerError(HTTPException):
     """Internal server error exception.
 

--- a/src/qdash/api/schemas/error.py
+++ b/src/qdash/api/schemas/error.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel
 class ErrorResponse(JSONResponse):
     """Base class for error responses."""
 
-    pass
 
 
 class InternalServerError(HTTPException):

--- a/src/qdash/api/services/calibration_service.py
+++ b/src/qdash/api/services/calibration_service.py
@@ -5,7 +5,6 @@ using repository abstractions for data access.
 """
 
 from qdash.api.schemas.calibration import CalibrationNoteResponse
-from qdash.repository.calibration_note import MongoCalibrationNoteRepository
 from qdash.repository.protocols import CalibrationNoteRepository
 
 

--- a/src/qdash/api/services/execution_service.py
+++ b/src/qdash/api/services/execution_service.py
@@ -13,7 +13,6 @@ from qdash.api.schemas.execution import (
     ExecutionResponseSummary,
     Task,
 )
-from qdash.dbmodel.execution_history import ExecutionHistoryDocument
 
 logger = logging.getLogger(__name__)
 

--- a/src/qdash/api/services/execution_service.py
+++ b/src/qdash/api/services/execution_service.py
@@ -159,7 +159,7 @@ class ExecutionService:
         """
         grouped_tasks: dict[str, list[dict[str, Any]]] = {}
 
-        for key, result in task_results.items():
+        for result in task_results.values():
             if not isinstance(result, dict):
                 result = result.model_dump()  # noqa: PLW2901
 
@@ -186,7 +186,7 @@ class ExecutionService:
 
             # カップリングタスクの処理
             if "coupling_tasks" in result:
-                for sub_key, tasks in result["coupling_tasks"].items():
+                for tasks in result["coupling_tasks"].values():
                     if "coupling" not in grouped_tasks:
                         grouped_tasks["coupling"] = []
                     grouped_tasks["coupling"].extend(tasks)

--- a/src/qdash/api/services/outlier_detection.py
+++ b/src/qdash/api/services/outlier_detection.py
@@ -59,7 +59,6 @@ class OutlierDetector(ABC):
         Returns:
             Tuple of (min_bound, max_bound)
         """
-        pass
 
     @abstractmethod
     def extract_parameter_values(
@@ -75,7 +74,6 @@ class OutlierDetector(ABC):
         Returns:
             Dictionary mapping qid to parameter value
         """
-        pass
 
     def detect_outliers(
         self,

--- a/src/qdash/api/services/outlier_detection.py
+++ b/src/qdash/api/services/outlier_detection.py
@@ -7,7 +7,7 @@ This module provides base and specialized outlier detectors for quantum calibrat
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -23,10 +23,10 @@ class OutlierResult:
     original_count: int
     filtered_count: int
     outlier_count: int
-    outlier_qids: List[str]
+    outlier_qids: list[str]
     method_used: str
-    parameters: Dict[str, Any]
-    physical_violations: List[str]
+    parameters: dict[str, Any]
+    physical_violations: list[str]
 
 
 class OutlierDetector(ABC):
@@ -49,7 +49,7 @@ class OutlierDetector(ABC):
         }
 
     @abstractmethod
-    def get_physical_bounds(self, parameter_name: str) -> Tuple[float, float]:
+    def get_physical_bounds(self, parameter_name: str) -> tuple[float, float]:
         """
         Get physical bounds for the parameter.
 
@@ -63,8 +63,8 @@ class OutlierDetector(ABC):
 
     @abstractmethod
     def extract_parameter_values(
-        self, data: Dict[str, Any], parameter_name: str
-    ) -> Dict[str, float]:
+        self, data: dict[str, Any], parameter_name: str
+    ) -> dict[str, float]:
         """
         Extract parameter values from task results.
 
@@ -79,7 +79,7 @@ class OutlierDetector(ABC):
 
     def detect_outliers(
         self,
-        data: Dict[str, Any],
+        data: dict[str, Any],
         parameter_name: str,
         method: str = "combined",
         **kwargs: Any,
@@ -143,8 +143,8 @@ class OutlierDetector(ABC):
         )
 
     def _modified_z_score(
-        self, values: npt.NDArray[np.floating[Any]], threshold: Optional[float] = None
-    ) -> Tuple[npt.NDArray[np.bool_], List[str]]:
+        self, values: npt.NDArray[np.floating[Any]], threshold: float | None = None
+    ) -> tuple[npt.NDArray[np.bool_], list[str]]:
         """
         Modified Z-score using Median Absolute Deviation (MAD).
         More robust than standard Z-score for non-normal distributions.
@@ -165,8 +165,8 @@ class OutlierDetector(ABC):
         return outlier_mask, violations
 
     def _iqr_method(
-        self, values: npt.NDArray[np.floating[Any]], multiplier: Optional[float] = None
-    ) -> Tuple[npt.NDArray[np.bool_], List[str]]:
+        self, values: npt.NDArray[np.floating[Any]], multiplier: float | None = None
+    ) -> tuple[npt.NDArray[np.bool_], list[str]]:
         """
         Interquartile Range (IQR) method for outlier detection.
         Robust to skewed distributions.
@@ -186,7 +186,7 @@ class OutlierDetector(ABC):
 
     def _physical_bounds(
         self, values: npt.NDArray[np.floating[Any]], parameter_name: str
-    ) -> Tuple[npt.NDArray[np.bool_], List[str]]:
+    ) -> tuple[npt.NDArray[np.bool_], list[str]]:
         """Check physical bounds for the parameter."""
         min_bound, max_bound = self.get_physical_bounds(parameter_name)
 
@@ -202,7 +202,7 @@ class OutlierDetector(ABC):
 
     def _combined_method(
         self, values: npt.NDArray[np.floating[Any]], parameter_name: str, **kwargs: Any
-    ) -> Tuple[npt.NDArray[np.bool_], List[str]]:
+    ) -> tuple[npt.NDArray[np.bool_], list[str]]:
         """Combine physical bounds and statistical methods."""
         # Always check physical bounds first
         physical_outliers, physical_violations = self._physical_bounds(values, parameter_name)
@@ -228,8 +228,8 @@ class OutlierDetector(ABC):
         return combined_outliers, combined_violations
 
     def _z_score_scipy(
-        self, values: npt.NDArray[np.floating[Any]], threshold: Optional[float] = None
-    ) -> Tuple[npt.NDArray[np.bool_], List[str]]:
+        self, values: npt.NDArray[np.floating[Any]], threshold: float | None = None
+    ) -> tuple[npt.NDArray[np.bool_], list[str]]:
         """Simple Z-score using scipy."""
         threshold = threshold or self.default_thresholds["z_score"]
 
@@ -241,7 +241,7 @@ class OutlierDetector(ABC):
         return outlier_mask, [f"Z-score > {threshold}"]
 
 
-def extract_coherence_time_values(data: Dict[str, Any], parameter_name: str) -> Dict[str, float]:
+def extract_coherence_time_values(data: dict[str, Any], parameter_name: str) -> dict[str, float]:
     """Extract coherence time values from task results."""
     extracted = {}
 
@@ -268,7 +268,7 @@ def extract_coherence_time_values(data: Dict[str, Any], parameter_name: str) -> 
     return extracted
 
 
-def extract_fidelity_values(data: Dict[str, Any], parameter_name: str) -> Dict[str, float]:
+def extract_fidelity_values(data: dict[str, Any], parameter_name: str) -> dict[str, float]:
     """Extract fidelity values from task results."""
     extracted = {}
 
@@ -295,53 +295,53 @@ def extract_fidelity_values(data: Dict[str, Any], parameter_name: str) -> Dict[s
 class T2StarOutlierDetector(OutlierDetector):
     """Detector for T2* (Ramsey) measurements."""
 
-    def get_physical_bounds(self, parameter_name: str) -> Tuple[float, float]:
+    def get_physical_bounds(self, parameter_name: str) -> tuple[float, float]:
         return (0.0, 1000.0)  # 0 to 1ms
 
     def extract_parameter_values(
-        self, data: Dict[str, Any], parameter_name: str
-    ) -> Dict[str, float]:
+        self, data: dict[str, Any], parameter_name: str
+    ) -> dict[str, float]:
         return extract_coherence_time_values(data, parameter_name)
 
 
 class T2EchoOutlierDetector(OutlierDetector):
     """Detector for T2 echo measurements."""
 
-    def get_physical_bounds(self, parameter_name: str) -> Tuple[float, float]:
+    def get_physical_bounds(self, parameter_name: str) -> tuple[float, float]:
         return (0.0, 2000.0)  # 0 to 2ms
 
     def extract_parameter_values(
-        self, data: Dict[str, Any], parameter_name: str
-    ) -> Dict[str, float]:
+        self, data: dict[str, Any], parameter_name: str
+    ) -> dict[str, float]:
         return extract_coherence_time_values(data, parameter_name)
 
 
 class T1OutlierDetector(OutlierDetector):
     """Detector for T1 relaxation time measurements."""
 
-    def get_physical_bounds(self, parameter_name: str) -> Tuple[float, float]:
+    def get_physical_bounds(self, parameter_name: str) -> tuple[float, float]:
         return (0.0, 10000.0)  # 0 to 10ms
 
     def extract_parameter_values(
-        self, data: Dict[str, Any], parameter_name: str
-    ) -> Dict[str, float]:
+        self, data: dict[str, Any], parameter_name: str
+    ) -> dict[str, float]:
         return extract_coherence_time_values(data, parameter_name)
 
 
 class GateFidelityOutlierDetector(OutlierDetector):
     """Detector for gate fidelity measurements."""
 
-    def get_physical_bounds(self, parameter_name: str) -> Tuple[float, float]:
+    def get_physical_bounds(self, parameter_name: str) -> tuple[float, float]:
         return (0.0, 1.0)  # 0 to 1 (100%)
 
     def extract_parameter_values(
-        self, data: Dict[str, Any], parameter_name: str
-    ) -> Dict[str, float]:
+        self, data: dict[str, Any], parameter_name: str
+    ) -> dict[str, float]:
         return extract_fidelity_values(data, parameter_name)
 
 
 # Factory function to get appropriate detector
-def get_outlier_detector(task_name: str) -> Optional[OutlierDetector]:
+def get_outlier_detector(task_name: str) -> OutlierDetector | None:
     """
     Factory function to get the appropriate outlier detector for a task.
 
@@ -351,7 +351,7 @@ def get_outlier_detector(task_name: str) -> Optional[OutlierDetector]:
     Returns:
         Appropriate OutlierDetector instance or None
     """
-    detector_mapping: Dict[str, Type[OutlierDetector]] = {
+    detector_mapping: dict[str, type[OutlierDetector]] = {
         "CheckRamsey": T2StarOutlierDetector,
         "Ramsey": T2StarOutlierDetector,
         "T2Star": T2StarOutlierDetector,
@@ -374,11 +374,11 @@ def get_outlier_detector(task_name: str) -> Optional[OutlierDetector]:
 
 
 def filter_task_results_for_outliers(
-    task_results: Dict[str, Any],
+    task_results: dict[str, Any],
     task_name: str,
     enable_filtering: bool = True,
     method: str = "combined",
-) -> Tuple[Dict[str, Any], Optional[OutlierResult]]:
+) -> tuple[dict[str, Any], OutlierResult | None]:
     """
     Filter task results to remove outliers based on task type.
 

--- a/src/qdash/api/services/outlier_detection.py
+++ b/src/qdash/api/services/outlier_detection.py
@@ -249,14 +249,13 @@ def extract_coherence_time_values(data: dict[str, Any], parameter_name: str) -> 
         value = None
 
         # Handle different data structures
-        if isinstance(task_result, dict):
-            if "output_parameters" in task_result:
-                param_value = task_result["output_parameters"].get(parameter_name)
-                if param_value is not None:
-                    if isinstance(param_value, dict):
-                        value = float(param_value.get("value", param_value.get("mean", 0)))
-                    else:
-                        value = float(param_value)
+        if isinstance(task_result, dict) and "output_parameters" in task_result:
+            param_value = task_result["output_parameters"].get(parameter_name)
+            if param_value is not None:
+                if isinstance(param_value, dict):
+                    value = float(param_value.get("value", param_value.get("mean", 0)))
+                else:
+                    value = float(param_value)
 
         # Validate and convert to microseconds if needed
         if value is not None and not np.isnan(value) and value > 0:
@@ -276,14 +275,13 @@ def extract_fidelity_values(data: dict[str, Any], parameter_name: str) -> dict[s
         value = None
 
         # Handle different data structures
-        if isinstance(task_result, dict):
-            if "output_parameters" in task_result:
-                param_value = task_result["output_parameters"].get(parameter_name)
-                if param_value is not None:
-                    if isinstance(param_value, dict):
-                        value = float(param_value.get("value", param_value.get("mean", 0)))
-                    else:
-                        value = float(param_value)
+        if isinstance(task_result, dict) and "output_parameters" in task_result:
+            param_value = task_result["output_parameters"].get(parameter_name)
+            if param_value is not None:
+                if isinstance(param_value, dict):
+                    value = float(param_value.get("value", param_value.get("mean", 0)))
+                else:
+                    value = float(param_value)
 
         # Include all numeric values for outlier detection
         if value is not None and not np.isnan(value):

--- a/src/qdash/api/services/response_processor.py
+++ b/src/qdash/api/services/response_processor.py
@@ -5,7 +5,7 @@ This service handles post-processing of API responses, including outlier filteri
 """
 
 import logging
-from typing import Any, Dict, TypeVar
+from typing import Any, TypeVar
 
 from qdash.api.services.outlier_detection import filter_task_results_for_outliers
 
@@ -48,7 +48,7 @@ class ResponseProcessor:
         response.result = filtered_results
         return response
 
-    def _apply_outlier_filtering(self, results: Dict[str, Any], task_name: str) -> Dict[str, Any]:
+    def _apply_outlier_filtering(self, results: dict[str, Any], task_name: str) -> dict[str, Any]:
         """Apply outlier filtering to task results."""
         # Convert Task objects to dict for outlier detection
         task_dict = {}

--- a/src/qdash/datamodel/task.py
+++ b/src/qdash/datamodel/task.py
@@ -7,7 +7,6 @@ from typing import Any, Final, Literal
 import numpy as np
 import pendulum
 from pydantic import BaseModel, Field, field_validator
-
 from qdash.datamodel.system_info import SystemInfoModel
 
 SCHDULED = "scheduled"

--- a/src/qdash/datamodel/task.py
+++ b/src/qdash/datamodel/task.py
@@ -172,7 +172,7 @@ class CalibDataModel(BaseModel):
     def __getitem__(self, key: str) -> dict[str, dict[str, OutputParameterModel]]:
         """Get the item by key."""
         if key in ("qubit", "coupling"):
-            return getattr(self, key)  # type: ignore #noqa: PGH003
+            return getattr(self, key)  # type: ignore
         raise KeyError(f"Invalid key: {key}")
 
 
@@ -278,7 +278,7 @@ class BaseTaskResultModel(BaseModel):
         except Exception as e:
             error_message = f"Failed to parse the time. {e}"
             raise ValueError(error_message)
-        return end_time.diff_for_humans(start_time, absolute=True)  # type: ignore #noqa: PGH003
+        return end_time.diff_for_humans(start_time, absolute=True)  # type: ignore
 
 
 class SystemTaskModel(BaseTaskResultModel):

--- a/src/qdash/dbmodel/execution_lock.py
+++ b/src/qdash/dbmodel/execution_lock.py
@@ -37,7 +37,7 @@ class ExecutionLockDocument(Document):
         return doc.locked
 
     @classmethod
-    def set_lock(cls, lock: bool, project_id: str) -> None:  # noqa: FBT001
+    def set_lock(cls, lock: bool, project_id: str) -> None:
         doc = cls.find_one({"project_id": project_id}).run()
         if doc is None:
             doc = cls(project_id=project_id, locked=lock)

--- a/src/qdash/dbmodel/flow.py
+++ b/src/qdash/dbmodel/flow.py
@@ -3,9 +3,8 @@
 from datetime import datetime
 from typing import Any
 
-from bunnet import Document
+from bunnet import Document, SortDirection
 from pydantic import ConfigDict, Field
-from bunnet import SortDirection
 from pymongo import ASCENDING, DESCENDING
 
 

--- a/src/qdash/repository/__init__.py
+++ b/src/qdash/repository/__init__.py
@@ -3,6 +3,22 @@
 This module provides data access abstractions for both API and workflow components.
 """
 
+# MongoDB implementations
+from qdash.repository.backend import MongoBackendRepository
+from qdash.repository.calibration_note import MongoCalibrationNoteRepository
+from qdash.repository.chip import MongoChipRepository
+from qdash.repository.chip_history import MongoChipHistoryRepository
+from qdash.repository.coupling import MongoCouplingCalibrationRepository
+from qdash.repository.execution import MongoExecutionRepository
+from qdash.repository.execution_counter import MongoExecutionCounterRepository
+from qdash.repository.execution_history import MongoExecutionHistoryRepository
+from qdash.repository.execution_lock import MongoExecutionLockRepository
+
+# Filesystem implementations
+from qdash.repository.filesystem import FilesystemCalibDataSaver
+from qdash.repository.flow import MongoFlowRepository
+from qdash.repository.project import MongoProjectRepository
+from qdash.repository.project_membership import MongoProjectMembershipRepository
 from qdash.repository.protocols import (
     CalibDataSaver,
     CalibrationNoteRepository,
@@ -17,29 +33,12 @@ from qdash.repository.protocols import (
     TaskResultHistoryRepository,
     UserRepository,
 )
-
-# MongoDB implementations
-from qdash.repository.backend import MongoBackendRepository
-from qdash.repository.calibration_note import MongoCalibrationNoteRepository
-from qdash.repository.chip import MongoChipRepository
-from qdash.repository.chip_history import MongoChipHistoryRepository
-from qdash.repository.coupling import MongoCouplingCalibrationRepository
-from qdash.repository.execution import MongoExecutionRepository
-from qdash.repository.execution_counter import MongoExecutionCounterRepository
-from qdash.repository.execution_history import MongoExecutionHistoryRepository
-from qdash.repository.execution_lock import MongoExecutionLockRepository
-from qdash.repository.flow import MongoFlowRepository
-from qdash.repository.project import MongoProjectRepository
-from qdash.repository.project_membership import MongoProjectMembershipRepository
 from qdash.repository.qubit import MongoQubitCalibrationRepository
 from qdash.repository.tag import MongoTagRepository
 from qdash.repository.task import MongoTaskRepository
 from qdash.repository.task_definition import MongoTaskDefinitionRepository
 from qdash.repository.task_result_history import MongoTaskResultHistoryRepository
 from qdash.repository.user import MongoUserRepository
-
-# Filesystem implementations
-from qdash.repository.filesystem import FilesystemCalibDataSaver
 
 __all__ = [
     # Protocols

--- a/src/qdash/repository/calibration_note.py
+++ b/src/qdash/repository/calibration_note.py
@@ -5,11 +5,9 @@ persistence operations. Used by both API and workflow components.
 """
 
 import logging
-from typing import Any
 
 import pendulum
 from bunnet import SortDirection
-
 from qdash.datamodel.calibration_note import CalibrationNoteModel
 from qdash.dbmodel.calibration_note import CalibrationNoteDocument
 

--- a/src/qdash/repository/execution_history.py
+++ b/src/qdash/repository/execution_history.py
@@ -5,10 +5,8 @@ history persistence operations.
 """
 
 import logging
-from typing import Any
 
 from bunnet import SortDirection
-
 from qdash.dbmodel.execution_history import ExecutionHistoryDocument
 
 logger = logging.getLogger(__name__)

--- a/src/qdash/repository/inmemory/chip.py
+++ b/src/qdash/repository/inmemory/chip.py
@@ -4,8 +4,6 @@ This module provides a mock implementation that stores data in memory,
 useful for unit testing without requiring a MongoDB instance.
 """
 
-from typing import Any
-
 from qdash.datamodel.chip import ChipModel
 from qdash.datamodel.task import CalibDataModel
 

--- a/src/qdash/repository/protocols.py
+++ b/src/qdash/repository/protocols.py
@@ -9,7 +9,8 @@ The protocols follow the Repository pattern, providing:
 - Clear separation between domain logic and data access
 """
 
-from typing import Any, Callable, Protocol, runtime_checkable
+from collections.abc import Callable
+from typing import Any, Protocol, runtime_checkable
 
 from qdash.datamodel.calibration_note import CalibrationNoteModel
 from qdash.datamodel.chip import ChipModel

--- a/src/qdash/repository/task_result_history.py
+++ b/src/qdash/repository/task_result_history.py
@@ -8,7 +8,6 @@ import logging
 from typing import Any
 
 from bunnet import SortDirection
-
 from qdash.datamodel.execution import ExecutionModel
 from qdash.datamodel.task import BaseTaskResultModel
 from qdash.dbmodel.task_result_history import TaskResultHistoryDocument

--- a/src/qdash/workflow/calibtasks/__init__.py
+++ b/src/qdash/workflow/calibtasks/__init__.py
@@ -1,7 +1,7 @@
 from qdash.workflow.calibtasks.active_protocols import generate_task_instances
 from qdash.workflow.calibtasks.base import BaseTask
-from qdash.workflow.calibtasks.fake import *  # noqa: F403, F401
-from qdash.workflow.calibtasks.qubex import *  # noqa: F403, F401
+from qdash.workflow.calibtasks.fake import *  # noqa: F403
+from qdash.workflow.calibtasks.qubex import *  # noqa: F403
 from qdash.workflow.calibtasks.results import PostProcessResult, PreProcessResult, RunResult
 
 __all__ = [

--- a/src/qdash/workflow/calibtasks/fake/fake_rabi.py
+++ b/src/qdash/workflow/calibtasks/fake/fake_rabi.py
@@ -5,7 +5,7 @@ import numpy as np
 import numpy.typing as npt
 import plotly.graph_objects as go
 import qubex as qx
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     PreProcessResult,
@@ -15,7 +15,6 @@ from qdash.workflow.calibtasks.fake.base import FakeTask
 from qdash.workflow.engine.backend.fake import FakeBackend
 from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
 from qubex.simulator import Control, QuantumSimulator, QuantumSystem, SimulationResult, Transmon
-from qdash.datamodel.task import TaskTypes
 
 
 def downsample(

--- a/src/qdash/workflow/calibtasks/fake/fake_rabi.py
+++ b/src/qdash/workflow/calibtasks/fake/fake_rabi.py
@@ -109,7 +109,7 @@ class FakeRabi(FakeTask):
     }
     output_parameters: ClassVar[dict[str, OutputParameterModel]] = {}
 
-    def preprocess(self, backend: FakeBackend, qid: str) -> PreProcessResult:  # noqa: ARG002
+    def preprocess(self, backend: FakeBackend, qid: str) -> PreProcessResult:
         """Preprocess the task."""
         return PreProcessResult(input_parameters=self.input_parameters)
 

--- a/src/qdash/workflow/calibtasks/qubex/base.py
+++ b/src/qdash/workflow/calibtasks/qubex/base.py
@@ -1,5 +1,6 @@
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Any
 
 from qdash.datamodel.task import InputParameterModel
 from qdash.workflow.calibtasks.base import (

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/randomized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/randomized_benchmarking.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class RandomizedBenchmarking(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/x180_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/x180_interleaved_randoized_benchmarking.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class X180InterleavedRandomizedBenchmarking(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/x90_interleaved_randomized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/x90_interleaved_randomized_benchmarking.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class X90InterleavedRandomizedBenchmarking(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class ZX90InterleavedRandomizedBenchmarking(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/check_noise.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/check_noise.py
@@ -22,7 +22,7 @@ class CheckNoise(QubexTask):
     ) -> PostProcessResult:
         return PostProcessResult(output_parameters={})
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         exp.check_noise()
         self.save_calibration(backend)

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/check_status.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/check_status.py
@@ -22,7 +22,7 @@ class CheckStatus(QubexTask):
     ) -> PostProcessResult:
         return PostProcessResult(output_parameters={})
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         result = exp.check_status()
         self.save_calibration(backend)

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/configure.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/configure.py
@@ -22,7 +22,7 @@ class Configure(QubexTask):
     ) -> PostProcessResult:
         return PostProcessResult(output_parameters={})
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         exp.state_manager.load(
             chip_id=exp.chip_id, config_dir=exp.config_path, params_dir=exp.params_path

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/dump_box.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/dump_box.py
@@ -22,7 +22,7 @@ class DumpBox(QubexTask):
     ) -> PostProcessResult:
         return PostProcessResult(output_parameters={})
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         for _id in exp.box_ids:
             box_info = {}

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/link_up.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/link_up.py
@@ -22,7 +22,7 @@ class LinkUp(QubexTask):
     ) -> PostProcessResult:
         return PostProcessResult(output_parameters={})
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         exp.linkup()
         self.save_calibration(backend)

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/readout_configure.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/readout_configure.py
@@ -29,7 +29,7 @@ class ReadoutConfigure(QubexTask):
     ) -> PostProcessResult:
         return PostProcessResult(output_parameters={})
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
 
         def readout_configure() -> RunResult | None:

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_electrical_delay.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_electrical_delay.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckElectricalDelay(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_frequencies.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_frequencies.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckQubitFrequencies(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckQubitSpectroscopy(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_readout_amplitude.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_readout_amplitude.py
@@ -2,14 +2,13 @@ from typing import Any, ClassVar
 
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckReadoutAmplitude(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_readout_amplitude.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_readout_amplitude.py
@@ -85,7 +85,7 @@ class CheckReadoutAmplitude(QubexTask):
         output_parameters = self.attach_execution_id(execution_id)
         return PostProcessResult(output_parameters=output_parameters, figures=figures)
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         """Run the task."""
         return RunResult(raw_result=None)
 

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_reflection_coefficient.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_reflection_coefficient.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.dbmodel.initialize import initialize
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
@@ -8,7 +8,6 @@ from qdash.workflow.calibtasks.base import (
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckReflectionCoefficient(QubexTask):
@@ -57,7 +56,7 @@ class CheckReflectionCoefficient(QubexTask):
         labels = [self.get_qubit_label(backend, qid) for qid in qids]
         results = {}
         initialize()
-        for label, qid in zip(labels, qids):
+        for label, qid in zip(labels, qids, strict=False):
             result = exp.measure_reflection_coefficient(
                 target=label,  # center_frequency=chip.qubits[qid].data["coarse_resonator_frequency"]["value"]
             )

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_frequencies.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_frequencies.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 PEAKS_COUNT = 4
 peak_positions = {

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckResonatorSpectroscopy(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/measurement/readout_classification.py
+++ b/src/qdash/workflow/calibtasks/qubex/measurement/readout_classification.py
@@ -3,14 +3,13 @@ from typing import Any, ClassVar
 import numpy as np
 import numpy.typing as npt
 import plotly.graph_objs as go
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class ReadoutClassification(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_dispersive_shift.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_dispersive_shift.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckDispersiveShift(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_hpi_pulse.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckHPIPulse(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_optimal_readout_amplitude.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_optimal_readout_amplitude.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckOptimalReadoutAmplitude(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_pi_pulse.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckPIPulse(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_qubit.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_qubit.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
 
 

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_qubit_frequency.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_qubit_frequency.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -10,7 +10,6 @@ from qdash.workflow.calibtasks.base import (
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckQubitFrequency(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckRabi(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_ramsey.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_ramsey.py
@@ -1,7 +1,7 @@
 from typing import Any, ClassVar
 
 import plotly.graph_objects as go
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.base import (
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckRamsey(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_readout_frequency.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_readout_frequency.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -10,7 +10,6 @@ from qdash.workflow.calibtasks.base import (
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckReadoutFrequency(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1.py
@@ -1,7 +1,7 @@
 from typing import ClassVar
 
 import numpy as np
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.base import (
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckT1(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo.py
@@ -1,7 +1,7 @@
 from typing import ClassVar
 
 import numpy as np
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.base import (
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckT2Echo(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/chevron_pattern.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/chevron_pattern.py
@@ -1,14 +1,13 @@
 from typing import ClassVar
 
 import numpy as np
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class ChevronPattern(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS, HPI_DURATION
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class CreateHPIPulse(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
@@ -1,6 +1,6 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -9,7 +9,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS, PI_DURATION
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class CreatePIPulse(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/rabi_oscillation.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/rabi_oscillation.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class RabiOscillation(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/rabi_oscillation.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/rabi_oscillation.py
@@ -22,7 +22,7 @@ class RabiOscillation(QubexTask):
     ) -> PostProcessResult:
         return PostProcessResult(output_parameters={})
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         default_rabi_amplitudes = {label: 0.01 for label in exp.qubit_labels}
         exp.rabi_experiment(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_hpi_pulse.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckDRAGHPIPulse(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_pi_pulse.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckDRAGPIPulse(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -11,7 +11,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS, DRAG_HPI_DURATION
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class CreateDRAGHPIPulse(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
     import plotly.graph_objs as go
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -11,7 +11,6 @@ from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS, DRAG_PI_DURATION
 from qubex.measurement.measurement import DEFAULT_INTERVAL
-from qdash.datamodel.task import TaskTypes
 
 
 class CreateDRAGPIPulse(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/system/check_skew.py
+++ b/src/qdash/workflow/calibtasks/qubex/system/check_skew.py
@@ -41,7 +41,7 @@ class CheckSkew(QubexTask):
         with (Path.cwd() / Path(filename)).open() as file:
             return yaml.safe_load(file)
 
-    def run(self, backend: QubexBackend, qid: str) -> RunResult:  # noqa: ARG002
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
         chip_id = backend.config.get("chip_id", None)
         qubex_paths = get_qubex_paths()
         skew_file_path = str(qubex_paths.skew_yaml(chip_id))
@@ -65,7 +65,7 @@ class CheckSkew(QubexTask):
             exp.system_manager.experiment_system.control_system.clock_master_address
         )
         box_ids = exp.box_ids
-        all_box_ids = list(set(list(box_ids) + [ref_port]))
+        all_box_ids = list({*list(box_ids), ref_port})
         skew = Skew.from_yaml(
             str(skew_file_path),
             box_yaml=str(box_file_path),

--- a/src/qdash/workflow/calibtasks/qubex/system/check_skew.py
+++ b/src/qdash/workflow/calibtasks/qubex/system/check_skew.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import yaml
-
 from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
@@ -1,13 +1,12 @@
 from typing import Any, ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckBellState(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
@@ -2,14 +2,13 @@ from typing import Any, ClassVar
 
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckBellStateTomography(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
@@ -2,14 +2,13 @@ from typing import Any, ClassVar
 
 import numpy as np
 import plotly.graph_objects as go
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckCrossResonance(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
@@ -1,13 +1,12 @@
 from typing import ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CheckZX90(QubexTask):

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
@@ -1,13 +1,12 @@
 from typing import Any, ClassVar
 
-from qdash.datamodel.task import InputParameterModel, OutputParameterModel
+from qdash.datamodel.task import InputParameterModel, OutputParameterModel, TaskTypes
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qdash.datamodel.task import TaskTypes
 
 
 class CreateZX90(QubexTask):

--- a/src/qdash/workflow/calibtasks/results.py
+++ b/src/qdash/workflow/calibtasks/results.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import plotly.graph_objs as go
 from pydantic import BaseModel
-
 from qdash.datamodel.task import OutputParameterModel
 
 

--- a/src/qdash/workflow/deployment_service.py
+++ b/src/qdash/workflow/deployment_service.py
@@ -241,7 +241,7 @@ async def set_schedule(request: SetScheduleRequest) -> SetScheduleResponse:
             except Exception as e:
                 logger.error(f"Failed to update deployment: {e}")
                 raise HTTPException(
-                    status_code=500, detail=f"Failed to update deployment: {str(e)}"
+                    status_code=500, detail=f"Failed to update deployment: {e!s}"
                 )
 
             logger.info(
@@ -259,7 +259,7 @@ async def set_schedule(request: SetScheduleRequest) -> SetScheduleResponse:
         raise
     except Exception as e:
         logger.error(f"Failed to set schedule (unexpected error): {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {e!s}")
 
 
 @app.post("/create-scheduled-run", response_model=CreateScheduledRunResponse)
@@ -288,7 +288,7 @@ async def create_scheduled_run(request: CreateScheduledRunRequest) -> CreateSche
             logger.info(f"Parsed scheduled time: {scheduled_time}")
         except Exception as e:
             logger.error(f"Failed to parse scheduled time: {e}")
-            raise HTTPException(status_code=400, detail=f"Invalid scheduled_time format: {str(e)}")
+            raise HTTPException(status_code=400, detail=f"Invalid scheduled_time format: {e!s}")
 
         async with get_client() as client:
             try:
@@ -300,7 +300,7 @@ async def create_scheduled_run(request: CreateScheduledRunRequest) -> CreateSche
                 logger.info(f"Successfully created scheduled run {flow_run.id}")
             except Exception as e:
                 logger.error(f"Failed to create flow run: {e}")
-                raise HTTPException(status_code=500, detail=f"Failed to create flow run: {str(e)}")
+                raise HTTPException(status_code=500, detail=f"Failed to create flow run: {e!s}")
 
             logger.info(f"Created scheduled run {flow_run.id} for {scheduled_time}")
 
@@ -314,4 +314,4 @@ async def create_scheduled_run(request: CreateScheduledRunRequest) -> CreateSche
         raise
     except Exception as e:
         logger.error(f"Failed to create scheduled run (unexpected error): {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {e!s}")

--- a/src/qdash/workflow/deployment_service.py
+++ b/src/qdash/workflow/deployment_service.py
@@ -240,9 +240,7 @@ async def set_schedule(request: SetScheduleRequest) -> SetScheduleResponse:
                     logger.info("Successfully updated deployment parameters")
             except Exception as e:
                 logger.error(f"Failed to update deployment: {e}")
-                raise HTTPException(
-                    status_code=500, detail=f"Failed to update deployment: {e!s}"
-                )
+                raise HTTPException(status_code=500, detail=f"Failed to update deployment: {e!s}")
 
             logger.info(
                 f"Set schedule on deployment {request.deployment_id}: cron={request.cron}, active={request.active}"

--- a/src/qdash/workflow/deployment_service.py
+++ b/src/qdash/workflow/deployment_service.py
@@ -13,7 +13,6 @@ from fastapi import FastAPI, HTTPException
 from prefect.client.orchestration import get_client
 from prefect.deployments import Deployment
 from pydantic import BaseModel
-
 from qdash.workflow.paths import get_path_resolver
 
 app = FastAPI(title="QDash Deployment Service")

--- a/src/qdash/workflow/engine/__init__.py
+++ b/src/qdash/workflow/engine/__init__.py
@@ -81,11 +81,11 @@ See Also
 
 # Orchestration components
 from qdash.workflow.engine.config import CalibConfig
-from qdash.workflow.engine.orchestrator import CalibOrchestrator
 
 # Execution components
 from qdash.workflow.engine.execution.service import ExecutionService
 from qdash.workflow.engine.execution.state_manager import ExecutionStateManager
+from qdash.workflow.engine.orchestrator import CalibOrchestrator
 
 # Scheduler components
 from qdash.workflow.engine.scheduler.cr_scheduler import CRScheduler, CRScheduleResult

--- a/src/qdash/workflow/engine/backend/base.py
+++ b/src/qdash/workflow/engine/backend/base.py
@@ -33,7 +33,6 @@ class BaseBackend(ABC):
         project_id: str | None = None,
     ) -> None:
         """Save calibration note. Override in subclasses that support notes."""
-        pass
 
     def update_note(
         self,
@@ -45,4 +44,3 @@ class BaseBackend(ABC):
         project_id: str | None = None,
     ) -> None:
         """Update calibration note. Override in subclasses that support notes."""
-        pass

--- a/src/qdash/workflow/engine/execution/service.py
+++ b/src/qdash/workflow/engine/execution/service.py
@@ -5,7 +5,8 @@ state management and persistence through the repository layer.
 """
 
 import logging
-from typing import Any, Callable, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 from qdash.datamodel.execution import (
     CalibDataModel,
@@ -15,12 +16,12 @@ from qdash.datamodel.execution import (
 )
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.initialize import initialize
+from qdash.repository import MongoExecutionRepository
+from qdash.repository.protocols import ExecutionRepository
 from qdash.workflow.engine.execution.models import ExecutionNote
 from qdash.workflow.engine.execution.state_manager import (
     ExecutionStateManager,
 )
-from qdash.repository import MongoExecutionRepository
-from qdash.repository.protocols import ExecutionRepository
 
 initialize()
 

--- a/src/qdash/workflow/engine/orchestrator.py
+++ b/src/qdash/workflow/engine/orchestrator.py
@@ -13,11 +13,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from prefect import get_run_logger
-
 from qdash.workflow.engine.backend.base import BaseBackend
 from qdash.workflow.engine.backend.factory import create_backend
-from qdash.workflow.engine.execution.service import ExecutionService
 from qdash.workflow.engine.config import CalibConfig
+from qdash.workflow.engine.execution.service import ExecutionService
 from qdash.workflow.engine.task.context import TaskContext
 
 if TYPE_CHECKING:
@@ -53,7 +52,7 @@ class CalibOrchestrator:
     def __init__(
         self,
         config: CalibConfig,
-        github_integration: "GitHubIntegration | None" = None,
+        github_integration: GitHubIntegration | None = None,
     ) -> None:
         """Initialize the session manager.
 
@@ -358,6 +357,7 @@ class CalibOrchestrator:
     ) -> TaskContext:
         """Prepare a TaskContext for task execution."""
         from copy import deepcopy
+
         from qdash.datamodel.task import CalibDataModel
 
         config = self.config

--- a/src/qdash/workflow/engine/orchestrator.py
+++ b/src/qdash/workflow/engine/orchestrator.py
@@ -13,13 +13,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from prefect import get_run_logger
-from qdash.workflow.engine.backend.base import BaseBackend
 from qdash.workflow.engine.backend.factory import create_backend
-from qdash.workflow.engine.config import CalibConfig
 from qdash.workflow.engine.execution.service import ExecutionService
 from qdash.workflow.engine.task.context import TaskContext
 
 if TYPE_CHECKING:
+    from qdash.workflow.engine.backend.base import BaseBackend
+    from qdash.workflow.engine.config import CalibConfig
     from qdash.workflow.service.github import GitHubIntegration
 
 

--- a/src/qdash/workflow/engine/params_updater.py
+++ b/src/qdash/workflow/engine/params_updater.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import tempfile
 from pathlib import Path
@@ -161,10 +162,8 @@ class _QubexParamsUpdater:
             return None
 
         if hasattr(value, "item"):
-            try:
+            with contextlib.suppress(Exception):
                 value = value.item()
-            except Exception:
-                pass
 
         if isinstance(value, (int, float)):
             numeric = float(value)

--- a/src/qdash/workflow/engine/params_updater.py
+++ b/src/qdash/workflow/engine/params_updater.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from filelock import FileLock
-
 from qdash.datamodel.task import OutputParameterModel
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 from qdash.workflow.worker.flows.push_props.formatter import represent_none
@@ -24,7 +23,7 @@ class ParamsUpdater(Protocol):
 
 
 def get_params_updater(
-    backend: "BaseBackend | None", chip_id: str | None = None
+    backend: BaseBackend | None, chip_id: str | None = None
 ) -> ParamsUpdater | None:
     """Resolve a backend-specific params updater for the given backend."""
     if backend is None:
@@ -35,7 +34,7 @@ def get_params_updater(
     return None
 
 
-def _resolve_qubex_updater(backend: "BaseBackend", chip_id: str | None) -> ParamsUpdater | None:
+def _resolve_qubex_updater(backend: BaseBackend, chip_id: str | None) -> ParamsUpdater | None:
     try:
         from qdash.workflow.engine.backend.qubex import QubexBackend
     except ImportError:

--- a/src/qdash/workflow/engine/scheduler/cr_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/cr_scheduler.py
@@ -215,7 +215,7 @@ class CRScheduler:
         """Extract all two-qubit coupling IDs from chip data."""
         return [
             coupling_id
-            for coupling_id in chip.couplings.keys()
+            for coupling_id in chip.couplings
             if "-" in coupling_id and len(coupling_id.split("-")) == 2
         ]
 
@@ -390,7 +390,7 @@ class CRScheduler:
             q1b, q2b = pair_b.split("-")
 
             # Conflict 1: Shared qubits
-            if set([q1a, q2a]) & set([q1b, q2b]):
+            if {q1a, q2a} & {q1b, q2b}:
                 conflict_graph.add_edge(pair_a, pair_b)
                 continue
 

--- a/src/qdash/workflow/engine/scheduler/cr_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/cr_scheduler.py
@@ -48,11 +48,11 @@ from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 import yaml
-from qdash.datamodel.chip import ChipModel
-from qdash.datamodel.qubit import QubitModel
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 
 if TYPE_CHECKING:
+    from qdash.datamodel.chip import ChipModel
+    from qdash.datamodel.qubit import QubitModel
     from qdash.repository.protocols import ChipRepository
 
 logger = logging.getLogger(__name__)

--- a/src/qdash/workflow/engine/scheduler/cr_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/cr_scheduler.py
@@ -48,7 +48,6 @@ from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 import yaml
-
 from qdash.datamodel.chip import ChipModel
 from qdash.datamodel.qubit import QubitModel
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths

--- a/src/qdash/workflow/engine/scheduler/one_qubit_plugins.py
+++ b/src/qdash/workflow/engine/scheduler/one_qubit_plugins.py
@@ -228,10 +228,7 @@ class CheckerboardOrderingStrategy(MuxOrderingStrategy):
     ) -> list[str]:
         """Order qubits for checkerboard pattern."""
         # Determine which offset order to use
-        if mux_id % 2 == 0:
-            offset_order = self.EVEN_MUX_ORDER
-        else:
-            offset_order = self.ODD_MUX_ORDER
+        offset_order = self.EVEN_MUX_ORDER if mux_id % 2 == 0 else self.ODD_MUX_ORDER
 
         # Base qubit ID for this MUX
         base_qid = mux_id * 4
@@ -295,10 +292,7 @@ class CheckerboardOrderingStrategy(MuxOrderingStrategy):
             base_qid = mux_id * 4
 
             # Determine offset order for this MUX
-            if mux_id % 2 == 0:
-                offset_order = self.EVEN_MUX_ORDER
-            else:
-                offset_order = self.ODD_MUX_ORDER
+            offset_order = self.EVEN_MUX_ORDER if mux_id % 2 == 0 else self.ODD_MUX_ORDER
 
             # Add qubits to corresponding steps
             for step_idx, offset in enumerate(offset_order):

--- a/src/qdash/workflow/engine/scheduler/one_qubit_plugins.py
+++ b/src/qdash/workflow/engine/scheduler/one_qubit_plugins.py
@@ -92,7 +92,7 @@ class MuxOrderingStrategy(ABC):
         self,
         mux_ids: list[int],
         qids: list[str],
-        context: "OrderingContext",
+        context: OrderingContext,
     ) -> list[list[str]]:
         """Generate synchronized parallel steps across all MUXes.
 

--- a/src/qdash/workflow/engine/scheduler/one_qubit_plugins.py
+++ b/src/qdash/workflow/engine/scheduler/one_qubit_plugins.py
@@ -76,7 +76,6 @@ class MuxOrderingStrategy(ABC):
         Returns:
             Ordered list of qubit IDs for sequential execution within this MUX
         """
-        pass
 
     @abstractmethod
     def get_metadata(self) -> dict[str, Any]:
@@ -85,7 +84,6 @@ class MuxOrderingStrategy(ABC):
         Returns:
             Dictionary containing strategy-specific metadata
         """
-        pass
 
     @abstractmethod
     def generate_synchronized_steps(
@@ -105,7 +103,6 @@ class MuxOrderingStrategy(ABC):
             List of steps, where each step is a list of qubit IDs
             that can be executed simultaneously
         """
-        pass
 
     def __repr__(self) -> str:
         """String representation of the strategy."""

--- a/src/qdash/workflow/engine/scheduler/one_qubit_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/one_qubit_scheduler.py
@@ -546,10 +546,7 @@ class OneQubitScheduler:
         # Apply ordering strategy if provided
         if ordering_strategy is not None:
             # Determine grid size from chip_id
-            if "144" in self.chip_id:
-                grid_size = 12
-            else:
-                grid_size = 8
+            grid_size = 12 if "144" in self.chip_id else 8
             mux_grid_size = grid_size // 2
 
             context = OrderingContext(
@@ -809,7 +806,7 @@ class OneQubitScheduler:
             qids = [qid for qid in qids if qid not in exclude_set]
             excluded_count = original_count - len(qids)
             logger.info(
-                f"Excluded {excluded_count} qubits: {sorted(exclude_set & set(str(mux_id * 4 + o) for mux_id in mux_ids for o in range(4)))}"
+                f"Excluded {excluded_count} qubits: {sorted(exclude_set & {str(mux_id * 4 + o) for mux_id in mux_ids for o in range(4)})}"
             )
 
             if len(qids) == 0:
@@ -934,10 +931,7 @@ class OneQubitScheduler:
         qid_to_mux = self._build_qubit_to_mux_map(wiring_config)
 
         # Determine grid size from chip_id
-        if "144" in self.chip_id:
-            grid_size = 12
-        else:
-            grid_size = 8
+        grid_size = 12 if "144" in self.chip_id else 8
         mux_grid_size = grid_size // 2
 
         # Create ordering context

--- a/src/qdash/workflow/engine/scheduler/one_qubit_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/one_qubit_scheduler.py
@@ -52,7 +52,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
-
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 
 if TYPE_CHECKING:
@@ -918,7 +917,6 @@ class OneQubitScheduler:
         from qdash.workflow.engine.scheduler.one_qubit_plugins import (
             CheckerboardOrderingStrategy,
             DefaultSynchronizedStrategy,
-            MuxOrderingStrategy,
             OrderingContext,
         )
 

--- a/src/qdash/workflow/engine/scheduler/plugins.py
+++ b/src/qdash/workflow/engine/scheduler/plugins.py
@@ -44,9 +44,10 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from qdash.datamodel.chip import ChipModel
+if TYPE_CHECKING:
+    from qdash.datamodel.chip import ChipModel
 
 logger = logging.getLogger(__name__)
 
@@ -99,7 +100,6 @@ class CRPairFilter(ABC):
         Returns:
             Filtered list of CR pair strings
         """
-        pass
 
     @abstractmethod
     def get_stats(self) -> dict[str, Any]:
@@ -108,7 +108,6 @@ class CRPairFilter(ABC):
         Returns:
             Dictionary containing filter-specific statistics
         """
-        pass
 
     def __repr__(self) -> str:
         """String representation of the filter."""
@@ -133,7 +132,6 @@ class CRSchedulingStrategy(ABC):
         Returns:
             List of groups where each group contains CR pairs that can run in parallel
         """
-        pass
 
     @abstractmethod
     def get_metadata(self) -> dict[str, Any]:
@@ -142,7 +140,6 @@ class CRSchedulingStrategy(ABC):
         Returns:
             Dictionary containing scheduler-specific metadata
         """
-        pass
 
     def __repr__(self) -> str:
         """String representation of the scheduler."""

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -99,7 +99,6 @@ class TaskExecutionError(Exception):
     """Exception raised when task execution fails."""
 
 
-
 class TaskExecutionResult(BaseModel):
     """Result of task execution.
 

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -98,7 +98,6 @@ class BackendProtocol(Protocol):
 class TaskExecutionError(Exception):
     """Exception raised when task execution fails."""
 
-    pass
 
 
 class TaskExecutionResult(BaseModel):

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -15,9 +15,9 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 from qdash.datamodel.task import CalibDataModel, OutputParameterModel
+from qdash.repository import FilesystemCalibDataSaver
 from qdash.workflow.calibtasks.results import PostProcessResult, PreProcessResult, RunResult
 from qdash.workflow.engine.params_updater import get_params_updater
-from qdash.repository import FilesystemCalibDataSaver
 from qdash.workflow.engine.task.history_recorder import TaskHistoryRecorder
 from qdash.workflow.engine.task.result_processor import (
     FidelityValidationError,

--- a/src/qdash/workflow/engine/task/result_processor.py
+++ b/src/qdash/workflow/engine/task/result_processor.py
@@ -17,15 +17,12 @@ class TaskResultProcessingError(Exception):
     """Exception raised when task result processing fails."""
 
 
-
 class R2ValidationError(TaskResultProcessingError):
     """Exception raised when R² validation fails."""
 
 
-
 class FidelityValidationError(TaskResultProcessingError):
     """Exception raised when fidelity validation fails."""
-
 
 
 class TaskResultProcessor:

--- a/src/qdash/workflow/engine/task/result_processor.py
+++ b/src/qdash/workflow/engine/task/result_processor.py
@@ -16,19 +16,16 @@ logger = logging.getLogger(__name__)
 class TaskResultProcessingError(Exception):
     """Exception raised when task result processing fails."""
 
-    pass
 
 
 class R2ValidationError(TaskResultProcessingError):
     """Exception raised when R² validation fails."""
 
-    pass
 
 
 class FidelityValidationError(TaskResultProcessingError):
     """Exception raised when fidelity validation fails."""
 
-    pass
 
 
 class TaskResultProcessor:

--- a/src/qdash/workflow/engine/task/state_manager.py
+++ b/src/qdash/workflow/engine/task/state_manager.py
@@ -8,8 +8,6 @@ from collections.abc import Iterator
 from typing import Any, cast
 
 import pendulum
-
-from qdash.datamodel.task import TaskTypes
 from pydantic import BaseModel
 from qdash.datamodel.task import (
     BaseTaskResultModel,
@@ -21,6 +19,7 @@ from qdash.datamodel.task import (
     SystemTaskModel,
     TaskResultModel,
     TaskStatusModel,
+    TaskTypes,
 )
 
 

--- a/src/qdash/workflow/engine/task_runner.py
+++ b/src/qdash/workflow/engine/task_runner.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING
 
 from prefect import get_run_logger, task
 from qdash.dbmodel.initialize import initialize
-from qdash.workflow.calibtasks.base import BaseTask
-from qdash.workflow.engine.backend.base import BaseBackend
-from qdash.workflow.engine.execution.service import ExecutionService
-from qdash.workflow.engine.task.context import TaskContext
 
 if TYPE_CHECKING:
     from qdash.repository.protocols import TaskRepository
+    from qdash.workflow.calibtasks.base import BaseTask
+    from qdash.workflow.engine.backend.base import BaseBackend
+    from qdash.workflow.engine.execution.service import ExecutionService
+    from qdash.workflow.engine.task.context import TaskContext
 
 
 def validate_task_name(

--- a/src/qdash/workflow/paths.py
+++ b/src/qdash/workflow/paths.py
@@ -9,7 +9,7 @@ For host-side path customization, use .env and docker-compose.yaml volume mounts
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 # Re-export path constants from common module for backward compatibility
 from qdash.common.paths import (
@@ -20,6 +20,9 @@ from qdash.common.paths import (
     USER_FLOWS_DIR,
     WORKFLOW_DIR,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class PathResolver:

--- a/src/qdash/workflow/service/__init__.py
+++ b/src/qdash/workflow/service/__init__.py
@@ -55,16 +55,16 @@ from qdash.workflow.service.calib_service import (
     CalibService,
     generate_execution_id,
 )
+from qdash.workflow.service.github import (
+    ConfigFileType,
+    GitHubIntegration,
+    GitHubPushConfig,
+)
 from qdash.workflow.service.session_context import (
     SessionContext,
     clear_current_session,
     get_current_session,
     set_current_session,
-)
-from qdash.workflow.service.github import (
-    ConfigFileType,
-    GitHubIntegration,
-    GitHubPushConfig,
 )
 from qdash.workflow.service.steps import (
     CalibrationStep,

--- a/src/qdash/workflow/service/_internal/scheduling_tasks.py
+++ b/src/qdash/workflow/service/_internal/scheduling_tasks.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from qdash.workflow.service.calib_service import CalibService
 
 
-def _get_session() -> "CalibService":
+def _get_session() -> CalibService:
     """Get the current session from global context (internal use)."""
     from qdash.workflow.service.session_context import get_current_session
 

--- a/src/qdash/workflow/service/_internal/scheduling_tasks.py
+++ b/src/qdash/workflow/service/_internal/scheduling_tasks.py
@@ -111,7 +111,7 @@ def calibrate_step_qubits_parallel(parallel_qids: list[str], tasks: list[str]) -
     # Submit all qubits in parallel
     futures = [calibrate_single_qubit.submit(qid, tasks) for qid in parallel_qids]
     pair_results = [f.result() for f in futures]
-    return {qid: result for qid, result in pair_results}
+    return dict(pair_results)
 
 
 # =============================================================================
@@ -159,4 +159,4 @@ def calibrate_parallel_group(coupling_qids: list[str], tasks: list[str]) -> dict
     """
     futures = [execute_coupling_pair.submit(cqid, tasks) for cqid in coupling_qids]
     pair_results = [f.result() for f in futures]
-    return {qid: result for qid, result in pair_results}
+    return dict(pair_results)

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -29,16 +29,20 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from qdash.repository.protocols import (
         ExecutionCounterRepository,
         ExecutionLockRepository,
         UserRepository,
     )
+    from qdash.workflow.engine.backend.base import BaseBackend
+    from qdash.workflow.engine.execution.service import ExecutionService
+    from qdash.workflow.engine.task.context import TaskContext
     from qdash.workflow.service.steps import Step
     from qdash.workflow.service.targets import Target
 
@@ -47,10 +51,7 @@ from prefect import get_run_logger
 
 logger = logging.getLogger(__name__)
 from qdash.workflow.engine import CalibConfig, CalibOrchestrator
-from qdash.workflow.engine.backend.base import BaseBackend
-from qdash.workflow.engine.execution.service import ExecutionService
 from qdash.workflow.engine.params_updater import get_params_updater
-from qdash.workflow.engine.task.context import TaskContext
 from qdash.workflow.service.github import GitHubIntegration, GitHubPushConfig
 
 
@@ -523,7 +524,7 @@ class CalibService:
                 continue
             try:
                 updater_instance.update(qid, params)
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 logger.warning(f"Failed to sync params for qid={qid}: {exc}")
 
     def finish_calibration(

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -29,8 +29,9 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from qdash.repository.protocols import (
@@ -45,10 +46,10 @@ import pendulum
 from prefect import get_run_logger
 
 logger = logging.getLogger(__name__)
+from qdash.workflow.engine import CalibConfig, CalibOrchestrator
 from qdash.workflow.engine.backend.base import BaseBackend
 from qdash.workflow.engine.execution.service import ExecutionService
 from qdash.workflow.engine.params_updater import get_params_updater
-from qdash.workflow.engine import CalibConfig, CalibOrchestrator
 from qdash.workflow.engine.task.context import TaskContext
 from qdash.workflow.service.github import GitHubIntegration, GitHubPushConfig
 
@@ -693,8 +694,8 @@ class CalibService:
 
     def run(
         self,
-        targets: "Target",
-        steps: "Sequence[Step]",
+        targets: Target,
+        steps: Sequence[Step],
     ) -> dict[str, Any]:
         """Run calibration pipeline with targets and steps.
 
@@ -731,8 +732,8 @@ class CalibService:
 
     def _run_pipeline(
         self,
-        targets: "Target",
-        steps: "Sequence[Step]",
+        targets: Target,
+        steps: Sequence[Step],
     ) -> dict[str, Any]:
         """Execute a calibration pipeline with steps.
 

--- a/src/qdash/workflow/service/github.py
+++ b/src/qdash/workflow/service/github.py
@@ -15,7 +15,6 @@ from typing import Any
 
 from prefect import get_run_logger
 from pydantic import BaseModel, Field
-
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 
 

--- a/src/qdash/workflow/service/results.py
+++ b/src/qdash/workflow/service/results.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-
 # =============================================================================
 # Base Result Types
 # =============================================================================

--- a/src/qdash/workflow/service/steps/__init__.py
+++ b/src/qdash/workflow/service/steps/__init__.py
@@ -37,12 +37,6 @@ from qdash.workflow.service.steps.base import (
     TransformStep,
 )
 
-# Context and Pipeline
-from qdash.workflow.service.steps.pipeline import (
-    Pipeline,
-    StepContext,
-)
-
 # Filter steps
 from qdash.workflow.service.steps.filters import (
     FilterByMetric,
@@ -54,6 +48,12 @@ from qdash.workflow.service.steps.one_qubit import (
     CustomOneQubit,
     OneQubitCheck,
     OneQubitFineTune,
+)
+
+# Context and Pipeline
+from qdash.workflow.service.steps.pipeline import (
+    Pipeline,
+    StepContext,
 )
 
 # 2-Qubit and system steps

--- a/src/qdash/workflow/service/steps/base.py
+++ b/src/qdash/workflow/service/steps/base.py
@@ -79,7 +79,6 @@ class CalibrationStep(Step):
     Examples: OneQubitCheck, OneQubitFineTune, TwoQubitCalibration
     """
 
-    pass
 
 
 @dataclass
@@ -92,4 +91,3 @@ class TransformStep(Step):
     Examples: FilterByMetric, FilterByStatus, GenerateCRSchedule
     """
 
-    pass

--- a/src/qdash/workflow/service/steps/base.py
+++ b/src/qdash/workflow/service/steps/base.py
@@ -80,7 +80,6 @@ class CalibrationStep(Step):
     """
 
 
-
 @dataclass
 class TransformStep(Step):
     """Base class for steps that transform data without hardware execution.
@@ -90,4 +89,3 @@ class TransformStep(Step):
 
     Examples: FilterByMetric, FilterByStatus, GenerateCRSchedule
     """
-

--- a/src/qdash/workflow/service/steps/base.py
+++ b/src/qdash/workflow/service/steps/base.py
@@ -52,10 +52,10 @@ class Step(ABC):
     @abstractmethod
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Execute the step.
 
         Args:

--- a/src/qdash/workflow/service/steps/filters.py
+++ b/src/qdash/workflow/service/steps/filters.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from prefect import get_run_logger
-
 from qdash.workflow.service.results import FilterResult
 from qdash.workflow.service.steps.base import TransformStep
 
@@ -49,10 +48,10 @@ class FilterByMetric(TransformStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Filter candidate qubits by metric threshold."""
         logger = get_run_logger()
 
@@ -107,10 +106,10 @@ class FilterByStatus(TransformStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Filter candidate qubits by success status."""
         logger = get_run_logger()
 

--- a/src/qdash/workflow/service/steps/one_qubit.py
+++ b/src/qdash/workflow/service/steps/one_qubit.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from prefect import get_run_logger
-
 from qdash.workflow.service.results import OneQubitResult
 from qdash.workflow.service.steps.base import CalibrationStep
 from qdash.workflow.service.tasks import CHECK_1Q_TASKS, FULL_1Q_TASKS_AFTER_CHECK
@@ -58,10 +57,10 @@ class CustomOneQubit(CalibrationStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Execute custom 1-qubit calibration."""
         logger = get_run_logger()
 
@@ -102,7 +101,7 @@ class CustomOneQubit(CalibrationStep):
 
     def _execute_direct(
         self,
-        service: "CalibService",
+        service: CalibService,
         qids: list[str],
     ) -> dict[str, Any]:
         """Direct execution for QubitTargets."""
@@ -168,10 +167,10 @@ class OneQubitCheck(CalibrationStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Execute 1-qubit check calibration."""
         logger = get_run_logger()
         tasks = self.tasks or CHECK_1Q_TASKS
@@ -207,7 +206,7 @@ class OneQubitCheck(CalibrationStep):
 
     def _execute_direct(
         self,
-        service: "CalibService",
+        service: CalibService,
         qids: list[str],
         tasks: list[str],
     ) -> dict[str, Any]:
@@ -284,10 +283,10 @@ class OneQubitFineTune(CalibrationStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Execute 1-qubit fine-tuning calibration."""
         logger = get_run_logger()
         tasks = self.tasks or FULL_1Q_TASKS_AFTER_CHECK
@@ -318,7 +317,7 @@ class OneQubitFineTune(CalibrationStep):
 
     def _execute_with_qids(
         self,
-        service: "CalibService",
+        service: CalibService,
         qids: list[str],
         tasks: list[str],
     ) -> dict[str, Any]:
@@ -343,7 +342,7 @@ class OneQubitFineTune(CalibrationStep):
 
     def _execute_direct(
         self,
-        service: "CalibService",
+        service: CalibService,
         qids: list[str],
         tasks: list[str],
     ) -> dict[str, Any]:

--- a/src/qdash/workflow/service/steps/one_qubit.py
+++ b/src/qdash/workflow/service/steps/one_qubit.py
@@ -325,7 +325,7 @@ class OneQubitFineTune(CalibrationStep):
         from qdash.workflow.service.strategy import OneQubitConfig, get_one_qubit_strategy
 
         # Convert qids to mux_ids for strategy
-        mux_ids = sorted(set(int(qid) // 4 for qid in qids))
+        mux_ids = sorted({int(qid) // 4 for qid in qids})
         exclude_qids: list[str] = []
 
         config = OneQubitConfig(

--- a/src/qdash/workflow/service/steps/pipeline.py
+++ b/src/qdash/workflow/service/steps/pipeline.py
@@ -6,18 +6,18 @@ and Pipeline for validating step sequences.
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from qdash.workflow.service.results import (
-    FilterResult,
-    OneQubitResult,
-    SkewCheckResult,
-    TwoQubitResult,
-)
-
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+    from qdash.workflow.service.results import (
+        FilterResult,
+        OneQubitResult,
+        SkewCheckResult,
+        TwoQubitResult,
+    )
     from qdash.workflow.service.steps.base import Step
 
 

--- a/src/qdash/workflow/service/steps/pipeline.py
+++ b/src/qdash/workflow/service/steps/pipeline.py
@@ -6,8 +6,9 @@ and Pipeline for validating step sequences.
 
 from __future__ import annotations
 
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Iterator, Sequence
+from typing import TYPE_CHECKING, Any
 
 from qdash.workflow.service.results import (
     FilterResult,
@@ -73,7 +74,7 @@ class Pipeline:
         # Raises ValueError if dependencies are not satisfied
     """
 
-    steps: Sequence["Step"]
+    steps: Sequence[Step]
 
     def __post_init__(self) -> None:
         """Validate step dependencies."""
@@ -107,7 +108,7 @@ class Pipeline:
             # Add what this step provides
             available.update(step.provides)
 
-    def __iter__(self) -> Iterator["Step"]:
+    def __iter__(self) -> Iterator[Step]:
         """Iterate over steps."""
         return iter(self.steps)
 

--- a/src/qdash/workflow/service/steps/two_qubit.py
+++ b/src/qdash/workflow/service/steps/two_qubit.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from prefect import get_run_logger
-
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 from qdash.workflow.service.results import SkewCheckResult, TwoQubitResult
 from qdash.workflow.service.steps.base import CalibrationStep, TransformStep
@@ -64,10 +63,10 @@ class CustomTwoQubit(CalibrationStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Execute custom 2-qubit calibration."""
         logger = get_run_logger()
 
@@ -213,10 +212,10 @@ class GenerateCRSchedule(TransformStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Generate CR schedule from candidate qubits."""
         logger = get_run_logger()
 
@@ -287,10 +286,10 @@ class TwoQubitCalibration(CalibrationStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Execute 2-qubit calibration."""
         logger = get_run_logger()
         tasks = self.tasks or FULL_2Q_TASKS
@@ -439,10 +438,10 @@ class CheckSkew(CalibrationStep):
 
     def execute(
         self,
-        service: "CalibService",
-        targets: "Target",
-        ctx: "StepContext",
-    ) -> "StepContext":
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
         """Execute skew check."""
         logger = get_run_logger()
 

--- a/src/qdash/workflow/service/strategy.py
+++ b/src/qdash/workflow/service/strategy.py
@@ -10,11 +10,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from prefect import get_run_logger
-
 from qdash.workflow.engine import OneQubitScheduler
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 from qdash.workflow.service._internal.scheduling_tasks import (
     calibrate_mux_qubits as _calibrate_mux_qubits,
+)
+from qdash.workflow.service._internal.scheduling_tasks import (
     calibrate_step_qubits_parallel as _calibrate_step_qubits_parallel,
 )
 from qdash.workflow.service.calib_service import finish_calibration, get_session, init_calibration

--- a/src/qdash/workflow/service/targets.py
+++ b/src/qdash/workflow/service/targets.py
@@ -45,7 +45,6 @@ class Target(ABC):
         Returns:
             List of qubit IDs
         """
-        pass
 
     @abstractmethod
     def to_coupling_ids(self, chip_id: str) -> list[str]:
@@ -57,7 +56,6 @@ class Target(ABC):
         Returns:
             List of coupling IDs (e.g., ["0-1", "2-3"])
         """
-        pass
 
 
 @dataclass

--- a/src/qdash/workflow/templates/check_skew.py
+++ b/src/qdash/workflow/templates/check_skew.py
@@ -13,7 +13,6 @@ Example:
 from typing import Any
 
 from prefect import flow, get_run_logger
-
 from qdash.workflow.service import CalibService
 
 

--- a/src/qdash/workflow/templates/full_calibration.py
+++ b/src/qdash/workflow/templates/full_calibration.py
@@ -21,7 +21,6 @@ Example:
 from typing import Any
 
 from prefect import flow
-
 from qdash.workflow.service import CalibService
 from qdash.workflow.service.steps import (
     FilterByMetric,

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -13,7 +13,6 @@ Example:
 from typing import Any
 
 from prefect import flow
-
 from qdash.workflow.service import CalibService
 from qdash.workflow.service.steps import (
     FilterByStatus,

--- a/src/qdash/workflow/templates/simple.py
+++ b/src/qdash/workflow/templates/simple.py
@@ -14,7 +14,6 @@ Example:
 from typing import Any
 
 from prefect import flow
-
 from qdash.workflow.service import CalibService
 from qdash.workflow.service.steps import CustomOneQubit
 from qdash.workflow.service.targets import QubitTargets

--- a/src/qdash/workflow/worker/flows/push_calib_note/flow.py
+++ b/src/qdash/workflow/worker/flows/push_calib_note/flow.py
@@ -2,9 +2,8 @@ import json
 from pathlib import Path
 
 from prefect import flow
-
-from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 from qdash.repository import MongoCalibrationNoteRepository
+from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 from qdash.workflow.worker.tasks.push_github import push_github
 
 

--- a/src/qdash/workflow/worker/flows/push_props/flow.py
+++ b/src/qdash/workflow/worker/flows/push_props/flow.py
@@ -1,5 +1,4 @@
 from prefect import flow
-
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 from qdash.workflow.worker.flows.push_props.create_props import create_chip_properties
 from qdash.workflow.worker.tasks.push_github import push_github

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,7 +144,6 @@ def test_client(init_db):
 
     """
     from fastapi.testclient import TestClient
-
     from qdash.api.main import app
 
     return TestClient(app)

--- a/tests/data/sample_data.py
+++ b/tests/data/sample_data.py
@@ -1,7 +1,7 @@
 """Sample test data for various test scenarios."""
 
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any
 
 # User test data
 SAMPLE_USERS = {
@@ -210,9 +210,9 @@ SAMPLE_ERROR_RESPONSES = {
 }
 
 
-def get_sample_data(category: str, key: str) -> Dict[str, Any]:
+def get_sample_data(category: str, key: str) -> dict[str, Any]:
     """Get sample data by category and key."""
-    data_maps: Dict[str, Dict[str, Any]] = {
+    data_maps: dict[str, dict[str, Any]] = {
         "users": SAMPLE_USERS,
         "chips": SAMPLE_CHIPS,
         "calibrations": SAMPLE_CALIBRATIONS,
@@ -231,9 +231,9 @@ def get_sample_data(category: str, key: str) -> Dict[str, Any]:
     return data_maps[category][key].copy()
 
 
-def get_all_sample_data(category: str) -> Dict[str, Any]:
+def get_all_sample_data(category: str) -> dict[str, Any]:
     """Get all sample data for a category."""
-    data_maps: Dict[str, Dict[str, Any]] = {
+    data_maps: dict[str, dict[str, Any]] = {
         "users": SAMPLE_USERS,
         "chips": SAMPLE_CHIPS,
         "calibrations": SAMPLE_CALIBRATIONS,

--- a/tests/qdash/api/routers/test_admin.py
+++ b/tests/qdash/api/routers/test_admin.py
@@ -1,7 +1,6 @@
 """Tests for admin API endpoints."""
 
 import pytest
-
 from qdash.datamodel.project import ProjectRole
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.datamodel.user import SystemRole

--- a/tests/qdash/api/routers/test_backend.py
+++ b/tests/qdash/api/routers/test_backend.py
@@ -1,7 +1,6 @@
 """Tests for backend router endpoints."""
 
 import pytest
-
 from qdash.datamodel.project import ProjectRole
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.backend import BackendDocument

--- a/tests/qdash/api/routers/test_chip.py
+++ b/tests/qdash/api/routers/test_chip.py
@@ -1,7 +1,6 @@
 """Tests for chip router endpoints."""
 
 import pytest
-
 from qdash.datamodel.project import ProjectRole
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.chip import ChipDocument

--- a/tests/qdash/api/routers/test_flow.py
+++ b/tests/qdash/api/routers/test_flow.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from qdash.datamodel.project import ProjectRole
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.flow import FlowDocument

--- a/tests/qdash/workflow/engine/execution/test_service.py
+++ b/tests/qdash/workflow/engine/execution/test_service.py
@@ -3,8 +3,6 @@
 from collections.abc import Callable
 
 import pytest
-from unittest.mock import MagicMock, patch
-
 from qdash.datamodel.execution import (
     CalibDataModel,
     ExecutionModel,
@@ -13,9 +11,6 @@ from qdash.datamodel.execution import (
 )
 from qdash.datamodel.task import OutputParameterModel
 from qdash.workflow.engine.execution.service import ExecutionService
-from qdash.workflow.engine.execution.state_manager import (
-    ExecutionStateManager,
-)
 
 
 class MockExecutionRepository:

--- a/tests/qdash/workflow/engine/repository/test_filesystem_impl.py
+++ b/tests/qdash/workflow/engine/repository/test_filesystem_impl.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import numpy as np
 import plotly.graph_objs as go
 import pytest
-
 from qdash.repository.filesystem import FilesystemCalibDataSaver
 
 

--- a/tests/qdash/workflow/engine/repository/test_inmemory_impl.py
+++ b/tests/qdash/workflow/engine/repository/test_inmemory_impl.py
@@ -1,7 +1,6 @@
 """Tests for InMemory repository implementations."""
 
 import pytest
-
 from qdash.datamodel.execution import (
     ExecutionModel,
     ExecutionStatusModel,

--- a/tests/qdash/workflow/engine/repository/test_inmemory_integration.py
+++ b/tests/qdash/workflow/engine/repository/test_inmemory_integration.py
@@ -5,7 +5,6 @@ enabling MongoDB-free testing of workflow logic.
 """
 
 import pytest
-
 from qdash.datamodel.execution import ExecutionModel, ExecutionStatusModel
 from qdash.workflow.engine.repository import (
     InMemoryExecutionCounterRepository,

--- a/tests/qdash/workflow/engine/scheduler/test_cr_scheduler.py
+++ b/tests/qdash/workflow/engine/scheduler/test_cr_scheduler.py
@@ -7,10 +7,9 @@ These tests verify the CRScheduler functionality including:
 - Parallel grouping
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
-from pathlib import Path
 
+import pytest
 from qdash.workflow.engine.scheduler.cr_scheduler import CRScheduler, CRScheduleResult
 
 

--- a/tests/qdash/workflow/engine/scheduler/test_one_qubit_plugins.py
+++ b/tests/qdash/workflow/engine/scheduler/test_one_qubit_plugins.py
@@ -1,7 +1,6 @@
 """Tests for 1-Qubit Scheduler Ordering Plugins."""
 
 import pytest
-
 from qdash.workflow.engine.scheduler.one_qubit_plugins import (
     CheckerboardOrderingStrategy,
     DefaultOrderingStrategy,

--- a/tests/qdash/workflow/engine/scheduler/test_one_qubit_scheduler.py
+++ b/tests/qdash/workflow/engine/scheduler/test_one_qubit_scheduler.py
@@ -9,16 +9,12 @@ These tests verify the OneQubitScheduler functionality including:
 
 import pytest
 import yaml
-
 from qdash.workflow.engine.scheduler.one_qubit_scheduler import (
     BOX_A,
     BOX_B,
     BOX_MIXED,
     OneQubitScheduler,
     OneQubitScheduleResult,
-    OneQubitStageInfo,
-    SynchronizedOneQubitScheduleResult,
-    SynchronizedStepInfo,
 )
 
 

--- a/tests/qdash/workflow/engine/scheduler/test_plugins.py
+++ b/tests/qdash/workflow/engine/scheduler/test_plugins.py
@@ -7,17 +7,17 @@ These tests verify the pluggable filter and scheduler architecture including:
 - Integration with CRScheduler
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
 from qdash.workflow.engine.scheduler.cr_scheduler import CRScheduler
 from qdash.workflow.engine.scheduler.plugins import (
     CandidateQubitFilter,
     FidelityFilter,
     FilterContext,
     FrequencyDirectionalityFilter,
-    MuxConflictScheduler,
     IntraThenInterMuxScheduler,
+    MuxConflictScheduler,
     ScheduleContext,
 )
 

--- a/tests/qdash/workflow/engine/task/test_executor.py
+++ b/tests/qdash/workflow/engine/task/test_executor.py
@@ -1,9 +1,10 @@
 """Tests for TaskExecutor."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from qdash.datamodel.task import OutputParameterModel, QubitTaskModel, TaskStatusModel
+from qdash.workflow.calibtasks.base import PostProcessResult, PreProcessResult, RunResult
 from qdash.workflow.engine.task.executor import (
     TaskExecutionError,
     TaskExecutor,
@@ -13,7 +14,6 @@ from qdash.workflow.engine.task.result_processor import (
     FidelityValidationError,
     R2ValidationError,
 )
-from qdash.workflow.calibtasks.base import PostProcessResult, PreProcessResult, RunResult
 
 
 class MockTask:

--- a/tests/qdash/workflow/engine/task/test_history_recorder.py
+++ b/tests/qdash/workflow/engine/task/test_history_recorder.py
@@ -1,6 +1,6 @@
 """Tests for TaskHistoryRecorder."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from qdash.datamodel.execution import ExecutionModel, ExecutionStatusModel

--- a/tests/qdash/workflow/engine/test_params_updater.py
+++ b/tests/qdash/workflow/engine/test_params_updater.py
@@ -6,10 +6,9 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from qdash.workflow.engine.params_updater import _QubexParamsUpdater
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
-
-from qdash.workflow.engine.params_updater import _QubexParamsUpdater
 
 
 class TestParamsUpdaterNoneHandling:
@@ -165,7 +164,7 @@ data:
     def test_atomic_write_no_partial_content(self, updater, yaml_file):
         """Test that atomic write prevents partial content."""
         # Read original content
-        original_content = yaml_file.read_text()
+        yaml_file.read_text()
 
         # Update should be atomic
         updater._update_yaml(yaml_file, "Q00", 100.0)

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -3,9 +3,9 @@
 These tests verify the CalibService API and helper functions for custom calibration flows.
 """
 
-import pytest
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock
 
+import pytest
 from qdash.workflow.service.calib_service import (
     CalibService,
     finish_calibration,


### PR DESCRIPTION
- Enable additional Ruff rule sets (type-checking, pylint, perflint, bandit, etc.)
- Add targeted global/per-file ignores to match project conventions and reduce noise
- Update metrics PDF generator to use TYPE_CHECKING imports and iterate via `.values()` to satisfy lint/perf rules
- Drop unused-argument suppression where no longer needed in task runners
