### PR TITLE
Style/#808 metrics overlap index

### DIFF
--- a/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
@@ -24,10 +24,7 @@ import {
   getQubitGridPosition,
   type TopologyLayoutParams,
 } from "@/lib/utils/grid-position";
-import {
-  calculateGridDimension,
-  cellFontSize,
-} from "@/lib/utils/grid-layout";
+import { calculateGridDimension, cellFontSize } from "@/lib/utils/grid-layout";
 
 import { CouplingMetricHistoryModal } from "./CouplingMetricHistoryModal";
 

--- a/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
@@ -24,29 +24,23 @@ import {
   getQubitGridPosition,
   type TopologyLayoutParams,
 } from "@/lib/utils/grid-position";
-import { calculateGridDimension } from "@/lib/utils/grid-layout";
+import {
+  calculateGridDimension,
+  cellFontSize,
+} from "@/lib/utils/grid-layout";
 
 import { CouplingMetricHistoryModal } from "./CouplingMetricHistoryModal";
 
-// Dynamic font size calculation based on cell size
+// Font sizes scale linearly with cellSize so the text-to-cell ratio is
+// constant across devices.
 function getCouplingFontSizes(cellSize: number): {
   qubitLabelSize: string;
   valueSize: string;
 } {
-  // Scale font sizes proportionally to cell size
-  // Base reference: 60px cell = 14px label, 12px value
-  if (cellSize >= 60) {
-    return { qubitLabelSize: "0.875rem", valueSize: "0.75rem" };
-  } else if (cellSize >= 50) {
-    return { qubitLabelSize: "0.75rem", valueSize: "0.65rem" };
-  } else if (cellSize >= 40) {
-    return { qubitLabelSize: "0.625rem", valueSize: "0.55rem" };
-  } else if (cellSize >= 30) {
-    return { qubitLabelSize: "0.5rem", valueSize: "0.525rem" };
-  } else {
-    // Very small cells (< 30px)
-    return { qubitLabelSize: "0.45rem", valueSize: "0.475rem" };
-  }
+  return {
+    qubitLabelSize: cellFontSize(cellSize, 0.2),
+    valueSize: cellFontSize(cellSize, 0.17),
+  };
 }
 
 interface MetricValue {
@@ -464,7 +458,10 @@ export function CouplingMetricsGrid({
                   transform: "translate(-50%, -50%)",
                 }}
               >
-                <div className="text-[0.45rem] md:text-[0.6rem] font-semibold text-base-content/30 bg-base-100/60 px-1 py-px rounded border border-base-content/5">
+                <div
+                  className="font-semibold text-base-content/30 bg-base-100/60 px-1 py-px rounded border border-base-content/5"
+                  style={{ fontSize: cellFontSize(displayCellSize, 0.13) }}
+                >
                   MUX{muxIndex}
                 </div>
               </div>

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -164,6 +164,16 @@ const GridCell = memo(function GridCell({
         </div>
       )}
 
+      {/* Unit Label */}
+      {showLabels && effectiveShowUnits && (
+        <div
+          className="absolute top-0.5 right-1 text-white/90 font-medium drop-shadow leading-tight"
+          style={{ fontSize: fontSizes.unitSize }}
+        >
+          ({unit})
+        </div>
+      )}
+
       {/* Value Display */}
       {value !== null && value !== undefined && showValues && (
         <div
@@ -186,14 +196,6 @@ const GridCell = memo(function GridCell({
               style={{ fontSize: fontSizes.unitSize }}
             >
               ± {stddev.toFixed(2)}
-            </div>
-          )}
-          {effectiveShowUnits && (
-            <div
-              className="text-white/90 font-medium drop-shadow"
-              style={{ fontSize: fontSizes.unitSize }}
-            >
-              {unit}
             </div>
           )}
         </div>

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -153,7 +153,7 @@ const GridCell = memo(function GridCell({
       {/* QID Label */}
       {showLabels && (
         <div
-          className={`absolute top-0.5 left-0.5 backdrop-blur-sm px-0.5 py-px rounded font-bold shadow-sm ${
+          className={`absolute top-0.5 left-0.5 backdrop-blur-sm px-0.5 py-px rounded font-bold shadow-sm leading-tight ${
             value !== null && value !== undefined
               ? "bg-black/30 text-white"
               : "bg-base-content/20 text-base-content"
@@ -166,7 +166,14 @@ const GridCell = memo(function GridCell({
 
       {/* Value Display */}
       {value !== null && value !== undefined && showValues && (
-        <div className="flex flex-col items-center justify-center h-full">
+        <div
+          className="flex flex-col items-center justify-center h-full leading-tight"
+          style={{
+            paddingTop: showLabels
+              ? cellFontSize(cellSize, 0.22)
+              : undefined,
+          }}
+        >
           <div
             className="font-bold text-white drop-shadow-md"
             style={{ fontSize: fontSizes.valueSize }}
@@ -194,7 +201,14 @@ const GridCell = memo(function GridCell({
 
       {/* No data indicator */}
       {(value === null || value === undefined) && showValues && (
-        <div className="flex flex-col items-center justify-center h-full">
+        <div
+          className="flex flex-col items-center justify-center h-full leading-tight"
+          style={{
+            paddingTop: showLabels
+              ? cellFontSize(cellSize, 0.22)
+              : undefined,
+          }}
+        >
           <div
             className="text-base-content/40 font-medium"
             style={{ fontSize: fontSizes.valueSize }}

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -18,7 +18,10 @@ import {
   getQubitGridPosition,
   type TopologyLayoutParams,
 } from "@/lib/utils/grid-position";
-import { calculateGridContainerWidth } from "@/lib/utils/grid-layout";
+import {
+  calculateGridContainerWidth,
+  cellFontSize,
+} from "@/lib/utils/grid-layout";
 
 import { QubitMetricHistoryModal } from "./QubitMetricHistoryModal";
 
@@ -80,7 +83,8 @@ function ZoomControls() {
   );
 }
 
-// Dynamic font size calculation based on cell size
+// Font sizes scale linearly with cellSize so the text-to-cell ratio is
+// constant across devices.
 function getCellFontSizes(cellSize: number): {
   labelSize: string;
   valueSize: string;
@@ -88,45 +92,12 @@ function getCellFontSizes(cellSize: number): {
   /** Whether stddev and unit should be hidden to save space */
   hideExtras: boolean;
 } {
-  // Scale font sizes proportionally to cell size
-  // Base reference: 60px cell = 12px label, 16px value, 10px unit
-  if (cellSize >= 60) {
-    return {
-      labelSize: "0.75rem",
-      valueSize: "1rem",
-      unitSize: "0.625rem",
-      hideExtras: false,
-    };
-  } else if (cellSize >= 50) {
-    return {
-      labelSize: "0.65rem",
-      valueSize: "0.875rem",
-      unitSize: "0.5rem",
-      hideExtras: false,
-    };
-  } else if (cellSize >= 40) {
-    return {
-      labelSize: "0.55rem",
-      valueSize: "0.75rem",
-      unitSize: "0.45rem",
-      hideExtras: false,
-    };
-  } else if (cellSize >= 30) {
-    return {
-      labelSize: "0.5rem",
-      valueSize: "0.675rem",
-      unitSize: "0.4rem",
-      hideExtras: true,
-    };
-  } else {
-    // Very small cells (< 30px): show only the value
-    return {
-      labelSize: "0.45rem",
-      valueSize: "0.6rem",
-      unitSize: "0.35rem",
-      hideExtras: true,
-    };
-  }
+  return {
+    labelSize: cellFontSize(cellSize, 0.17),
+    valueSize: cellFontSize(cellSize, 0.23),
+    unitSize: cellFontSize(cellSize, 0.14),
+    hideExtras: cellSize < 40,
+  };
 }
 
 // Memoized grid cell component for performance
@@ -616,7 +587,10 @@ export function QubitMetricsGrid({
                       gridRow: `${startRow} / span ${spanRows}`,
                     }}
                   >
-                    <div className="text-[0.45rem] md:text-[0.6rem] font-semibold text-base-content/30 bg-base-100/60 px-1 py-px rounded border border-base-content/5">
+                    <div
+                      className="font-semibold text-base-content/30 bg-base-100/60 px-1 py-px rounded border border-base-content/5"
+                      style={{ fontSize: cellFontSize(displayCellSize, 0.13) }}
+                    >
                       MUX{muxIndex}
                     </div>
                   </div>

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -179,9 +179,7 @@ const GridCell = memo(function GridCell({
         <div
           className="flex flex-col items-center justify-center h-full leading-tight"
           style={{
-            paddingTop: showLabels
-              ? cellFontSize(cellSize, 0.22)
-              : undefined,
+            paddingTop: showLabels ? cellFontSize(cellSize, 0.22) : undefined,
           }}
         >
           <div
@@ -206,9 +204,7 @@ const GridCell = memo(function GridCell({
         <div
           className="flex flex-col items-center justify-center h-full leading-tight"
           style={{
-            paddingTop: showLabels
-              ? cellFontSize(cellSize, 0.22)
-              : undefined,
+            paddingTop: showLabels ? cellFontSize(cellSize, 0.22) : undefined,
           }}
         >
           <div

--- a/ui/src/lib/utils/grid-layout.ts
+++ b/ui/src/lib/utils/grid-layout.ts
@@ -159,6 +159,22 @@ export function checkIsMobile(viewportWidth: number): boolean {
 }
 
 /**
+ * Compute a font size proportional to cellSize so that the text-to-cell
+ * ratio stays constant across devices and viewport sizes.
+ *
+ * Returns a `${px}px` string suitable for inline style. A minimum floor
+ * keeps text legible when cells become very small; two devices ending up
+ * at the same cellSize still produce identical output.
+ */
+export function cellFontSize(
+  cellSize: number,
+  ratio: number,
+  minPx = 6,
+): string {
+  return `${Math.max(cellSize * ratio, minPx)}px`;
+}
+
+/**
  * Calculate optimal cell size to fit grid in available space
  */
 export function calculateCellSize(params: {


### PR DESCRIPTION
## Ticket
close #808 

## Summary
  On the qubit/coupling metrics grid, the text-to-cell ratio visibly jumped between devices and the QID label in the top-left overlapped the centered value/stddev/unit stack at smaller cell sizes. The cause was that cell sizes were computed continuously from the viewport while font sizes used discrete tiers (cellSize >= 60 / 50 / 40 …) in rem plus Tailwind md: breakpoints, so devices landing in different tiers produced different ratios; the value column was also vertically centered with no top reservation, so it collided with the absolutely-positioned QID label. 

## Changes
Added a cellFontSize(cellSize, ratio, minPx) helper in ui/src/lib/utils/grid-layout.ts that returns a px value strictly proportional to cellSize, and switched the QID label, value, stddev, unit, and MUX label in QubitMetricsGrid.tsx and CouplingMetricsGrid.tsx to use it (ratios trimmed ~15% for legibility). The unit was moved to the top-right as (unit) to mirror the QID label, and a cellSize-proportional paddingTop plus leading-tight was applied to the value stack so it no longer overlaps the QID label.