### PR TITLE
fix: grid increasing bug fixed

### DIFF
--- a/ui/src/components/features/chip/TaskResultGrid/index.tsx
+++ b/ui/src/components/features/chip/TaskResultGrid/index.tsx
@@ -531,7 +531,7 @@ export function TaskResultGrid({
         );
 
         if (!qid) {
-          return <EmptyCell key={index} muxBgClass={muxBgClass} />;
+          return <EmptyCell key={`empty-${index}`} muxBgClass={muxBgClass} />;
         }
 
         const task = getTaskResult(qid);


### PR DESCRIPTION
## Ticket
#745

## Summary

As an example, consider an **8×8 grid (64-qubit) chip**. In the **MUX topology**, the qubit numbering does not match the physical position on the grid:

**Grid position (row, col) → array index (row × 8 + col)**

```
qid "0" → (row:0, col:0) → index 0
qid "1" → (row:0, col:1) → index 1
qid "2" → (row:1, col:0) → index 8  <-
qid "3" → (row:1, col:1) → index 9
qid "4" → (row:0, col:2) → index 2  <-
qid "5" → (row:0, col:3) → index 3
...
```

`qid "2"` is located at **index 8**, while **index 2 corresponds to qid "4"**.

---

### Step 1: Select “Latest”

The API returns data for **all qubits (qid 0–63)**.

Contents of the array used to render the grid:

```
index 2 → data for qid "4" exists → <GridCell key="4" />
index 8 → data for qid "2" exists → <GridCell key="2" />
```

All keys are unique. No problem.

---

### Step 2: Switch to a “Historical Date”

On this date, **qid "4" has no data** (it was not calibrated that day), but **qid "2" does have data**.

```
index 2 → no data for qid "4" → <EmptyCell key={2} />
                                ↓ React converts numbers to strings
                                key = "2"  ←★

index 8 → data for qid "2" exists → <GridCell key="2" />
                                     key = "2"  ←★
```

Now there are **two elements with `key="2"` in the same array**.

---

### Step 3: React Gets Confused

React uses keys to **match elements between renders**.
If two elements share the same key:

> React: “There should be only one element with `key="2"`. Why are there two? Which one is the real one?”

As a result, React’s internal reconciliation breaks and **extra DOM nodes are created**.

At this point, **two ghost cells appear** that should not normally be rendered (for example qid `"2"` and qid `"3"`), because multiple pairs of collisions exist.

---

### Step 4: Switch Back to “Latest”

React attempts to re-render, but the **ghost cell DOM nodes are not properly cleaned up and remain**.

---

### Step 5: Accumulation on Every Toggle

```
Latest → Date   : +2 ghost cells
Date   → Latest : remaining ghost cells are not removed
Latest → Date   : +2 more
...
```

This is why **two additional cells appear every time the view is toggled**.

## Changes

```jsx
// Before
<EmptyCell key={index} />         // key="2" may collide with GridCell key="2"
```

```jsx
// After
<EmptyCell key={`empty-${index}`} />  // key="empty-2" → guaranteed not to collide
```

By adding the `"empty-"` prefix, the keys for `EmptyCell` become:

```
"empty-0", "empty-1", "empty-2", ...
```

These can **never conflict** with the `GridCell` keys such as `"2"` or `"3"`.

As a result, **React can correctly track the diff**, and the **ghost cells no longer appear**.


