### PR TITLE
fix: skip all labeler jobs on bot PR

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   labeler:
+    if: ${{ !contains(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -70,7 +71,6 @@ jobs:
           labels: ${{ steps.set-labels.outputs.labels }}
 
       - name: Assign PR creator
-        if: ${{ !contains(github.actor, '[bot]') }}
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
## Ticket
<!-- Link to the ticket / issue -->

## Summary
The labeler is skipped for bot PRs, as the bot creates labels autonomously.

The reason for this success is unknown, but there's no need to reveal it by skipping.
https://github.com/oqtopus-team/qdash/actions/runs/21985322765/job/63525050118

## Changes
I changed from skipping a partial if to skipping the entire job.
