### PR TITLE
fix(flow): add timeouts and retries for deployment calls

### DIFF
--- a/src/qdash/api/lib/auth.py
+++ b/src/qdash/api/lib/auth.py
@@ -8,20 +8,20 @@ from qdash.datamodel.user import SystemRole
 from qdash.dbmodel.initialize import initialize
 from qdash.dbmodel.user import UserDocument
 
-# ロガーの設定
+# Logger configuration
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
-# モジュールレベルで初期化
+# Initialize at module level
 initialize()
 
-# bcryptの設定を最適化
+# Optimize bcrypt settings
 pwd_context = CryptContext(
     schemes=["bcrypt"],
     deprecated="auto",
-    bcrypt__rounds=10,  # 開発環境では少なめに設定
+    bcrypt__rounds=10,  # Lower rounds for development
     bcrypt__ident="2b",
-    truncate_error=False,  # パスワードの長さチェックを無効化
+    truncate_error=False,  # Disable password length check
 )
 
 # Bearer Token authentication scheme

--- a/src/qdash/api/lib/current_user.py
+++ b/src/qdash/api/lib/current_user.py
@@ -4,7 +4,7 @@ from typing import cast
 from fastapi import Depends
 from qdash.api.lib.auth import get_user, username_header
 
-# ロガーの設定
+# Logger configuration
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -33,7 +33,7 @@ def get_current_user_id(username: str | None = Depends(username_header)) -> str:
     except Exception as e:
         logger.debug(f"Error getting user from username: {e}")
 
-    # デフォルトユーザーを返す
+    # Return default user
     default_user = "default"
     logger.debug(f"Using default user: {default_user}")
     return default_user

--- a/src/qdash/api/routers/device_topology.py
+++ b/src/qdash/api/routers/device_topology.py
@@ -39,7 +39,7 @@ def search_coupling_data_by_control_qid(
     """Search for coupling data by control qubit id."""
     filtered = {}
     for key, value in cr_params.items():
-        # キーが '-' を含む場合は、左側を抽出
+        # If key contains '-', extract the left side
         left_side = key.split("-")[0] if "-" in key else key
         if left_side == search_term:
             filtered[key] = value

--- a/src/qdash/api/routers/execution.py
+++ b/src/qdash/api/routers/execution.py
@@ -66,7 +66,7 @@ def get_figure_by_path(path: str) -> FileResponse:
             status_code=404,
             detail=f"File not found: {path}",
         )
-    # FileResponse を使うことで Content-Length が設定され、chunked encoding が不要になる
+    # FileResponse sets Content-Length, avoiding chunked encoding
     return FileResponse(path, media_type="image/png")
 
 

--- a/src/qdash/api/services/execution_service.py
+++ b/src/qdash/api/services/execution_service.py
@@ -163,7 +163,7 @@ class ExecutionService:
             if not isinstance(result, dict):
                 result = result.model_dump()  # noqa: PLW2901
 
-            # グローバルタスクの処理
+            # Process global tasks
             if "global_tasks" in result:
                 if "global" not in grouped_tasks:
                     grouped_tasks["global"] = []
@@ -174,7 +174,7 @@ class ExecutionService:
                     grouped_tasks["system"] = []
                 grouped_tasks["system"].extend(result["system_tasks"])
 
-            # キュービットタスクの処理
+            # Process qubit tasks
             if "qubit_tasks" in result:
                 for qid, tasks in result["qubit_tasks"].items():
                     if qid not in grouped_tasks:
@@ -184,18 +184,18 @@ class ExecutionService:
                             task["qid"] = qid
                         grouped_tasks[qid].append(task)
 
-            # カップリングタスクの処理
+            # Process coupling tasks
             if "coupling_tasks" in result:
                 for tasks in result["coupling_tasks"].values():
                     if "coupling" not in grouped_tasks:
                         grouped_tasks["coupling"] = []
                     grouped_tasks["coupling"].extend(tasks)
 
-        # 各グループ内でstart_atによるソート
+        # Sort tasks within each group by start_at
         for group_tasks in grouped_tasks.values():
             group_tasks.sort(key=lambda x: x.get("start_at", "") or "9999-12-31T23:59:59")
 
-        # グループ自体をstart_atの早い順にソート
+        # Sort groups by earliest start_at
         def get_group_completion_time(group: list[dict[str, Any]]) -> str:
             completed_tasks = [t for t in group if t.get("start_at")]
             if not completed_tasks:
@@ -204,7 +204,7 @@ class ExecutionService:
 
         sorted_groups = sorted(grouped_tasks.items(), key=lambda x: get_group_completion_time(x[1]))
 
-        # ソートされたグループを1つのリストに結合
+        # Merge sorted groups into a single list
         flat_tasks = []
         for _, tasks in sorted_groups:
             flat_tasks.extend(tasks)

--- a/src/qdash/repository/backend.py
+++ b/src/qdash/repository/backend.py
@@ -37,4 +37,4 @@ class MongoBackendRepository:
 
         """
         backends = BackendDocument.find({"project_id": project_id}).to_list()
-        return [backend.dict() for backend in backends]
+        return [backend.model_dump() for backend in backends]

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/readout_configure.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/readout_configure.py
@@ -42,12 +42,12 @@ class ReadoutConfigure(QubexTask):
             qubits = [exp.get_qubit_label(int(qid)) for qid in qubits]
             for r in sys.resonators:
                 if r.qubit not in qubits:
-                    r.frequency = np.nan  # readoutだけ更新
+                    r.frequency = np.nan  # Update readout only
             exp.system_manager.set_experiment_system(sys)
             exp.system_manager.experiment_system.configure()
             exp.system_manager.push(
                 exp.box_ids, confirm=False
-            )  # controlはconfigの値でreadoutは指定した量子ビットのreadoutが紐づいているboxを更新
+            )  # Use config values for control, update box linked to specified qubit's readout
             return None
 
         readout_configure()

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_ramsey.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_ramsey.py
@@ -56,7 +56,7 @@ class CheckRamsey(QubexTask):
         y_data = result_y.normalized.astype(float)
         sweep = result_x.sweep_range.astype(float)
 
-        # 色を sweep の逆順でカラーマップ化
+        # Map colors in reverse order of sweep
         fig = go.Figure()
 
         fig.add_trace(

--- a/src/qdash/workflow/engine/backend/qubex.py
+++ b/src/qdash/workflow/engine/backend/qubex.py
@@ -180,7 +180,7 @@ class QubexBackend(BaseBackend):
         )
 
         if master_note is None:
-            # マスターノートが存在しない場合は新規作成
+            # Create new master note if it doesn't exist
             repo.upsert(
                 CalibrationNoteModel(
                     project_id=project_id,
@@ -192,7 +192,7 @@ class QubexBackend(BaseBackend):
                 )
             )
         else:
-            # マスターノートが存在する場合はマージ
+            # Merge with existing master note
             merged_note = merge_notes_by_timestamp(master_note.note, calib_note)
             repo.upsert(
                 CalibrationNoteModel(

--- a/src/qdash/workflow/worker/tasks/push_github.py
+++ b/src/qdash/workflow/worker/tasks/push_github.py
@@ -66,7 +66,7 @@ def push_github(
 
         # Git operations
         repo.index.add([str(target_file_path.relative_to(temp_dir))])
-        # 差分がなければスキップ
+        # Skip if no changes
         diff = repo.index.diff("HEAD")
         if not diff:
             logger.info("No changes to commit")


### PR DESCRIPTION
- Introduce a shared default httpx timeout configuration
- Add a POST helper with retry/backoff to reduce transient deployment failures
- Refactor cron scheduling response to reuse computed next_run value
- Translate inline comments from Japanese to English for consistency
