### PR TITLE
style: Closes the sidebar by default on mobile devices.

### DIFF
--- a/ui/src/components/features/chat/CopilotChatPage.tsx
+++ b/ui/src/components/features/chat/CopilotChatPage.tsx
@@ -382,6 +382,11 @@ export function CopilotChatPage() {
 
   const [input, setInput] = useState("");
   const [showSessionSidebar, setShowSessionSidebar] = useState(true);
+  useEffect(() => {
+    if (window.innerWidth < 640) {
+      setShowSessionSidebar(false);
+    }
+  }, []);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 


### PR DESCRIPTION
## Ticket
#749 

## Summary
There was no explicit branch in the initial state.

## Changes
Use `useEffect` to branch the initial state.
