### PR TITLE
feat(workflow): add control_amplitude parameter to calibration tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,4 @@ src/tools/schedule/*
 /.claude/settings.local.json
 docs/internal/*
 docs/papers/*
+config/qubex-config

--- a/src/qdash/workflow/calibtasks/fake/fake_rabi.py
+++ b/src/qdash/workflow/calibtasks/fake/fake_rabi.py
@@ -13,7 +13,7 @@ from qdash.workflow.calibtasks.base import (
 )
 from qdash.workflow.calibtasks.fake.base import FakeTask
 from qdash.workflow.engine.backend.fake import FakeBackend
-from qubex.measurement.measurement_defaults import DEFAULT_INTERVAL, DEFAULT_SHOTS
+from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
 from qubex.simulator import Control, QuantumSimulator, QuantumSystem, SimulationResult, Transmon
 
 

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/chevron_pattern.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/chevron_pattern.py
@@ -27,6 +27,9 @@ class ChevronPattern(QubexTask):
     input_parameters: ClassVar[dict[str, ParameterModel | None]] = {
         "qubit_frequency": None,
         "readout_frequency": None,
+        "control_amplitude": ParameterModel(
+            value=DEFAULT_CONTROL_AMPLITUDE, unit="a.u.", description="Control pulse amplitude"
+        ),
         "readout_length": ParameterModel(
             value=DEFAULT_READOUT_DURATION, unit="ns", description="Readout pulse length"
         ),
@@ -37,12 +40,6 @@ class ChevronPattern(QubexTask):
             value_type="float",
             value=DEFAULT_READOUT_AMPLITUDE,
             description="Readout amplitude",
-        ),
-        "control_amplitude": RunParameterModel(
-            unit="a.u.",
-            value_type="float",
-            value=DEFAULT_CONTROL_AMPLITUDE,
-            description="Control pulse amplitude",
         ),
     }
     output_parameters: ClassVar[dict[str, ParameterModel]] = {
@@ -56,9 +53,9 @@ class ChevronPattern(QubexTask):
         """Preprocess: load params from DB and validate control_amplitude."""
         result = super().preprocess(backend, qid)
 
-        # Validate control_amplitude from run_parameters
-        param = self.run_parameters.get("control_amplitude")
-        value = param.get_value() if param is not None else None
+        # Validate control_amplitude from input_parameters
+        param = self.input_parameters.get("control_amplitude")
+        value = param.value if param is not None else None
         if (
             value is None
             or not isinstance(value, (int, float))
@@ -71,7 +68,13 @@ class ChevronPattern(QubexTask):
                 f"({CONTROL_AMPLITUDE_MIN}, {CONTROL_AMPLITUDE_MAX}), "
                 f"using default={DEFAULT_CONTROL_AMPLITUDE}"
             )
-            if param is not None:
+            if param is None:
+                self.input_parameters["control_amplitude"] = ParameterModel(
+                    value=DEFAULT_CONTROL_AMPLITUDE,
+                    unit="a.u.",
+                    description="Control pulse amplitude (default)",
+                )
+            else:
                 param.value = DEFAULT_CONTROL_AMPLITUDE
 
         return result
@@ -104,9 +107,9 @@ class ChevronPattern(QubexTask):
         ra_param = self.run_parameters.get("readout_amplitude")
         readout_amp = ra_param.get_value() if ra_param is not None else DEFAULT_READOUT_AMPLITUDE
 
-        # Get control_amplitude from run_parameters
-        ca_param = self.run_parameters.get("control_amplitude")
-        ctrl_amp_value = ca_param.get_value() if ca_param is not None else DEFAULT_CONTROL_AMPLITUDE
+        # Get control_amplitude from input_parameters (loaded from DB or default)
+        ca_param = self.input_parameters.get("control_amplitude")
+        ctrl_amp_value = ca_param.value if ca_param is not None else DEFAULT_CONTROL_AMPLITUDE
 
         # Fallback to default if control_amplitude value is invalid
         if (

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
@@ -64,6 +64,9 @@ class CreateHPIPulse(QubexTask):
         readout_amp_param = self.input_parameters["readout_amplitude"]
         if readout_amp_param is not None:
             exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
+        control_amp_param = self.input_parameters["control_amplitude"]
+        if control_amp_param is not None:
+            exp.params.control_amplitude[labels[0]] = control_amp_param.value
         result = exp.calibrate_hpi_pulse(
             targets=labels,
             n_rotations=1,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
@@ -64,6 +64,9 @@ class CreatePIPulse(QubexTask):
         readout_amp_param = self.input_parameters["readout_amplitude"]
         if readout_amp_param is not None:
             exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
+        control_amp_param = self.input_parameters["control_amplitude"]
+        if control_amp_param is not None:
+            exp.params.control_amplitude[labels[0]] = control_amp_param.value
         result = exp.calibrate_pi_pulse(
             targets=labels,
             n_rotations=1,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
@@ -73,6 +73,9 @@ class CreateDRAGHPIPulse(QubexTask):
         readout_amp_param = self.input_parameters["readout_amplitude"]
         if readout_amp_param is not None:
             exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
+        control_amp_param = self.input_parameters["control_amplitude"]
+        if control_amp_param is not None:
+            exp.params.control_amplitude[labels[0]] = control_amp_param.value
         result = exp.calibrate_drag_hpi_pulse(
             targets=labels,
             n_rotations=4,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
@@ -73,6 +73,9 @@ class CreateDRAGPIPulse(QubexTask):
         readout_amp_param = self.input_parameters["readout_amplitude"]
         if readout_amp_param is not None:
             exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
+        control_amp_param = self.input_parameters["control_amplitude"]
+        if control_amp_param is not None:
+            exp.params.control_amplitude[labels[0]] = control_amp_param.value
         result = exp.calibrate_drag_pi_pulse(
             targets=labels,
             n_rotations=4,


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced a new `control_amplitude` parameter to enhance calibration tasks, allowing for more precise control pulse amplitude settings.
- This change improves the flexibility of the calibration process and may affect existing workflows that utilize these tasks.

## Changes
- Added `control_amplitude` to the input parameters of the `ChevronPattern` class.
- Updated validation logic to ensure proper handling of the new parameter.
- Adjusted the run methods to incorporate the new `control_amplitude` in calibration processes.
- Marked the `qubex-config` submodule as dirty and added it to `.gitignore`.

