### PR TITLE
fix: Select field width improved at chip details page

### DIFF
--- a/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitsId]/page.tsx
+++ b/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitsId]/page.tsx
@@ -216,29 +216,35 @@ function QubitDetailPageContent() {
 
           {/* Controls */}
           <div className="flex gap-4">
-            <ChipSelector
-              selectedChip={chipId}
-              onChipSelect={(newChipId) => {
-                // Navigate to the new chip's qubit detail page
-                window.location.href = `/chip/${newChipId}/qubit/${qubitId}`;
-              }}
-            />
+            <div className="w-full sm:w-auto">
+              <ChipSelector
+                selectedChip={chipId}
+                onChipSelect={(newChipId) => {
+                  // Navigate to the new chip's qubit detail page
+                  window.location.href = `/chip/${newChipId}/qubit/${qubitId}`;
+                }}
+              />
+            </div>
 
             {viewMode !== "history" && (
-              <DateSelector
-                chipId={chipId}
-                selectedDate={selectedDate}
-                onDateSelect={setSelectedDate}
-                disabled={!chipId}
-              />
+              <div className="w-full sm:w-auto">
+                <DateSelector
+                  chipId={chipId}
+                  selectedDate={selectedDate}
+                  onDateSelect={setSelectedDate}
+                  disabled={!chipId}
+                />
+              </div>
             )}
 
-            <TaskSelector
-              tasks={filteredTasks}
-              selectedTask={selectedTask}
-              onTaskSelect={setSelectedTask}
-              disabled={false}
-            />
+            <div className="w-full sm:w-auto">
+              <TaskSelector
+                tasks={filteredTasks}
+                selectedTask={selectedTask}
+                onTaskSelect={setSelectedTask}
+                disabled={false}
+              />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Ticket
#610 

## Summary
This was due to the style being set, but changing the style is dangerous.
The styles are defined in `qdash/ui/src/hooks/useSelectStyles.ts`.

## Changes
I wrapped it with `sm:w-auto`.

<img width="1268" height="679" alt="size" src="https://github.com/user-attachments/assets/a0ae422e-6287-4e72-a149-2031c477e29c" />
