### PR TITLE
Fix/#826 mismatch time format 2

### DIFF
--- a/ui/src/components/features/metrics/MetricsPageContent.tsx
+++ b/ui/src/components/features/metrics/MetricsPageContent.tsx
@@ -26,6 +26,7 @@ import { useMetricsUrlState } from "@/hooks/useUrlState";
 import { getDaisySelectStyles } from "@/lib/react-select-theme";
 import { Card } from "@/components/ui/Card";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { getTimezoneOffsetString } from "@/lib/utils/datetime";
 import { PageFiltersBar } from "@/components/ui/PageFiltersBar";
 
 type MetricOption = {
@@ -138,8 +139,12 @@ export function MetricsPageContent() {
             ? 24 * 30
             : 24 * 7; // Default to 7 days
 
-  const absoluteStartIso = startDate ? `${startDate}T00:00:00+09:00` : null;
-  const absoluteEndIso = endDate ? `${endDate}T23:59:59+09:00` : null;
+  const absoluteStartIso = startDate
+    ? `${startDate}T00:00:00${getTimezoneOffsetString()}`
+    : null;
+  const absoluteEndIso = endDate
+    ? `${endDate}T23:59:59${getTimezoneOffsetString()}`
+    : null;
 
   const metricsQueryParams = isAbsolute
     ? {

--- a/ui/src/components/features/metrics/MetricsPageContent.tsx
+++ b/ui/src/components/features/metrics/MetricsPageContent.tsx
@@ -138,8 +138,8 @@ export function MetricsPageContent() {
             ? 24 * 30
             : 24 * 7; // Default to 7 days
 
-  const absoluteStartIso = startDate ? `${startDate}T00:00:00` : null;
-  const absoluteEndIso = endDate ? `${endDate}T23:59:59` : null;
+  const absoluteStartIso = startDate ? `${startDate}T00:00:00+09:00` : null;
+  const absoluteEndIso = endDate ? `${endDate}T23:59:59+09:00` : null;
 
   const metricsQueryParams = isAbsolute
     ? {

--- a/ui/src/lib/utils/__tests__/datetime.test.ts
+++ b/ui/src/lib/utils/__tests__/datetime.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  getTimezoneOffsetString,
+  toIsoSeconds,
+  toDateTimeLocal,
+} from "../datetime";
+
+describe("getTimezoneOffsetString", () => {
+  it("returns +09:00 for Asia/Tokyo", () => {
+    expect(getTimezoneOffsetString("Asia/Tokyo")).toBe("+09:00");
+  });
+
+  it("returns +00:00 for UTC", () => {
+    expect(getTimezoneOffsetString("UTC")).toBe("+00:00");
+  });
+
+  it("returns a valid offset for America/New_York", () => {
+    const offset = getTimezoneOffsetString("America/New_York");
+    expect(offset).toMatch(/^-0[45]:00$/);
+  });
+});
+
+describe("toIsoSeconds", () => {
+  it("appends seconds and timezone offset to 16-char datetime", () => {
+    const result = toIsoSeconds("2024-06-15T12:00");
+    expect(result).toBe("2024-06-15T12:00:00+09:00");
+  });
+
+  it("returns input unchanged when length is not 16", () => {
+    const input = "2024-06-15T12:00:00+09:00";
+    expect(toIsoSeconds(input)).toBe(input);
+  });
+});
+
+describe("toDateTimeLocal", () => {
+  it("slices to first 16 chars when input contains T", () => {
+    expect(toDateTimeLocal("2024-06-15T12:00:00+09:00")).toBe(
+      "2024-06-15T12:00",
+    );
+  });
+
+  it("appends T00:00 when input has no T", () => {
+    expect(toDateTimeLocal("2024-06-15")).toBe("2024-06-15T00:00");
+  });
+});

--- a/ui/src/lib/utils/datetime.ts
+++ b/ui/src/lib/utils/datetime.ts
@@ -15,11 +15,26 @@ export function toDateTimeLocal(isoString: string): string {
 }
 
 export function toIsoSeconds(dt: string): string {
-  if (dt.length === 16) return `${dt}:00+09:00`;
+  if (dt.length === 16) return `${dt}:00${getTimezoneOffsetString()}`;
   return dt;
 }
 
 const DEFAULT_TIMEZONE = process.env.NEXT_PUBLIC_TIMEZONE || "Asia/Tokyo";
+
+export function getTimezoneOffsetString(
+  timezone: string = DEFAULT_TIMEZONE,
+): string {
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    timeZoneName: "longOffset",
+  });
+  const part = fmt
+    .formatToParts(new Date())
+    .find((p) => p.type === "timeZoneName");
+  const raw = part?.value ?? "GMT";
+  if (raw === "GMT") return "+00:00";
+  return raw.replace("GMT", "");
+}
 
 /**
  * Format a UTC datetime string to local timezone.

--- a/ui/src/lib/utils/datetime.ts
+++ b/ui/src/lib/utils/datetime.ts
@@ -15,7 +15,7 @@ export function toDateTimeLocal(isoString: string): string {
 }
 
 export function toIsoSeconds(dt: string): string {
-  if (dt.length === 16) return `${dt}:00`;
+  if (dt.length === 16) return `${dt}:00+09:00`;
   return dt;
 }
 


### PR DESCRIPTION
## Ticket
close #826

## Summary
Fix timezone mismatch in date range queries by appending the JST offset (`+09:00`) to all datetime strings sent to the API, ensuring consistent time interpretation between frontend and backend.

## Changes
- Add `+09:00` timezone offset to absolute start/end date strings in `MetricsPageContent.tsx`
- Update `toIsoSeconds` in `datetime.ts` to include `+09:00` offset when padding seconds
