### PR TITLE
chore(workflow): update import path for measurement defaults

### DIFF
--- a/src/qdash/workflow/calibtasks/fake/fake_rabi.py
+++ b/src/qdash/workflow/calibtasks/fake/fake_rabi.py
@@ -13,7 +13,7 @@ from qdash.workflow.calibtasks.base import (
 )
 from qdash.workflow.calibtasks.fake.base import FakeTask
 from qdash.workflow.engine.backend.fake import FakeBackend
-from qubex.measurement.measurement import DEFAULT_INTERVAL, DEFAULT_SHOTS
+from qubex.measurement.measurement_defaults import DEFAULT_INTERVAL, DEFAULT_SHOTS
 from qubex.simulator import Control, QuantumSimulator, QuantumSystem, SimulationResult, Transmon
 
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updated the import path for measurement defaults to improve code organization and clarity.
- This change affects the workflow component and ensures compatibility with future updates.

## Changes
- Changed import statement from `qubex.measurement.measurement` to `qubex.measurement.measurement_defaults` for `DEFAULT_INTERVAL` and `DEFAULT_SHOTS`.

