### PR TITLE
test: add tests for skipping coupling-format QIDs in seed import

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -370,6 +370,7 @@ numpy==1.26.0
     #   ml-dtypes
     #   optax
     #   osqp
+    #   pandas
     #   pylabrad
     #   qctrl-visualizer
     #   qdash
@@ -404,6 +405,8 @@ packaging==24.2
     #   pytest
     #   quel-ic-config
     #   qutip
+pandas==2.3.3 ; python_full_version < '3.11'
+pandas==3.0.1 ; python_full_version >= '3.11'
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.4
@@ -506,6 +509,7 @@ python-dateutil==2.9.0.post0
     #   croniter
     #   jupyter-client
     #   matplotlib
+    #   pandas
     #   pendulum
 python-dotenv==1.0.1
     # via
@@ -517,7 +521,9 @@ python-json-logger==3.3.0
 python-multipart==0.0.20
     # via fastapi
 pytz==2025.2
-    # via croniter
+    # via
+    #   croniter
+    #   pandas
 pywin32==308 ; platform_python_implementation != 'PyPy' and sys_platform == 'win32'
     # via jupyter-core
 pywinpty==2.0.15 ; os_name == 'nt'
@@ -730,7 +736,9 @@ typing-extensions==4.12.2
     #   typer
     #   uvicorn
 tzdata==2025.2
-    # via pendulum
+    # via
+    #   pandas
+    #   pendulum
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.3.0

--- a/docs/development/copilot/tool-result-compression.md
+++ b/docs/development/copilot/tool-result-compression.md
@@ -1,0 +1,124 @@
+# Tool Result Compression
+
+Copilot tool results are truncated at `MAX_TOOL_RESULT_CHARS = 30000`. Raw MongoDB documents easily exceed this, so tools apply semantic compression. Additionally, large-data tools use a **data store** pattern to avoid sending full datasets to the LLM at all.
+
+## Two categories of tools
+
+### Stored tools (data store pattern)
+
+Tools that return large datasets store full results server-side in `data_store` and return only a compact summary to the LLM. The sandbox (`execute_python_analysis`) receives the full data automatically via the `data` variable.
+
+| Tool | data_key | Description |
+|------|----------|-------------|
+| `get_chip_parameter_timeseries` | `args["parameter_name"]` (e.g., `"t1"`) | Per-qubit timeseries + stats |
+| `get_chip_summary` | `"chip_summary"` | All qubits with statistics |
+
+**Data flow:**
+
+```
+Tool → full data → data_store["t1"] (server-side)
+     → summary (schema + stats) → json.dumps → LLM (~1K chars)
+LLM → execute_python_analysis(code)  ← no context_data needed
+→ sandbox: data["t1"] provides full dataset
+```
+
+**Summary format (`_build_llm_summary`):**
+
+Lists of dicts are replaced with schema info:
+
+```python
+# Full result (stored in data_store)
+{"qubits": [{"qid": "0", "latest": 5.05}, {"qid": "1", "latest": 4.98}]}
+
+# Summary (sent to LLM)
+{"qubits": {"_schema": ["qid", "latest"], "_rows": 2},
+ "data_key": "t1",
+ "_note": "Full data available as data['t1'] in execute_python_analysis. Do NOT pass data manually."}
+```
+
+Scalar values (chip_id, unit, num_qubits, statistics) pass through unchanged, giving the LLM enough context to decide what analysis to run.
+
+### Direct tools (JSON to LLM)
+
+Smaller-data tools return results directly to the LLM as JSON. These apply value-level compression to reduce token usage.
+
+| Tool | Compression |
+|------|-------------|
+| `search_task_results` | `_compact_output_parameters`, `_compact_timestamp`, `_compact_number` |
+| `get_task_history` | `_compact_output_parameters`, `_compact_timestamp` |
+| `compare_qubits` | Value-only extraction, `_compact_number` |
+| `get_provenance_lineage_graph` | Uniform `nodes` list, `edges` list, `_compact_number`, `_compact_timestamp` |
+| `get_parameter_lineage` | `_compact_number`, `_compact_timestamp` |
+| `get_execution_history` | `_compact_timestamp`, `_compact_number` |
+
+## Value-level helpers
+
+Three module-level functions in `copilot_data_service.py` handle common compression tasks for **direct tools**.
+
+### `_compact_number(value)`
+
+Rounds floats to 4 significant figures. Returns `int` when the fractional part is zero.
+
+```python
+_compact_number(45.23456789012)  # -> 45.23
+_compact_number(0.000123456)     # -> 0.0001235
+_compact_number(1200.0)          # -> 1200 (int)
+```
+
+Non-float inputs and non-finite values (`NaN`, `inf`) pass through unchanged.
+
+### `_compact_timestamp(iso_str)`
+
+Strips year, seconds, and microseconds from ISO timestamps.
+
+```python
+_compact_timestamp("2026-02-24T02:22:04.211000")  # -> "02-24 02:22"
+_compact_timestamp(None)                            # -> ""
+```
+
+**Note:** Stored tools (timeseries) keep full ISO timestamps because the sandbox needs them for Plotly datetime parsing.
+
+### `_compact_output_parameters(params)`
+
+Reduces `output_parameters` from 10 fields per parameter to only what the LLM needs:
+
+```python
+# Before: 10 fields per parameter
+{"qubit_frequency": {"parameter_name": "...", "value": 5.234567890, ...}}
+
+# After: 2-3 fields
+{"qubit_frequency": {"value": 5.235, "unit": "GHz", "error": 0.001234}}
+```
+
+## Stored tools: no value compression
+
+Stored tools (`get_chip_parameter_timeseries`, `get_chip_summary`) do **not** apply `_compact_number` or `_compact_timestamp` to data that goes into `data_store`. The sandbox receives full-precision values and full ISO timestamps.
+
+However, per-qubit **summary stats** (latest, min, max, mean, trend) and **chip-wide statistics** still use `_compact_number` because these appear in the LLM summary.
+
+## Serialization
+
+Tool results are serialized with:
+
+```python
+json.dumps(_sanitize_nan(tool_result), default=str, ensure_ascii=False)
+```
+
+- `_sanitize_nan`: Replaces `NaN`/`Inf` float values with `None` for valid JSON
+- `default=str`: Handles non-primitive types (datetime, ObjectId, etc.)
+- Charts bypass the LLM entirely and go directly to the frontend
+
+## Adding a new tool
+
+When adding a tool to `CopilotDataService`:
+
+1. **Decide: stored or direct?** If the tool returns large datasets (100+ rows), make it a stored tool by adding it to `_STORED_TOOLS` in `copilot_agent.py`.
+2. For **direct tools**: apply `_compact_timestamp()`, `_compact_number()`, and `_compact_output_parameters()` as appropriate.
+3. For **stored tools**: keep full precision in the data (no `_compact_number` on timeseries values). Use `_compact_number` only on summary statistics that appear in the LLM summary.
+4. Use list-of-dicts (not dict-of-dicts) for tabular data — move the key into a field (e.g., `{"qid": "0", ...}`).
+5. Flatten nested structures into separate lists.
+
+## References
+
+- `src/qdash/api/services/copilot_data_service.py` — all tool implementations and helpers
+- `src/qdash/api/lib/copilot_agent.py` — `_build_llm_summary`, `_wrap_tool_executors`, `_STORED_TOOLS`, `_sanitize_nan`, and `MAX_TOOL_RESULT_CHARS` truncation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ api = [
     "pendulum>=3.1.0",  # For timestamp formatting in Git commits
     "pydantic-settings>=2.0.0",  # For Settings configuration
     "reportlab>=4.4.1",  # For PDF generation
+    "pandas>=2.0.0",  # For copilot sandbox data analysis
     "plotly>=5.18.0",  # For chart generation
     "kaleido>=0.2.1",  # For Plotly image export
     "pillow>=10.0.0",  # For image processing

--- a/src/qdash/api/lib/copilot_agent.py
+++ b/src/qdash/api/lib/copilot_agent.py
@@ -39,6 +39,12 @@ You have access to tools that can fetch data from the calibration database.
 When the user asks about parameters or results from other experiments,
 use the available tools to retrieve the data rather than saying it's unavailable.
 The current qubit context (chip_id, qid) is provided in the system prompt below.
+
+Tool results are returned in JSON format.
+Some tools (get_chip_parameter_timeseries, get_chip_summary) store full data
+server-side and return only a summary with a `data_key` field.
+In execute_python_analysis, access stored data via data["<data_key>"]
+(e.g., data["t1"]). Do NOT pass context_data manually.
 """
 
 MAX_TOOL_ROUNDS = 10
@@ -145,8 +151,9 @@ AGENT_TOOLS: list[dict[str, Any]] = [
             "Use this when you need to perform calculations, statistical analysis, "
             "or generate Plotly charts from data retrieved by other tools. "
             "Available libraries: numpy, pandas, scipy, scipy.stats, plotly, math, statistics, "
-            "json, datetime, collections. "
-            "Pass data from previous tool calls via context_data (accessible as 'data' in code). "
+            "json, datetime, collections, io. "
+            "Stored tool results are automatically available as data['<data_key>'] "
+            "(e.g., data['t1'], data['chip_summary']). Do NOT pass data manually. "
             "Set a 'result' variable as a dict with 'output' (text) and optionally "
             "'chart' (single Plotly spec or a list of Plotly specs, each with 'data' and 'layout' keys). "
             "You can use plotly.graph_objects, plotly.express, or plotly.subplots."
@@ -157,14 +164,11 @@ AGENT_TOOLS: list[dict[str, Any]] = [
                 "code": {
                     "type": "string",
                     "description": (
-                        "Python code to execute. Use 'data' to access context_data. "
+                        "Python code to execute. Use data['<key>'] to access stored tool results "
+                        "(e.g., data['t1']['timeseries'] for timeseries data). "
                         "Set result = {'output': '...', 'chart': {'data': [...], 'layout': {...}}} "
                         "for single chart, or 'chart': [chart1, chart2, ...] for multiple charts."
                     ),
-                },
-                "context_data": {
-                    "type": "object",
-                    "description": "Data from previous tool calls to make available as 'data' variable in the code.",
                 },
             },
             "required": ["code"],
@@ -175,8 +179,9 @@ AGENT_TOOLS: list[dict[str, Any]] = [
         "type": "function",
         "name": "get_chip_summary",
         "description": (
-            "Get a summary of all qubits on a chip with per-qubit parameters and "
-            "computed statistics (mean, median, std, min, max) for numeric parameters. "
+            "Get a summary of all qubits on a chip. Returns: "
+            "(1) statistics: per-parameter mean/median/std/min/max across all qubits, "
+            "(2) qubits: dict mapping qid to {param: value} for each qubit. "
             "Use this for chip-wide analysis or when the user asks about overall chip quality."
         ),
         "parameters": {
@@ -994,18 +999,70 @@ def _parse_blocks_response(content: str) -> dict[str, Any]:
         }
 
 
-def _wrap_chart_executors(
-    tool_executors: ToolExecutors,
-) -> tuple[ToolExecutors, list[dict[str, Any]]]:
-    """Wrap tool executors to intercept chart results from chart-generating tools.
+_STORED_TOOLS: dict[str, Any] = {
+    "get_chip_parameter_timeseries": lambda args: args["parameter_name"],
+    "get_chip_summary": lambda _args: "chip_summary",
+}
 
-    Charts from ``generate_chip_heatmap`` and ``execute_python_analysis`` are
-    collected so they can be injected directly into the blocks response,
-    avoiding the need for the LLM to reproduce large chart JSON.
+
+def _build_llm_summary(full_result: dict[str, Any], data_key: str) -> dict[str, Any]:
+    """Replace list items with schema info and attach data_key.
+
+    The LLM receives only a compact summary (schema + row count) instead of
+    the full dataset, which is stored server-side in ``data_store``.
+    """
+    summary: dict[str, Any] = {}
+    for key, value in full_result.items():
+        if isinstance(value, list):
+            if value and isinstance(value[0], dict):
+                summary[key] = {"_schema": list(value[0].keys()), "_rows": len(value)}
+            else:
+                summary[key] = {"_rows": len(value)}
+        else:
+            summary[key] = value
+    summary["data_key"] = data_key
+    summary["_note"] = (
+        f"Full data available as data['{data_key}'] in execute_python_analysis. "
+        f"Do NOT pass data manually."
+    )
+    return summary
+
+
+def _wrap_tool_executors(
+    tool_executors: ToolExecutors,
+    data_store: dict[str, Any],
+) -> tuple[ToolExecutors, list[dict[str, Any]]]:
+    """Wrap tool executors to handle data store and chart collection.
+
+    - **Stored tools** (``get_chip_parameter_timeseries``, ``get_chip_summary``):
+      full results go to *data_store*; the LLM receives only a summary.
+    - **Heatmap**: chart is collected for direct injection into the response.
+    - **execute_python_analysis**: *data_store* is auto-injected as ``data``;
+      charts are collected.
     """
     collected_charts: list[dict[str, Any]] = []
     wrapped = dict(tool_executors)
 
+    # Stored tools: full data → data_store, summary → LLM
+    for tool_name, key_fn in _STORED_TOOLS.items():
+        original = wrapped.get(tool_name)
+        if original:
+
+            def stored_wrapper(
+                args: dict[str, Any],
+                _orig: Any = original,
+                _kfn: Any = key_fn,
+            ) -> Any:
+                result = _orig(args)
+                if isinstance(result, dict) and "error" not in result:
+                    key = _kfn(args) if callable(_kfn) else _kfn
+                    data_store[key] = result
+                    return _build_llm_summary(result, key)
+                return result
+
+            wrapped[tool_name] = stored_wrapper
+
+    # Heatmap: chart collection
     original_heatmap = wrapped.get("generate_chip_heatmap")
     if original_heatmap:
 
@@ -1025,25 +1082,25 @@ def _wrap_chart_executors(
 
         wrapped["generate_chip_heatmap"] = heatmap_wrapper
 
-    original_python = wrapped.get("execute_python_analysis")
-    if original_python:
+    # execute_python_analysis: data_store auto-injected + chart collection
+    def python_wrapper(args: dict[str, Any]) -> Any:
+        from qdash.api.lib.copilot_sandbox import execute_python_analysis
 
-        def python_wrapper(args: dict[str, Any], _orig: Any = original_python) -> Any:
-            result = _orig(args)
-            if isinstance(result, dict) and result.get("chart"):
-                chart = result["chart"]
-                if isinstance(chart, list):
-                    collected_charts.extend(chart)
-                else:
-                    collected_charts.append(chart)
-                return {
-                    "output": result.get("output", ""),
-                    "chart": None,
-                    "chart_note": "Chart(s) generated. They will be automatically appended to your response.",
-                }
-            return result
+        result = execute_python_analysis(args["code"], data_store)
+        if isinstance(result, dict) and result.get("chart"):
+            chart = result["chart"]
+            if isinstance(chart, list):
+                collected_charts.extend(chart)
+            else:
+                collected_charts.append(chart)
+            return {
+                "output": result.get("output", ""),
+                "chart": None,
+                "chart_note": "Chart(s) generated. They will be automatically appended to your response.",
+            }
+        return result
 
-        wrapped["execute_python_analysis"] = python_wrapper
+    wrapped["execute_python_analysis"] = python_wrapper
 
     return wrapped, collected_charts
 
@@ -1093,7 +1150,11 @@ def _wrap_rate_limited_executors(tool_executors: ToolExecutors) -> ToolExecutors
 
 
 def _sanitize_nan(obj: Any) -> Any:
-    """Recursively replace NaN/Inf float values with None for valid JSON."""
+    """Recursively replace NaN/Inf float values with None for valid JSON.
+
+    Preserves non-primitive types (e.g. numpy arrays) so that Plotly
+    chart specs remain valid.
+    """
     if isinstance(obj, float) and (math.isnan(obj) or math.isinf(obj)):
         return None
     if isinstance(obj, dict):
@@ -1210,6 +1271,12 @@ async def _run_responses_api(
                 else:
                     try:
                         tool_result = executor(args)
+                    except KeyError as e:
+                        logger.warning("Tool %s missing required argument: %s", fc.name, e)
+                        tool_result = {
+                            "error": f"Missing required argument: {e}. "
+                            f"Please provide all required parameters."
+                        }
                     except Exception as e:
                         logger.warning("Tool %s execution failed: %s", fc.name, e)
                         tool_result = {"error": str(e)}
@@ -1408,11 +1475,12 @@ async def run_analysis(
             user_message, image_base64, conversation_history, expected_images
         )
 
-        # Wrap chart-generating tools to collect charts for direct injection
+        # Wrap tools: data store + chart collection + rate limiting
         if tool_executors:
             wrapped_executors: ToolExecutors | None = None
+            data_store: dict[str, Any] = {}
             rate_limited = _wrap_rate_limited_executors(tool_executors)
-            wrapped_executors, collected_charts = _wrap_chart_executors(rate_limited)
+            wrapped_executors, collected_charts = _wrap_tool_executors(rate_limited, data_store)
         else:
             wrapped_executors, collected_charts = None, []
 
@@ -1460,6 +1528,12 @@ CHAT_SYSTEM_PROMPT = """\
 You are an expert in superconducting qubit calibration.
 You analyze calibration results for fixed-frequency transmon qubits
 on a square-lattice chip with fixed couplers.
+
+Tool results are returned in JSON format.
+Some tools (get_chip_parameter_timeseries, get_chip_summary) store full data
+server-side and return only a summary with a `data_key` field.
+In execute_python_analysis, access stored data via data["<data_key>"]
+(e.g., data["t1"]). Do NOT pass context_data manually.
 
 Your role:
 - Answer questions about qubit calibration data and parameters
@@ -1512,11 +1586,14 @@ When showing data trends, create charts using the blocks response format.
 ## Using execute_python_analysis
 
 For complex analysis (correlations, statistics, distributions, fitting), use execute_python_analysis:
-1. First, retrieve data using get_qubit_params, get_parameter_timeseries, etc.
-2. Then call execute_python_analysis with:
-   - "code": Python code that uses 'data' variable to access context_data
-   - "context_data": Pass the retrieved data as a dict
-3. Available libraries: numpy, pandas, scipy, scipy.stats, plotly (graph_objects, express, subplots), math, statistics, json, datetime, collections
+1. First, retrieve data using get_chip_parameter_timeseries, get_chip_summary, etc.
+   These "stored" tools save full data server-side and return a summary with a `data_key`.
+2. Then call execute_python_analysis with only "code" — NO context_data needed.
+   Stored data is automatically available as `data["<data_key>"]`.
+   For example, after calling get_chip_parameter_timeseries for "t1":
+   - `data["t1"]["timeseries"]` contains the full timeseries list
+   - `data["t1"]["qubits"]` contains per-qubit stats
+3. Available libraries: numpy, pandas, scipy, scipy.stats, plotly (graph_objects, express, subplots), math, statistics, json, datetime, collections, io.
 4. In the code, set a 'result' variable:
    ```python
    result = {
@@ -1560,7 +1637,7 @@ When you analyse data, ALWAYS provide evidence with your conclusions:
    | 0     | 45.2   | stable | 43.1 | 46.0 |
    | 1     | 38.7   | decreasing | 37.5 | 42.3 |
 
-2. **Charts**: Use execute_python_analysis to create Plotly charts for visual evidence — bar charts comparing qubits, scatter plots for trends, histograms for distributions, etc. Pass the data from previous tool calls via context_data.
+2. **Charts**: Use execute_python_analysis to create Plotly charts for visual evidence — bar charts comparing qubits, scatter plots for trends, histograms for distributions, etc. Stored tool data is automatically available as data["<data_key>"].
 
 3. **Statistics**: Always report chip-wide statistics (mean, median, stdev, min, max) returned by tools. Highlight outliers (values > 2 stdev from mean).
 
@@ -1658,11 +1735,12 @@ async def run_chat(
     else:
         input_items = _build_input(user_message, image_base64, conversation_history)
 
-        # Wrap chart-generating tools to collect charts for direct injection
+        # Wrap tools: data store + chart collection + rate limiting
         if tool_executors:
             wrapped_executors: ToolExecutors | None = None
+            data_store: dict[str, Any] = {}
             rate_limited = _wrap_rate_limited_executors(tool_executors)
-            wrapped_executors, collected_charts = _wrap_chart_executors(rate_limited)
+            wrapped_executors, collected_charts = _wrap_tool_executors(rate_limited, data_store)
         else:
             wrapped_executors, collected_charts = None, []
 

--- a/src/qdash/api/lib/copilot_sandbox.py
+++ b/src/qdash/api/lib/copilot_sandbox.py
@@ -38,6 +38,7 @@ ALLOWED_MODULES = frozenset(
         "datetime",
         "_strptime",
         "collections",
+        "io",
     }
 )
 

--- a/src/qdash/api/requirements.txt
+++ b/src/qdash/api/requirements.txt
@@ -96,6 +96,7 @@ numpy==1.26.0
     # via
     #   contourpy
     #   matplotlib
+    #   pandas
     #   qdash
     #   scipy
 openai==2.21.0
@@ -104,6 +105,8 @@ packaging==24.2
     #   gunicorn
     #   matplotlib
     #   plotly
+pandas==2.3.3 ; python_full_version < '3.11'
+pandas==3.0.1 ; python_full_version >= '3.11'
 passlib==1.7.4
 pendulum==3.1.0
     # via qdash
@@ -138,6 +141,7 @@ python-dateutil==2.9.0.post0
     # via
     #   croniter
     #   matplotlib
+    #   pandas
     #   pendulum
 python-dotenv==1.0.1
     # via
@@ -148,7 +152,9 @@ python-json-logger==3.3.0
 python-multipart==0.0.20
     # via fastapi
 pytz==2025.2
-    # via croniter
+    # via
+    #   croniter
+    #   pandas
 pyyaml==6.0.1
     # via uvicorn
 reportlab==4.4.3
@@ -199,7 +205,9 @@ typing-extensions==4.12.2
     #   typer
     #   uvicorn
 tzdata==2025.2
-    # via pendulum
+    # via
+    #   pandas
+    #   pendulum
 uvicorn==0.34.0
     # via
     #   fastapi

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,12 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
 
@@ -505,8 +509,12 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", marker = "python_full_version >= '3.11'" },
@@ -1143,8 +1151,12 @@ name = "ipython"
 version = "9.4.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
@@ -1229,8 +1241,12 @@ name = "jax"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "jaxlib", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1276,8 +1292,12 @@ name = "jaxlib"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "ml-dtypes", marker = "python_full_version >= '3.11'" },
@@ -2015,8 +2035,12 @@ name = "networkx"
 version = "3.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz", hash = "sha256:d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037", size = 2471065, upload-time = "2025-05-29T11:35:07.804Z" }
 wheels = [
@@ -2173,6 +2197,81 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/f7/f425a00df4fcc22b292c6895c6831c0c8ae1d9fac1e024d16f98a9ce8749/pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c", size = 11555763, upload-time = "2025-09-29T23:16:53.287Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a", size = 10801217, upload-time = "2025-09-29T23:17:04.522Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/03/3fc4a529a7710f890a239cc496fc6d50ad4a0995657dccc1d64695adb9f4/pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1", size = 12148791, upload-time = "2025-09-29T23:17:18.444Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838", size = 12769373, upload-time = "2025-09-29T23:17:35.846Z" },
+    { url = "https://files.pythonhosted.org/packages/df/91/82cc5169b6b25440a7fc0ef3a694582418d875c8e3ebf796a6d6470aa578/pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250", size = 13200444, upload-time = "2025-09-29T23:17:49.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ae/89b3283800ab58f7af2952704078555fa60c807fff764395bb57ea0b0dbd/pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4", size = 13858459, upload-time = "2025-09-29T23:18:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/85/72/530900610650f54a35a19476eca5104f38555afccda1aa11a92ee14cb21d/pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826", size = 11346086, upload-time = "2025-09-29T23:18:18.505Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
+    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
+    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
+    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/0c/b28ed414f080ee0ad153f848586d61d1878f91689950f037f976ce15f6c8/pandas-3.0.1.tar.gz", hash = "sha256:4186a699674af418f655dbd420ed87f50d56b4cd6603784279d9eef6627823c8", size = 4641901, upload-time = "2026-02-17T22:20:16.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/07/c7087e003ceee9b9a82539b40414ec557aa795b584a1a346e89180853d79/pandas-3.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de09668c1bf3b925c07e5762291602f0d789eca1b3a781f99c1c78f6cac0e7ea", size = 10323380, upload-time = "2026-02-17T22:18:16.133Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/27/90683c7122febeefe84a56f2cde86a9f05f68d53885cebcc473298dfc33e/pandas-3.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:24ba315ba3d6e5806063ac6eb717504e499ce30bd8c236d8693a5fd3f084c796", size = 9923455, upload-time = "2026-02-17T22:18:19.13Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f1/ed17d927f9950643bc7631aa4c99ff0cc83a37864470bc419345b656a41f/pandas-3.0.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:406ce835c55bac912f2a0dcfaf27c06d73c6b04a5dde45f1fd3169ce31337389", size = 10753464, upload-time = "2026-02-17T22:18:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7c/870c7e7daec2a6c7ff2ac9e33b23317230d4e4e954b35112759ea4a924a7/pandas-3.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:830994d7e1f31dd7e790045235605ab61cff6c94defc774547e8b7fdfbff3dc7", size = 11255234, upload-time = "2026-02-17T22:18:24.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/39/3653fe59af68606282b989c23d1a543ceba6e8099cbcc5f1d506a7bae2aa/pandas-3.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a64ce8b0f2de1d2efd2ae40b0abe7f8ae6b29fbfb3812098ed5a6f8e235ad9bf", size = 11767299, upload-time = "2026-02-17T22:18:26.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/31/1daf3c0c94a849c7a8dab8a69697b36d313b229918002ba3e409265c7888/pandas-3.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9832c2c69da24b602c32e0c7b1b508a03949c18ba08d4d9f1c1033426685b447", size = 12333292, upload-time = "2026-02-17T22:18:28.996Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/af63f83cd6ca603a00fe8530c10a60f0879265b8be00b5930e8e78c5b30b/pandas-3.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:84f0904a69e7365f79a0c77d3cdfccbfb05bf87847e3a51a41e1426b0edb9c79", size = 9892176, upload-time = "2026-02-17T22:18:31.79Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ab/9c776b14ac4b7b4140788eca18468ea39894bc7340a408f1d1e379856a6b/pandas-3.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:4a68773d5a778afb31d12e34f7dd4612ab90de8c6fb1d8ffe5d4a03b955082a1", size = 9151328, upload-time = "2026-02-17T22:18:35.721Z" },
+    { url = "https://files.pythonhosted.org/packages/37/51/b467209c08dae2c624873d7491ea47d2b47336e5403309d433ea79c38571/pandas-3.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:476f84f8c20c9f5bc47252b66b4bb25e1a9fc2fa98cead96744d8116cb85771d", size = 10344357, upload-time = "2026-02-17T22:18:38.262Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f1/e2567ffc8951ab371db2e40b2fe068e36b81d8cf3260f06ae508700e5504/pandas-3.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ab749dfba921edf641d4036c4c21c0b3ea70fea478165cb98a998fb2a261955", size = 9884543, upload-time = "2026-02-17T22:18:41.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/39/327802e0b6d693182403c144edacbc27eb82907b57062f23ef5a4c4a5ea7/pandas-3.0.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8e36891080b87823aff3640c78649b91b8ff6eea3c0d70aeabd72ea43ab069b", size = 10396030, upload-time = "2026-02-17T22:18:43.822Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fe/89d77e424365280b79d99b3e1e7d606f5165af2f2ecfaf0c6d24c799d607/pandas-3.0.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:532527a701281b9dd371e2f582ed9094f4c12dd9ffb82c0c54ee28d8ac9520c4", size = 10876435, upload-time = "2026-02-17T22:18:45.954Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a6/2a75320849dd154a793f69c951db759aedb8d1dd3939eeacda9bdcfa1629/pandas-3.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:356e5c055ed9b0da1580d465657bc7d00635af4fd47f30afb23025352ba764d1", size = 11405133, upload-time = "2026-02-17T22:18:48.533Z" },
+    { url = "https://files.pythonhosted.org/packages/58/53/1d68fafb2e02d7881df66aa53be4cd748d25cbe311f3b3c85c93ea5d30ca/pandas-3.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9d810036895f9ad6345b8f2a338dd6998a74e8483847403582cab67745bff821", size = 11932065, upload-time = "2026-02-17T22:18:50.837Z" },
+    { url = "https://files.pythonhosted.org/packages/75/08/67cc404b3a966b6df27b38370ddd96b3b023030b572283d035181854aac5/pandas-3.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:536232a5fe26dd989bd633e7a0c450705fdc86a207fec7254a55e9a22950fe43", size = 9741627, upload-time = "2026-02-17T22:18:53.905Z" },
+    { url = "https://files.pythonhosted.org/packages/86/4f/caf9952948fb00d23795f09b893d11f1cacb384e666854d87249530f7cbe/pandas-3.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:0f463ebfd8de7f326d38037c7363c6dacb857c5881ab8961fb387804d6daf2f7", size = 9052483, upload-time = "2026-02-17T22:18:57.31Z" },
+]
+
+[[package]]
 name = "pandocfilters"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2258,7 +2357,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2927,6 +3026,8 @@ api = [
     { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy" },
     { name = "openai" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pendulum" },
     { name = "pillow" },
@@ -2997,6 +3098,7 @@ api = [
     { name = "networkx", specifier = ">=3.4.2" },
     { name = "numpy", specifier = ">=1.26.0,<1.27.0" },
     { name = "openai", specifier = ">=1.0.0" },
+    { name = "pandas", specifier = ">=2.0.0" },
     { name = "passlib", extras = ["bcrypt"], specifier = "==1.7.4" },
     { name = "pendulum", specifier = ">=3.1.0" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -3463,8 +3565,12 @@ name = "scipy"
 version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
-    "python_full_version == '3.11.*'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", marker = "python_full_version >= '3.11'" },


### PR DESCRIPTION
<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
- N/A

## Summary
- Introduced tests to ensure that coupling-format QIDs are correctly skipped during seed import processes. This change enhances data integrity by preventing invalid QIDs from being processed.

## Changes
- Added unit tests for `_import_from_manual` and `_import_from_qubex` methods to verify that QIDs containing '-' are skipped.
- Updated the `_import_from_manual` and `_import_from_qubex` methods to count and report skipped QIDs. 
- Enhanced JSON sanitization to handle additional data types. 
- Included necessary dependencies for testing.

