### PR TITLE
fix: condition check logic updated

### DIFF
--- a/ui/src/components/features/execution/ExecutionPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionPageContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 import { ExternalLink, ArrowUpRight, StopCircle } from "lucide-react";
 import Link from "next/link";
@@ -78,9 +78,6 @@ export function ExecutionPageContent() {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 20;
 
-  // Track if we've already set the default chip to prevent race conditions
-  const hasSetDefaultChip = useRef(false);
-
   // Use custom hook for date navigation (unused but kept for potential future use)
   useDateNavigation(selectedChip || "", selectedDate, setSelectedDate);
 
@@ -99,13 +96,7 @@ export function ExecutionPageContent() {
 
   // Set the latest chip as default when chips are loaded and no chip is selected from URL
   useEffect(() => {
-    if (
-      isInitialized &&
-      !selectedChip &&
-      !hasSetDefaultChip.current &&
-      sortedChips.length > 0
-    ) {
-      hasSetDefaultChip.current = true;
+    if (isInitialized && !selectedChip && sortedChips.length > 0) {
       setSelectedChip(sortedChips[0].chip_id);
     }
   }, [isInitialized, selectedChip, sortedChips, setSelectedChip]);


### PR DESCRIPTION
## Ticket
close #789

## Summary
A useRef flag (hasSetDefaultChip) was used to prevent the default chip from being set more than once, but it persisted across navigation without resetting — so when the user navigated away and back to the Execution page, the flag was still true, blocking the default chip from being set again, leaving the Select UI empty.

1. The user navigates to the Execution page.
2. The effect runs with `hasSetDefaultChip.current = false`, sets the default chip, and flips the flag to true.
3. The user navigates away to another page via the sidebar.                                                                                          
4. The user clicks Execution again.                                                                                                                  
5. The component remounts, but `useRef` does not reset `hasSetDefaultChip.current` remains true.                                                       
6. The condition `!hasSetDefaultChip.current` evaluates to false, so the effect skips setting the default chip.                                        
7. `selectedChip` stays empty, leaving the `Select UI` blank. 

## Changes
Removed the `useRef` flag entirely, relying solely on the existing condition `!selectedChip` to guard against redundant updates this naturally allows the default chip to be set again whenever the component remounts with no chip selected. 