### PR TITLE
fix: Chip page select width improved

### DIFF
--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -406,13 +406,13 @@ export function ChipPageContent() {
           {/* Selection Controls */}
           <PageFiltersBar>
             <PageFiltersBar.Group>
-              <PageFiltersBar.Item>
+              <PageFiltersBar.Item className="sm:min-w-48">
                 <ChipSelector
                   selectedChip={selectedChip}
                   onChipSelect={setSelectedChip}
                 />
               </PageFiltersBar.Item>
-              <PageFiltersBar.Item>
+              <PageFiltersBar.Item className="sm:min-w-48">
                 <DateSelector
                   chipId={selectedChip}
                   selectedDate={selectedDate}
@@ -420,7 +420,7 @@ export function ChipPageContent() {
                   disabled={!selectedChip}
                 />
               </PageFiltersBar.Item>
-              <PageFiltersBar.Item>
+              <PageFiltersBar.Item className="sm:min-w-96">
                 <TaskSelector
                   tasks={filteredTasks}
                   selectedTask={selectedTask}


### PR DESCRIPTION
## Ticket
#624 

## Summary
It had no minimum width set, so it was dynamically sizing.

## Changes
I set a minimum width for the select on that page.

<img width="1433" height="856" alt="01" src="https://github.com/user-attachments/assets/7c586885-10b6-4390-b3cf-10da8ac37dc8" />
<img width="391" height="568" alt="02" src="https://github.com/user-attachments/assets/cd490b17-fe1b-4357-9b6b-f74eaa0ac264" />
