### PR TITLE
fix: Space added at Projects member adding page

### DIFF
--- a/ui/src/app/(auth)/admin/page.tsx
+++ b/ui/src/app/(auth)/admin/page.tsx
@@ -1255,7 +1255,7 @@ function MembersModal({
                     <span className="label-text font-medium">User</span>
                   </label>
                   <select
-                    className="select select-bordered"
+                    className="select select-bordered ml-2"
                     value={selectedUsername}
                     onChange={(e) => setSelectedUsername(e.target.value)}
                   >


### PR DESCRIPTION
## Ticket
#638 

## Summary
There was no space between the user label and the select.

## Changes
Margin-left added.

<img width="1296" height="685" alt="space" src="https://github.com/user-attachments/assets/aba2530e-4409-426f-b792-61afd25c3ae1" />

