### PR TITLE
refactor(dbmodel): remove deprecated node/edge UI fields

### DIFF
--- a/docs/development/api/testing.md
+++ b/docs/development/api/testing.md
@@ -601,10 +601,6 @@ Define constants at the module level:
 # Test constants
 TEST_DATE = "2024-01-01T00:00:00Z"
 TEST_USERNAME = "test_user"
-DEFAULT_POSITION_X = 0.0
-DEFAULT_POSITION_Y = 0.0
-DEFAULT_COUPLING_SIZE = 1
-DEFAULT_COUPLING_FILL = "#000000"
 ```
 
 ### Helper Functions
@@ -614,32 +610,23 @@ Create helper functions for test data creation:
 ```python
 def create_test_qubit(qid: str, x_180_length: float = 30.0) -> QubitModel:
     """Helper function to create a test qubit."""
-    node_info = NodeInfoModel(position=PositionModel(x=DEFAULT_POSITION_X, y=DEFAULT_POSITION_Y))
     return QubitModel(
         username=TEST_USERNAME,
         chip_id="test_chip",
         status="active",
         qid=qid,
         data={"x_180_length": x_180_length},
-        node_info=node_info,
     )
 
 
-def create_test_coupling(qid: str, source: str, target: str) -> CouplingModel:
+def create_test_coupling(qid: str) -> CouplingModel:
     """Helper function to create a test coupling."""
-    edge_info = EdgeInfoModel(
-        source=source,
-        target=target,
-        size=DEFAULT_COUPLING_SIZE,
-        fill=DEFAULT_COUPLING_FILL,
-    )
     return CouplingModel(
         username=TEST_USERNAME,
         chip_id="test_chip",
         status="active",
         qid=qid,
         data={},
-        edge_info=edge_info,
     )
 ```
 

--- a/docs/reference/database-structure.md
+++ b/docs/reference/database-structure.md
@@ -111,13 +111,6 @@ class ChipModel(BaseModel):
 Model representing an individual qubit.
 
 ```python
-class PositionModel(BaseModel):
-    x: float  # X coordinate
-    y: float  # Y coordinate
-
-class NodeInfoModel(BaseModel):
-    position: PositionModel  # Display position
-
 class QubitModel(BaseModel):
     project_id: str        # Owning project ID
     username: str | None   # Username
@@ -125,8 +118,6 @@ class QubitModel(BaseModel):
     status: str            # Status ("pending", "completed", etc.)
     chip_id: str | None    # Parent chip ID
     data: dict             # Calibration data
-    best_data: dict        # Best calibration results
-    node_info: NodeInfoModel  # UI display information
 ```
 
 **Example data field structure:**
@@ -153,12 +144,6 @@ class QubitModel(BaseModel):
 Model representing coupling between qubits.
 
 ```python
-class EdgeInfoModel(BaseModel):
-    source: str   # Source node ID
-    target: str   # Target node ID
-    size: int     # Edge size
-    fill: str     # Fill color
-
 class CouplingModel(BaseModel):
     project_id: str        # Owning project ID
     username: str | None   # Username
@@ -166,8 +151,6 @@ class CouplingModel(BaseModel):
     status: str            # Status
     chip_id: str | None    # Chip ID
     data: dict             # Calibration data
-    best_data: dict        # Best calibration results
-    edge_info: EdgeInfoModel  # UI display information
 ```
 
 ---
@@ -410,17 +393,8 @@ class QubitDocument(Document):
     status: str = "pending"
     chip_id: str
     data: dict
-    best_data: dict = {}
-    node_info: NodeInfoModel
     system_info: SystemInfoModel
 ```
-
-**Fidelity Metrics (tracked in best_data):**
-
-- `average_readout_fidelity`
-- `readout_fidelity_0`, `readout_fidelity_1`
-- `x90_gate_fidelity`, `x180_gate_fidelity`
-- `t1`, `t2_echo`, `t2_star`
 
 **Key Methods:**
 
@@ -446,15 +420,8 @@ class CouplingDocument(Document):
     status: str = "pending"
     chip_id: str
     data: dict
-    best_data: dict = {}
-    edge_info: EdgeInfoModel
     system_info: SystemInfoModel
 ```
-
-**Fidelity Metrics (tracked in best_data):**
-
-- `zx90_gate_fidelity`
-- `bell_state_fidelity`
 
 ---
 
@@ -562,8 +529,6 @@ class QubitHistoryDocument(Document):
     status: str
     chip_id: str
     data: dict
-    best_data: dict = {}
-    node_info: NodeInfoModel
     system_info: SystemInfoModel
     recorded_date: str  # YYYYMMDD format
 ```
@@ -609,8 +574,6 @@ class CouplingHistoryDocument(Document):
     status: str
     chip_id: str
     data: dict
-    best_data: dict = {}
-    edge_info: EdgeInfoModel
     system_info: SystemInfoModel
     recorded_date: str  # YYYYMMDD format
 ```
@@ -895,15 +858,6 @@ To avoid MongoDB's 16MB document limit with large qubit counts:
 │  CouplingDocument       │     (persistent storage)
 └─────────────────────────┘
 ```
-
-### Best Data Update Logic
-
-The `best_data` field tracks the best fidelity metrics:
-
-- **Qubit**: `average_readout_fidelity`, `readout_fidelity_0/1`, `x90/x180_gate_fidelity`, `t1`, `t2_echo`, `t2_star`
-- **Coupling**: `zx90_gate_fidelity`, `bell_state_fidelity`
-
-Values are only updated when new calibration results exceed existing values.
 
 ---
 

--- a/src/qdash/datamodel/coupling.py
+++ b/src/qdash/datamodel/coupling.py
@@ -3,22 +3,6 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 
-class EdgeInfoModel(BaseModel):
-    """Data model for an edge information.
-
-    Attributes
-    ----------
-        fill (str): The fill color.
-        position (PositionModel): The position.
-
-    """
-
-    source: str = Field(..., description="The source node")
-    target: str = Field(..., description="The target node")
-    size: int = Field(..., description="The size of the edge")
-    fill: str = Field(..., description="The fill color")
-
-
 class CouplingModel(BaseModel):
     """Data model for a coupling.
 
@@ -27,7 +11,6 @@ class CouplingModel(BaseModel):
         qid (str): The coupling ID. e.g. "0-1".
         chip_id (str): The chip ID. e.g. "chip1".
         data (dict): The data of the coupling. e.g. {"coupling_strength": 0.1}.
-        edge_info (EdgeInfoModel): The edge information. e.g. {"fill": "red", "position": {"x": 0.0, "y": 0.0}}.
 
     """
 
@@ -39,6 +22,3 @@ class CouplingModel(BaseModel):
     status: str = Field(default="pending", description="The status of the coupling")
     chip_id: str | None = Field(None, description="The chip ID")
     data: dict[str, Any] = Field(..., description="The data of the coupling")
-    edge_info: EdgeInfoModel | None = Field(
-        default=None, description="The edge information (deprecated)"
-    )

--- a/src/qdash/datamodel/qubit.py
+++ b/src/qdash/datamodel/qubit.py
@@ -4,33 +4,6 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 
-class PositionModel(BaseModel):
-    """Data model for a position.
-
-    Attributes
-    ----------
-        x (float): The x-coordinate.
-        y (float): The y-coordinate.
-
-    """
-
-    x: float = Field(..., description="The x-coordinate")
-    y: float = Field(..., description="The y-coordinate")
-
-
-class NodeInfoModel(BaseModel):
-    """Data model for a node information.
-
-    Attributes
-    ----------
-        fill (str): The fill color.
-        position (PositionModel): The position.
-
-    """
-
-    position: PositionModel = Field(..., description="The position")
-
-
 class QubitModel(BaseModel):
     """Model for a qubit.
 
@@ -39,7 +12,6 @@ class QubitModel(BaseModel):
         qubit_id (str): The qubit ID. e.g. "0".
         status (str): The status of the qubit.
         data (dict): The data of the qubit.
-        node_info (NodeInfo): The node information.
 
     """
 
@@ -49,9 +21,6 @@ class QubitModel(BaseModel):
     status: str = Field(default="pending", description="The status of the qubit")
     chip_id: str | None = Field(None, description="The chip ID")
     data: dict[str, Any] = Field(..., description="The data of the qubit")
-    node_info: NodeInfoModel | None = Field(
-        default=None, description="The node information (deprecated)"
-    )
 
     @field_validator("data", mode="before")
     @classmethod

--- a/src/qdash/dbmodel/coupling.py
+++ b/src/qdash/dbmodel/coupling.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar
 from bunnet import Document
 from pydantic import ConfigDict, Field
 from pymongo import ASCENDING, IndexModel
-from qdash.datamodel.coupling import CouplingModel, EdgeInfoModel
+from qdash.datamodel.coupling import CouplingModel
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.coupling_history import CouplingHistoryDocument
 
@@ -18,7 +18,6 @@ class CouplingDocument(Document):
         chip_id (str): The chip ID. e.g. "chip1".
         data (dict): The data of the coupling. e.g. {"coupling_strength": 0.1}.
         calibrated_at (str): The time when the coupling was calibrated. e.g. "2021-01-01T00:00:00Z".
-        edge_info (EdgeInfoModel): The edge information. e.g. {"fill": "red", "position": {"x": 0.0, "y": 0.0}}.
         system_info (SystemInfo): The system information. e.g. {"created_at": "2021-01-01T00:00:00Z", "updated_at": "2021-01-01T00:00:00Z"}.
 
     """
@@ -29,10 +28,6 @@ class CouplingDocument(Document):
     status: str = Field("pending", description="The status of the coupling")
     chip_id: str = Field(..., description="The chip ID")
     data: dict[str, Any] = Field(..., description="The data of the coupling")
-    edge_info: EdgeInfoModel | None = Field(
-        default=None, description="The edge information (deprecated)"
-    )
-
     system_info: SystemInfoModel = Field(..., description="The system information")
 
     model_config = ConfigDict(
@@ -88,7 +83,6 @@ class CouplingDocument(Document):
             qid=qid,
             chip_id=chip_id,
             data=coupling_doc.data,
-            edge_info=coupling_doc.edge_info,
             username=username,
         )
         CouplingHistoryDocument.create_history(coupling_model)

--- a/src/qdash/dbmodel/coupling_history.py
+++ b/src/qdash/dbmodel/coupling_history.py
@@ -4,7 +4,7 @@ from bunnet import Document
 from pydantic import ConfigDict, Field
 from pymongo import ASCENDING, DESCENDING, IndexModel
 from qdash.common.datetime_utils import now
-from qdash.datamodel.coupling import CouplingModel, EdgeInfoModel
+from qdash.datamodel.coupling import CouplingModel
 from qdash.datamodel.system_info import SystemInfoModel
 
 
@@ -18,7 +18,6 @@ class CouplingHistoryDocument(Document):
         chip_id (str): The chip ID. e.g. "chip1".
         data (dict): The data of the coupling.
         status (str): The status of the coupling.
-        edge_info (EdgeInfoModel): The edge information.
         system_info (SystemInfo): The system information.
         recorded_date (str): The date when this history record was created (YYYYMMDD).
 
@@ -30,9 +29,6 @@ class CouplingHistoryDocument(Document):
     status: str = Field(..., description="The status of the coupling")
     chip_id: str = Field(..., description="The chip ID")
     data: dict[str, Any] = Field(..., description="The data of the coupling")
-    edge_info: EdgeInfoModel | None = Field(
-        default=None, description="The edge information (deprecated)"
-    )
     system_info: SystemInfoModel = Field(..., description="The system information")
     recorded_date: str = Field(
         default_factory=lambda: now().strftime("%Y%m%d"),
@@ -80,7 +76,6 @@ class CouplingHistoryDocument(Document):
             history = existing_history
             history.data = coupling.data
             history.status = coupling.status
-            history.edge_info = coupling.edge_info
         else:
             history = cls(
                 project_id=coupling.project_id,
@@ -89,7 +84,6 @@ class CouplingHistoryDocument(Document):
                 status=coupling.status,
                 chip_id=coupling.chip_id,
                 data=coupling.data,
-                edge_info=coupling.edge_info,
                 system_info=SystemInfoModel(),
             )
         history.save()

--- a/src/qdash/dbmodel/qubit.py
+++ b/src/qdash/dbmodel/qubit.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar
 from bunnet import Document
 from pydantic import ConfigDict, Field
 from pymongo import ASCENDING, IndexModel
-from qdash.datamodel.qubit import NodeInfoModel, QubitModel
+from qdash.datamodel.qubit import QubitModel
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.qubit_history import QubitHistoryDocument
 
@@ -28,10 +28,6 @@ class QubitDocument(Document):
     status: str = Field("pending", description="The status of the qubit")
     chip_id: str = Field(..., description="The chip ID")
     data: dict[str, Any] = Field(..., description="The data of the qubit")
-    node_info: NodeInfoModel | None = Field(
-        default=None, description="The node information (deprecated)"
-    )
-
     system_info: SystemInfoModel = Field(..., description="The system information")
 
     model_config = ConfigDict(

--- a/src/qdash/dbmodel/qubit_history.py
+++ b/src/qdash/dbmodel/qubit_history.py
@@ -4,7 +4,7 @@ from bunnet import Document
 from pydantic import ConfigDict, Field
 from pymongo import ASCENDING, DESCENDING, IndexModel
 from qdash.common.datetime_utils import now
-from qdash.datamodel.qubit import NodeInfoModel, QubitModel
+from qdash.datamodel.qubit import QubitModel
 from qdash.datamodel.system_info import SystemInfoModel
 
 
@@ -18,7 +18,6 @@ class QubitHistoryDocument(Document):
         chip_id (str): The chip ID. e.g. "chip1".
         data (dict): The data of the qubit.
         status (str): The status of the qubit.
-        node_info (NodeInfoModel): The node information.
         system_info (SystemInfo): The system information.
         recorded_date (str): The date when this history record was created (YYYYMMDD).
 
@@ -30,9 +29,6 @@ class QubitHistoryDocument(Document):
     status: str = Field(..., description="The status of the qubit")
     chip_id: str = Field(..., description="The chip ID")
     data: dict[str, Any] = Field(..., description="The data of the qubit")
-    node_info: NodeInfoModel | None = Field(
-        default=None, description="The node information (deprecated)"
-    )
     system_info: SystemInfoModel = Field(..., description="The system information")
     recorded_date: str = Field(
         default_factory=lambda: now().strftime("%Y%m%d"),
@@ -80,7 +76,6 @@ class QubitHistoryDocument(Document):
             history = existing_history
             history.data = qubit.data
             history.status = qubit.status
-            history.node_info = qubit.node_info
         else:
             # Create a new history record
             history = cls(
@@ -90,7 +85,6 @@ class QubitHistoryDocument(Document):
                 status=qubit.status,
                 chip_id=qubit.chip_id,
                 data=qubit.data,
-                node_info=qubit.node_info,
                 system_info=SystemInfoModel(),
             )
         history.save()

--- a/src/qdash/repository/coupling.py
+++ b/src/qdash/repository/coupling.py
@@ -144,5 +144,4 @@ class MongoCouplingCalibrationRepository:
             status=doc.status,
             chip_id=doc.chip_id,
             data=doc.data,
-            edge_info=doc.edge_info,
         )

--- a/src/qdash/repository/inmemory/coupling.py
+++ b/src/qdash/repository/inmemory/coupling.py
@@ -76,7 +76,6 @@ class InMemoryCouplingCalibrationRepository:
                 status="",
                 chip_id=chip_id,
                 data={},
-                edge_info=None,
             )
             self._couplings[key] = coupling
 

--- a/src/qdash/repository/inmemory/qubit.py
+++ b/src/qdash/repository/inmemory/qubit.py
@@ -76,7 +76,6 @@ class InMemoryQubitCalibrationRepository:
                 status="",
                 chip_id=chip_id,
                 data={},
-                node_info=None,
             )
             self._qubits[key] = qubit
 

--- a/src/qdash/repository/qubit.py
+++ b/src/qdash/repository/qubit.py
@@ -142,5 +142,4 @@ class MongoQubitCalibrationRepository:
             status=doc.status,
             chip_id=doc.chip_id,
             data=doc.data,
-            node_info=doc.node_info,
         )

--- a/src/tools/calc_poisition.py
+++ b/src/tools/calc_poisition.py
@@ -1,6 +1,5 @@
 """Qubit initialization module."""
 
-from qdash.datamodel.qubit import NodeInfoModel, PositionModel
 from qdash.dbmodel.initialize import initialize
 from qdash.dbmodel.qubit import QubitDocument
 
@@ -84,12 +83,6 @@ def generate_dummy_data(num_qubits: int, pos: dict, username: str, chip_id: str)
             chip_id=chip_id,
             qid=f"{i}",
             status="pending",
-            node_info=NodeInfoModel(
-                position=PositionModel(
-                    x=pos[i][0],
-                    y=pos[i][1],
-                ),
-            ),
             data={},
             system_info={},
         )


### PR DESCRIPTION
Drop PositionModel/NodeInfoModel/EdgeInfoModel and the deprecated
node_info/edge_info (and best_data) fields from QubitModel and
CouplingModel to align the schema with current usage.

Update API testing docs and helper functions to stop populating UI-only
metadata in test fixtures.

