### PR TITLE
feat(workflow): add readout amplitude parameter handling in tasks

### DIFF
--- a/src/qdash/api/services/device_topology_service.py
+++ b/src/qdash/api/services/device_topology_service.py
@@ -25,7 +25,7 @@ from qdash.api.schemas.device_topology import (
     QubitGateDuration,
     QubitLifetime,
 )
-from qdash.common.datetime_utils import now, to_datetime
+from qdash.common.datetime_utils import ensure_timezone, now, to_datetime
 from qdash.common.qubit_utils import qid_to_label
 from qdash.common.topology_config import load_topology
 
@@ -156,7 +156,7 @@ class DeviceTopologyService:
             device_id=request.device_id,
             qubits=filtered_qubits,
             couplings=filtered_couplings,
-            calibrated_at=latest.timestamp or "",
+            calibrated_at=ensure_timezone(latest.timestamp) or "",
         )
 
     def _build_qubits(

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/randomized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/randomized_benchmarking.py
@@ -76,6 +76,9 @@ class RandomizedBenchmarking(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         label = self.get_qubit_label(backend, qid)
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[label] = readout_amp_param.value
         result = exp.randomized_benchmarking(
             targets=label,
             n_trials=self.run_parameters["n_trials"].get_value(),

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/x90_interleaved_randomized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/x90_interleaved_randomized_benchmarking.py
@@ -78,6 +78,9 @@ class X90InterleavedRandomizedBenchmarking(QubexTask):
         """Run the X90 interleaved randomized benchmarking task with timeout."""
         exp = self.get_experiment(backend)
         label = self.get_qubit_label(backend, qid)
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[label] = readout_amp_param.value
         result = exp.interleaved_randomized_benchmarking(
             targets=label,
             interleaved_clifford="X90",

--- a/src/qdash/workflow/calibtasks/qubex/measurement/readout_classification.py
+++ b/src/qdash/workflow/calibtasks/qubex/measurement/readout_classification.py
@@ -141,6 +141,9 @@ class ReadoutClassification(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         label = self.get_qubit_label(backend, qid)
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[label] = readout_amp_param.value
         result = exp.build_classifier(
             targets=label,
             save_dir=exp.classifier_dir,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_hpi_pulse.py
@@ -55,6 +55,9 @@ class CheckHPIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         hpi_pulse = {qubit: exp.hpi_pulse[qubit] for qubit in labels}
         result = exp.repeat_sequence(
             sequence=hpi_pulse,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_optimal_readout_amplitude.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_optimal_readout_amplitude.py
@@ -21,7 +21,7 @@ class CheckOptimalReadoutAmplitude(QubexTask):
         "amplitude_range": RunParameterModel(
             unit="a.u.",
             value_type="np.arange",
-            value=(0.01, 0.21, 0.01),
+            value=(0.01, 0.25, 0.01),
             description="Readout amplitude range",
         ),
         "shots": RunParameterModel(
@@ -38,9 +38,7 @@ class CheckOptimalReadoutAmplitude(QubexTask):
         ),
     }
     output_parameters: ClassVar[dict[str, ParameterModel]] = {
-        "optimal_readout_amplitude": ParameterModel(
-            unit="a.u.", description="Optimal Readout Amplitude"
-        ),
+        "readout_amplitude": ParameterModel(unit="a.u.", description="Optimal Readout Amplitude"),
     }
 
     def postprocess(
@@ -48,7 +46,7 @@ class CheckOptimalReadoutAmplitude(QubexTask):
     ) -> PostProcessResult:
         """Process the results of the task."""
         result = run_result.raw_result
-        self.output_parameters["optimal_readout_amplitude"].value = result["optimal_amplitude"]
+        self.output_parameters["readout_amplitude"].value = result["optimal_amplitude"]
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result["fig"]]
         return PostProcessResult(output_parameters=output_parameters, figures=figures)

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_pi_pulse.py
@@ -55,6 +55,9 @@ class CheckPIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         pi_pulse = {qubit: exp.pi_pulse[qubit] for qubit in labels}
         result = exp.repeat_sequence(
             sequence=pi_pulse,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -29,17 +29,14 @@ class CheckRabi(QubexTask):
         "qubit_frequency": None,
         "control_amplitude": None,
         "readout_frequency": None,
+        "readout_amplitude": ParameterModel(
+            value=DEFAULT_READOUT_AMPLITUDE, unit="a.u.", description="Readout amplitude"
+        ),
         "readout_length": ParameterModel(
             value=DEFAULT_READOUT_DURATION, unit="ns", description="Readout pulse length"
         ),
     }
     run_parameters: ClassVar[dict[str, RunParameterModel]] = {
-        "readout_amplitude": RunParameterModel(
-            unit="a.u.",
-            value_type="float",
-            value=DEFAULT_READOUT_AMPLITUDE,
-            description="Readout amplitude",
-        ),
         "time_range": RunParameterModel(
             unit="ns",
             value_type="range",
@@ -153,12 +150,13 @@ class CheckRabi(QubexTask):
 
         control_amplitude_param = self.input_parameters["control_amplitude"]
         qubit_frequency_param = self.input_parameters["qubit_frequency"]
+        readout_amplitude_param = self.input_parameters["readout_amplitude"]
         assert control_amplitude_param is not None
         assert qubit_frequency_param is not None
+        assert readout_amplitude_param is not None
 
-        # Get readout_amplitude from run_parameters
-        ra_param = self.run_parameters.get("readout_amplitude")
-        readout_amp = ra_param.get_value() if ra_param is not None else DEFAULT_READOUT_AMPLITUDE
+        # Get readout_amplitude from input_parameters (loaded from DB)
+        readout_amp = readout_amplitude_param.value
         exp.params.readout_amplitude[label] = readout_amp
 
         print(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_ramsey.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_ramsey.py
@@ -279,6 +279,9 @@ class CheckRamsey(QubexTask):
         """Run the task."""
         exp = self.get_experiment(backend)
         label = self.get_qubit_label(backend, qid)
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[label] = readout_amp_param.value
 
         # Apply frequency override if qubit_frequency was explicitly provided
         with self._apply_frequency_override(backend, qid):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1.py
@@ -65,8 +65,10 @@ class CheckT1(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
 
-        # Apply frequency override if qubit_frequency was explicitly provided
         result = exp.t1_experiment(
             time_range=self.run_parameters["time_range"].get_value(),
             shots=self.run_parameters["shots"].get_value(),

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1_average.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1_average.py
@@ -72,6 +72,9 @@ class CheckT1Average(QubexTask):
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
         label = labels[0]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[label] = readout_amp_param.value
 
         n_runs = int(self.run_parameters["n_runs"].get_value())
 

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo.py
@@ -65,6 +65,9 @@ class CheckT2Echo(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
 
         # Apply frequency override if qubit_frequency was explicitly provided
         with self._apply_frequency_override(backend, qid):

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo_average.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo_average.py
@@ -72,6 +72,9 @@ class CheckT2EchoAverage(QubexTask):
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
         label = labels[0]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[label] = readout_amp_param.value
 
         n_runs = int(self.run_parameters["n_runs"].get_value())
 

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/chevron_pattern.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/chevron_pattern.py
@@ -27,9 +27,6 @@ class ChevronPattern(QubexTask):
     input_parameters: ClassVar[dict[str, ParameterModel | None]] = {
         "qubit_frequency": None,
         "readout_frequency": None,
-        "control_amplitude": ParameterModel(
-            value=0.0625, unit="a.u.", description="Control pulse amplitude"
-        ),
         "readout_length": ParameterModel(
             value=DEFAULT_READOUT_DURATION, unit="ns", description="Readout pulse length"
         ),
@@ -40,6 +37,12 @@ class ChevronPattern(QubexTask):
             value_type="float",
             value=DEFAULT_READOUT_AMPLITUDE,
             description="Readout amplitude",
+        ),
+        "control_amplitude": RunParameterModel(
+            unit="a.u.",
+            value_type="float",
+            value=DEFAULT_CONTROL_AMPLITUDE,
+            description="Control pulse amplitude",
         ),
     }
     output_parameters: ClassVar[dict[str, ParameterModel]] = {
@@ -53,9 +56,9 @@ class ChevronPattern(QubexTask):
         """Preprocess: load params from DB and validate control_amplitude."""
         result = super().preprocess(backend, qid)
 
-        # Validate control_amplitude from DB; use default if invalid
-        param = self.input_parameters.get("control_amplitude")
-        value = param.value if param is not None else None
+        # Validate control_amplitude from run_parameters
+        param = self.run_parameters.get("control_amplitude")
+        value = param.get_value() if param is not None else None
         if (
             value is None
             or not isinstance(value, (int, float))
@@ -68,14 +71,7 @@ class ChevronPattern(QubexTask):
                 f"({CONTROL_AMPLITUDE_MIN}, {CONTROL_AMPLITUDE_MAX}), "
                 f"using default={DEFAULT_CONTROL_AMPLITUDE}"
             )
-            if param is None:
-                self.input_parameters["control_amplitude"] = ParameterModel(
-                    value=DEFAULT_CONTROL_AMPLITUDE,
-                    unit="a.u.",
-                    description="Control pulse amplitude (default)",
-                )
-            else:
-                param.value = DEFAULT_CONTROL_AMPLITUDE
+            param.value = DEFAULT_CONTROL_AMPLITUDE
 
         return result
 
@@ -100,17 +96,18 @@ class ChevronPattern(QubexTask):
 
         readout_frequency = self.input_parameters["readout_frequency"]
         qubit_frequency = self.input_parameters["qubit_frequency"]
-        control_amplitude = self.input_parameters["control_amplitude"]
         assert readout_frequency is not None
         assert qubit_frequency is not None
-        assert control_amplitude is not None
 
         # Get readout_amplitude from run_parameters
         ra_param = self.run_parameters.get("readout_amplitude")
         readout_amp = ra_param.get_value() if ra_param is not None else DEFAULT_READOUT_AMPLITUDE
 
+        # Get control_amplitude from run_parameters
+        ca_param = self.run_parameters.get("control_amplitude")
+        ctrl_amp_value = ca_param.get_value() if ca_param is not None else DEFAULT_CONTROL_AMPLITUDE
+
         # Fallback to default if control_amplitude value is invalid
-        ctrl_amp_value = control_amplitude.value
         if (
             ctrl_amp_value is None
             or not isinstance(ctrl_amp_value, (int, float))

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/chevron_pattern.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/chevron_pattern.py
@@ -71,7 +71,8 @@ class ChevronPattern(QubexTask):
                 f"({CONTROL_AMPLITUDE_MIN}, {CONTROL_AMPLITUDE_MAX}), "
                 f"using default={DEFAULT_CONTROL_AMPLITUDE}"
             )
-            param.value = DEFAULT_CONTROL_AMPLITUDE
+            if param is not None:
+                param.value = DEFAULT_CONTROL_AMPLITUDE
 
         return result
 

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
@@ -61,6 +61,9 @@ class CreateHPIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         result = exp.calibrate_hpi_pulse(
             targets=labels,
             n_rotations=1,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
@@ -61,6 +61,9 @@ class CreatePIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         result = exp.calibrate_pi_pulse(
             targets=labels,
             n_rotations=1,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_hpi_pulse.py
@@ -56,6 +56,9 @@ class CheckDRAGHPIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         drag_hpi_pulse = {qubit: exp.drag_hpi_pulse[qubit] for qubit in labels}
         result = exp.repeat_sequence(
             sequence=drag_hpi_pulse,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/check_drag_pi_pulse.py
@@ -56,6 +56,9 @@ class CheckDRAGPIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         drag_pi_pulse = {qubit: exp.drag_pi_pulse[qubit] for qubit in labels}
         result = exp.repeat_sequence(
             sequence=drag_pi_pulse,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
@@ -70,6 +70,9 @@ class CreateDRAGHPIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         result = exp.calibrate_drag_hpi_pulse(
             targets=labels,
             n_rotations=4,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
@@ -70,6 +70,9 @@ class CreateDRAGPIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        readout_amp_param = self.input_parameters["readout_amplitude"]
+        if readout_amp_param is not None:
+            exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         result = exp.calibrate_drag_pi_pulse(
             targets=labels,
             n_rotations=4,

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
@@ -136,9 +136,9 @@ class CheckCrossResonance(QubexTask):
         output_parameters = self.attach_execution_id(execution_id)
         fig = self._plot_coeffs_history(result["coeffs_history"], label=label)
         figures: list[Any] = [fig]
-        for figs in result["figs_history"]:
-            figures.append(figs["fig_c"])
-            figures.append(figs["fig_t"])
+        # for figs in result["figs_history"]:
+        #     figures.append(figs["fig_c"])
+        #     figures.append(figs["fig_t"])
         raw_data: list[Any] = []
         return PostProcessResult(
             output_parameters=output_parameters, figures=figures, raw_data=raw_data
@@ -172,7 +172,7 @@ class CheckCrossResonance(QubexTask):
             "rotary_amplitude": fit_result["rotary_amplitude"],
             "zx_rotation_rate": fit_result["zx_rotation_rate"],
             "coeffs_history": raw_result["coeffs_history"],
-            "figs_history": raw_result.data["figs_history"],
+            # "figs_history": raw_result.data["figs_history"],
         }
         self.save_calibration(backend)
         return RunResult(raw_result=result)

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -473,7 +473,7 @@ class TaskExecutor:
                 for k, v in snap_input.items()
                 if (m := self._reconstruct_param(ParameterModel, k, v)) is not None
             }
-            task.input_parameters = reconstructed_input  # type: ignore[attr-defined]
+            task.input_parameters = reconstructed_input
             # Re-record in state_manager
             self.state_manager.put_input_parameters(task_name, reconstructed_input, task_type, qid)
 
@@ -515,7 +515,7 @@ class TaskExecutor:
 
         if input_overrides:
             for key, new_value in input_overrides.items():
-                param = task.input_parameters.get(key)  # type: ignore[attr-defined]
+                param = task.input_parameters.get(key)
                 if isinstance(param, ParameterModel):
                     param.value = new_value
                     logger.info("User override applied: input.%s = %s", key, new_value)
@@ -523,7 +523,7 @@ class TaskExecutor:
                 task_name,
                 task.input_parameters,
                 task_type,
-                qid,  # type: ignore[attr-defined]
+                qid,
             )
 
         if run_overrides:

--- a/src/qdash/workflow/engine/task/types.py
+++ b/src/qdash/workflow/engine/task/types.py
@@ -22,6 +22,7 @@ class TaskProtocol(Protocol):
     name: str
     r2_threshold: float
     backend: str
+    input_parameters: ClassVar[dict[str, Any]]
     run_parameters: ClassVar[dict[str, Any]]
 
     def get_name(self) -> str:

--- a/src/qdash/workflow/service/tasks.py
+++ b/src/qdash/workflow/service/tasks.py
@@ -44,6 +44,8 @@ BRINGUP_TASKS: list[str] = [
 CHECK_1Q_TASKS: list[str] = [
     "CheckRabi",
     "CheckRabi",
+    "CheckOptimalReadoutAmplitude",
+    "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",
     "CheckT1",

--- a/tests/qdash/workflow/engine/task/test_executor.py
+++ b/tests/qdash/workflow/engine/task/test_executor.py
@@ -689,8 +689,8 @@ class TestSnapshotOverrides:
         result = executor.execute_task(task, session, "0")
 
         assert result["success"] is True
-        # Snapshot should have been queried (called twice: before and after preprocess)
-        assert mock_snapshot_loader.get_snapshot.call_count == 2
+        # Snapshot should have been queried once (before preprocess in step 1.5)
+        assert mock_snapshot_loader.get_snapshot.call_count == 1
 
     def test_execute_without_snapshot_loader_skips_overrides(
         self, mock_state_manager: MagicMock

--- a/tests/qdash/workflow/engine/task/test_executor.py
+++ b/tests/qdash/workflow/engine/task/test_executor.py
@@ -17,6 +17,7 @@ from qdash.workflow.engine.task.types import TaskExecutionError, TaskProtocol
 class MockTask:
     """Mock task for testing."""
 
+    input_parameters: ClassVar[dict[str, Any]] = {}
     run_parameters: ClassVar[dict[str, Any]] = {}
 
     def __init__(
@@ -30,7 +31,6 @@ class MockTask:
         self._task_type = task_type
         self.r2_threshold = r2_threshold
         self.backend = backend
-        self.input_parameters: dict[str, Any] = {}
 
     def get_name(self) -> str:
         return self.name


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced handling for the readout amplitude parameter across various tasks to enhance calibration accuracy.
- This change impacts the workflow by allowing tasks to utilize a specified readout amplitude, improving measurement precision.

## Changes
- Added readout amplitude parameter handling in multiple calibration tasks.
- Updated relevant methods to incorporate the readout amplitude into the experiment parameters.

