### PR TITLE
feat(agent): refine triage criteria for calibration results

### DIFF
--- a/config/copilot.yaml
+++ b/config/copilot.yaml
@@ -156,8 +156,11 @@ analysis:
     - CheckResonatorSpectroscopy
   ai_triage_message: >-
     Review this calibration result and attach a concise operational
-    triage note. Be strict about PASS: history consistency alone is not enough
-    to accept visually unsupported output parameters.
+    triage note. Auto-pass results that are good enough for routine parameter
+    update. History consistency alone is not enough to accept visually
+    unsupported output parameters, but weak f12 support by itself should usually
+    become PASS_WITH_NOTE when f01 is clearly supported and no stronger
+    competing transition is visible.
   # Maximum conversation turns to maintain in context
   max_conversation_turns: 10
 

--- a/src/qdash/common/copilot/agent.py
+++ b/src/qdash/common/copilot/agent.py
@@ -78,9 +78,18 @@ Keep the triage fields internally consistent:
 - Use `PASS_WITH_NOTE` only when all output parameters that would be updated are
   acceptable without human intervention, but there is a minor caveat or optional
   follow-up. Put non-blocking caveats in `Optional note`, not in `Needs review`.
+- For `CheckQubitSpectroscopy`, a weak or missing f12 is not automatically
+  review-blocking when f01 is clearly supported, the f12/anharmonicity value is
+  plausible if present, and there is no stronger competing transition. Prefer
+  `PASS_WITH_NOTE` for this weak-f12-only boundary. Use `REVIEW` only when f01
+  itself is weak/ambiguous, f12/anharmonicity is unsupported enough to make an
+  automatic parameter update unsafe, or a competing feature could change the
+  selected transition.
 - Use `REVIEW` when any important output parameter should not be auto-accepted without a
-  human check. If you use labels such as `weak_signal`, `boundary_case`, `ambiguous_doublet`,
-  or `frequency_offset` for a parameter that affects acceptance, prefer `REVIEW`.
+  human check. If you use labels such as `ambiguous_doublet` or `frequency_offset`
+  for a parameter that affects acceptance, prefer `REVIEW`. Do not make
+  `weak_signal` or `boundary_case` alone review-blocking when the detailed
+  explanation says the result is acceptable for automatic use.
 - If the detailed explanation says a parameter should be treated cautiously, maintained
   from history, not overwritten, rechecked before update, or used only as a reference value,
   then that parameter MUST appear in `Needs review` and the decision MUST be `REVIEW`.


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Refined the triage criteria for calibration results to improve accuracy in automatic assessments.
- Adjustments enhance the decision-making process regarding parameter updates, impacting the overall calibration workflow.

## Changes
- Updated triage messaging to allow auto-passing of certain results.
- Clarified conditions under which `PASS_WITH_NOTE` and `REVIEW` labels should be used.
- Enhanced guidelines for handling weak or missing parameters in spectroscopy checks.

