### PR TITLE
feat(workflow): add inverse parameter for CR direction control

### DIFF
--- a/src/qdash/workflow/engine/scheduler/cr_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/cr_scheduler.py
@@ -794,14 +794,25 @@ class CRScheduler:
             cr_pairs = [p for p in all_pairs if p in topology_directions]
         elif use_design_based:
             direction_method = "design_based"
-            logger.info("Using design-based frequency directionality (checkerboard pattern)")
-            cr_pairs = [
-                pair
-                for pair in all_pairs
-                if (qubits := pair.split("-"))
-                and len(qubits) == 2
-                and self._infer_direction_from_design(qubits[0], qubits[1], grid_size)
-            ]
+            logger.info(
+                f"Using design-based frequency directionality (checkerboard pattern, inverse={inverse})"
+            )
+            if inverse:
+                cr_pairs = [
+                    pair
+                    for pair in all_pairs
+                    if (qubits := pair.split("-"))
+                    and len(qubits) == 2
+                    and not self._infer_direction_from_design(qubits[0], qubits[1], grid_size)
+                ]
+            else:
+                cr_pairs = [
+                    pair
+                    for pair in all_pairs
+                    if (qubits := pair.split("-"))
+                    and len(qubits) == 2
+                    and self._infer_direction_from_design(qubits[0], qubits[1], grid_size)
+                ]
         else:
             direction_method = "measured"
             logger.info("Using measured frequency directionality")

--- a/src/qdash/workflow/service/steps/two_qubit.py
+++ b/src/qdash/workflow/service/steps/two_qubit.py
@@ -285,11 +285,16 @@ class GenerateCRSchedule(TransformStep):
     - Frequency constraints
     - Candidate qubit availability
 
+    The `inverse` parameter controls the CR direction based on the checkerboard pattern:
+    - False (default): Forward direction (control has lower frequency by design)
+    - True: Reverse direction (control has higher frequency by design)
+
     Requires: candidate_qids (at least 2 qubits)
     Provides: candidate_couplings (scheduled coupling pairs)
     """
 
     max_parallel_ops: int = 10
+    inverse: bool = False
 
     @property
     def name(self) -> str:
@@ -329,6 +334,7 @@ class GenerateCRSchedule(TransformStep):
         schedule = scheduler.generate(
             candidate_qubits=candidate_qubits,
             max_parallel_ops=self.max_parallel_ops,
+            inverse=self.inverse,
         )
 
         if not schedule.parallel_groups:
@@ -343,9 +349,10 @@ class GenerateCRSchedule(TransformStep):
         # Store schedule in metadata for TwoQubitCalibration
         ctx.metadata["cr_schedule"] = schedule.parallel_groups
 
+        direction = "reverse" if self.inverse else "forward"
         logger.info(
             f"[{self.name}] Generated {len(all_couplings)} couplings in "
-            f"{len(schedule.parallel_groups)} groups"
+            f"{len(schedule.parallel_groups)} groups (direction: {direction})"
         )
         return ctx
 

--- a/src/qdash/workflow/templates/full_calibration.py
+++ b/src/qdash/workflow/templates/full_calibration.py
@@ -45,6 +45,7 @@ def full_calibration(
     project_id: str | None = None,
     fidelity_threshold: float = 0.90,
     max_parallel_ops: int = 10,
+    inverse: bool = False,
 ) -> Any:
     """Full calibration using step-based pipeline.
 
@@ -58,6 +59,11 @@ def full_calibration(
         project_id: Project ID (auto-injected)
         fidelity_threshold: Minimum X90 fidelity for 2Q candidates (default: 0.90)
         max_parallel_ops: Max parallel CR operations (default: 10)
+        inverse: CR direction control based on checkerboard pattern.
+            False (default): Forward direction - control qubit is at even parity
+            position (lower design frequency).
+            True: Reverse direction - control qubit is at odd parity position
+            (higher design frequency).
 
     Returns:
         Pipeline results with typed step outputs
@@ -89,8 +95,8 @@ def full_calibration(
         OneQubitFineTune(mode="synchronized"),
         # Stage 3: Filter by X90 fidelity
         FilterByMetric(metric="x90_fidelity", threshold=fidelity_threshold),
-        # Stage 4: Generate 2Q schedule
-        GenerateCRSchedule(max_parallel_ops=max_parallel_ops),
+        # Stage 4: Generate 2Q schedule with explicit direction
+        GenerateCRSchedule(max_parallel_ops=max_parallel_ops, inverse=inverse),
         # Stage 5: 2Q calibration
         TwoQubitCalibration(),
     ]

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -26,7 +26,7 @@
   {
     "id": "full_calibration",
     "name": "Full Calibration",
-    "description": "Complete calibration using step-based pipeline: 1Q Check -> 1Q Fine-tune -> Filter -> CR Schedule -> 2Q.",
+    "description": "Complete calibration using step-based pipeline: 1Q Check -> 1Q Fine-tune -> Filter -> CR Schedule (forward/reverse) -> 2Q.",
     "category": "production",
     "filename": "full_calibration.py",
     "function_name": "full_calibration"
@@ -34,7 +34,7 @@
   {
     "id": "two_qubit",
     "name": "2Q Calibration",
-    "description": "Two-qubit calibration from candidate qubits. Auto-generates optimal CR schedule based on hardware constraints.",
+    "description": "Two-qubit calibration from candidate qubits. Auto-generates optimal CR schedule with explicit checkerboard direction (forward/reverse). Default: forward.",
     "category": "production",
     "filename": "two_qubit.py",
     "function_name": "two_qubit"

--- a/src/qdash/workflow/templates/two_qubit.py
+++ b/src/qdash/workflow/templates/two_qubit.py
@@ -3,14 +3,29 @@
 This template takes a list of candidate qubit IDs and automatically generates
 an optimal CR schedule using CRScheduler, then executes 2-qubit calibration.
 
+The CR direction is determined by the checkerboard pattern:
+- Forward (inverse=False, default): Control qubit has lower design frequency
+  (even parity position → low freq ~8000 MHz)
+- Reverse (inverse=True): Control qubit has higher design frequency
+  (odd parity position → high freq ~9000 MHz)
+
 Use this when you have already completed 1Q calibration and want to run 2Q
 calibration on specific qubits without going through the full pipeline.
 
 Example:
+    # Forward direction (default)
     two_qubit(
         username="alice",
         chip_id="64Qv3",
         qids=["0", "1", "4", "5", "8", "9"],
+    )
+
+    # Reverse direction
+    two_qubit(
+        username="alice",
+        chip_id="64Qv3",
+        qids=["0", "1", "4", "5", "8", "9"],
+        inverse=True,
     )
 """
 
@@ -33,6 +48,7 @@ def two_qubit(
     chip_id: str,
     qids: list[str] | None = None,
     tasks: list[str] | None = None,
+    inverse: bool = False,
     max_parallel_ops: int = 10,
     tags: list[str] | None = None,
     flow_name: str | None = None,
@@ -42,7 +58,7 @@ def two_qubit(
 
     Takes candidate qubit IDs and generates an optimal CR schedule based on:
     - MUX conflicts (pairs sharing MUX cannot run in parallel)
-    - Frequency constraints (CR direction based on qubit frequencies)
+    - Frequency constraints (CR direction based on checkerboard pattern)
     - Hardware topology (valid coupling pairs from chip design)
 
     Args:
@@ -57,6 +73,11 @@ def two_qubit(
             - CheckBellState
             - CheckBellStateTomography
             - ZX90InterleavedRandomizedBenchmarking
+        inverse: CR direction control based on checkerboard pattern.
+            False (default): Forward direction - control qubit is at even parity
+            position (lower design frequency).
+            True: Reverse direction - control qubit is at odd parity position
+            (higher design frequency).
         max_parallel_ops: Maximum number of CR operations to run in parallel.
             Limited by hardware constraints. Default: 10.
         flow_name: Flow name (auto-injected)
@@ -66,11 +87,19 @@ def two_qubit(
         Pipeline results with typed step outputs
 
     Example:
-        # Run full 2Q calibration on candidate qubits
+        # Run full 2Q calibration (forward direction, default)
         two_qubit(
             username="alice",
             chip_id="64Qv3",
             qids=["0", "1", "4", "5", "8", "9"],
+        )
+
+        # Run full 2Q calibration (reverse direction)
+        two_qubit(
+            username="alice",
+            chip_id="64Qv3",
+            qids=["0", "1", "4", "5", "8", "9"],
+            inverse=True,
         )
 
         # Run only specific 2Q tasks
@@ -110,8 +139,11 @@ def two_qubit(
     # =========================================================================
 
     steps: list[Step] = [
-        # Generate CR schedule from candidate qubits
-        GenerateCRSchedule(max_parallel_ops=max_parallel_ops),
+        # Generate CR schedule from candidate qubits with explicit direction
+        GenerateCRSchedule(
+            max_parallel_ops=max_parallel_ops,
+            inverse=inverse,
+        ),
     ]
 
     if tasks is not None:


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced an `inverse` parameter to control the CR direction based on a checkerboard pattern, allowing for both forward and reverse configurations.
- This change enhances flexibility in qubit calibration, impacting the scheduling workflow.

## Changes
- Added `inverse` parameter to `GenerateCRSchedule` and `full_calibration` functions.
- Updated logging to reflect the direction of CR operations.
- Modified documentation to clarify the use of the `inverse` parameter in the calibration process.

