### PR TITLE
feat(api): enhance issue knowledge schema with additional fields

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -114,9 +114,10 @@ WORKDIR /workspace/qdash/ui
 
 # Copy only package.json and bun.lock (cache optimization)
 COPY ./ui/package.json ./package.json
+COPY ./ui/bun.lock ./bun.lock
 
 # Install dependencies
-RUN bun install
+RUN bun install --frozen-lockfile
 # ========================================
 # Stage 5: Final image
 # ========================================
@@ -130,6 +131,10 @@ RUN echo "umask 022" >> /etc/profile && \
 # Install Claude Code (native install)
 RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV PATH="/root/.local/bin:${PATH}"
+
+# Install OpenAI Codex CLI
+RUN npm install -g @openai/codex && \
+    codex --version
 
 # Configure Zsh (execute last)
 ENV SHELL=/bin/zsh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,6 +47,7 @@
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
     "source=claude-code-config-${devcontainerId},target=/home/root/.claude,type=volume",
+    "source=codex-config-${devcontainerId},target=/root/.codex,type=volume",
     "source=qdash-vscode-extensions-${devcontainerId},target=/root/.vscode-server/extensions,type=volume",
     "source=qdash-pip-cache,target=/root/.cache/pip,type=volume",
     "source=qdash-uv-cache,target=/root/.cache/uv,type=volume"
@@ -64,7 +65,7 @@
   "shutdownAction": "none",
 
   // Run bun install after container creation
-  "postCreateCommand": "uv sync --all-groups && cd /workspace/qdash/ui && bun install",
+  "postCreateCommand": "uv sync --all-groups && cd /workspace/qdash/ui && bun install --frozen-lockfile",
 
   // Set umask to ensure files are readable by all users (for host-side Docker builds)
   "postStartCommand": "git config --global --add safe.directory /workspace/qdash; grep -q 'umask 022' ~/.bashrc || echo 'umask 022' >> ~/.bashrc; grep -q 'umask 022' ~/.zshrc || echo 'umask 022' >> ~/.zshrc",

--- a/src/qdash/api/routers/issue_knowledge.py
+++ b/src/qdash/api/routers/issue_knowledge.py
@@ -102,10 +102,21 @@ def update_issue_knowledge(
         knowledge_id=knowledge_id,
         title=body.title,
         severity=body.severity,
+        human_label=body.human_label,
+        failure_mode_labels=body.failure_mode_labels,
+        case_type=body.case_type,
+        model_error_type=body.model_error_type,
+        resolution_label=body.resolution_label,
         symptom=body.symptom,
+        model_prediction=body.model_prediction,
+        human_review_decision=body.human_review_decision,
         root_cause=body.root_cause,
         resolution=body.resolution,
+        boundary_criteria=body.boundary_criteria,
         lesson_learned=body.lesson_learned,
+        applicability=body.applicability,
+        counterexample=body.counterexample,
+        prompt_guidance=body.prompt_guidance,
     )
 
 

--- a/src/qdash/api/schemas/issue_knowledge.py
+++ b/src/qdash/api/schemas/issue_knowledge.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class IssueKnowledgeResponse(BaseModel):
@@ -21,10 +21,21 @@ class IssueKnowledgeResponse(BaseModel):
     chip_id: str = Field(default="", description="Chip identifier")
     qid: str = Field(default="", description="Qubit identifier")
     resolution_status: str = Field(default="resolved", description="Case outcome")
+    human_label: str = Field(default="", description="Human review label")
+    failure_mode_labels: list[str] = Field(default_factory=list, description="Failure labels")
+    case_type: list[str] = Field(default_factory=list, description="Knowledge case type labels")
+    model_error_type: str = Field(default="", description="Verifier error/outcome type")
+    resolution_label: str = Field(default="", description="Structured resolution label")
     symptom: str = Field(default="", description="Observed symptom")
+    model_prediction: str = Field(default="", description="Verifier/model prediction summary")
+    human_review_decision: str = Field(default="", description="Human review decision summary")
     root_cause: str = Field(default="", description="Identified root cause")
     resolution: str = Field(default="", description="How the issue was resolved")
+    boundary_criteria: str = Field(default="", description="Boundary criteria")
     lesson_learned: list[str] = Field(default_factory=list, description="Key takeaways")
+    applicability: str = Field(default="", description="When this case should be retrieved")
+    counterexample: str = Field(default="", description="What rule this case counters")
+    prompt_guidance: str = Field(default="", description="Prompt/checklist guidance")
 
     figure_paths: list[str] = Field(default_factory=list, description="Task result figure paths")
     thread_image_urls: list[str] = Field(
@@ -35,6 +46,7 @@ class IssueKnowledgeResponse(BaseModel):
     pr_url: str | None = Field(default=None, description="GitHub PR URL (set on approve)")
     created_at: datetime = Field(..., description="When the draft was created")
     updated_at: datetime = Field(..., description="When the draft was last updated")
+    model_config = ConfigDict(protected_namespaces=())
 
 
 _VALID_SEVERITIES = {"critical", "warning", "info"}
@@ -47,12 +59,24 @@ class IssueKnowledgeUpdate(BaseModel):
     severity: Literal["critical", "warning", "info"] | None = Field(
         default=None, description="Updated severity"
     )
+    human_label: str | None = Field(default=None, max_length=64, description="Human label")
+    failure_mode_labels: list[str] | None = Field(default=None, max_length=50)
+    case_type: list[str] | None = Field(default=None, max_length=50)
+    model_error_type: str | None = Field(default=None, max_length=64)
+    resolution_label: str | None = Field(default=None, max_length=64)
     symptom: str | None = Field(default=None, max_length=5000, description="Updated symptom")
+    model_prediction: str | None = Field(default=None, max_length=5000)
+    human_review_decision: str | None = Field(default=None, max_length=5000)
     root_cause: str | None = Field(default=None, max_length=5000, description="Updated root cause")
     resolution: str | None = Field(default=None, max_length=5000, description="Updated resolution")
+    boundary_criteria: str | None = Field(default=None, max_length=5000)
     lesson_learned: list[str] | None = Field(
         default=None, max_length=50, description="Updated lessons"
     )
+    applicability: str | None = Field(default=None, max_length=5000)
+    counterexample: str | None = Field(default=None, max_length=5000)
+    prompt_guidance: str | None = Field(default=None, max_length=5000)
+    model_config = ConfigDict(protected_namespaces=())
 
     @field_validator("lesson_learned")
     @classmethod

--- a/src/qdash/api/schemas/task.py
+++ b/src/qdash/api/schemas/task.py
@@ -81,10 +81,22 @@ class KnowledgeCaseResponse(BaseModel):
     chip_id: str = ""
     qid: str = ""
     status: str = "resolved"
+    human_label: str = ""
+    failure_mode_labels: list[str] = []
+    case_type: list[str] = []
+    model_error_type: str = ""
+    resolution_label: str = ""
     symptom: str = ""
+    model_prediction: str = ""
+    human_review_decision: str = ""
     root_cause: str = ""
     resolution: str = ""
+    boundary_criteria: str = ""
     lesson_learned: list[str] = []
+    applicability: str = ""
+    counterexample: str = ""
+    prompt_guidance: str = ""
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class TaskKnowledgeResponse(BaseModel):

--- a/src/qdash/api/services/issue_knowledge_service.py
+++ b/src/qdash/api/services/issue_knowledge_service.py
@@ -47,10 +47,21 @@ Be concise but precise. Use English for all fields.
 {{
   "title": "Short descriptive title of the case",
   "severity": "critical | warning | info",
+  "human_label": "CORRECT | SUSPICIOUS | MISASSIGNMENT | NO_SIGNAL | ANOMALY | empty if unknown",
+  "failure_mode_labels": ["weak_signal", "ambiguous_assignment", "model_missed_issue"],
+  "case_type": ["positive_example | negative_example | boundary_case | counterexample | prompt_guidance | operator_note"],
+  "model_error_type": "true_positive | false_positive | true_negative | false_negative | not_applicable | empty if unknown",
+  "resolution_label": "accept_heuristic | override_parameter | rerun_task | adjust_search_range | update_heuristic | update_review_policy | add_task_knowledge | ignore_known_artifact | empty if unknown",
   "symptom": "What was observed (1-3 sentences)",
+  "model_prediction": "What the model/verifier predicted, if discussed",
+  "human_review_decision": "What the human reviewer decided, if discussed",
   "root_cause": "Why it happened (1-3 sentences)",
   "resolution": "How it was resolved (1-3 sentences)",
-  "lesson_learned": ["Key takeaway 1", "Key takeaway 2"]
+  "boundary_criteria": "Criteria that make this a boundary case or counterexample, if applicable",
+  "lesson_learned": ["Key takeaway 1", "Key takeaway 2"],
+  "applicability": "When this case should be retrieved in future analyses",
+  "counterexample": "What overly broad rule this case counters, if applicable",
+  "prompt_guidance": "Prompt or checklist guidance derived from this case"
 }}
 
 Respond with ONLY the JSON object, no other text.
@@ -74,10 +85,21 @@ class IssueKnowledgeService:
             chip_id=doc.chip_id,
             qid=doc.qid,
             resolution_status=doc.resolution_status,
+            human_label=doc.human_label,
+            failure_mode_labels=doc.failure_mode_labels,
+            case_type=doc.case_type,
+            model_error_type=doc.model_error_type,
+            resolution_label=doc.resolution_label,
             symptom=doc.symptom,
+            model_prediction=doc.model_prediction,
+            human_review_decision=doc.human_review_decision,
             root_cause=doc.root_cause,
             resolution=doc.resolution,
+            boundary_criteria=doc.boundary_criteria,
             lesson_learned=doc.lesson_learned,
+            applicability=doc.applicability,
+            counterexample=doc.counterexample,
+            prompt_guidance=doc.prompt_guidance,
             figure_paths=doc.figure_paths,
             thread_image_urls=doc.thread_image_urls,
             reviewed_by=doc.reviewed_by,
@@ -213,10 +235,21 @@ class IssueKnowledgeService:
             chip_id=chip_id,
             qid=qid,
             resolution_status="resolved",
+            human_label=validated.get("human_label", ""),
+            failure_mode_labels=validated.get("failure_mode_labels", []),
+            case_type=validated.get("case_type", []),
+            model_error_type=validated.get("model_error_type", ""),
+            resolution_label=validated.get("resolution_label", ""),
             symptom=validated.get("symptom", ""),
+            model_prediction=validated.get("model_prediction", ""),
+            human_review_decision=validated.get("human_review_decision", ""),
             root_cause=validated.get("root_cause", ""),
             resolution=validated.get("resolution", ""),
+            boundary_criteria=validated.get("boundary_criteria", ""),
             lesson_learned=validated.get("lesson_learned", []),
+            applicability=validated.get("applicability", ""),
+            counterexample=validated.get("counterexample", ""),
+            prompt_guidance=validated.get("prompt_guidance", ""),
             figure_paths=figure_paths,
             thread_image_urls=thread_image_urls,
         )
@@ -247,8 +280,32 @@ class IssueKnowledgeService:
         else:
             validated["severity"] = "warning"
 
+        # Short label fields
+        for key in ("human_label", "model_error_type", "resolution_label"):
+            val = data.get(key)
+            if isinstance(val, str):
+                validated[key] = val.strip()[:64]
+
+        # Label lists
+        for key in ("failure_mode_labels", "case_type"):
+            val = data.get(key)
+            if isinstance(val, list):
+                validated[key] = [
+                    str(item).strip()[:64] for item in val[:50] if isinstance(item, str)
+                ]
+
         # Free-text fields – truncate to 5000 chars
-        for key in ("symptom", "root_cause", "resolution"):
+        for key in (
+            "symptom",
+            "model_prediction",
+            "human_review_decision",
+            "root_cause",
+            "resolution",
+            "boundary_criteria",
+            "applicability",
+            "counterexample",
+            "prompt_guidance",
+        ):
             val = data.get(key)
             if isinstance(val, str):
                 validated[key] = val.strip()[:5000]
@@ -364,10 +421,21 @@ class IssueKnowledgeService:
         knowledge_id: str,
         title: str | None = None,
         severity: str | None = None,
+        human_label: str | None = None,
+        failure_mode_labels: list[str] | None = None,
+        case_type: list[str] | None = None,
+        model_error_type: str | None = None,
+        resolution_label: str | None = None,
         symptom: str | None = None,
+        model_prediction: str | None = None,
+        human_review_decision: str | None = None,
         root_cause: str | None = None,
         resolution: str | None = None,
+        boundary_criteria: str | None = None,
         lesson_learned: list[str] | None = None,
+        applicability: str | None = None,
+        counterexample: str | None = None,
+        prompt_guidance: str | None = None,
     ) -> IssueKnowledgeResponse:
         """Update a knowledge draft's content."""
         from bson import ObjectId
@@ -384,14 +452,36 @@ class IssueKnowledgeService:
             doc.title = title
         if severity is not None:
             doc.severity = severity
+        if human_label is not None:
+            doc.human_label = human_label
+        if failure_mode_labels is not None:
+            doc.failure_mode_labels = failure_mode_labels
+        if case_type is not None:
+            doc.case_type = case_type
+        if model_error_type is not None:
+            doc.model_error_type = model_error_type
+        if resolution_label is not None:
+            doc.resolution_label = resolution_label
         if symptom is not None:
             doc.symptom = symptom
+        if model_prediction is not None:
+            doc.model_prediction = model_prediction
+        if human_review_decision is not None:
+            doc.human_review_decision = human_review_decision
         if root_cause is not None:
             doc.root_cause = root_cause
         if resolution is not None:
             doc.resolution = resolution
+        if boundary_criteria is not None:
+            doc.boundary_criteria = boundary_criteria
         if lesson_learned is not None:
             doc.lesson_learned = lesson_learned
+        if applicability is not None:
+            doc.applicability = applicability
+        if counterexample is not None:
+            doc.counterexample = counterexample
+        if prompt_guidance is not None:
+            doc.prompt_guidance = prompt_guidance
 
         doc.system_info.update_time()
         doc.save()
@@ -429,6 +519,16 @@ class IssueKnowledgeService:
             meta.append(f"- qid: {doc.qid}")
         if doc.resolution_status:
             meta.append(f"- status: {doc.resolution_status}")
+        if doc.human_label:
+            meta.append(f"- human_label: {doc.human_label}")
+        if doc.failure_mode_labels:
+            meta.append(f"- failure_mode_labels: {', '.join(doc.failure_mode_labels)}")
+        if doc.case_type:
+            meta.append(f"- case_type: {', '.join(doc.case_type)}")
+        if doc.model_error_type:
+            meta.append(f"- model_error_type: {doc.model_error_type}")
+        if doc.resolution_label:
+            meta.append(f"- resolution_label: {doc.resolution_label}")
         if doc.issue_id:
             meta.append(f"- issue_id: {doc.issue_id}")
         if meta:
@@ -437,16 +537,28 @@ class IssueKnowledgeService:
 
         if doc.symptom:
             lines.extend(["## Symptom", "", doc.symptom, ""])
+        if doc.model_prediction:
+            lines.extend(["## Model prediction", "", doc.model_prediction, ""])
+        if doc.human_review_decision:
+            lines.extend(["## Human review decision", "", doc.human_review_decision, ""])
         if doc.root_cause:
             lines.extend(["## Root cause", "", doc.root_cause, ""])
         if doc.resolution:
             lines.extend(["## Resolution", "", doc.resolution, ""])
+        if doc.boundary_criteria:
+            lines.extend(["## Boundary criteria", "", doc.boundary_criteria, ""])
         if doc.lesson_learned:
             lines.append("## Lesson learned")
             lines.append("")
             for lesson in doc.lesson_learned:
                 lines.append(f"- {lesson}")
             lines.append("")
+        if doc.applicability:
+            lines.extend(["## Applicability", "", doc.applicability, ""])
+        if doc.counterexample:
+            lines.extend(["## Counterexample", "", doc.counterexample, ""])
+        if doc.prompt_guidance:
+            lines.extend(["## Prompt guidance", "", doc.prompt_guidance, ""])
 
         if doc.figure_paths:
             lines.append("## Figures")

--- a/src/qdash/datamodel/task_knowledge.py
+++ b/src/qdash/datamodel/task_knowledge.py
@@ -18,7 +18,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -98,17 +98,46 @@ class KnowledgeCase(BaseModel):
     chip_id: str = Field(default="", description="Chip identifier")
     qid: str = Field(default="", description="Qubit identifier")
     status: str = Field(default="resolved", description="Case status: resolved, open, workaround")
+    human_label: str = Field(default="", description="Human review label for the case")
+    failure_mode_labels: list[str] = Field(
+        default_factory=list,
+        description="Structured failure-mode labels for retrieval and filtering",
+    )
+    case_type: list[str] = Field(
+        default_factory=list,
+        description="Knowledge case type: positive_example, boundary_case, counterexample, etc.",
+    )
+    model_error_type: str = Field(
+        default="",
+        description="Verifier outcome type: true_positive, false_positive, false_negative, etc.",
+    )
+    resolution_label: str = Field(
+        default="",
+        description="Structured resolution label such as accept_heuristic or rerun_task",
+    )
     symptom: str = Field(default="", description="Observed symptom")
+    model_prediction: str = Field(default="", description="Verifier/model prediction summary")
+    human_review_decision: str = Field(default="", description="Human review decision summary")
     root_cause: str = Field(default="", description="Identified root cause")
     resolution: str = Field(default="", description="How the issue was resolved")
+    boundary_criteria: str = Field(
+        default="",
+        description="Criteria that make this a boundary or counterexample case",
+    )
     lesson_learned: list[str] = Field(
         default_factory=list,
         description="Key takeaways from the case",
+    )
+    applicability: str = Field(default="", description="When this case should be retrieved")
+    counterexample: str = Field(default="", description="What rule this case counters")
+    prompt_guidance: str = Field(
+        default="", description="Prompt/checklist guidance derived from case"
     )
     images: list[TaskKnowledgeImage] = Field(
         default_factory=list,
         description="Image references from the case file (with base64 data)",
     )
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class TaskKnowledge(BaseModel):
@@ -267,14 +296,39 @@ class TaskKnowledge(BaseModel):
                         header += f", {case.qid}"
                     header += ")"
                 lines.append(header)
+                labels = []
+                if case.human_label:
+                    labels.append(f"human_label={case.human_label}")
+                if case.failure_mode_labels:
+                    labels.append(f"failure_modes={', '.join(case.failure_mode_labels)}")
+                if case.case_type:
+                    labels.append(f"case_type={', '.join(case.case_type)}")
+                if case.model_error_type:
+                    labels.append(f"model_error_type={case.model_error_type}")
+                if case.resolution_label:
+                    labels.append(f"resolution_label={case.resolution_label}")
+                if labels:
+                    lines.append(f"   - Labels: {'; '.join(labels)}")
                 if case.symptom:
                     lines.append(f"   - Symptom: {case.symptom}")
+                if case.model_prediction:
+                    lines.append(f"   - Model prediction: {case.model_prediction}")
+                if case.human_review_decision:
+                    lines.append(f"   - Human review decision: {case.human_review_decision}")
                 if case.root_cause:
                     lines.append(f"   - Root cause: {case.root_cause}")
                 if case.resolution:
                     lines.append(f"   - Resolution: {case.resolution}")
+                if case.boundary_criteria:
+                    lines.append(f"   - Boundary criteria: {case.boundary_criteria}")
                 if case.lesson_learned:
                     lines.append(f"   - Lessons: {'; '.join(case.lesson_learned)}")
+                if case.applicability:
+                    lines.append(f"   - Applicability: {case.applicability}")
+                if case.counterexample:
+                    lines.append(f"   - Counterexample: {case.counterexample}")
+                if case.prompt_guidance:
+                    lines.append(f"   - Prompt guidance: {case.prompt_guidance}")
                 if case.images:
                     for img in case.images:
                         lines.append(f"   - Image: {img.alt_text} ({img.relative_path})")

--- a/src/qdash/dbmodel/issue_knowledge.py
+++ b/src/qdash/dbmodel/issue_knowledge.py
@@ -52,10 +52,23 @@ class IssueKnowledgeDocument(Document):
     resolution_status: str = Field(
         default="resolved", description="Case outcome: resolved, open, workaround"
     )
+    human_label: str = Field(default="", description="Human review label")
+    failure_mode_labels: list[str] = Field(
+        default_factory=list, description="Structured failure-mode labels"
+    )
+    case_type: list[str] = Field(default_factory=list, description="Knowledge case type labels")
+    model_error_type: str = Field(default="", description="Verifier error/outcome type")
+    resolution_label: str = Field(default="", description="Structured resolution label")
     symptom: str = Field(default="", description="Observed symptom")
+    model_prediction: str = Field(default="", description="Verifier/model prediction summary")
+    human_review_decision: str = Field(default="", description="Human review decision summary")
     root_cause: str = Field(default="", description="Identified root cause")
     resolution: str = Field(default="", description="How the issue was resolved")
+    boundary_criteria: str = Field(default="", description="Boundary criteria for this case")
     lesson_learned: list[str] = Field(default_factory=list, description="Key takeaways")
+    applicability: str = Field(default="", description="When this case should be retrieved")
+    counterexample: str = Field(default="", description="What rule this case counters")
+    prompt_guidance: str = Field(default="", description="Prompt/checklist guidance")
 
     # Images
     figure_paths: list[str] = Field(
@@ -102,4 +115,5 @@ class IssueKnowledgeDocument(Document):
 
     model_config = ConfigDict(
         from_attributes=True,
+        protected_namespaces=(),
     )

--- a/tests/qdash/api/services/test_issue_knowledge_service.py
+++ b/tests/qdash/api/services/test_issue_knowledge_service.py
@@ -47,10 +47,21 @@ def _make_doc(
     chip_id: str = "chip-A",
     qid: str = "Q0",
     resolution_status: str = "resolved",
+    human_label: str = "",
+    failure_mode_labels: list[str] | object = _SENTINEL,
+    case_type: list[str] | object = _SENTINEL,
+    model_error_type: str = "",
+    resolution_label: str = "",
     symptom: str = "T1 dropped below threshold",
+    model_prediction: str = "",
+    human_review_decision: str = "",
     root_cause: str = "Cosmic ray event",
     resolution: str = "Recalibrated qubit",
+    boundary_criteria: str = "",
     lesson_learned: list[str] | object = _SENTINEL,
+    applicability: str = "",
+    counterexample: str = "",
+    prompt_guidance: str = "",
     figure_paths: list[str] | object = _SENTINEL,
     thread_image_urls: list[str] | object = _SENTINEL,
     reviewed_by: str | None = None,
@@ -71,12 +82,23 @@ def _make_doc(
     doc.chip_id = chip_id
     doc.qid = qid
     doc.resolution_status = resolution_status
+    doc.human_label = human_label
+    doc.failure_mode_labels = [] if failure_mode_labels is _SENTINEL else failure_mode_labels
+    doc.case_type = [] if case_type is _SENTINEL else case_type
+    doc.model_error_type = model_error_type
+    doc.resolution_label = resolution_label
     doc.symptom = symptom
+    doc.model_prediction = model_prediction
+    doc.human_review_decision = human_review_decision
     doc.root_cause = root_cause
     doc.resolution = resolution
+    doc.boundary_criteria = boundary_criteria
     doc.lesson_learned = (
         ["Always check T1 after cooldown"] if lesson_learned is _SENTINEL else lesson_learned
     )
+    doc.applicability = applicability
+    doc.counterexample = counterexample
+    doc.prompt_guidance = prompt_guidance
     doc.figure_paths = [] if figure_paths is _SENTINEL else figure_paths
     doc.thread_image_urls = [] if thread_image_urls is _SENTINEL else thread_image_urls
     doc.reviewed_by = reviewed_by


### PR DESCRIPTION
## Ticket
N/A

## Summary
- Enhanced the issue knowledge schema by adding several new fields to improve data representation and facilitate better issue tracking.
- Changes impact the API and may require updates to client implementations that interact with the knowledge schema.

## Changes
- Added fields: `human_label`, `failure_mode_labels`, `case_type`, `model_error_type`, `resolution_label`, `model_prediction`, `human_review_decision`, `boundary_criteria`, `applicability`, `counterexample`, and `prompt_guidance` to the `IssueKnowledgeDocument` and `KnowledgeCaseResponse` models.
- Updated the `update_issue_knowledge` function to handle the new fields.
- Adjusted the Dockerfile to install the OpenAI Codex CLI and modified the bun install command for consistency.

