### PR TITLE
feat: support configurable MongoDB db name and rename migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ ENV="oqtopus"
 # =============================================================================
 MONGO_INITDB_ROOT_USERNAME=root
 MONGO_INITDB_ROOT_PASSWORD=example
+MONGO_DB_NAME=qdash
 
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=prefect

--- a/src/qdash/api/db/session.py
+++ b/src/qdash/api/db/session.py
@@ -49,7 +49,8 @@ def get_database() -> Database[Any]:
     """
     global _database
     if _database is None:
-        _database = get_mongo_client().qubex
+        db_name = os.getenv("MONGO_DB_NAME", "qdash")
+        _database = get_mongo_client()[db_name]
     return _database
 
 

--- a/src/qdash/config.py
+++ b/src/qdash/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     mongo_data_path: str
     calib_data_path: str
     backend: str = "qubex"  # Default backend is 'qubex'
+    # MongoDB
+    mongo_db_name: str = "qdash"  # MongoDB database name
     # Ports
     mongo_port: int = 27017
     mongo_express_port: int = 8081

--- a/src/qdash/dbmodel/initialize.py
+++ b/src/qdash/dbmodel/initialize.py
@@ -50,8 +50,9 @@ def initialize() -> None:
     if os.getenv("ENV") == "test":
         return
 
+    db_name = os.getenv("MONGO_DB_NAME", "qdash")
     init_bunnet(
-        database=_get_client().qubex,
+        database=_get_client()[db_name],
         document_models=document_models(),
     )
 

--- a/src/qdash/dbmodel/migration.py
+++ b/src/qdash/dbmodel/migration.py
@@ -3,10 +3,16 @@
 Run migrations with:
     python -m qdash.dbmodel.migration remove-best-data          # dry-run
     python -m qdash.dbmodel.migration remove-best-data --execute  # execute
+
+    python -m qdash.dbmodel.migration rename-database --from qubex --to qdash  # dry-run
+    python -m qdash.dbmodel.migration rename-database --from qubex --to qdash --execute
 """
 
 import logging
+import os
 from typing import Any
+
+from pymongo import MongoClient
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +97,139 @@ def migrate_remove_best_data(dry_run: bool = True) -> dict[str, int]:
     return stats
 
 
+def _get_mongo_client() -> MongoClient[Any]:
+    """Get MongoDB client for migration."""
+    return MongoClient(
+        os.getenv("MONGO_HOST", "mongo"),
+        port=27017,
+        username=os.getenv("MONGO_INITDB_ROOT_USERNAME"),
+        password=os.getenv("MONGO_INITDB_ROOT_PASSWORD"),
+    )
+
+
+def migrate_rename_database(
+    source_db: str,
+    target_db: str,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Copy all collections from source database to target database.
+
+    This migration copies all data from the source database to the target database.
+    After successful migration, you should:
+    1. Update MONGO_DB_NAME environment variable to the new database name
+    2. Restart services
+    3. Verify the application works correctly
+    4. Optionally drop the old database
+
+    Args:
+        source_db: Source database name (e.g., 'qubex')
+        target_db: Target database name (e.g., 'qdash')
+        dry_run: If True, only reports what would be done
+
+    Returns:
+        Migration statistics with document counts per collection
+
+    Raises:
+        MigrationError: If source database doesn't exist or target already has data
+    """
+    client = _get_mongo_client()
+
+    # Verify source database exists
+    db_names = client.list_database_names()
+    if source_db not in db_names:
+        raise MigrationError(f"Source database '{source_db}' does not exist")
+
+    source = client[source_db]
+    target = client[target_db]
+
+    # Get all collections (excluding system collections)
+    collections = [c for c in source.list_collection_names() if not c.startswith("system.")]
+
+    if not collections:
+        logger.warning(f"No collections found in source database '{source_db}'")
+        return {"collections": 0, "documents": 0}
+
+    # Check if target database already has data
+    target_collections = target.list_collection_names()
+    if target_collections and not dry_run:
+        existing = [c for c in target_collections if not c.startswith("system.")]
+        if existing:
+            logger.warning(
+                f"Target database '{target_db}' already has collections: {existing}. "
+                "Data will be merged/overwritten."
+            )
+
+    stats: dict[str, Any] = {
+        "source_db": source_db,
+        "target_db": target_db,
+        "collections": {},
+        "total_documents": 0,
+    }
+
+    for collection_name in collections:
+        source_col = source[collection_name]
+        doc_count = source_col.count_documents({})
+        stats["collections"][collection_name] = doc_count
+        stats["total_documents"] += doc_count
+
+        logger.info(f"Collection '{collection_name}': {doc_count} documents")
+
+        if not dry_run and doc_count > 0:
+            target_col = target[collection_name]
+
+            # Copy indexes first
+            indexes = list(source_col.list_indexes())
+            for index in indexes:
+                if index["name"] != "_id_":  # Skip default _id index
+                    try:
+                        keys = list(index["key"].items())
+                        options = {k: v for k, v in index.items() if k not in ("key", "v", "ns")}
+                        target_col.create_index(keys, **options)
+                        logger.debug(f"  Created index: {index['name']}")
+                    except Exception as e:
+                        logger.warning(f"  Failed to create index {index['name']}: {e}")
+
+            # Copy documents in batches
+            copied = 0
+            cursor = source_col.find({})
+            batch: list[dict[str, Any]] = []
+
+            for doc in cursor:
+                batch.append(doc)
+                if len(batch) >= BATCH_SIZE:
+                    target_col.insert_many(batch, ordered=False)
+                    copied += len(batch)
+                    batch = []
+                    logger.debug(f"  Copied {copied}/{doc_count} documents")
+
+            # Insert remaining documents
+            if batch:
+                target_col.insert_many(batch, ordered=False)
+                copied += len(batch)
+
+            logger.info(f"  Copied {copied} documents to '{target_db}.{collection_name}'")
+
+    if dry_run:
+        logger.info(
+            f"[DRY RUN] Would copy {len(collections)} collections "
+            f"({stats['total_documents']} documents) from '{source_db}' to '{target_db}'"
+        )
+    else:
+        logger.info(
+            f"Successfully copied {len(collections)} collections "
+            f"({stats['total_documents']} documents) from '{source_db}' to '{target_db}'"
+        )
+        logger.info(
+            f"\nNext steps:\n"
+            f"  1. Update MONGO_DB_NAME={target_db} in .env\n"
+            f"  2. Restart services: docker compose restart\n"
+            f"  3. Verify the application works correctly\n"
+            f"  4. (Optional) Drop old database: db.dropDatabase() on '{source_db}'"
+        )
+
+    return stats
+
+
 if __name__ == "__main__":
     import argparse
 
@@ -110,6 +249,29 @@ if __name__ == "__main__":
         help="Actually execute the migration (default is dry-run)",
     )
 
+    # rename-database migration
+    rename_db_parser = subparsers.add_parser(
+        "rename-database",
+        help="Copy all collections from source database to target database",
+    )
+    rename_db_parser.add_argument(
+        "--from",
+        dest="source_db",
+        required=True,
+        help="Source database name (e.g., 'qubex')",
+    )
+    rename_db_parser.add_argument(
+        "--to",
+        dest="target_db",
+        required=True,
+        help="Target database name (e.g., 'qdash')",
+    )
+    rename_db_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually execute the migration (default is dry-run)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "remove-best-data":
@@ -117,6 +279,13 @@ if __name__ == "__main__":
 
         initialize()
         stats = migrate_remove_best_data(dry_run=not args.execute)
+        logger.info(f"Migration complete: {stats}")
+    elif args.command == "rename-database":
+        stats = migrate_rename_database(
+            source_db=args.source_db,
+            target_db=args.target_db,
+            dry_run=not args.execute,
+        )
         logger.info(f"Migration complete: {stats}")
     else:
         parser.print_help()

--- a/src/qdash/repository/execution.py
+++ b/src/qdash/repository/execution.py
@@ -75,7 +75,7 @@ class MongoExecutionRepository:
         port: int | None = None,
         username: str | None = None,
         password: str | None = None,
-        database: str = "qubex",
+        database: str | None = None,
     ):
         """Initialize MongoExecutionRepository.
 
@@ -89,15 +89,15 @@ class MongoExecutionRepository:
             MongoDB username (defaults to env var)
         password : str | None
             MongoDB password (defaults to env var)
-        database : str
-            Database name (defaults to 'qubex')
+        database : str | None
+            Database name (defaults to MONGO_DB_NAME env var or 'qdash')
 
         """
         self._host = host or "mongo"
         self._port = port or 27017
         self._username = username or os.getenv("MONGO_INITDB_ROOT_USERNAME")
         self._password = password or os.getenv("MONGO_INITDB_ROOT_PASSWORD")
-        self._database = database
+        self._database: str = database if database else os.getenv("MONGO_DB_NAME") or "qdash"
 
     def _get_client(self) -> MongoClient[Any]:
         """Get MongoDB client.


### PR DESCRIPTION
- Add `MONGO_DB_NAME` (default: `qdash`) to configuration and `.env.example`
- Stop hardcoding the `qubex` database by selecting the MongoDB database via env var in session and Bunnet initialization
- Introduce a `rename-database` migration to copy collections from an old DB name to a new one to support safe transitions between database names
