### PR TITLE
Feat/#772 task error alert 02

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -14687,6 +14687,16 @@
             "title": "Tags",
             "default": []
           },
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "default": ""
+          },
+          "stack_trace": {
+            "type": "string",
+            "title": "Stack Trace",
+            "default": ""
+          },
           "source_task_id": {
             "anyOf": [
               {

--- a/src/qdash/api/schemas/task.py
+++ b/src/qdash/api/schemas/task.py
@@ -171,6 +171,8 @@ class TaskResultResponse(BaseModel):
     output_parameters: dict[str, Any]
     run_parameters: dict[str, Any] = {}
     tags: list[str] = []
+    message: str = ""
+    stack_trace: str = ""
     source_task_id: str | None = None
     re_executions: list[ReExecutionEntry] = []
     start_at: datetime | None = None

--- a/src/qdash/api/services/task_service.py
+++ b/src/qdash/api/services/task_service.py
@@ -153,6 +153,8 @@ class TaskService:
             output_parameters=task_result.output_parameters,
             run_parameters=task_result.run_parameters,
             tags=task_result.tags,
+            message=task_result.message,
+            stack_trace=task_result.stack_trace,
             source_task_id=task_result.source_task_id,
             re_executions=re_executions,
             start_at=task_result.start_at,

--- a/src/qdash/datamodel/task.py
+++ b/src/qdash/datamodel/task.py
@@ -229,6 +229,7 @@ class BaseTaskResultModel(BaseModel):
     upstream_id: str = ""
     status: TaskStatusModel = TaskStatusModel.SCHEDULED
     message: str = ""
+    stack_trace: str = ""
     input_parameters: dict[str, Any] = {}
     output_parameters: dict[str, Any] = {}
     output_parameter_names: list[str] = []

--- a/src/qdash/dbmodel/task_result_history.py
+++ b/src/qdash/dbmodel/task_result_history.py
@@ -38,6 +38,7 @@ class TaskResultHistoryDocument(Document):
     upstream_id: str = Field(..., description="The upstream task ID")
     status: str = Field(..., description="The status of the execution")
     message: str = Field(..., description="The message")
+    stack_trace: str = Field("", description="The stack trace")
     input_parameters: dict[str, Any] = Field(..., description="The input parameters")
     output_parameters: dict[str, Any] = Field(..., description="The output parameters")
     output_parameter_names: list[str] = Field(..., description="The output parameter names")
@@ -159,6 +160,7 @@ class TaskResultHistoryDocument(Document):
             upstream_id=task.upstream_id,
             status=task.status,
             message=task.message,
+            stack_trace=task.stack_trace,
             input_parameters=task.input_parameters,
             output_parameters=task.output_parameters,
             output_parameter_names=task.output_parameter_names,
@@ -195,6 +197,7 @@ class TaskResultHistoryDocument(Document):
         doc.upstream_id = task.upstream_id
         doc.status = task.status
         doc.message = task.message
+        doc.stack_trace = task.stack_trace
         doc.input_parameters = task.input_parameters
         doc.output_parameters = task.output_parameters
         doc.output_parameter_names = task.output_parameter_names

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -11,6 +11,7 @@ The TaskExecutor is responsible for the complete task execution lifecycle:
 """
 
 import logging
+import traceback
 from typing import TYPE_CHECKING, Any
 
 from qdash.repository import FilesystemCalibDataSaver
@@ -197,9 +198,14 @@ class TaskExecutor:
         task_type: str,
         qid: str,
         message: str,
+        stack_trace: str = "",
     ) -> None:
         """Mark task as failed."""
-        self.state_manager.update_task_status_to_failed(task_name, message, task_type, qid)
+        if len(stack_trace) > 10000:
+            stack_trace = stack_trace[:9950] + "\n... (truncated)"
+        self.state_manager.update_task_status_to_failed(
+            task_name, message, task_type, qid, stack_trace
+        )
 
     def execute(
         self,
@@ -391,13 +397,17 @@ class TaskExecutor:
             result.message = "Completed"
 
         except (R2ValidationError, FidelityValidationError, ValueError) as e:
-            self._fail_task(task_name, task_type, qid, str(e))
+            tb = traceback.format_exc()
+            self._fail_task(task_name, task_type, qid, str(e), tb)
             result.message = str(e)
+            result.stack_trace = tb
             raise
 
         except Exception as e:
-            self._fail_task(task_name, task_type, qid, str(e))
+            tb = traceback.format_exc()
+            self._fail_task(task_name, task_type, qid, str(e), tb)
             result.message = str(e)
+            result.stack_trace = tb
             raise TaskExecutionError(f"Task {task_name} failed: {e}") from e
 
         finally:
@@ -459,7 +469,7 @@ class TaskExecutor:
 
         snap_input, snap_run = snapshot
         logger.info(
-            "Applying snapshot overrides for task=%s, qid=%s " "(input_params=%d, run_params=%d)",
+            "Applying snapshot overrides for task=%s, qid=%s (input_params=%d, run_params=%d)",
             task_name,
             qid,
             len(snap_input),

--- a/src/qdash/workflow/engine/task/state_manager/manager.py
+++ b/src/qdash/workflow/engine/task/state_manager/manager.py
@@ -122,12 +122,13 @@ class TaskStateManager(BaseModel):
         task.message = message
 
     def update_task_status_to_failed(
-        self, task_name: str, message: str, task_type: str, qid: str
+        self, task_name: str, message: str, task_type: str, qid: str, stack_trace: str = ""
     ) -> None:
         """Update task status to FAILED."""
         task = self._ensure_task_exists(task_name, task_type, qid)
         task.status = TaskStatusModel.FAILED
         task.message = message
+        task.stack_trace = stack_trace
 
     def update_task_status_to_skipped(
         self, task_name: str, message: str, task_type: str, qid: str

--- a/src/qdash/workflow/engine/task/types.py
+++ b/src/qdash/workflow/engine/task/types.py
@@ -96,6 +96,7 @@ class TaskExecutionResult(BaseModel):
     qid: str
     success: bool = False
     message: str = ""
+    stack_trace: str = ""
     output_parameters: dict[str, Any] = Field(default_factory=dict)
     r2: dict[str, float | None] | None = None
     calib_data_delta: CalibDataModel = Field(

--- a/tests/qdash/workflow/engine/task/test_executor.py
+++ b/tests/qdash/workflow/engine/task/test_executor.py
@@ -256,6 +256,24 @@ class TestTaskExecutorExecuteTask:
 
         mock_state_manager.update_task_status_to_failed.assert_called_once()
 
+    def test_execute_task_raises_value_error_on_validate_fidelity_failure(
+        self,
+        executor: TaskExecutor,
+        mock_result_processor: MagicMock,
+        mock_state_manager: MagicMock,
+    ) -> None:
+        """Test execute_task converts FidelityValidationError from validate_fidelity to ValueError."""
+        mock_result_processor.validate_fidelity.side_effect = FidelityValidationError(
+            "Fidelity exceeds 100%"
+        )
+        task = MockTask()
+        session: Any = MockSession()
+
+        with pytest.raises(ValueError, match="Fidelity exceeds 100%"):
+            executor.execute_task(task, session, "0")
+
+        mock_state_manager.update_task_status_to_failed.assert_called_once()
+
     def test_execute_task_raises_task_execution_error_on_exception(
         self, executor: TaskExecutor, mock_state_manager: MagicMock
     ) -> None:

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   ChevronDown,
   ChevronRight,
   RotateCcw,
+  AlertCircle,
 } from "lucide-react";
 import { useGetTaskResult, getGetTaskResultQueryKey } from "@/client/task/task";
 import {
@@ -685,6 +686,34 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
               parameters={taskResult.run_parameters as Record<string, unknown>}
             />
           )}
+
+        {taskResult.status === "failed" && taskResult.message && (
+          <div className="border border-error/40 rounded-lg overflow-hidden">
+            <div className="flex items-center gap-2 px-3 py-2 bg-error/10 text-error text-sm font-semibold">
+              <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+              Error Log
+            </div>
+            <pre className="px-3 py-3 text-xs font-mono text-error/80 whitespace-pre-wrap break-all bg-error/5">
+              {taskResult.message}
+            </pre>
+            {taskResult.stack_trace && (
+              <>
+                <div className="px-3 py-1 text-xs font-semibold text-error/60 bg-error/5 border-t border-error/20 flex justify-between items-center">
+                  Stack Trace
+                  <button
+                    className="btn btn-ghost btn-xs"
+                    onClick={() => navigator.clipboard.writeText(taskResult.stack_trace ?? "")}
+                  >
+                    Copy
+                  </button>
+                </div>
+                <pre className="px-3 py-3 text-xs font-mono text-error/60 whitespace-pre-wrap break-all bg-error/5">
+                  {taskResult.stack_trace}
+                </pre>
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Divider: Issues */}

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -702,7 +702,11 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
                   Stack Trace
                   <button
                     className="btn btn-ghost btn-xs"
-                    onClick={() => navigator.clipboard.writeText(taskResult.stack_trace ?? "")}
+                    onClick={() =>
+                      navigator.clipboard.writeText(
+                        taskResult.stack_trace ?? "",
+                      )
+                    }
                   >
                     Copy
                   </button>

--- a/ui/src/schemas/taskResultResponse.ts
+++ b/ui/src/schemas/taskResultResponse.ts
@@ -47,6 +47,8 @@ export interface TaskResultResponse {
   output_parameters: TaskResultResponseOutputParameters;
   run_parameters?: TaskResultResponseRunParameters;
   tags?: string[];
+  message?: string;
+  stack_trace?: string;
   source_task_id?: TaskResultResponseSourceTaskId;
   re_executions?: ReExecutionEntry[];
   start_at?: TaskResultResponseStartAt;


### PR DESCRIPTION
## Ticket
close #772 

## Summary
We needed to be able to see the backend trace.

## Changes
- Add `stack_trace: str = ""` field to `BaseTaskResultModel`, `TaskResultHistoryDocument`, and `TaskResultResponse`.
- Capture `traceback.format_exc()` in executor's except blocks and propagate it through `_fail_task` → `update_task_status_to_failed`. so it is persisted to MongoDB (`task_result_history` collection)                                                                   
- Expose `stack_trace` via the API response and display it as a collapsible "Stack Trace" section below the existing "Error Log" on the task result detail page