### PR TITLE
style: hide expand button in TaskResultGrid grid cells

### DIFF
--- a/ui/src/components/features/chip/TaskResultGrid/index.tsx
+++ b/ui/src/components/features/chip/TaskResultGrid/index.tsx
@@ -188,7 +188,7 @@ const GridCell = memo(function GridCell({
       }`}
     >
       {task.figure_path && figurePath && (
-        <div className="absolute inset-1">
+        <div className="absolute inset-1 [&_button]:hidden">
           <TaskFigure
             path={figurePath}
             qid={qid}


### PR DESCRIPTION
## Ticket
close #763

## Summary
This general-purpose UI, TaskFigure, was not optimized for use in cells.

## Changes
I decided against modifying the TaskFigure because it could have a wide-ranging impact.
Instead, I hid the TaskResultGrid, which is an exception, by specifying `[&_button]:hidden`.