### PR TITLE
feat(workflow): add interval parameter to HPI and PI pulse checks

### DIFF
--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_hpi_pulse.py
@@ -7,7 +7,7 @@ from qdash.workflow.calibtasks.base import (
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qubex.measurement.measurement import DEFAULT_READOUT_DURATION
+from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_READOUT_DURATION
 
 
 class CheckHPIPulse(QubexTask):
@@ -31,7 +31,13 @@ class CheckHPIPulse(QubexTask):
             value_type="int",
             value=20,
             description="Number of repetitions for the HPI pulse",
-        )
+        ),
+        "interval": RunParameterModel(
+            unit="ns",
+            value_type="int",
+            value=DEFAULT_INTERVAL,
+            description="Time interval",
+        ),
     }
     output_parameters: ClassVar[dict[str, ParameterModel]] = {}
 
@@ -53,6 +59,7 @@ class CheckHPIPulse(QubexTask):
         result = exp.repeat_sequence(
             sequence=hpi_pulse,
             repetitions=self.run_parameters["repetitions"].get_value(),
+            interval=self.run_parameters["interval"].get_value(),
         )
         self.save_calibration(backend)
         return RunResult(raw_result=result)

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_pi_pulse.py
@@ -7,7 +7,7 @@ from qdash.workflow.calibtasks.base import (
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qubex.measurement.measurement import DEFAULT_READOUT_DURATION
+from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_READOUT_DURATION
 
 
 class CheckPIPulse(QubexTask):
@@ -31,7 +31,13 @@ class CheckPIPulse(QubexTask):
             value_type="int",
             value=20,
             description="Number of repetitions for the PI pulse",
-        )
+        ),
+        "interval": RunParameterModel(
+            unit="ns",
+            value_type="int",
+            value=DEFAULT_INTERVAL,
+            description="Time interval",
+        ),
     }
     output_parameters: ClassVar[dict[str, ParameterModel]] = {}
 
@@ -53,6 +59,7 @@ class CheckPIPulse(QubexTask):
         result = exp.repeat_sequence(
             sequence=pi_pulse,
             repetitions=self.run_parameters["repetitions"].get_value(),
+            interval=self.run_parameters["interval"].get_value(),
         )
         self.save_calibration(backend)
         return RunResult(raw_result=result)

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_hpi_pulse.py
@@ -7,7 +7,7 @@ from qdash.workflow.calibtasks.base import (
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qubex.measurement.measurement import DEFAULT_READOUT_DURATION
+from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_READOUT_DURATION
 
 
 class CheckDRAGHPIPulse(QubexTask):
@@ -32,7 +32,13 @@ class CheckDRAGHPIPulse(QubexTask):
             value_type="int",
             value=20,
             description="Number of repetitions for the PI pulse",
-        )
+        ),
+        "interval": RunParameterModel(
+            unit="ns",
+            value_type="int",
+            value=DEFAULT_INTERVAL,
+            description="Time interval",
+        ),
     }
     output_parameters: ClassVar[dict[str, ParameterModel]] = {}
 
@@ -54,6 +60,7 @@ class CheckDRAGHPIPulse(QubexTask):
         result = exp.repeat_sequence(
             sequence=drag_hpi_pulse,
             repetitions=self.run_parameters["repetitions"].get_value(),
+            interval=self.run_parameters["interval"].get_value(),
         )
         self.save_calibration(backend)
         return RunResult(raw_result=result)

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_pi_pulse.py
@@ -7,7 +7,7 @@ from qdash.workflow.calibtasks.base import (
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
 from qdash.workflow.engine.backend.qubex import QubexBackend
-from qubex.measurement.measurement import DEFAULT_READOUT_DURATION
+from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_READOUT_DURATION
 
 
 class CheckDRAGPIPulse(QubexTask):
@@ -32,7 +32,13 @@ class CheckDRAGPIPulse(QubexTask):
             value_type="int",
             value=20,
             description="Number of repetitions for the PI pulse",
-        )
+        ),
+        "interval": RunParameterModel(
+            unit="ns",
+            value_type="int",
+            value=DEFAULT_INTERVAL,
+            description="Time interval",
+        ),
     }
     output_parameters: ClassVar[dict[str, ParameterModel]] = {}
 
@@ -54,6 +60,7 @@ class CheckDRAGPIPulse(QubexTask):
         result = exp.repeat_sequence(
             sequence=drag_pi_pulse,
             repetitions=self.run_parameters["repetitions"].get_value(),
+            interval=self.run_parameters["interval"].get_value(),
         )
         self.save_calibration(backend)
         return RunResult(raw_result=result)

--- a/src/qdash/workflow/templates/bringup.py
+++ b/src/qdash/workflow/templates/bringup.py
@@ -71,5 +71,8 @@ def bringup(
         tags=tags,
         project_id=project_id,
         skip_execution=True,
+        default_run_parameters={
+            "interval": {"value": 150 * 1024, "value_type": "int"},
+        },
     )
     return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/full_calibration.py
+++ b/src/qdash/workflow/templates/full_calibration.py
@@ -117,6 +117,7 @@ def full_calibration(
             "pi_duration": {"value": 32, "value_type": "int"},
             "drag_hpi_duration": {"value": 16, "value_type": "int"},
             "drag_pi_duration": {"value": 24, "value_type": "int"},
+            "interval": {"value": 150 * 1024, "value_type": "int"},
         },
     )
     return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -83,6 +83,7 @@ def one_qubit(
             "pi_duration": {"value": 32, "value_type": "int"},
             "drag_hpi_duration": {"value": 16, "value_type": "int"},
             "drag_pi_duration": {"value": 24, "value_type": "int"},
+            "interval": {"value": 150 * 1024, "value_type": "int"},
         },
     )
     return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/simple.py
+++ b/src/qdash/workflow/templates/simple.py
@@ -114,6 +114,7 @@ def simple_calibration(
         skip_execution=True,  # Child sessions create their own Executions
         default_run_parameters={
             "hpi_duration": {"value": 32, "value_type": "int"},
+            "interval": {"value": 150 * 1024, "value_type": "int"},
         },
     )
     return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/two_qubit.py
+++ b/src/qdash/workflow/templates/two_qubit.py
@@ -169,5 +169,8 @@ def two_qubit(
         tags=tags,
         project_id=project_id,
         skip_execution=True,  # Child sessions create their own Executions
+        default_run_parameters={
+            "interval": {"value": 150 * 1024, "value_type": "int"},
+        },
     )
     return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/two_qubit_scheduled.py
+++ b/src/qdash/workflow/templates/two_qubit_scheduled.py
@@ -138,5 +138,8 @@ def two_qubit_scheduled(
         tags=tags,
         project_id=project_id,
         skip_execution=True,  # Child sessions create their own Executions
+        default_run_parameters={
+            "interval": {"value": 150 * 1024, "value_type": "int"},
+        },
     )
     return cal.run(targets, steps=steps)


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced an interval parameter for HPI and PI pulse checks to enhance control over pulse timing.
- This change impacts the workflow by allowing users to specify the time interval between pulse repetitions, improving flexibility in pulse execution.

## Changes
- Added an `interval` parameter to `CheckHPIPulse`, `CheckPIPulse`, `CheckDRAGHPIPulse`, and `CheckDRAGPIPulse` classes.
- Updated the `run` method to utilize the new interval parameter during pulse execution.
- Modified calibration functions to include default interval settings.

