### PR TITLE
feat(common): add dynamic qid_to_label function and corresponding tests

### DIFF
--- a/src/qdash/api/routers/device_topology.py
+++ b/src/qdash/api/routers/device_topology.py
@@ -1,7 +1,6 @@
 """Device topology router for QDash API."""
 
 import io
-import re
 from datetime import timedelta
 from typing import Annotated, Any
 
@@ -24,6 +23,7 @@ from qdash.api.schemas.device_topology import (
     QubitLifetime,
 )
 from qdash.common.datetime_utils import now, to_datetime
+from qdash.common.qubit_utils import qid_to_label
 from qdash.common.topology_config import load_topology
 from qdash.repository import MongoCalibrationNoteRepository, MongoChipRepository
 
@@ -45,14 +45,6 @@ def search_coupling_data_by_control_qid(
         if left_side == search_term:
             filtered[key] = value
     return filtered
-
-
-def qid_to_label(qid: str) -> str:
-    """Convert a numeric qid string to a label with at least two digits. e.g. '0' -> 'Q00'."""
-    if re.fullmatch(r"\d+", qid):
-        return "Q" + qid.zfill(2)
-    error_message = "Invalid qid format."
-    raise ValueError(error_message)
 
 
 def is_within_24h(calibrated_at: str | None) -> bool:
@@ -233,8 +225,12 @@ def get_device_topology(
         t2 = get_value_within_24h_fallback(
             t2_data, request.condition.qubit_fidelity.is_within_24h, fallback=100.0
         )
-        drag_hpi_duration = drag_hpi_params.get(qid_to_label(qid), {"duration": 20})["duration"]
-        drag_pi_duration = drag_pi_params.get(qid_to_label(qid), {"duration": 20})["duration"]
+        drag_hpi_duration = drag_hpi_params.get(
+            qid_to_label(qid, topology.num_qubits), {"duration": 20}
+        )["duration"]
+        drag_pi_duration = drag_pi_params.get(
+            qid_to_label(qid, topology.num_qubits), {"duration": 20}
+        )["duration"]
         # readout_fidelity_0 = (
         #     readout_0_data["value"] if is_within_24h(readout_0_data.get("calibrated_at")) else 0.25
         # )
@@ -292,7 +288,9 @@ def get_device_topology(
 
     # Process couplings
     for qid in request.qubits:
-        search_result = search_coupling_data_by_control_qid(cr_params, qid_to_label(qid))
+        search_result = search_coupling_data_by_control_qid(
+            cr_params, qid_to_label(qid, topology.num_qubits)
+        )
         for cr_key, cr_value in search_result.items():
             target = cr_value["target"]
             control, target = split_q_string(cr_key)

--- a/src/qdash/api/routers/metrics.py
+++ b/src/qdash/api/routers/metrics.py
@@ -511,7 +511,9 @@ async def get_qubit_metric_history(
     """
     # Normalize qid format (remove "Q" prefix if present)
     normalized_qid = normalize_qid(qid)
-    qid_variants = list({normalized_qid, qid, f"Q{normalized_qid.zfill(2)}"})
+    qid_variants = list(
+        {normalized_qid, qid, f"Q{normalized_qid.zfill(2)}", f"Q{normalized_qid.zfill(3)}"}
+    )
 
     # Calculate cutoff time
     cutoff_time = None

--- a/src/qdash/common/qubit_utils.py
+++ b/src/qdash/common/qubit_utils.py
@@ -1,0 +1,32 @@
+"""Qubit utility functions shared between API and Workflow modules."""
+
+import re
+
+
+def qid_to_label(qid: str, num_qubits: int) -> str:
+    """Convert a numeric qid string to a label with dynamic zero-padding.
+
+    The padding width is determined by the total number of qubits in the system,
+    with a minimum of 2 digits. For example:
+      - 64-qubit system:  qid='5' -> 'Q05'  (2 digits)
+      - 144-qubit system: qid='5' -> 'Q005' (3 digits)
+
+    Args:
+    ----
+        qid: Numeric qubit identifier as a string (e.g., '0', '5', '63')
+        num_qubits: Total number of qubits in the system
+
+    Returns:
+    -------
+        Qubit label string (e.g., 'Q00', 'Q005')
+
+    Raises:
+    ------
+        ValueError: If qid is not a purely numeric string
+
+    """
+    if re.fullmatch(r"\d+", qid):
+        width = max(2, len(str(num_qubits)))
+        return "Q" + qid.zfill(width)
+    error_message = "Invalid qid format."
+    raise ValueError(error_message)

--- a/src/qdash/workflow/calibtasks/fake/base.py
+++ b/src/qdash/workflow/calibtasks/fake/base.py
@@ -39,16 +39,17 @@ class FakeTask(BaseTask):
             f"Batch run is not implemented for {self.name} task. Use run method instead."
         )
 
-    def get_label(self, qid: str) -> str:
+    def get_label(self, qid: str, num_qubits: int = 64) -> str:
         """Convert qubit ID to label.
 
         Args:
         ----
             qid: Qubit ID (as string)
+            num_qubits: Total number of qubits in the system (default: 64)
 
         Returns:
         -------
             The qubit label string (e.g., "Q00", "Q01", etc.)
 
         """
-        return str(qid_to_label(qid))
+        return str(qid_to_label(qid, num_qubits))

--- a/src/qdash/workflow/engine/util.py
+++ b/src/qdash/workflow/engine/util.py
@@ -1,27 +1,21 @@
 """Utility functions and classes for calibration workflows."""
 
-import re
 from datetime import datetime
 from typing import Any
 
 from prefect import task
 from pydantic import BaseModel, Field
 from qdash.common.datetime_utils import now
+from qdash.common.qubit_utils import qid_to_label
 from qdash.datamodel.task import TaskModel
 from qdash.workflow.calibtasks.base import BaseTask
+
+__all__ = ["qid_to_label"]
 
 
 def get_current_timestamp() -> datetime:
     """Get current timestamp in configured timezone."""
     return now()
-
-
-def qid_to_label(qid: str) -> str:
-    """Convert a numeric qid string to a label with at least two digits. e.g. '0' -> 'Q00'."""
-    if re.fullmatch(r"\d+", qid):
-        return "Q" + qid.zfill(2)
-    error_message = "Invalid qid format."
-    raise ValueError(error_message)
 
 
 def pydantic_serializer(obj: BaseModel) -> dict[str, Any]:

--- a/tests/qdash/common/test_qubit_utils.py
+++ b/tests/qdash/common/test_qubit_utils.py
@@ -1,0 +1,53 @@
+"""Tests for qdash.common.qubit_utils module."""
+
+import pytest
+from qdash.common.qubit_utils import qid_to_label
+
+
+class TestQidToLabel:
+    """Tests for qid_to_label function."""
+
+    def test_64q_system_single_digit(self) -> None:
+        assert qid_to_label("5", 64) == "Q05"
+
+    def test_64q_system_double_digit(self) -> None:
+        assert qid_to_label("63", 64) == "Q63"
+
+    def test_64q_system_zero(self) -> None:
+        assert qid_to_label("0", 64) == "Q00"
+
+    def test_144q_system_single_digit(self) -> None:
+        assert qid_to_label("5", 144) == "Q005"
+
+    def test_144q_system_double_digit(self) -> None:
+        assert qid_to_label("63", 144) == "Q063"
+
+    def test_144q_system_triple_digit(self) -> None:
+        assert qid_to_label("143", 144) == "Q143"
+
+    def test_144q_system_zero(self) -> None:
+        assert qid_to_label("0", 144) == "Q000"
+
+    def test_1000q_system(self) -> None:
+        assert qid_to_label("5", 1000) == "Q0005"
+
+    def test_small_system_minimum_two_digits(self) -> None:
+        assert qid_to_label("3", 5) == "Q03"
+
+    def test_10q_system(self) -> None:
+        assert qid_to_label("9", 10) == "Q09"
+
+    def test_100q_system(self) -> None:
+        assert qid_to_label("5", 100) == "Q005"
+
+    def test_invalid_qid_raises_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid qid format"):
+            qid_to_label("Q00", 64)
+
+    def test_non_numeric_raises_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid qid format"):
+            qid_to_label("abc", 64)
+
+    def test_empty_string_raises_error(self) -> None:
+        with pytest.raises(ValueError, match="Invalid qid format"):
+            qid_to_label("", 64)


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced a dynamic `qid_to_label` function that adjusts zero-padding based on the total number of qubits, enhancing flexibility for different system sizes.
- Added comprehensive tests to ensure the function handles various cases, including invalid inputs.

## Changes
- Implemented `qid_to_label` in `qdash.common.qubit_utils`.
- Updated existing code to utilize the new function with dynamic padding.
- Created a test suite for `qid_to_label` covering multiple scenarios and edge cases.

