### PR TITLE
feat(ui): increase metric history limit and duration for better data retrieval

### DIFF
--- a/ui/src/components/features/metrics/CouplingMetricHistoryModal.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricHistoryModal.tsx
@@ -81,7 +81,7 @@ export function CouplingMetricHistoryModal({
   const { data, isLoading, isError } = useGetCouplingMetricHistory(
     chipId,
     activeCouplingId,
-    { metric: metricName, limit: 20, within_days: 30 },
+    { metric: metricName, limit: 100, within_days: 365 },
     {
       query: {
         staleTime: 30000,

--- a/ui/src/components/features/metrics/CouplingMetricHistoryModal.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricHistoryModal.tsx
@@ -234,7 +234,7 @@ export function CouplingMetricHistoryModal({
           </svg>
           <span>
             No {metricName} history available for {activeCouplingId} in the last
-            30 days
+            365 days
           </span>
         </div>
       </div>

--- a/ui/src/components/features/metrics/QubitMetricHistoryModal.tsx
+++ b/ui/src/components/features/metrics/QubitMetricHistoryModal.tsx
@@ -196,7 +196,7 @@ export function QubitMetricHistoryModal({
           />
         </svg>
         <span>
-          No {metricName} history available for {qid} in the last 30 days
+          No {metricName} history available for {qid} in the last 365 days
         </span>
       </div>
     );

--- a/ui/src/components/features/metrics/QubitMetricHistoryModal.tsx
+++ b/ui/src/components/features/metrics/QubitMetricHistoryModal.tsx
@@ -65,7 +65,7 @@ export function QubitMetricHistoryModal({
   const { data, isLoading, isError } = useGetQubitMetricHistory(
     chipId,
     qid,
-    { metric: metricName, limit: 20, within_days: 30 },
+    { metric: metricName, limit: 100, within_days: 365 },
     {
       query: {
         staleTime: 30000,


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Increased the metric history limit to 100 and duration to 365 days for improved data retrieval.
- Enhancements affect the CouplingMetricHistoryModal and QubitMetricHistoryModal components, allowing users to access a broader range of historical data.

## Changes
- Updated metric history limit and duration in CouplingMetricHistoryModal.
- Updated metric history limit and duration in QubitMetricHistoryModal.

