### PR TITLE
fix: delete the cause line

### DIFF
--- a/ui/src/app/(public)/login/page.tsx
+++ b/ui/src/app/(public)/login/page.tsx
@@ -32,7 +32,6 @@ export default function LoginPage() {
     try {
       await authLogin(userName, password);
       router.replace("/execution");
-      window.location.href = "/execution";
     } catch (err) {
       setError("Login failed. Please check your user ID and password.");
     }


### PR DESCRIPTION
<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
#586

## Summary
I think `router.replace("/execution")` and `window.location.href = "/execution"` were competing. Even though I was able to log in once, one of them was evaluated asynchronously, and logout processes such as `removeAuth()` were executed. 
And I suspect this asynchronicity is unique to Safari. 

## Changes
I removed `window.location.href = "/execution"`.

before:
```ts
    try {
      await authLogin(userName, password);
      router.replace("/execution");
      window.location.href = "/execution";
    } catch (err) {
      setError("Login failed. Please check your user ID and password.");
    }
```

```ts
    try {
      await authLogin(userName, password);
      router.replace("/execution");
    } catch (err) {
      setError("Login failed. Please check your user ID and password.");
    }
```
