### PR TITLE
feat(ui): add conditional styling for pan-zoom view in metrics grid

### DIFF
--- a/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
@@ -647,7 +647,13 @@ export function CouplingMetricsGrid({
       )}
 
       {/* Grid display */}
-      <div className="flex-1 p-1 md:p-4 relative overflow-hidden flex justify-center">
+      <div
+        className={`flex-1 p-1 md:p-4 relative overflow-hidden flex justify-center ${
+          viewMode === "pan-zoom"
+            ? "bg-base-200/30 border-2 border-dashed border-base-300 rounded-lg m-1 md:m-2"
+            : ""
+        }`}
+      >
         {viewMode === "pan-zoom" ? (
           <TransformWrapper
             initialScale={1}

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -676,7 +676,11 @@ export function QubitMetricsGrid({
 
       {/* Grid display */}
       <div
-        className="flex-1 p-1 md:p-4 relative overflow-hidden flex justify-center"
+        className={`flex-1 p-1 md:p-4 relative overflow-hidden flex justify-center ${
+          viewMode === "pan-zoom"
+            ? "bg-base-200/30 border-2 border-dashed border-base-300 rounded-lg m-1 md:m-2"
+            : ""
+        }`}
         ref={containerRef}
       >
         {viewMode === "pan-zoom" ? (


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced conditional styling for the pan-zoom view in the metrics grid to enhance visual distinction.
- This change improves user experience by providing clearer feedback on the current view mode.

## Changes
- Added conditional classes to the `CouplingMetricsGrid` and `QubitMetricsGrid` components for the pan-zoom view.
- Applied background and border styles when the view mode is set to pan-zoom.

