### PR TITLE
fix: Alignment of selects on mobile improved

### DIFF
--- a/ui/src/components/features/analysis/TimeSeriesView/index.tsx
+++ b/ui/src/components/features/analysis/TimeSeriesView/index.tsx
@@ -732,91 +732,79 @@ export function TimeSeriesView() {
             Refresh
           </button>
         </div>
-        <div className="child w-full">
-          <table className="w-full table-auto">
-            <tr>
-              <th className="px-4 text-left">
-                <label className="text-sm font-medium text-base-content/70">
-                  Chip
-                </label>
-              </th>
-              <th className="px-4 text-left">
-                <label className="text-sm font-medium text-base-content/70">
-                  Parameter
-                  <span className="ml-1 text-xs text-primary">(Left Y)</span>
-                </label>
-              </th>
-              <th className="px-4 text-left">
-                <label className="text-sm font-medium text-base-content/70">
-                  Tag
-                </label>
-              </th>
-            </tr>
-            <tr>
-              <td className="px-4">
-                <div>
-                  <ChipSelector
-                    selectedChip={selectedChip}
-                    onChipSelect={setSelectedChip}
-                  />
-                </div>
-              </td>
-              <td className="px-4">
-                <div className="space-y-1">
-                  <Select<{ value: string; label: string }, false>
-                    options={availableParameters}
-                    value={
-                      currentMetricConfig
-                        ? {
-                            value: currentMetricConfig.key,
-                            label: currentMetricConfig.title,
-                          }
-                        : null
-                    }
-                    onChange={(option) => {
-                      if (option) {
-                        setSelectedParameter(option.value);
-                        // Clear secondary if it's the same as new primary
-                        if (secondaryParameter === option.value) {
-                          handleRemoveSecondaryAxis();
-                        }
+        <div className="flex flex-col sm:flex-row child w-full gap-4 sm:gap-6">
+          <div className="flex-1">
+            <label className="text-sm font-medium text-base-content/70">
+              Chip
+            </label>
+            <div>
+              <ChipSelector
+                selectedChip={selectedChip}
+                onChipSelect={setSelectedChip}
+              />
+            </div>
+          </div>
+          <div className="flex-1">
+            <label className="text-sm font-medium text-base-content/70">
+              Parameter
+              <span className="ml-1 text-xs text-primary">(Left Y)</span>
+            </label>
+            <div className="space-y-1">
+              <Select<{ value: string; label: string }, false>
+                options={availableParameters}
+                value={
+                  currentMetricConfig
+                    ? {
+                        value: currentMetricConfig.key,
+                        label: currentMetricConfig.title,
                       }
-                    }}
-                    placeholder="Select parameter"
-                    className="text-base-content"
-                    styles={{
-                      control: (base) => ({
-                        ...base,
-                        minHeight: "38px",
-                        height: "auto",
-                        borderRadius: "0.5rem",
-                        borderColor: "#1f77b4",
-                        borderWidth: "2px",
-                      }),
-                      valueContainer: (base) => ({
-                        ...base,
-                        padding: "2px 8px",
-                      }),
-                      menu: (base) => ({
-                        ...base,
-                        zIndex: 50,
-                      }),
-                    }}
-                  />
-                </div>
-              </td>
-              <td className="px-4">
-                <div>
-                  <TagSelector
-                    tags={tags}
-                    selectedTag={selectedTag}
-                    onTagSelect={setSelectedTag}
-                    disabled={isLoadingTags}
-                  />
-                </div>
-              </td>
-            </tr>
-          </table>
+                    : null
+                }
+                onChange={(option) => {
+                  if (option) {
+                    setSelectedParameter(option.value);
+                    // Clear secondary if it's the same as new primary
+                    if (secondaryParameter === option.value) {
+                      handleRemoveSecondaryAxis();
+                    }
+                  }
+                }}
+                placeholder="Select parameter"
+                className="text-base-content"
+                styles={{
+                  control: (base) => ({
+                    ...base,
+                    minHeight: "38px",
+                    height: "auto",
+                    borderRadius: "0.5rem",
+                    borderColor: "#1f77b4",
+                    borderWidth: "2px",
+                  }),
+                  valueContainer: (base) => ({
+                    ...base,
+                    padding: "2px 8px",
+                  }),
+                  menu: (base) => ({
+                    ...base,
+                    zIndex: 50,
+                  }),
+                }}
+              />
+            </div>
+          </div>
+          <div className="flex-1">
+            <label className="text-sm font-medium text-base-content/70">
+              Tag
+            </label>
+            <div>
+              <TagSelector
+                tags={tags}
+                selectedTag={selectedTag}
+                onTagSelect={setSelectedTag}
+                disabled={isLoadingTags}
+              />
+            </div>
+          </div>
         </div>
 
         {/* Secondary Axis Section */}

--- a/ui/src/components/features/analysis/TimeSeriesView/index.tsx
+++ b/ui/src/components/features/analysis/TimeSeriesView/index.tsx
@@ -732,7 +732,7 @@ export function TimeSeriesView() {
             Refresh
           </button>
         </div>
-        <div className="flex flex-col sm:flex-row child w-full gap-4 sm:gap-6">
+        <div className="flex flex-col sm:flex-row w-full gap-4 sm:gap-6">
           <div className="flex-1">
             <label className="text-sm font-medium text-base-content/70">
               Chip
@@ -809,7 +809,7 @@ export function TimeSeriesView() {
 
         {/* Secondary Axis Section */}
         <div className="mt-4 pt-4 border-t border-base-300">
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
+          <div className="flex flex-col sm:flex-row w-full gap-4 sm:gap-6">
             <div className="space-y-1">
               <label className="text-sm font-medium text-base-content/70">
                 Secondary Parameter


### PR DESCRIPTION
## Ticket
#701 

## Summary
The flex alignment did not work because of the table.

## Changes
I stopped using tables and instead used divs.

<img width="441" height="828" alt="mobile" src="https://github.com/user-attachments/assets/689c12ac-5e38-49e6-bafe-2b4101bd0308" />
<img width="1407" height="705" alt="pc" src="https://github.com/user-attachments/assets/7ac81f5c-c003-4942-a381-399d36c65289" />

