### PR TITLE
feat(api): make tag parameter optional in timeseries results

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -4479,17 +4479,6 @@
             "description": "Chip ID"
           },
           {
-            "name": "tag",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Tag to filter by",
-              "title": "Tag"
-            },
-            "description": "Tag to filter by"
-          },
-          {
             "name": "parameter",
             "in": "query",
             "required": true,
@@ -4521,6 +4510,24 @@
               "title": "End At"
             },
             "description": "End time in ISO format"
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Tag to filter by",
+              "title": "Tag"
+            },
+            "description": "Tag to filter by"
           },
           {
             "name": "qid",
@@ -8922,6 +8929,18 @@
             ],
             "title": "Parameter Overrides",
             "description": "Optional parameter overrides: {run: {...}, input: {...}}"
+          },
+          "update_params": {
+            "type": "boolean",
+            "title": "Update Params",
+            "description": "Update backend parameters (e.g. qubex YAML) after execution",
+            "default": true
+          },
+          "reconfigure": {
+            "type": "boolean",
+            "title": "Reconfigure",
+            "description": "Run Configure (system_manager load + push) before executing the task",
+            "default": false
           }
         },
         "type": "object",
@@ -9296,7 +9315,7 @@
             "type": "number",
             "title": "Delta Per Step",
             "description": "Average delta per step",
-            "default": 0
+            "default": 0.0
           },
           "current_value": {
             "anyOf": [
@@ -10590,7 +10609,12 @@
           "severity": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "critical",
+                  "warning",
+                  "info"
+                ]
               },
               {
                 "type": "null"
@@ -10644,7 +10668,8 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "maxItems": 50
               },
               {
                 "type": "null"
@@ -12077,7 +12102,7 @@
           "error": {
             "type": "number",
             "title": "Error",
-            "default": 0
+            "default": 0.0
           },
           "previous_error": {
             "anyOf": [
@@ -12315,7 +12340,7 @@
           "error": {
             "type": "number",
             "title": "Error",
-            "default": 0
+            "default": 0.0
           },
           "version": {
             "type": "integer",
@@ -12456,7 +12481,7 @@
           "error": {
             "type": "number",
             "title": "Error",
-            "default": 0
+            "default": 0.0
           },
           "valid_from": {
             "anyOf": [

--- a/src/qdash/api/routers/task_result.py
+++ b/src/qdash/api/routers/task_result.py
@@ -347,12 +347,12 @@ def get_coupling_task_history(
 )
 def get_timeseries_task_results(
     chip_id: Annotated[str, Query(description="Chip ID")],
-    tag: Annotated[str, Query(description="Tag to filter by")],
     parameter: Annotated[str, Query(description="Parameter name")],
     start_at: Annotated[str, Query(description="Start time in ISO format")],
     end_at: Annotated[str, Query(description="End time in ISO format")],
     ctx: Annotated[ProjectContext, Depends(get_project_context)],
     service: Annotated[TaskResultService, Depends(get_task_result_service)],
+    tag: Annotated[str | None, Query(description="Tag to filter by")] = None,
     qid: Annotated[str | None, Query(description="Optional qubit ID to filter by")] = None,
 ) -> TimeSeriesData:
     """Get timeseries task results filtered by tag and parameter.

--- a/src/qdash/api/services/task_result_service.py
+++ b/src/qdash/api/services/task_result_service.py
@@ -11,7 +11,7 @@ import logging
 import zipfile
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bunnet import SortDirection
 from qdash.api.schemas.task_result import (
@@ -234,7 +234,7 @@ class TaskResultService:
     def get_timeseries(
         self,
         chip_id: str,
-        tag: str,
+        tag: str | None,
         parameter: str,
         project_id: str,
         target_qid: str | None = None,
@@ -272,14 +272,17 @@ class TaskResultService:
             start_at_dt = datetime.fromisoformat(start_at)
             end_at_dt = datetime.fromisoformat(end_at)
 
+        query_filter: dict[str, Any] = {
+            "project_id": project_id,
+            "chip_id": chip_id,
+            "output_parameter_names": parameter,
+            "start_at": {"$gte": start_at_dt, "$lte": end_at_dt},
+        }
+        if tag is not None:
+            query_filter["tags"] = tag
+
         task_results = self._task_result_repo.find_with_projection(
-            {
-                "project_id": project_id,
-                "chip_id": chip_id,
-                "tags": tag,
-                "output_parameter_names": parameter,
-                "start_at": {"$gte": start_at_dt, "$lte": end_at_dt},
-            },
+            query_filter,
             projection_model=TimeSeriesProjection,
             sort=[("start_at", SortDirection.ASCENDING)],
         )

--- a/ui/src/components/features/analysis/TimeSeriesView/index.tsx
+++ b/ui/src/components/features/analysis/TimeSeriesView/index.tsx
@@ -207,13 +207,13 @@ export function TimeSeriesView() {
     {
       chip_id: selectedChip,
       parameter: selectedParameter as ParameterKey,
-      tag: selectedTag as TagKey,
+      tag: (selectedTag || undefined) as TagKey,
       start_at: timeRange.startAt,
       end_at: timeRange.endAt,
     },
     {
       query: {
-        enabled: Boolean(selectedChip && selectedParameter && selectedTag),
+        enabled: Boolean(selectedChip && selectedParameter),
         staleTime: 30000, // Keep data fresh for 30 seconds
       },
     },
@@ -229,13 +229,13 @@ export function TimeSeriesView() {
     {
       chip_id: selectedChip,
       parameter: secondaryParameter as ParameterKey,
-      tag: selectedTag as TagKey,
+      tag: (selectedTag || undefined) as TagKey,
       start_at: timeRange.startAt,
       end_at: timeRange.endAt,
     },
     {
       query: {
-        enabled: Boolean(selectedChip && secondaryParameter && selectedTag),
+        enabled: Boolean(selectedChip && secondaryParameter),
         staleTime: 30000,
       },
     },
@@ -1064,13 +1064,10 @@ export function TimeSeriesView() {
         }
         isLoading={isLoadingTimeseries || isLoadingSecondary}
         hasData={Boolean(
-          selectedChip &&
-          selectedParameter &&
-          selectedTag &&
-          plotData.length > 0,
+          selectedChip && selectedParameter && plotData.length > 0,
         )}
         emptyStateMessage={
-          !selectedChip || !selectedParameter || !selectedTag
+          !selectedChip || !selectedParameter
             ? "Select chip and parameters to visualize data"
             : "No data available for the selected parameters"
         }

--- a/ui/src/components/features/issue-knowledge/IssueKnowledgeDetailPage.tsx
+++ b/ui/src/components/features/issue-knowledge/IssueKnowledgeDetailPage.tsx
@@ -138,7 +138,7 @@ export function IssueKnowledgeDetailPage({
   const handleSave = async () => {
     await update({
       title: editTitle,
-      severity: editSeverity,
+      severity: editSeverity as "critical" | "warning" | "info" | null,
       symptom: editSymptom,
       root_cause: editRootCause,
       resolution: editResolution,

--- a/ui/src/components/selectors/TagSelector/index.tsx
+++ b/ui/src/components/selectors/TagSelector/index.tsx
@@ -29,15 +29,14 @@ export function TagSelector({
   }));
 
   const handleChange = (option: SingleValue<TagOption>) => {
-    if (option) {
-      onTagSelect(option.value);
-    }
+    onTagSelect(option ? option.value : "");
   };
 
   return (
     <Select<TagOption>
+      isClearable
       options={options}
-      value={options.find((option) => option.value === selectedTag)}
+      value={options.find((option) => option.value === selectedTag) ?? null}
       onChange={handleChange}
       placeholder="Select tag"
       className="text-base-content w-full"

--- a/ui/src/hooks/url-state/__tests__/useAnalysisUrlState.test.ts
+++ b/ui/src/hooks/url-state/__tests__/useAnalysisUrlState.test.ts
@@ -13,7 +13,7 @@ describe("useAnalysisUrlState", () => {
     expect(result.current.selectedChip).toBe("");
     expect(result.current.selectedParameter).toBe("t1");
     expect(result.current.selectedParameters).toEqual([]);
-    expect(result.current.selectedTag).toBe("daily");
+    expect(result.current.selectedTag).toBe("");
     expect(result.current.analysisViewType).toBe("timeseries");
   });
 

--- a/ui/src/hooks/url-state/useAnalysisUrlState.ts
+++ b/ui/src/hooks/url-state/useAnalysisUrlState.ts
@@ -81,8 +81,7 @@ export function useAnalysisUrlState(): UseAnalysisUrlStateResult {
 
   const setSelectedTag = useCallback(
     (tag: string) => {
-      // Always include tag in URL for complete state management
-      setSelectedTagState(tag);
+      setSelectedTagState(tag || null);
     },
     [setSelectedTagState],
   );
@@ -99,7 +98,7 @@ export function useAnalysisUrlState(): UseAnalysisUrlStateResult {
     selectedChip: selectedChip ?? "",
     selectedParameter: selectedParameter ?? "t1",
     selectedParameters: selectedParameters ?? [],
-    selectedTag: selectedTag ?? "daily",
+    selectedTag: selectedTag ?? "",
     analysisViewType: analysisViewType ?? "timeseries",
     setSelectedChip,
     setSelectedParameter,

--- a/ui/src/hooks/useIssueKnowledge.ts
+++ b/ui/src/hooks/useIssueKnowledge.ts
@@ -13,6 +13,7 @@ import {
   useDeleteIssueKnowledge,
   useExtractIssueKnowledge,
 } from "@/client/issue-knowledge/issue-knowledge";
+import type { IssueKnowledgeUpdate } from "@/schemas/issueKnowledgeUpdate";
 
 type StatusFilter = "draft" | "approved" | "rejected" | "all";
 
@@ -125,14 +126,7 @@ export function useIssueKnowledgeDetail(knowledgeId: string) {
   }, [queryClient, knowledgeId]);
 
   const update = useCallback(
-    async (updates: {
-      title?: string;
-      severity?: string;
-      symptom?: string;
-      root_cause?: string;
-      resolution?: string;
-      lesson_learned?: string[];
-    }) => {
+    async (updates: IssueKnowledgeUpdate) => {
       await updateMutation.mutateAsync({
         knowledgeId,
         data: updates,

--- a/ui/src/schemas/bodyReExecuteTaskResult.ts
+++ b/ui/src/schemas/bodyReExecuteTaskResult.ts
@@ -10,4 +10,8 @@ import type { BodyReExecuteTaskResultParameterOverrides } from "./bodyReExecuteT
 export interface BodyReExecuteTaskResult {
   /** Optional parameter overrides: {run: {...}, input: {...}} */
   parameter_overrides?: BodyReExecuteTaskResultParameterOverrides;
+  /** Update backend parameters (e.g. qubex YAML) after execution */
+  update_params?: boolean;
+  /** Run Configure (system_manager load + push) before executing the task */
+  reconfigure?: boolean;
 }

--- a/ui/src/schemas/getTimeseriesTaskResultsParams.ts
+++ b/ui/src/schemas/getTimeseriesTaskResultsParams.ts
@@ -12,10 +12,6 @@ export type GetTimeseriesTaskResultsParams = {
    */
   chip_id: string;
   /**
-   * Tag to filter by
-   */
-  tag: string;
-  /**
    * Parameter name
    */
   parameter: string;
@@ -27,6 +23,10 @@ export type GetTimeseriesTaskResultsParams = {
    * End time in ISO format
    */
   end_at: string;
+  /**
+   * Tag to filter by
+   */
+  tag?: string | null;
   /**
    * Optional qubit ID to filter by
    */

--- a/ui/src/schemas/issueKnowledgeUpdateSeverity.ts
+++ b/ui/src/schemas/issueKnowledgeUpdateSeverity.ts
@@ -9,4 +9,8 @@
 /**
  * Updated severity
  */
-export type IssueKnowledgeUpdateSeverity = string | null;
+export type IssueKnowledgeUpdateSeverity =
+  | "critical"
+  | "warning"
+  | "info"
+  | null;


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updated the tag parameter in the timeseries results API to be optional, enhancing flexibility in data retrieval.
- This change impacts the API and related UI components, allowing for more versatile queries without requiring a tag.

## Changes
- Modified the `get_timeseries_task_results` API to accept an optional tag parameter.
- Updated relevant TypeScript schemas to reflect the optional nature of the tag.
- Adjusted UI components to handle cases where the tag may not be provided, ensuring smooth functionality.

