### PR TITLE
fix: the label width fixed

### DIFF
--- a/ui/src/components/features/analysis/HistogramView.tsx
+++ b/ui/src/components/features/analysis/HistogramView.tsx
@@ -859,7 +859,7 @@ export function HistogramView() {
 
           {/* Row 2: Threshold Slider */}
           <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-            <span className="text-xs sm:text-sm font-medium shrink-0">
+            <span className="text-xs sm:text-sm font-medium shrink-0 w-40">
               Threshold: {thresholdDisplayText}
             </span>
             <div className="flex items-center gap-2 flex-1 min-w-0">


### PR DESCRIPTION
## Ticket
#593 

## Summary
The slider vibrated because the label width changes.
The label width should be fixed.

## Changes
I fixed the label width to `w-40`. (160px)
