### PR TITLE
fix: delete unnecessary className "badge-outline"

### DIFF
--- a/ui/src/components/features/provenance/RecalibrationRecommendationsPanel.tsx
+++ b/ui/src/components/features/provenance/RecalibrationRecommendationsPanel.tsx
@@ -125,7 +125,7 @@ export function RecalibrationRecommendationsPanel({
                 depth: {rec.max_depth_reached ?? 0}
               </span>
               {rec.source_parameter_name && rec.source_qid && (
-                <span className="badge badge-primary badge-outline">
+                <span className="badge badge-primary">
                   {rec.source_parameter_name} ({rec.source_qid})
                 </span>
               )}


### PR DESCRIPTION
## Ticket
#589 

## Summary
Although the text color was set using `text-base-content/70`, it appeared that `badge-outline` was overriding it.
Since this element is statically associated with `badge-primary`, `badge-outline` is unnecessary.

## Changes
- Removing `badge-outline`

before:
<img width="1463" height="813" alt="Image" src="https://github.com/user-attachments/assets/57a59215-ff8b-4222-b6e2-7fa5b3b144f6" />

after:
<img width="373" height="254" alt="after-fixing" src="https://github.com/user-attachments/assets/523a3c5c-6877-4a21-972b-ff4f800146b4" />

