### PR TITLE
Feat/#772 task error alert

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -14687,6 +14687,11 @@
             "title": "Tags",
             "default": []
           },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "default": ""
+          },
           "source_task_id": {
             "anyOf": [
               {

--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -14692,6 +14692,11 @@
             "title": "Message",
             "default": ""
           },
+          "stack_trace": {
+            "type": "string",
+            "title": "Stack Trace",
+            "default": ""
+          },
           "source_task_id": {
             "anyOf": [
               {

--- a/src/qdash/api/schemas/task.py
+++ b/src/qdash/api/schemas/task.py
@@ -171,6 +171,7 @@ class TaskResultResponse(BaseModel):
     output_parameters: dict[str, Any]
     run_parameters: dict[str, Any] = {}
     tags: list[str] = []
+    message: str = ""
     source_task_id: str | None = None
     re_executions: list[ReExecutionEntry] = []
     start_at: datetime | None = None

--- a/src/qdash/api/schemas/task.py
+++ b/src/qdash/api/schemas/task.py
@@ -172,6 +172,7 @@ class TaskResultResponse(BaseModel):
     run_parameters: dict[str, Any] = {}
     tags: list[str] = []
     message: str = ""
+    stack_trace: str = ""
     source_task_id: str | None = None
     re_executions: list[ReExecutionEntry] = []
     start_at: datetime | None = None

--- a/src/qdash/api/services/task_service.py
+++ b/src/qdash/api/services/task_service.py
@@ -50,7 +50,9 @@ class TaskService:
         """Initialize the service with repositories."""
         self._task_def_repo = task_definition_repository
 
-    def list_tasks(self, project_id: str, backend: str | None = None) -> ListTaskResponse:
+    def list_tasks(
+        self, project_id: str, backend: str | None = None
+    ) -> ListTaskResponse:
         """List all tasks for a project.
 
         Parameters
@@ -265,15 +267,23 @@ class TaskService:
             summary=knowledge.summary,
             what_it_measures=knowledge.what_it_measures,
             physical_principle=knowledge.physical_principle,
-            expected_result=ExpectedResultResponse(**knowledge.expected_result.model_dump()),
+            expected_result=ExpectedResultResponse(
+                **knowledge.expected_result.model_dump()
+            ),
             evaluation_criteria=knowledge.evaluation_criteria,
             check_questions=knowledge.check_questions,
             failure_modes=[fm.model_dump() for fm in knowledge.failure_modes],
             tips=knowledge.tips,
-            output_parameters_info=[p.model_dump() for p in knowledge.output_parameters_info],
+            output_parameters_info=[
+                p.model_dump() for p in knowledge.output_parameters_info
+            ],
             analysis_guide=knowledge.analysis_guide,
             prerequisites=knowledge.prerequisites,
-            images=[KnowledgeImageResponse(**img.model_dump()) for img in knowledge.images],
-            cases=[KnowledgeCaseResponse(**case.model_dump()) for case in knowledge.cases],
+            images=[
+                KnowledgeImageResponse(**img.model_dump()) for img in knowledge.images
+            ],
+            cases=[
+                KnowledgeCaseResponse(**case.model_dump()) for case in knowledge.cases
+            ],
             prompt_text=knowledge.to_prompt(),
         )

--- a/src/qdash/api/services/task_service.py
+++ b/src/qdash/api/services/task_service.py
@@ -153,6 +153,7 @@ class TaskService:
             output_parameters=task_result.output_parameters,
             run_parameters=task_result.run_parameters,
             tags=task_result.tags,
+            message=task_result.message,
             source_task_id=task_result.source_task_id,
             re_executions=re_executions,
             start_at=task_result.start_at,

--- a/src/qdash/api/services/task_service.py
+++ b/src/qdash/api/services/task_service.py
@@ -154,6 +154,7 @@ class TaskService:
             run_parameters=task_result.run_parameters,
             tags=task_result.tags,
             message=task_result.message,
+            stack_trace=task_result.stack_trace,
             source_task_id=task_result.source_task_id,
             re_executions=re_executions,
             start_at=task_result.start_at,

--- a/src/qdash/api/services/task_service.py
+++ b/src/qdash/api/services/task_service.py
@@ -50,9 +50,7 @@ class TaskService:
         """Initialize the service with repositories."""
         self._task_def_repo = task_definition_repository
 
-    def list_tasks(
-        self, project_id: str, backend: str | None = None
-    ) -> ListTaskResponse:
+    def list_tasks(self, project_id: str, backend: str | None = None) -> ListTaskResponse:
         """List all tasks for a project.
 
         Parameters
@@ -267,23 +265,15 @@ class TaskService:
             summary=knowledge.summary,
             what_it_measures=knowledge.what_it_measures,
             physical_principle=knowledge.physical_principle,
-            expected_result=ExpectedResultResponse(
-                **knowledge.expected_result.model_dump()
-            ),
+            expected_result=ExpectedResultResponse(**knowledge.expected_result.model_dump()),
             evaluation_criteria=knowledge.evaluation_criteria,
             check_questions=knowledge.check_questions,
             failure_modes=[fm.model_dump() for fm in knowledge.failure_modes],
             tips=knowledge.tips,
-            output_parameters_info=[
-                p.model_dump() for p in knowledge.output_parameters_info
-            ],
+            output_parameters_info=[p.model_dump() for p in knowledge.output_parameters_info],
             analysis_guide=knowledge.analysis_guide,
             prerequisites=knowledge.prerequisites,
-            images=[
-                KnowledgeImageResponse(**img.model_dump()) for img in knowledge.images
-            ],
-            cases=[
-                KnowledgeCaseResponse(**case.model_dump()) for case in knowledge.cases
-            ],
+            images=[KnowledgeImageResponse(**img.model_dump()) for img in knowledge.images],
+            cases=[KnowledgeCaseResponse(**case.model_dump()) for case in knowledge.cases],
             prompt_text=knowledge.to_prompt(),
         )

--- a/src/qdash/datamodel/task.py
+++ b/src/qdash/datamodel/task.py
@@ -229,6 +229,7 @@ class BaseTaskResultModel(BaseModel):
     upstream_id: str = ""
     status: TaskStatusModel = TaskStatusModel.SCHEDULED
     message: str = ""
+    stack_trace: str = ""
     input_parameters: dict[str, Any] = {}
     output_parameters: dict[str, Any] = {}
     output_parameter_names: list[str] = []

--- a/src/qdash/datamodel/task.py
+++ b/src/qdash/datamodel/task.py
@@ -54,17 +54,23 @@ class RunParameterModel(BaseModel):
         """
         if self.value_type == "np.linspace":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.linspace requires a tuple/list of (start, stop, num)")
+                raise ValueError(
+                    "np.linspace requires a tuple/list of (start, stop, num)"
+                )
             start, stop, num = self.value
             return np.linspace(float(start), float(stop), int(num))
         elif self.value_type == "np.logspace":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.logspace requires a tuple/list of (start, stop, num)")
+                raise ValueError(
+                    "np.logspace requires a tuple/list of (start, stop, num)"
+                )
             start, stop, num = self.value
             return np.logspace(float(start), float(stop), int(num))
         elif self.value_type == "np.arange":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.arange requires a tuple/list of (start, stop, step)")
+                raise ValueError(
+                    "np.arange requires a tuple/list of (start, stop, step)"
+                )
             start, stop, step = self.value
             return np.arange(float(start), float(stop), float(step))
         elif self.value_type == "range":
@@ -184,12 +190,16 @@ class CalibDataModel(BaseModel):
     qubit: dict[str, dict[str, ParameterModel]] = Field(default_factory=dict)
     coupling: dict[str, dict[str, ParameterModel]] = Field(default_factory=dict)
 
-    def put_qubit_data(self, qid: str, parameter_name: str, data: ParameterModel) -> None:
+    def put_qubit_data(
+        self, qid: str, parameter_name: str, data: ParameterModel
+    ) -> None:
         if qid not in self.qubit:
             self.qubit[qid] = {}
         self.qubit[qid][parameter_name] = data
 
-    def put_coupling_data(self, qid: str, parameter_name: str, data: ParameterModel) -> None:
+    def put_coupling_data(
+        self, qid: str, parameter_name: str, data: ParameterModel
+    ) -> None:
         if qid not in self.coupling:
             self.coupling[qid] = {}
         self.coupling[qid][parameter_name] = data
@@ -223,7 +233,9 @@ class BaseTaskResultModel(BaseModel):
 
     """
 
-    project_id: str | None = Field(default=None, description="Owning project identifier")
+    project_id: str | None = Field(
+        default=None, description="Owning project identifier"
+    )
     task_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str = ""
     upstream_id: str = ""
@@ -428,10 +440,16 @@ class TaskModel(BaseModel):
     """
 
     project_id: str | None = Field(None, description="Owning project identifier")
-    username: str = Field(..., description="The username of the user who created the task")
+    username: str = Field(
+        ..., description="The username of the user who created the task"
+    )
     name: str = Field(..., description="The name of the task")
     backend: str | None = Field(None, description="The backend of the task")
     description: str = Field(..., description="Detailed description of the task")
     task_type: str = Field(..., description="The type of the task")
-    input_parameters: dict[str, Any] = Field(..., description="The input parameters of the task")
-    output_parameters: dict[str, Any] = Field(..., description="The output parameters of the task")
+    input_parameters: dict[str, Any] = Field(
+        ..., description="The input parameters of the task"
+    )
+    output_parameters: dict[str, Any] = Field(
+        ..., description="The output parameters of the task"
+    )

--- a/src/qdash/datamodel/task.py
+++ b/src/qdash/datamodel/task.py
@@ -54,23 +54,17 @@ class RunParameterModel(BaseModel):
         """
         if self.value_type == "np.linspace":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError(
-                    "np.linspace requires a tuple/list of (start, stop, num)"
-                )
+                raise ValueError("np.linspace requires a tuple/list of (start, stop, num)")
             start, stop, num = self.value
             return np.linspace(float(start), float(stop), int(num))
         elif self.value_type == "np.logspace":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError(
-                    "np.logspace requires a tuple/list of (start, stop, num)"
-                )
+                raise ValueError("np.logspace requires a tuple/list of (start, stop, num)")
             start, stop, num = self.value
             return np.logspace(float(start), float(stop), int(num))
         elif self.value_type == "np.arange":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError(
-                    "np.arange requires a tuple/list of (start, stop, step)"
-                )
+                raise ValueError("np.arange requires a tuple/list of (start, stop, step)")
             start, stop, step = self.value
             return np.arange(float(start), float(stop), float(step))
         elif self.value_type == "range":
@@ -190,16 +184,12 @@ class CalibDataModel(BaseModel):
     qubit: dict[str, dict[str, ParameterModel]] = Field(default_factory=dict)
     coupling: dict[str, dict[str, ParameterModel]] = Field(default_factory=dict)
 
-    def put_qubit_data(
-        self, qid: str, parameter_name: str, data: ParameterModel
-    ) -> None:
+    def put_qubit_data(self, qid: str, parameter_name: str, data: ParameterModel) -> None:
         if qid not in self.qubit:
             self.qubit[qid] = {}
         self.qubit[qid][parameter_name] = data
 
-    def put_coupling_data(
-        self, qid: str, parameter_name: str, data: ParameterModel
-    ) -> None:
+    def put_coupling_data(self, qid: str, parameter_name: str, data: ParameterModel) -> None:
         if qid not in self.coupling:
             self.coupling[qid] = {}
         self.coupling[qid][parameter_name] = data
@@ -233,9 +223,7 @@ class BaseTaskResultModel(BaseModel):
 
     """
 
-    project_id: str | None = Field(
-        default=None, description="Owning project identifier"
-    )
+    project_id: str | None = Field(default=None, description="Owning project identifier")
     task_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str = ""
     upstream_id: str = ""
@@ -440,16 +428,10 @@ class TaskModel(BaseModel):
     """
 
     project_id: str | None = Field(None, description="Owning project identifier")
-    username: str = Field(
-        ..., description="The username of the user who created the task"
-    )
+    username: str = Field(..., description="The username of the user who created the task")
     name: str = Field(..., description="The name of the task")
     backend: str | None = Field(None, description="The backend of the task")
     description: str = Field(..., description="Detailed description of the task")
     task_type: str = Field(..., description="The type of the task")
-    input_parameters: dict[str, Any] = Field(
-        ..., description="The input parameters of the task"
-    )
-    output_parameters: dict[str, Any] = Field(
-        ..., description="The output parameters of the task"
-    )
+    input_parameters: dict[str, Any] = Field(..., description="The input parameters of the task")
+    output_parameters: dict[str, Any] = Field(..., description="The output parameters of the task")

--- a/src/qdash/dbmodel/task_result_history.py
+++ b/src/qdash/dbmodel/task_result_history.py
@@ -32,9 +32,7 @@ class TaskResultHistoryDocument(Document):
     """
 
     project_id: str | None = Field(None, description="Owning project identifier")
-    username: str = Field(
-        ..., description="The username of the user who created the task"
-    )
+    username: str = Field(..., description="The username of the user who created the task")
     task_id: str = Field(..., description="The task ID")
     name: str = Field(..., description="The task name")
     upstream_id: str = Field(..., description="The upstream task ID")
@@ -43,22 +41,14 @@ class TaskResultHistoryDocument(Document):
     stack_trace: str = Field("", description="The stack trace")
     input_parameters: dict[str, Any] = Field(..., description="The input parameters")
     output_parameters: dict[str, Any] = Field(..., description="The output parameters")
-    output_parameter_names: list[str] = Field(
-        ..., description="The output parameter names"
-    )
-    run_parameters: dict[str, Any] = Field(
-        default_factory=dict, description="The run parameters"
-    )
+    output_parameter_names: list[str] = Field(..., description="The output parameter names")
+    run_parameters: dict[str, Any] = Field(default_factory=dict, description="The run parameters")
     note: dict[str, Any] = Field(..., description="The note")
     figure_path: list[str] = Field(..., description="The path to the figure")
     json_figure_path: list[str] = Field([], description="The path to the JSON figure")
     raw_data_path: list[str] = Field([], description="The path to the raw data")
-    start_at: datetime | None = Field(
-        ..., description="The time when the execution started"
-    )
-    end_at: datetime | None = Field(
-        ..., description="The time when the execution ended"
-    )
+    start_at: datetime | None = Field(..., description="The time when the execution started")
+    end_at: datetime | None = Field(..., description="The time when the execution ended")
     elapsed_time: float | None = Field(..., description="The elapsed time in seconds")
     task_type: str = Field(..., description="The task type")
     system_info: SystemInfoModel = Field(..., description="The system information")
@@ -107,16 +97,10 @@ class TaskResultHistoryDocument(Document):
         name = "task_result_history"
         indexes: ClassVar = [
             # Primary indexes
-            IndexModel(
-                [("project_id", ASCENDING), ("task_id", ASCENDING)], unique=True
-            ),
+            IndexModel([("project_id", ASCENDING), ("task_id", ASCENDING)], unique=True),
             IndexModel([("project_id", ASCENDING), ("execution_id", ASCENDING)]),
             IndexModel(
-                [
-                    ("project_id", ASCENDING),
-                    ("chip_id", ASCENDING),
-                    ("start_at", DESCENDING),
-                ]
+                [("project_id", ASCENDING), ("chip_id", ASCENDING), ("start_at", DESCENDING)]
             ),
             # Index for latest task result queries (task_result.py: get_latest_*_task_results)
             IndexModel(
@@ -224,9 +208,7 @@ class TaskResultHistoryDocument(Document):
         doc.raw_data_path = task.raw_data_path
         doc.start_at = task.start_at
         doc.end_at = task.end_at
-        doc.elapsed_time = (
-            task.elapsed_time.total_seconds() if task.elapsed_time else None
-        )
+        doc.elapsed_time = task.elapsed_time.total_seconds() if task.elapsed_time else None
         doc.task_type = task.task_type
         doc.system_info = task.system_info
         doc.qid = getattr(task, "qid", "")

--- a/src/qdash/dbmodel/task_result_history.py
+++ b/src/qdash/dbmodel/task_result_history.py
@@ -32,7 +32,9 @@ class TaskResultHistoryDocument(Document):
     """
 
     project_id: str | None = Field(None, description="Owning project identifier")
-    username: str = Field(..., description="The username of the user who created the task")
+    username: str = Field(
+        ..., description="The username of the user who created the task"
+    )
     task_id: str = Field(..., description="The task ID")
     name: str = Field(..., description="The task name")
     upstream_id: str = Field(..., description="The upstream task ID")
@@ -41,14 +43,22 @@ class TaskResultHistoryDocument(Document):
     stack_trace: str = Field("", description="The stack trace")
     input_parameters: dict[str, Any] = Field(..., description="The input parameters")
     output_parameters: dict[str, Any] = Field(..., description="The output parameters")
-    output_parameter_names: list[str] = Field(..., description="The output parameter names")
-    run_parameters: dict[str, Any] = Field(default_factory=dict, description="The run parameters")
+    output_parameter_names: list[str] = Field(
+        ..., description="The output parameter names"
+    )
+    run_parameters: dict[str, Any] = Field(
+        default_factory=dict, description="The run parameters"
+    )
     note: dict[str, Any] = Field(..., description="The note")
     figure_path: list[str] = Field(..., description="The path to the figure")
     json_figure_path: list[str] = Field([], description="The path to the JSON figure")
     raw_data_path: list[str] = Field([], description="The path to the raw data")
-    start_at: datetime | None = Field(..., description="The time when the execution started")
-    end_at: datetime | None = Field(..., description="The time when the execution ended")
+    start_at: datetime | None = Field(
+        ..., description="The time when the execution started"
+    )
+    end_at: datetime | None = Field(
+        ..., description="The time when the execution ended"
+    )
     elapsed_time: float | None = Field(..., description="The elapsed time in seconds")
     task_type: str = Field(..., description="The task type")
     system_info: SystemInfoModel = Field(..., description="The system information")
@@ -97,10 +107,16 @@ class TaskResultHistoryDocument(Document):
         name = "task_result_history"
         indexes: ClassVar = [
             # Primary indexes
-            IndexModel([("project_id", ASCENDING), ("task_id", ASCENDING)], unique=True),
+            IndexModel(
+                [("project_id", ASCENDING), ("task_id", ASCENDING)], unique=True
+            ),
             IndexModel([("project_id", ASCENDING), ("execution_id", ASCENDING)]),
             IndexModel(
-                [("project_id", ASCENDING), ("chip_id", ASCENDING), ("start_at", DESCENDING)]
+                [
+                    ("project_id", ASCENDING),
+                    ("chip_id", ASCENDING),
+                    ("start_at", DESCENDING),
+                ]
             ),
             # Index for latest task result queries (task_result.py: get_latest_*_task_results)
             IndexModel(
@@ -208,7 +224,9 @@ class TaskResultHistoryDocument(Document):
         doc.raw_data_path = task.raw_data_path
         doc.start_at = task.start_at
         doc.end_at = task.end_at
-        doc.elapsed_time = task.elapsed_time.total_seconds() if task.elapsed_time else None
+        doc.elapsed_time = (
+            task.elapsed_time.total_seconds() if task.elapsed_time else None
+        )
         doc.task_type = task.task_type
         doc.system_info = task.system_info
         doc.qid = getattr(task, "qid", "")

--- a/src/qdash/dbmodel/task_result_history.py
+++ b/src/qdash/dbmodel/task_result_history.py
@@ -38,6 +38,7 @@ class TaskResultHistoryDocument(Document):
     upstream_id: str = Field(..., description="The upstream task ID")
     status: str = Field(..., description="The status of the execution")
     message: str = Field(..., description="The message")
+    stack_trace: str = Field("", description="The stack trace")
     input_parameters: dict[str, Any] = Field(..., description="The input parameters")
     output_parameters: dict[str, Any] = Field(..., description="The output parameters")
     output_parameter_names: list[str] = Field(..., description="The output parameter names")
@@ -159,6 +160,7 @@ class TaskResultHistoryDocument(Document):
             upstream_id=task.upstream_id,
             status=task.status,
             message=task.message,
+            stack_trace=task.stack_trace,
             input_parameters=task.input_parameters,
             output_parameters=task.output_parameters,
             output_parameter_names=task.output_parameter_names,
@@ -195,6 +197,7 @@ class TaskResultHistoryDocument(Document):
         doc.upstream_id = task.upstream_id
         doc.status = task.status
         doc.message = task.message
+        doc.stack_trace = task.stack_trace
         doc.input_parameters = task.input_parameters
         doc.output_parameters = task.output_parameters
         doc.output_parameter_names = task.output_parameter_names

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -201,6 +201,8 @@ class TaskExecutor:
         stack_trace: str = "",
     ) -> None:
         """Mark task as failed."""
+        if len(stack_trace) > 10000:
+            stack_trace = stack_trace[:9950] + "\n... (truncated)"
         self.state_manager.update_task_status_to_failed(task_name, message, task_type, qid, stack_trace)
 
     def execute(

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -198,9 +198,10 @@ class TaskExecutor:
         task_type: str,
         qid: str,
         message: str,
+        stack_trace: str = "",
     ) -> None:
         """Mark task as failed."""
-        self.state_manager.update_task_status_to_failed(task_name, message, task_type, qid)
+        self.state_manager.update_task_status_to_failed(task_name, message, task_type, qid, stack_trace)
 
     def execute(
         self,
@@ -392,15 +393,17 @@ class TaskExecutor:
             result.message = "Completed"
 
         except (R2ValidationError, FidelityValidationError, ValueError) as e:
-            self._fail_task(task_name, task_type, qid, str(e))
+            tb = traceback.format_exc()
+            self._fail_task(task_name, task_type, qid, str(e), tb)
             result.message = str(e)
-            result.stack_trace = traceback.format_exc()
+            result.stack_trace = tb
             raise
 
         except Exception as e:
-            self._fail_task(task_name, task_type, qid, str(e))
+            tb = traceback.format_exc()
+            self._fail_task(task_name, task_type, qid, str(e), tb)
             result.message = str(e)
-            result.stack_trace = traceback.format_exc()
+            result.stack_trace = tb
             raise TaskExecutionError(f"Task {task_name} failed: {e}") from e
 
         finally:

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -203,7 +203,9 @@ class TaskExecutor:
         """Mark task as failed."""
         if len(stack_trace) > 10000:
             stack_trace = stack_trace[:9950] + "\n... (truncated)"
-        self.state_manager.update_task_status_to_failed(task_name, message, task_type, qid, stack_trace)
+        self.state_manager.update_task_status_to_failed(
+            task_name, message, task_type, qid, stack_trace
+        )
 
     def execute(
         self,
@@ -467,7 +469,7 @@ class TaskExecutor:
 
         snap_input, snap_run = snapshot
         logger.info(
-            "Applying snapshot overrides for task=%s, qid=%s " "(input_params=%d, run_params=%d)",
+            "Applying snapshot overrides for task=%s, qid=%s (input_params=%d, run_params=%d)",
             task_name,
             qid,
             len(snap_input),

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -11,6 +11,7 @@ The TaskExecutor is responsible for the complete task execution lifecycle:
 """
 
 import logging
+import traceback
 from typing import TYPE_CHECKING, Any
 
 from qdash.repository import FilesystemCalibDataSaver
@@ -393,11 +394,13 @@ class TaskExecutor:
         except (R2ValidationError, FidelityValidationError, ValueError) as e:
             self._fail_task(task_name, task_type, qid, str(e))
             result.message = str(e)
+            result.stack_trace = traceback.format_exc()
             raise
 
         except Exception as e:
             self._fail_task(task_name, task_type, qid, str(e))
             result.message = str(e)
+            result.stack_trace = traceback.format_exc()
             raise TaskExecutionError(f"Task {task_name} failed: {e}") from e
 
         finally:

--- a/src/qdash/workflow/engine/task/state_manager/manager.py
+++ b/src/qdash/workflow/engine/task/state_manager/manager.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from typing import Any
 
 from pydantic import BaseModel
+
 from qdash.common.datetime_utils import now
 from qdash.datamodel.task import (
     BaseTaskResultModel,

--- a/src/qdash/workflow/engine/task/state_manager/manager.py
+++ b/src/qdash/workflow/engine/task/state_manager/manager.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator
 from typing import Any
 
 from pydantic import BaseModel
-
 from qdash.common.datetime_utils import now
 from qdash.datamodel.task import (
     BaseTaskResultModel,

--- a/src/qdash/workflow/engine/task/state_manager/manager.py
+++ b/src/qdash/workflow/engine/task/state_manager/manager.py
@@ -122,12 +122,13 @@ class TaskStateManager(BaseModel):
         task.message = message
 
     def update_task_status_to_failed(
-        self, task_name: str, message: str, task_type: str, qid: str
+        self, task_name: str, message: str, task_type: str, qid: str, stack_trace: str = ""
     ) -> None:
         """Update task status to FAILED."""
         task = self._ensure_task_exists(task_name, task_type, qid)
         task.status = TaskStatusModel.FAILED
         task.message = message
+        task.stack_trace = stack_trace
 
     def update_task_status_to_skipped(
         self, task_name: str, message: str, task_type: str, qid: str

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -687,17 +687,30 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
             />
           )}
 
-        {taskResult.status === "failed" && taskResult.message && (
-          <div className="border border-error/40 rounded-lg overflow-hidden">
-            <div className="flex items-center gap-2 px-3 py-2 bg-error/10 text-error text-sm font-semibold">
-              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-              Error Log
+        {taskResult.status === "failed" &&
+          (taskResult.message || taskResult.stack_trace) && (
+            <div className="border border-error/40 rounded-lg overflow-hidden">
+              <div className="flex items-center gap-2 px-3 py-2 bg-error/10 text-error text-sm font-semibold">
+                <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                Error Log
+              </div>
+              {taskResult.message && (
+                <pre className="px-3 py-3 text-xs font-mono text-error/80 whitespace-pre-wrap break-all bg-error/5">
+                  {taskResult.message}
+                </pre>
+              )}
+              {taskResult.stack_trace && (
+                <>
+                  <div className="px-3 py-1 text-xs font-semibold text-error/60 bg-error/5 border-t border-error/20">
+                    Stack Trace
+                  </div>
+                  <pre className="px-3 py-3 text-xs font-mono text-error/60 whitespace-pre-wrap break-all bg-error/5">
+                    {taskResult.stack_trace}
+                  </pre>
+                </>
+              )}
             </div>
-            <pre className="px-3 py-3 text-xs font-mono text-error/80 whitespace-pre-wrap break-all bg-error/5">
-              {taskResult.message}
-            </pre>
-          </div>
-        )}
+          )}
       </div>
 
       {/* Divider: Issues */}

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   ChevronDown,
   ChevronRight,
   RotateCcw,
+  AlertCircle,
 } from "lucide-react";
 import { useGetTaskResult, getGetTaskResultQueryKey } from "@/client/task/task";
 import {
@@ -685,6 +686,18 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
               parameters={taskResult.run_parameters as Record<string, unknown>}
             />
           )}
+
+        {taskResult.status === "failed" && taskResult.message && (
+          <div className="border border-error/40 rounded-lg overflow-hidden">
+            <div className="flex items-center gap-2 px-3 py-2 bg-error/10 text-error text-sm font-semibold">
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+              Error Log
+            </div>
+            <pre className="px-3 py-3 text-xs font-mono text-error/80 whitespace-pre-wrap break-all bg-error/5">
+              {taskResult.message}
+            </pre>
+          </div>
+        )}
       </div>
 
       {/* Divider: Issues */}

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -687,30 +687,27 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
             />
           )}
 
-        {taskResult.status === "failed" &&
-          (taskResult.message || taskResult.stack_trace) && (
-            <div className="border border-error/40 rounded-lg overflow-hidden">
-              <div className="flex items-center gap-2 px-3 py-2 bg-error/10 text-error text-sm font-semibold">
-                <AlertCircle className="h-3.5 w-3.5 shrink-0" />
-                Error Log
-              </div>
-              {taskResult.message && (
-                <pre className="px-3 py-3 text-xs font-mono text-error/80 whitespace-pre-wrap break-all bg-error/5">
-                  {taskResult.message}
-                </pre>
-              )}
-              {taskResult.stack_trace && (
-                <>
-                  <div className="px-3 py-1 text-xs font-semibold text-error/60 bg-error/5 border-t border-error/20">
-                    Stack Trace
-                  </div>
-                  <pre className="px-3 py-3 text-xs font-mono text-error/60 whitespace-pre-wrap break-all bg-error/5">
-                    {taskResult.stack_trace}
-                  </pre>
-                </>
-              )}
+        {taskResult.status === "failed" && taskResult.message && (
+          <div className="border border-error/40 rounded-lg overflow-hidden">
+            <div className="flex items-center gap-2 px-3 py-2 bg-error/10 text-error text-sm font-semibold">
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+              Error Log
             </div>
-          )}
+            <pre className="px-3 py-3 text-xs font-mono text-error/80 whitespace-pre-wrap break-all bg-error/5">
+              {taskResult.message}
+            </pre>
+            {taskResult.stack_trace && (
+              <>
+                <div className="px-3 py-1 text-xs font-semibold text-error/60 bg-error/5 border-t border-error/20">
+                  Stack Trace
+                </div>
+                <pre className="px-3 py-3 text-xs font-mono text-error/60 whitespace-pre-wrap break-all bg-error/5">
+                  {taskResult.stack_trace}
+                </pre>
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Divider: Issues */}

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -698,8 +698,14 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
             </pre>
             {taskResult.stack_trace && (
               <>
-                <div className="px-3 py-1 text-xs font-semibold text-error/60 bg-error/5 border-t border-error/20">
+                <div className="px-3 py-1 text-xs font-semibold text-error/60 bg-error/5 border-t border-error/20 flex justify-between items-center">
                   Stack Trace
+                  <button
+                    className="btn btn-ghost btn-xs"
+                    onClick={() => navigator.clipboard.writeText(taskResult.stack_trace ?? "")}
+                  >
+                    Copy
+                  </button>
                 </div>
                 <pre className="px-3 py-3 text-xs font-mono text-error/60 whitespace-pre-wrap break-all bg-error/5">
                   {taskResult.stack_trace}

--- a/ui/src/schemas/taskResultResponse.ts
+++ b/ui/src/schemas/taskResultResponse.ts
@@ -47,6 +47,7 @@ export interface TaskResultResponse {
   output_parameters: TaskResultResponseOutputParameters;
   run_parameters?: TaskResultResponseRunParameters;
   tags?: string[];
+  message?: string;
   source_task_id?: TaskResultResponseSourceTaskId;
   re_executions?: ReExecutionEntry[];
   start_at?: TaskResultResponseStartAt;

--- a/ui/src/schemas/taskResultResponse.ts
+++ b/ui/src/schemas/taskResultResponse.ts
@@ -48,6 +48,7 @@ export interface TaskResultResponse {
   run_parameters?: TaskResultResponseRunParameters;
   tags?: string[];
   message?: string;
+  stack_trace?: string;
   source_task_id?: TaskResultResponseSourceTaskId;
   re_executions?: ReExecutionEntry[];
   start_at?: TaskResultResponseStartAt;


### PR DESCRIPTION
## Ticket
close #772 

## Summary
We needed to be able to see the backend trace.

## Changes
- Add `stack_trace: str = ""` field to `BaseTaskResultModel`, `TaskResultHistoryDocument`, and `TaskResultResponse`.
- Capture `traceback.format_exc()` in executor's except blocks and propagate it through `_fail_task` → `update_task_status_to_failed`. so it is persisted to MongoDB (`task_result_history` collection)                                                                   
- Expose `stack_trace` via the API response and display it as a collapsible "Stack Trace" section below the existing "Error Log" on
 the task result detail page
