### PR TITLE
feat(config): add gemma4:31b model for local VLM triage support

### DIFF
--- a/config/copilot.yaml
+++ b/config/copilot.yaml
@@ -41,6 +41,15 @@ analysis_models:
     temperature: 0.2
     max_output_tokens: 1200
   - provider: ollama
+    name: gemma4:31b
+    # Slower fallback model for local VLM triage when 26b returns malformed or
+    # under-specified review notes. Keep this selectable, but not the default.
+    base_url: env:GEMMA_BASE_URL
+    api_key_env: GEMMA_API_KEY
+    keep_alive: 30m
+    temperature: 0.2
+    max_output_tokens: 1200
+  - provider: ollama
     name: nvidia/Ising-Calibration-1-35B-A3B
     temperature: 0.7
     max_output_tokens: 4096

--- a/docs/development/copilot/architecture.md
+++ b/docs/development/copilot/architecture.md
@@ -59,6 +59,13 @@ analysis_models:
     keep_alive: 30m
     temperature: 0.2
     max_output_tokens: 1200
+  - provider: ollama
+    name: gemma4:31b
+    base_url: env:GEMMA_BASE_URL
+    api_key_env: GEMMA_API_KEY
+    keep_alive: 30m
+    temperature: 0.2
+    max_output_tokens: 1200
 
 # Metrics for chip health evaluation
 evaluation_metrics:


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced the `gemma4:31b` model to enhance local VLM triage support, providing a fallback option when the primary model returns inadequate results.
- This change improves the robustness of the model selection process, ensuring better handling of review notes.

## Changes
- Added `gemma4:31b` model configuration under `analysis_models`.
- Configured parameters such as `base_url`, `api_key_env`, `keep_alive`, `temperature`, and `max_output_tokens` for the new model.

