### PR TITLE
style: PageFilterBar layout improved

### DIFF
--- a/ui/src/components/features/metrics/MetricsPageContent.tsx
+++ b/ui/src/components/features/metrics/MetricsPageContent.tsx
@@ -430,7 +430,7 @@ export function MetricsPageContent() {
               </PageFiltersBar.Item>
             </PageFiltersBar.Group>
 
-            <PageFiltersBar.Group position="end">
+            <PageFiltersBar.Group>
               <PageFiltersBar.Item>
                 <ChipSelector
                   selectedChip={selectedChip}

--- a/ui/src/components/ui/PageFiltersBar.tsx
+++ b/ui/src/components/ui/PageFiltersBar.tsx
@@ -28,6 +28,7 @@ export function PageFiltersBar({
 }: PageFiltersBarProps) {
   return (
     <div
+      // Enable wrapping to prevent filter controls from overlapping on smaller screens
       className={`flex flex-col md:flex-row md:flex-wrap md:justify-between md:items-start gap-4 ${className}`}
     >
       {children}
@@ -55,6 +56,7 @@ function FilterGroup({
 
   return (
     <div
+      // Enable wrapping to prevent filter controls from overlapping on smaller screens
       className={`flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:gap-4 ${positionClass} ${className}`}
     >
       {children}

--- a/ui/src/components/ui/PageFiltersBar.tsx
+++ b/ui/src/components/ui/PageFiltersBar.tsx
@@ -28,7 +28,7 @@ export function PageFiltersBar({
 }: PageFiltersBarProps) {
   return (
     <div
-      className={`flex flex-col md:flex-row md:justify-between md:items-center gap-4 ${className}`}
+      className={`flex flex-col md:flex-row md:flex-wrap md:justify-between md:items-start gap-4 ${className}`}
     >
       {children}
     </div>
@@ -55,7 +55,7 @@ function FilterGroup({
 
   return (
     <div
-      className={`flex flex-col sm:flex-row gap-3 sm:gap-4 ${positionClass} ${className}`}
+      className={`flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:gap-4 ${positionClass} ${className}`}
     >
       {children}
     </div>


### PR DESCRIPTION
## Ticket
#618 

## Summary
It is because `flex-wrap` did not exist.

## Changes
I've speified `flex-wrap` explicitly.
I also check the impact of changes. I checked below:
- Metrics page
- Chip page
- Execution page
These seem to be fine.
