### PR TITLE
fix(api): allow regeneration of knowledge cases and update image handling

### DIFF
--- a/tests/qdash/api/services/test_issue_knowledge_service.py
+++ b/tests/qdash/api/services/test_issue_knowledge_service.py
@@ -771,12 +771,8 @@ class TestDocToMarkdown:
         )
         md = IssueKnowledgeService._doc_to_markdown(doc)
         assert "## Thread images" in md
-        assert (
-            "![Thread image 1](./figures/81909b81-af30-40d8-85b3-379bb4d75909.png)" in md
-        )
-        assert (
-            "![Thread image 2](./figures/abcdef12-3456-7890-abcd-ef1234567890.jpg)" in md
-        )
+        assert "![Thread image 1](./figures/81909b81-af30-40d8-85b3-379bb4d75909.png)" in md
+        assert "![Thread image 2](./figures/abcdef12-3456-7890-abcd-ef1234567890.jpg)" in md
 
     def test_thread_image_urls_mixed(self):
         """Mixed local and external thread image URLs are handled correctly."""

--- a/tests/qdash/api/services/test_issue_knowledge_service.py
+++ b/tests/qdash/api/services/test_issue_knowledge_service.py
@@ -751,8 +751,8 @@ class TestDocToMarkdown:
         assert "![Figure 2](./figures/fig2.png)" in md
         assert "![Figure 3](./figures/fig3.png)" in md
 
-    def test_thread_image_urls(self):
-        """Thread image URLs are included as-is."""
+    def test_thread_image_urls_external(self):
+        """External thread image URLs are included as-is."""
         doc = _make_doc(
             thread_image_urls=["https://img.example.com/a.png", "https://img.example.com/b.png"]
         )
@@ -760,6 +760,35 @@ class TestDocToMarkdown:
         assert "## Thread images" in md
         assert "![Thread image 1](https://img.example.com/a.png)" in md
         assert "![Thread image 2](https://img.example.com/b.png)" in md
+
+    def test_thread_image_urls_local_api(self):
+        """Local API thread image URLs are rewritten to relative paths."""
+        doc = _make_doc(
+            thread_image_urls=[
+                "/api/issues/images/81909b81-af30-40d8-85b3-379bb4d75909.png",
+                "/api/issues/images/abcdef12-3456-7890-abcd-ef1234567890.jpg",
+            ]
+        )
+        md = IssueKnowledgeService._doc_to_markdown(doc)
+        assert "## Thread images" in md
+        assert (
+            "![Thread image 1](./figures/81909b81-af30-40d8-85b3-379bb4d75909.png)" in md
+        )
+        assert (
+            "![Thread image 2](./figures/abcdef12-3456-7890-abcd-ef1234567890.jpg)" in md
+        )
+
+    def test_thread_image_urls_mixed(self):
+        """Mixed local and external thread image URLs are handled correctly."""
+        doc = _make_doc(
+            thread_image_urls=[
+                "/api/issues/images/abc123.png",
+                "https://img.example.com/ext.png",
+            ]
+        )
+        md = IssueKnowledgeService._doc_to_markdown(doc)
+        assert "![Thread image 1](./figures/abc123.png)" in md
+        assert "![Thread image 2](https://img.example.com/ext.png)" in md
 
     def test_omits_empty_sections(self):
         """Sections with empty content are omitted."""

--- a/ui/src/components/ui/FluentEmoji.tsx
+++ b/ui/src/components/ui/FluentEmoji.tsx
@@ -41,6 +41,7 @@ const EMOJI_MAP: Record<string, string> = {
   file: "Page%20facing%20up/3D/page_facing_up_3d.png",
 
   // Science & Tech
+  brain: "Brain/3D/brain_3d.png",
   atom: "Atom%20symbol/3D/atom_symbol_3d.png",
   microchip: "Desktop%20computer/3D/desktop_computer_3d.png",
   computer: "Desktop%20computer/3D/desktop_computer_3d.png",


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Enable regeneration of knowledge cases regardless of their status and improve handling of thread images by rewriting local API URLs to relative paths.
- These changes enhance the API's flexibility and ensure proper image referencing in generated markdown.

## Changes
- Removed restriction on regenerating approved knowledge cases.
- Updated markdown generation to handle local API thread images with relative paths.
- Added tests for local and mixed thread image URLs handling.

