### PR TITLE
chore(repo): remove qubex-config submodule from repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "config/qubex-config"]
-	path = config/qubex-config
-	url = https://github.com/oqtopus-team/qubex-config.git
-	ignore = all


### PR DESCRIPTION
<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
- N/A

## Summary
- Removed the `qubex-config` submodule from the repository to streamline dependencies and simplify the project structure.
- This change reduces complexity and potential issues related to submodule management.

## Changes
- Deleted submodule configuration for `qubex-config`.
- Removed associated subproject commit reference.

