### PR TITLE
fix: Multiselect appearance updated in Analytics CDF page

### DIFF
--- a/ui/src/components/features/analysis/CDFView.tsx
+++ b/ui/src/components/features/analysis/CDFView.tsx
@@ -707,7 +707,7 @@ export function CDFView() {
           {/* Row 1: Main Controls */}
           <div className="flex flex-col gap-3 sm:gap-4">
             {/* Row 1a: Type + Chip + Parameters */}
-            <div className="flex flex-wrap items-upper gap-2 sm:gap-3">
+            <div className="flex flex-wrap items-start gap-2 sm:gap-3">
               <div className="tabs tabs-boxed bg-base-200 h-8 sm:h-9">
                 <button
                   className={`tab h-full ${currentMetricType === "qubit" ? "tab-active" : ""}`}


### PR DESCRIPTION
## Ticket
#597 

## Summary
The dynamic size change was a feature, but it didn't look good.

## Changes
- Align elements to upper
- Multiselect set as flex-1

<img width="1256" height="719" alt="improve" src="https://github.com/user-attachments/assets/59fd321b-0903-4e99-bfa5-baf49a8a2196" />

max rows:
<img width="1258" height="589" alt="max" src="https://github.com/user-attachments/assets/e5d6794b-0d3a-49d7-b6d9-aab0c84e384a" />
