### PR TITLE
Fix/#663 labeler skip bot

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -6,9 +6,13 @@ on:
     branches:
       - develop
 
+#Permissions are required for PRs by dependabot.
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   labeler:
-    if: ${{ !contains(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Ticket
#663 

## Summary
Insufficient permissions were causing a permission error.

## Changes
Added permissions to the labeler workflow:
- `pull-requests: write`
- `contents: write`

Additionally, I removed unnecessary conditionals