### PR TITLE
docs(qdash): expand package structure docs and module docstrings

### DIFF
--- a/docs/development/workflow/quickstart.md
+++ b/docs/development/workflow/quickstart.md
@@ -1,0 +1,95 @@
+# Workflow Engine Quickstart
+
+This guide helps you get started with the QDash workflow engine.
+
+## Overview
+
+The workflow engine executes calibration tasks using [Prefect](https://www.prefect.io/).
+For detailed architecture, see [Engine Architecture](./engine-architecture.md).
+
+## Key Components
+
+```
+workflow/
+├── engine/           # Core execution engine
+│   ├── orchestrator.py   # Session lifecycle (start here)
+│   ├── task_runner.py    # Prefect task wrappers
+│   └── task/             # Task execution layer
+├── calibtasks/       # Calibration task definitions
+└── service/          # High-level service APIs
+```
+
+## Basic Usage
+
+### 1. Running a Calibration Session
+
+```python
+from qdash.workflow.engine import CalibOrchestrator, CalibConfig
+
+# Configure the session
+config = CalibConfig(
+    username="alice",
+    chip_id="64Qv3",
+    qids=["0", "1"],
+    execution_id="20240101-001",
+)
+
+# Initialize and run
+orchestrator = CalibOrchestrator(config)
+orchestrator.initialize()
+
+# Execute a task
+result = orchestrator.run_task("CheckRabi", qid="0")
+
+# Complete the session
+orchestrator.complete()
+```
+
+### 2. Understanding the Execution Flow
+
+1. `CalibOrchestrator.initialize()` - Creates directories, connects to backend
+2. `orchestrator.run_task()` - Executes a single calibration task
+3. `orchestrator.complete()` - Finalizes session, saves results to MongoDB
+
+## Adding a New Calibration Task
+
+1. Create a task class in `workflow/calibtasks/`:
+
+```python
+from qdash.workflow.calibtasks.base import BaseTask
+
+class MyNewTask(BaseTask):
+    name = "MyNewTask"
+    
+    def preprocess(self, backend):
+        # Extract input parameters
+        pass
+    
+    def run(self, backend):
+        # Execute measurement
+        pass
+    
+    def postprocess(self, backend, result):
+        # Process results, generate figures
+        pass
+```
+
+2. Register it in `workflow/calibtasks/active_protocols.py`
+
+## Testing
+
+Use the `FakeBackend` for testing without hardware:
+
+```python
+config = CalibConfig(
+    backend_name="fake",  # Use fake backend
+    ...
+)
+```
+
+See [Testing Guidelines](./testing.md) for more details.
+
+## Next Steps
+
+- [Engine Architecture](./engine-architecture.md) - Deep dive into components
+- [Testing Guidelines](./testing.md) - How to test workflow code

--- a/src/qdash/README.md
+++ b/src/qdash/README.md
@@ -1,1 +1,28 @@
-# QDash
+# QDash Python Package
+
+Python backend code for QDash.
+
+## Module Structure
+
+| Directory | Description |
+|-----------|-------------|
+| `api/` | FastAPI backend API |
+| `workflow/` | Prefect workflow engine |
+| `repository/` | Data access layer (Repository Pattern) |
+| `datamodel/` | Domain models (for business logic) |
+| `dbmodel/` | Database models (MongoDB/Bunnet) |
+| `common/` | Common utilities |
+| `config.py` | Application settings |
+
+## Entry Points
+
+- **API**: `api/main.py` - FastAPI application
+- **Workflow**: `workflow/deployment_service.py` - Prefect deployment
+
+## Documentation
+
+See [docs/development/](../../docs/development/) for details.
+
+- [API Design Guidelines](../../docs/development/api/design.md)
+- [Workflow Engine Architecture](../../docs/development/workflow/engine-architecture.md)
+- [Development Setup](../../docs/development/setup.md)

--- a/src/qdash/api/schemas/__init__.py
+++ b/src/qdash/api/schemas/__init__.py
@@ -1,4 +1,14 @@
-"""API schema definitions."""
+"""API Schemas.
+
+Defines request/response types for FastAPI endpoints.
+TypeScript types for the frontend are auto-generated based on OpenAPI spec.
+
+Related modules:
+- datamodel: Domain models for business logic
+- dbmodel: MongoDB persistence models
+
+Note: Run `task generate` to regenerate frontend types after modifying this directory.
+"""
 
 from qdash.api.schemas.auth import User, UserCreate
 from qdash.api.schemas.backend import BackendResponseModel

--- a/src/qdash/datamodel/__init__.py
+++ b/src/qdash/datamodel/__init__.py
@@ -1,4 +1,13 @@
-"""Convenience exports for datamodel package."""
+"""Domain Models.
+
+Defines data structures for business logic.
+These are pure Pydantic models without database dependencies.
+
+Related modules:
+- dbmodel: MongoDB persistence models (Bunnet Documents)
+- api/schemas: API request/response models
+- repository: Handles conversion between datamodel and dbmodel
+"""
 
 from qdash.datamodel.calibration_note import CalibrationNoteModel
 from qdash.datamodel.project import ProjectMembershipModel, ProjectModel, ProjectRole

--- a/src/qdash/dbmodel/__init__.py
+++ b/src/qdash/dbmodel/__init__.py
@@ -1,0 +1,10 @@
+"""Database Models.
+
+Defines Bunnet Document classes for MongoDB persistence.
+Each Document class includes collection name, indexes, and CRUD operations.
+
+Related modules:
+- datamodel: Domain models for business logic
+- api/schemas: API request/response models
+- repository: Handles conversion between datamodel and dbmodel
+"""


### PR DESCRIPTION
Add a detailed QDash package README plus clearer module docstrings for
api schemas, datamodel, and dbmodel to document responsibilities, entry
points, and cross-module relationships, improving onboarding and
maintenance.
