### PR TITLE
style: display grid on error

### DIFF
--- a/ui/src/components/features/chip/CouplingGrid/index.tsx
+++ b/ui/src/components/features/chip/CouplingGrid/index.tsx
@@ -226,8 +226,6 @@ export function CouplingGrid({
         <span className="loading loading-spinner loading-lg"></span>
       </div>
     );
-  if (isError)
-    return <div className="alert alert-error">Failed to load data</div>;
 
   // In pan-zoom mode, ensure cells are large enough for figures to be readable.
   const effectiveGridSize = gridSize;
@@ -675,6 +673,9 @@ export function CouplingGrid({
 
   return (
     <div className="flex flex-col h-full space-y-2">
+      {isError && (
+        <div className="alert alert-error">Failed to load data</div>
+      )}
       {/* View mode toggle and Download controls */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">

--- a/ui/src/components/features/chip/CouplingGrid/index.tsx
+++ b/ui/src/components/features/chip/CouplingGrid/index.tsx
@@ -673,9 +673,7 @@ export function CouplingGrid({
 
   return (
     <div className="flex flex-col h-full space-y-2">
-      {isError && (
-        <div className="alert alert-error">Failed to load data</div>
-      )}
+      {isError && <div className="alert alert-error">Failed to load data</div>}
       {/* View mode toggle and Download controls */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">

--- a/ui/src/components/features/chip/CouplingGrid/index.tsx
+++ b/ui/src/components/features/chip/CouplingGrid/index.tsx
@@ -673,7 +673,11 @@ export function CouplingGrid({
 
   return (
     <div className="flex flex-col h-full space-y-2">
-      {isError && <div className="alert alert-error">Failed to load data</div>}
+      {isError && (
+        <div className="alert alert-error">
+          Failed to load {selectedTask} data for {selectedDate}
+        </div>
+      )}
       {/* View mode toggle and Download controls */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">

--- a/ui/src/components/features/chip/TaskResultGrid/index.tsx
+++ b/ui/src/components/features/chip/TaskResultGrid/index.tsx
@@ -362,8 +362,6 @@ export function TaskResultGrid({
         <span className="loading loading-spinner loading-lg"></span>
       </div>
     );
-  if (isTaskError)
-    return <div className="alert alert-error">Failed to load data</div>;
 
   const gridPositions: { [key: string]: { row: number; col: number } } = {};
   if (taskResponse?.data?.result) {
@@ -691,6 +689,9 @@ export function TaskResultGrid({
 
   return (
     <div className="flex flex-col h-full space-y-2">
+      {isTaskError && (
+        <div className="alert alert-error">Failed to load data</div>
+      )}
       {/* View Mode Toggle and Download Controls */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Ticket
close #779 

## Summary
Due to early returns, the empty grid was not displayed.

## Changes
I removed the early return and display an error message and an empty grid.
