### PR TITLE
style: padding and height improved

### DIFF
--- a/ui/src/components/charts/PlotCard.tsx
+++ b/ui/src/components/charts/PlotCard.tsx
@@ -41,7 +41,7 @@ export function PlotCard({
   layout,
   config,
   height = "550px",
-  mobileHeight = "350px",
+  mobileHeight = "400px",
   className = "",
   children,
 }: PlotCardProps) {
@@ -62,7 +62,11 @@ export function PlotCard({
     return {
       ...layout,
       showlegend: false,
-      margin: { l: 50, r: 20, t: 40, b: 60 },
+      margin: { l: 50, r: 20, t: 80, b: 80 },
+      xaxis: {
+        ...(layout.xaxis ?? {}),
+        automargin: true,
+      },
       title: layout.title
         ? typeof layout.title === "string"
           ? { text: layout.title, font: { size: 14 } }


### PR DESCRIPTION
## Ticket
close #765

## Summary
The bottom margin (b: 60) in the mobile Plotly layout was too small, causing x-axis labels to overflow outside the container.

## Changes
Increased the container height (mobileHeight) from 350px to 400px, expanded top/bottom margins to t/b: 80, and added xaxis.automargin: true so Plotly automatically adjusts spacing based on label size.
