### PR TITLE
fix(agent): stabilize local gemma triage output handling

### DIFF
--- a/config/copilot.yaml
+++ b/config/copilot.yaml
@@ -29,7 +29,7 @@ model:
 # Specialized models for task result analysis (chevron patterns, Rabi, etc.).
 analysis_models:
   - provider: ollama
-    name: gemma4:26b
+    name: gemma4:31b
     # Ollama endpoint. Set GEMMA_BASE_URL to your Ollama server URL,
     # e.g. http://localhost:11434. QDash appends /v1 automatically.
     base_url: env:GEMMA_BASE_URL
@@ -41,9 +41,10 @@ analysis_models:
     temperature: 0.2
     max_output_tokens: 1200
   - provider: ollama
-    name: gemma4:31b
-    # Slower fallback model for local VLM triage when 26b returns malformed or
-    # under-specified review notes. Keep this selectable, but not the default.
+    name: gemma4:26b
+    # Faster local VLM option. Some Ollama/OpenAI-compatible deployments place
+    # its generated text in reasoning fields, so QDash keeps a parser fallback
+    # for this model but does not make it the default.
     base_url: env:GEMMA_BASE_URL
     api_key_env: GEMMA_API_KEY
     keep_alive: 30m

--- a/docs/development/copilot/architecture.md
+++ b/docs/development/copilot/architecture.md
@@ -53,14 +53,14 @@ model:
 
 analysis_models:
   - provider: ollama
-    name: gemma4:26b
+    name: gemma4:31b
     base_url: env:GEMMA_BASE_URL
     api_key_env: GEMMA_API_KEY
     keep_alive: 30m
     temperature: 0.2
     max_output_tokens: 1200
   - provider: ollama
-    name: gemma4:31b
+    name: gemma4:26b
     base_url: env:GEMMA_BASE_URL
     api_key_env: GEMMA_API_KEY
     keep_alive: 30m

--- a/src/qdash/api/lib/copilot_agent.py
+++ b/src/qdash/api/lib/copilot_agent.py
@@ -1152,14 +1152,8 @@ def _parse_response(content: str) -> AnalysisResponse:
         fallback_response = _extract_triage_fallback(content)
         if fallback_response is not None:
             return fallback_response
-        # If JSON parsing fails, treat the entire response as explanation
-        return AnalysisResponse(
-            summary="Analysis complete",
-            assessment="warning",
-            explanation=content,
-            potential_issues=[],
-            recommendations=[],
-        )
+        logger.warning("Local model response omitted required review triage block: %s", content)
+        return _missing_triage_response(content)
 
 
 _ASSESSMENT_LABELS_JA = {
@@ -1798,7 +1792,23 @@ async def _run_chat_completions(
             response = await client.chat.completions.create(**kwargs)
         else:
             raise
-    return response.choices[0].message.content or ""
+    message = response.choices[0].message
+    content = message.content or ""
+    if content:
+        return content
+
+    # Some local thinking models served through Ollama's OpenAI-compatible
+    # endpoint place generated text in non-standard reasoning fields while
+    # leaving content empty. Treat that as raw model output so the triage parser
+    # can extract a compact review block or mark it as a format error.
+    for field in ("reasoning", "reasoning_content", "thinking"):
+        value = getattr(message, field, None)
+        if isinstance(value, str) and value.strip():
+            logger.warning(
+                "Chat completion returned empty content; using message.%s fallback", field
+            )
+            return value
+    return ""
 
 
 async def run_analysis(

--- a/src/qdash/common/copilot/agent.py
+++ b/src/qdash/common/copilot/agent.py
@@ -1182,14 +1182,8 @@ def _parse_response(content: str) -> AnalysisResponse:
         fallback_response = _extract_triage_fallback(content)
         if fallback_response is not None:
             return fallback_response
-        # If JSON parsing fails, treat the entire response as explanation
-        return AnalysisResponse(
-            summary="Analysis complete",
-            assessment="warning",
-            explanation=content,
-            potential_issues=[],
-            recommendations=[],
-        )
+        logger.warning("Local model response omitted required review triage block: %s", content)
+        return _missing_triage_response(content)
 
 
 _ASSESSMENT_LABELS_JA = {
@@ -1828,7 +1822,23 @@ async def _run_chat_completions(
             response = await client.chat.completions.create(**kwargs)
         else:
             raise
-    return response.choices[0].message.content or ""
+    message = response.choices[0].message
+    content = message.content or ""
+    if content:
+        return content
+
+    # Some local thinking models served through Ollama's OpenAI-compatible
+    # endpoint place generated text in non-standard reasoning fields while
+    # leaving content empty. Treat that as raw model output so the triage parser
+    # can extract a compact review block or mark it as a format error.
+    for field in ("reasoning", "reasoning_content", "thinking"):
+        value = getattr(message, field, None)
+        if isinstance(value, str) and value.strip():
+            logger.warning(
+                "Chat completion returned empty content; using message.%s fallback", field
+            )
+            return value
+    return ""
 
 
 async def run_analysis(

--- a/tests/qdash/api/lib/test_copilot_agent.py
+++ b/tests/qdash/api/lib/test_copilot_agent.py
@@ -45,6 +45,16 @@ def test_parse_response_converts_missing_triage_json_to_safe_review() -> None:
     assert "- Suggested labels: `model_format_error`" in response.explanation
 
 
+def test_parse_response_converts_plain_missing_triage_text_to_safe_review() -> None:
+    response = _parse_response("解析完了")
+
+    assert response.assessment == "warning"
+    assert response.summary == "AI triage response did not include the required review block."
+    assert response.explanation.startswith("**Review triage**")
+    assert "- Decision: `REVIEW`" in response.explanation
+    assert "- Suggested labels: `model_format_error`" in response.explanation
+
+
 @pytest.mark.asyncio
 async def test_run_chat_completions_passes_ollama_keep_alive_and_num_ctx() -> None:
     captured = {}
@@ -72,3 +82,24 @@ async def test_run_chat_completions_passes_ollama_keep_alive_and_num_ctx() -> No
         "keep_alive": "30m",
         "options": {"num_ctx": 8192},
     }
+
+
+@pytest.mark.asyncio
+async def test_run_chat_completions_uses_reasoning_when_content_is_empty() -> None:
+    class _Completions:
+        async def create(self, **kwargs):
+            message = SimpleNamespace(content="", reasoning="reasoning triage text")
+            return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+    client: Any = SimpleNamespace(chat=SimpleNamespace(completions=_Completions()))
+    config = CopilotConfig(
+        model=ModelConfig(
+            provider="ollama",
+            name="gemma4:26b",
+            temperature=0,
+        )
+    )
+
+    content = await _run_chat_completions(client, [{"role": "user", "content": "hi"}], config)
+
+    assert content == "reasoning triage text"


### PR DESCRIPTION
This pull request improves how our Copilot agent handles and parses responses from local Ollama models, especially in cases where model outputs do not follow the expected format. It also updates the configuration and documentation to make `gemma4:31b` the default analysis model and adds new tests to ensure the fallback logic works as intended.

**Model configuration and documentation changes:**

* Made `gemma4:31b` the default analysis model in both `config/copilot.yaml` and `docs/development/copilot/architecture.md`, with `gemma4:26b` as the secondary, faster fallback option. Updated comments to clarify each model's purpose. [[1]](diffhunk://#diff-18bfba6093bfee50abb0f7701d0e4bd6e3a10c5409b438a9d428a858a03ce521L32-R32) [[2]](diffhunk://#diff-18bfba6093bfee50abb0f7701d0e4bd6e3a10c5409b438a9d428a858a03ce521L44-R47) [[3]](diffhunk://#diff-40c7ac33cbe96dd363565f97903cf924d3fca9ed5554a296f63d3f92cdba80caL56-R63)

**Copilot agent robustness improvements:**

* Enhanced `_run_chat_completions` in both `src/qdash/api/lib/copilot_agent.py` and `src/qdash/common/copilot/agent.py` to check for model output in alternative fields (`reasoning`, `reasoning_content`, `thinking`) if `content` is empty, improving compatibility with non-standard model responses. [[1]](diffhunk://#diff-e823433dc0d5098240e8e58cf9b638e4fa2cef4d60765fb5007c1f5ee70d65bfL1801-R1811) [[2]](diffhunk://#diff-517b6ca99cb86fee6ccd63ff6e30051395507fecf513aebc74520b593ab94db6L1831-R1841)
* Improved `_parse_response` to log a warning and return a safe fallback response if the required review triage block is missing, instead of treating the entire response as a generic explanation. [[1]](diffhunk://#diff-e823433dc0d5098240e8e58cf9b638e4fa2cef4d60765fb5007c1f5ee70d65bfL1155-R1156) [[2]](diffhunk://#diff-517b6ca99cb86fee6ccd63ff6e30051395507fecf513aebc74520b593ab94db6L1185-R1186)

**Testing improvements:**

* Added tests to ensure that missing triage blocks and reasoning field fallbacks are handled correctly by the parser and chat completion logic. [[1]](diffhunk://#diff-9979a8d3ae11994d09d99f47dbe87ff3159b311a2fa191eefaa0243bfc495d46R48-R57) [[2]](diffhunk://#diff-9979a8d3ae11994d09d99f47dbe87ff3159b311a2fa191eefaa0243bfc495d46R85-R105)<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
<!-- Link to the ticket / issue -->

## Summary
<!-- What and why (1–2 sentences) -->

## Changes
<!-- Bullet list of key changes -->
