### PR TITLE
style: grid jaggy bug fixed

### DIFF
--- a/ui/src/components/features/chip/CouplingGrid/index.tsx
+++ b/ui/src/components/features/chip/CouplingGrid/index.tsx
@@ -376,7 +376,6 @@ export function CouplingGrid({
           viewportHeight,
         ),
         maxWidth: viewMode === "pan-zoom" ? "none" : "100%",
-        willChange: viewMode === "pan-zoom" ? "transform" : "auto",
       }}
     >
       {/* Qubit positions - either from topology or computed, with MUX styling */}

--- a/ui/src/components/features/chip/TaskResultGrid/index.tsx
+++ b/ui/src/components/features/chip/TaskResultGrid/index.tsx
@@ -500,7 +500,6 @@ export function TaskResultGrid({
           isMobile,
           viewportHeight,
         ),
-        willChange: "transform",
       }}
     >
       {Array.from({

--- a/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
@@ -371,7 +371,6 @@ export function CouplingMetricsGrid({
           viewportHeight,
         ),
         maxWidth: viewMode === "pan-zoom" ? "none" : "100%",
-        willChange: viewMode === "pan-zoom" ? "transform" : "auto",
       }}
     >
       {/* Qubit cells (background) with MUX styling */}

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -542,7 +542,6 @@ export function QubitMetricsGrid({
             isMobile,
             viewportHeight,
           ),
-          willChange: "transform",
         }}
       >
         {gridCellsData.map((cell) => {


### PR DESCRIPTION
## Ticket
close #802

## Summary
When will-change: transform is set on the inner grid content div (inside TransformComponent), the browser rasterizes it into a GPU compositing texture at a fixed resolution.
When react-zoom-pan-pinch scales the parent TransformComponent, the GPU resamples this pre-baked texture — producing sharp results only at clean integer scales and blurry/jaggy results at fractional ones.                                                                                                                                                      

## Changes
Removed will-change: transform from the inner grid content in all four grid components, so the browser re-paints DOM elements at each zoom level instead of scaling a cached texture. This eliminates the non-deterministic sharp/blurry behavior and keeps rendering consistently crisp at any zoom scale.