### PR TITLE
Diagnose llm triage truncation

### DIFF
--- a/config/copilot.yaml
+++ b/config/copilot.yaml
@@ -39,7 +39,7 @@ analysis_models:
     # repeated cold model loads between short qdash reviews.
     keep_alive: 30m
     temperature: 0.2
-    max_output_tokens: 1200
+    max_output_tokens: 4096
   - provider: ollama
     name: gemma4:26b
     # Faster local VLM option. Some Ollama/OpenAI-compatible deployments place
@@ -49,7 +49,7 @@ analysis_models:
     api_key_env: GEMMA_API_KEY
     keep_alive: 30m
     temperature: 0.2
-    max_output_tokens: 1200
+    max_output_tokens: 4096
   - provider: ollama
     name: nvidia/Ising-Calibration-1-35B-A3B
     temperature: 0.7
@@ -158,14 +158,13 @@ analysis:
   enabled: true
   # Whether to send result figures to the LLM (requires multimodal model)
   multimodal: true
-  # Limit reference images for lower-latency local VLM triage. The actual
-  # experiment figure is still sent separately.
+  # Reference images to send during task analysis and automatic AI triage.
   max_expected_images: 2
-  # Automatic AI triage uses faster defaults than side-panel chat. Local VLMs
-  # are latency-sensitive, so the triage hook skips historical reference images
-  # by default and caps the response length.
-  ai_triage_max_expected_images: 0
-  ai_triage_max_output_tokens: 1024
+  # Automatic AI triage prioritizes review quality by default and inherits the
+  # same reference-image and output-token settings as task analysis. Set these
+  # optional overrides only when a lower-latency triage mode is required.
+  ai_triage_max_expected_images: null
+  ai_triage_max_output_tokens: null
   # Task results whose notes should receive automatic AI triage. Both completed
   # and failed results are eligible; the hook runs asynchronously after history
   # persistence and does not block calibration progress.

--- a/docs/development/copilot/architecture.md
+++ b/docs/development/copilot/architecture.md
@@ -58,14 +58,14 @@ analysis_models:
     api_key_env: GEMMA_API_KEY
     keep_alive: 30m
     temperature: 0.2
-    max_output_tokens: 1200
+    max_output_tokens: 4096
   - provider: ollama
     name: gemma4:26b
     base_url: env:GEMMA_BASE_URL
     api_key_env: GEMMA_API_KEY
     keep_alive: 30m
     temperature: 0.2
-    max_output_tokens: 1200
+    max_output_tokens: 4096
 
 # Metrics for chip health evaluation
 evaluation_metrics:
@@ -87,8 +87,8 @@ analysis:
   enabled: true
   multimodal: true
   max_expected_images: 2
-  ai_triage_max_expected_images: 0
-  ai_triage_max_output_tokens: 1024
+  ai_triage_max_expected_images: null
+  ai_triage_max_output_tokens: null
   ai_triage_tasks: [CheckQubitSpectroscopy, CheckResonatorSpectroscopy]
   ai_triage_message: >-
     Review this calibration result and attach a concise operational triage note.
@@ -137,9 +137,10 @@ Automatic AI triage attaches an LLM-generated operational review note to selecte
 - **Configuration**: `analysis.ai_triage_tasks` and `analysis.ai_triage_message` in `config/copilot.yaml`
 - **Execution model**: asynchronous background thread pool, de-duplicated by `task_id`
 - **Model selection**: `analysis_model`, then the first `analysis_models` entry, then the general `model`
-- **Local VLM speed path**: `analysis.ai_triage_max_expected_images` overrides
-  `analysis.max_expected_images` only for automatic triage, and
-  `analysis.ai_triage_max_output_tokens` caps only the selected triage model.
+- **AI triage quality path**: automatic triage inherits
+  `analysis.max_expected_images` and the selected model's `max_output_tokens`
+  by default. Set `analysis.ai_triage_max_expected_images` or
+  `analysis.ai_triage_max_output_tokens` only for an explicit low-latency mode.
 - **Storage**: task-result `user_note.content`, under a `## AI triage` Markdown section
 - **UI**: task detail modals render the note as Markdown; chip page badges are shown only when the triage decision requires review
 

--- a/src/qdash/api/lib/copilot_agent.py
+++ b/src/qdash/api/lib/copilot_agent.py
@@ -1792,8 +1792,42 @@ async def _run_chat_completions(
             response = await client.chat.completions.create(**kwargs)
         else:
             raise
-    message = response.choices[0].message
+    choice = response.choices[0]
+    message = choice.message
     content = message.content or ""
+    reasoning_chars = 0
+    for field in ("reasoning", "reasoning_content", "thinking"):
+        value = getattr(message, field, None)
+        if isinstance(value, str):
+            reasoning_chars += len(value)
+    usage = getattr(response, "usage", None)
+    prompt_tokens = getattr(usage, "prompt_tokens", None) if usage else None
+    completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
+    total_tokens = getattr(usage, "total_tokens", None) if usage else None
+    finish_reason = getattr(choice, "finish_reason", None)
+    logger.info(
+        "Chat completion finished: provider=%s model=%s finish_reason=%s "
+        "content_chars=%d reasoning_chars=%d prompt_tokens=%s completion_tokens=%s total_tokens=%s",
+        config.model.provider,
+        config.model.name,
+        finish_reason,
+        len(content),
+        reasoning_chars,
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+    )
+    if finish_reason == "length":
+        logger.warning(
+            "Chat completion hit token limit before stop: provider=%s model=%s "
+            "content_chars=%d reasoning_chars=%d completion_tokens=%s max_tokens=%s",
+            config.model.provider,
+            config.model.name,
+            len(content),
+            reasoning_chars,
+            completion_tokens,
+            config.model.max_output_tokens,
+        )
     if content:
         return content
 
@@ -1808,6 +1842,12 @@ async def _run_chat_completions(
                 "Chat completion returned empty content; using message.%s fallback", field
             )
             return value
+    logger.warning(
+        "Chat completion returned no usable text: provider=%s model=%s finish_reason=%s",
+        config.model.provider,
+        config.model.name,
+        finish_reason,
+    )
     return ""
 
 

--- a/src/qdash/api/lib/copilot_agent.py
+++ b/src/qdash/api/lib/copilot_agent.py
@@ -86,6 +86,23 @@ and use the following markdown shape:
 - Recommended action: one short operator action
 - Optional note: one short caveat only when useful, otherwise `none`
 
+For reliable parsing, the JSON `explanation` string MUST start exactly with
+`**Review triage**`. Every triage field line MUST begin with hyphen-space
+(`- `). Do not omit the hyphens, do not bold the field names, and do not put
+ordinary prose before the triage block. Use this exact skeleton before any
+detailed explanation:
+
+**Review triage**
+- Decision: `PASS` | `PASS_WITH_NOTE` | `REVIEW` | `FAIL`
+- Human label suggestion: `CORRECT` | `SUSPICIOUS` | `MISASSIGNMENT` | `NO_SIGNAL` | `ANOMALY`
+- Accepted parameter(s): ...
+- Needs review: ...
+- Primary reason: ...
+- Closest knowledge case: ...
+- Suggested labels: ...
+- Recommended action: ...
+- Optional note: ...
+
 Keep the triage fields internally consistent:
 - Use `PASS` only when all important output parameters are visually and physically supported.
   For `PASS`, set `Needs review: none`, `Suggested labels: none`, and make the recommended

--- a/src/qdash/api/lib/copilot_config.py
+++ b/src/qdash/api/lib/copilot_config.py
@@ -58,8 +58,8 @@ class AnalysisConfig(BaseModel):
     multimodal: bool = True
     max_conversation_turns: int = 10
     max_expected_images: int | None = None
-    ai_triage_max_expected_images: int | None = 0
-    ai_triage_max_output_tokens: int | None = 1024
+    ai_triage_max_expected_images: int | None = None
+    ai_triage_max_output_tokens: int | None = None
     ai_triage_tasks: list[str] = []
     ai_triage_message: str = (
         "Review this completed calibration result and attach a concise operational triage note."

--- a/src/qdash/api/services/task_result_service.py
+++ b/src/qdash/api/services/task_result_service.py
@@ -44,6 +44,23 @@ AI_TRIAGE_HEADER = "## AI triage"
 AI_TRIAGE_SEPARATOR = "\n\n---\n\n"
 MAX_AI_TRIAGE_NOTE_CHARS = 4500
 AI_TRIAGE_WORKERS = 2
+AI_TRIAGE_FORMAT_REMINDER = """\
+
+Required output format:
+Return JSON, but the JSON `explanation` string must start exactly with this
+markdown block. Do not put prose before it.
+
+**Review triage**
+- Decision: `PASS` | `PASS_WITH_NOTE` | `REVIEW` | `FAIL`
+- Human label suggestion: `CORRECT` | `SUSPICIOUS` | `MISASSIGNMENT` | `NO_SIGNAL` | `ANOMALY`
+- Accepted parameter(s): ...
+- Needs review: ...
+- Primary reason: ...
+- Closest knowledge case: ...
+- Suggested labels: ...
+- Recommended action: ...
+- Optional note: ...
+"""
 
 _AI_TRIAGE_EXECUTOR = ThreadPoolExecutor(
     max_workers=AI_TRIAGE_WORKERS,
@@ -559,7 +576,10 @@ class TaskResultService:
                 result = asyncio.run(
                     run_analysis(
                         context=ctx.context,
-                        user_message=config.analysis.ai_triage_message,
+                        user_message=(
+                            f"{config.analysis.ai_triage_message}\n\n"
+                            f"{AI_TRIAGE_FORMAT_REMINDER}"
+                        ),
                         config=config,
                         image_base64=ctx.image_base64,
                         expected_images=ctx.expected_images,

--- a/src/qdash/common/copilot/agent.py
+++ b/src/qdash/common/copilot/agent.py
@@ -1822,8 +1822,42 @@ async def _run_chat_completions(
             response = await client.chat.completions.create(**kwargs)
         else:
             raise
-    message = response.choices[0].message
+    choice = response.choices[0]
+    message = choice.message
     content = message.content or ""
+    reasoning_chars = 0
+    for field in ("reasoning", "reasoning_content", "thinking"):
+        value = getattr(message, field, None)
+        if isinstance(value, str):
+            reasoning_chars += len(value)
+    usage = getattr(response, "usage", None)
+    prompt_tokens = getattr(usage, "prompt_tokens", None) if usage else None
+    completion_tokens = getattr(usage, "completion_tokens", None) if usage else None
+    total_tokens = getattr(usage, "total_tokens", None) if usage else None
+    finish_reason = getattr(choice, "finish_reason", None)
+    logger.info(
+        "Chat completion finished: provider=%s model=%s finish_reason=%s "
+        "content_chars=%d reasoning_chars=%d prompt_tokens=%s completion_tokens=%s total_tokens=%s",
+        config.model.provider,
+        config.model.name,
+        finish_reason,
+        len(content),
+        reasoning_chars,
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+    )
+    if finish_reason == "length":
+        logger.warning(
+            "Chat completion hit token limit before stop: provider=%s model=%s "
+            "content_chars=%d reasoning_chars=%d completion_tokens=%s max_tokens=%s",
+            config.model.provider,
+            config.model.name,
+            len(content),
+            reasoning_chars,
+            completion_tokens,
+            config.model.max_output_tokens,
+        )
     if content:
         return content
 
@@ -1838,6 +1872,12 @@ async def _run_chat_completions(
                 "Chat completion returned empty content; using message.%s fallback", field
             )
             return value
+    logger.warning(
+        "Chat completion returned no usable text: provider=%s model=%s finish_reason=%s",
+        config.model.provider,
+        config.model.name,
+        finish_reason,
+    )
     return ""
 
 

--- a/src/qdash/common/copilot/agent.py
+++ b/src/qdash/common/copilot/agent.py
@@ -86,6 +86,23 @@ and use the following markdown shape:
 - Recommended action: one short operator action
 - Optional note: one short caveat only when useful, otherwise `none`
 
+For reliable parsing, the JSON `explanation` string MUST start exactly with
+`**Review triage**`. Every triage field line MUST begin with hyphen-space
+(`- `). Do not omit the hyphens, do not bold the field names, and do not put
+ordinary prose before the triage block. Use this exact skeleton before any
+detailed explanation:
+
+**Review triage**
+- Decision: `PASS` | `PASS_WITH_NOTE` | `REVIEW` | `FAIL`
+- Human label suggestion: `CORRECT` | `SUSPICIOUS` | `MISASSIGNMENT` | `NO_SIGNAL` | `ANOMALY`
+- Accepted parameter(s): ...
+- Needs review: ...
+- Primary reason: ...
+- Closest knowledge case: ...
+- Suggested labels: ...
+- Recommended action: ...
+- Optional note: ...
+
 Keep the triage fields internally consistent:
 - Use `PASS` only when all important output parameters are visually and physically supported.
   For `PASS`, set `Needs review: none`, `Suggested labels: none`, and make the recommended

--- a/src/qdash/common/copilot/config.py
+++ b/src/qdash/common/copilot/config.py
@@ -58,8 +58,8 @@ class AnalysisConfig(BaseModel):
     multimodal: bool = True
     max_conversation_turns: int = 10
     max_expected_images: int | None = None
-    ai_triage_max_expected_images: int | None = 0
-    ai_triage_max_output_tokens: int | None = 1024
+    ai_triage_max_expected_images: int | None = None
+    ai_triage_max_output_tokens: int | None = None
     ai_triage_tasks: list[str] = []
     ai_triage_message: str = (
         "Review this completed calibration result and attach a concise operational triage note."

--- a/src/qdash/workflow/engine/task/ai_triage.py
+++ b/src/qdash/workflow/engine/task/ai_triage.py
@@ -22,6 +22,23 @@ AI_TRIAGE_SEPARATOR = "\n\n---\n\n"
 AI_TRIAGE_SECTION_RE = re.compile(r"^## AI triage\n\n.*?(?:\n\n---\n\n|$)", re.DOTALL)
 MAX_AI_TRIAGE_NOTE_CHARS = 4500
 AI_TRIAGE_WORKERS = 2
+AI_TRIAGE_FORMAT_REMINDER = """\
+
+Required output format:
+Return JSON, but the JSON `explanation` string must start exactly with this
+markdown block. Do not put prose before it.
+
+**Review triage**
+- Decision: `PASS` | `PASS_WITH_NOTE` | `REVIEW` | `FAIL`
+- Human label suggestion: `CORRECT` | `SUSPICIOUS` | `MISASSIGNMENT` | `NO_SIGNAL` | `ANOMALY`
+- Accepted parameter(s): ...
+- Needs review: ...
+- Primary reason: ...
+- Closest knowledge case: ...
+- Suggested labels: ...
+- Recommended action: ...
+- Optional note: ...
+"""
 
 _EXECUTOR = ThreadPoolExecutor(max_workers=AI_TRIAGE_WORKERS, thread_name_prefix="ai-triage")
 _IN_FLIGHT_TASK_IDS: set[str] = set()
@@ -331,7 +348,7 @@ def _run_ai_triage(
     result = asyncio.run(
         run_analysis(
             context=ctx.context,
-            user_message=config.analysis.ai_triage_message,
+            user_message=f"{config.analysis.ai_triage_message}\n\n{AI_TRIAGE_FORMAT_REMINDER}",
             config=config,
             image_base64=ctx.image_base64,
             expected_images=ctx.expected_images,


### PR DESCRIPTION
This pull request focuses on improving the reliability and quality of automatic AI triage for calibration results, as well as increasing the output capacity of analysis models. The main changes include standardizing the required output format for AI triage, increasing token limits for analysis models, and improving logging and configuration flexibility for AI triage tasks.

**AI triage output and parsing improvements:**

* Added a strict format reminder for the AI triage output, requiring the JSON `explanation` string to start with a specific markdown block and field list, to ensure reliable parsing and consistency. This format reminder is now appended to the AI triage prompt in both the API and workflow services (`AI_TRIAGE_FORMAT_REMINDER`). [[1]](diffhunk://#diff-27814cc7eb62c9b25796fe87e49055d17031be2281d6a5af4615ed9f93b4c23dR47-R63) [[2]](diffhunk://#diff-7c5ba60fa4a3a686a8ea5c8b65bb3724d40fdd350a53cff20d198816da295b3bR25-R41) [[3]](diffhunk://#diff-27814cc7eb62c9b25796fe87e49055d17031be2281d6a5af4615ed9f93b4c23dL562-R582) [[4]](diffhunk://#diff-7c5ba60fa4a3a686a8ea5c8b65bb3724d40fdd350a53cff20d198816da295b3bL334-R351)
* Updated documentation and agent prompt instructions to reflect the new required AI triage format and parsing requirements. [[1]](diffhunk://#diff-e823433dc0d5098240e8e58cf9b638e4fa2cef4d60765fb5007c1f5ee70d65bfR89-R105) [[2]](diffhunk://#diff-517b6ca99cb86fee6ccd63ff6e30051395507fecf513aebc74520b593ab94db6R89-R105)

**Model and token limit configuration:**

* Increased `max_output_tokens` for all analysis models from 1200 to 4096 in both `config/copilot.yaml` and architecture documentation, allowing for longer and more detailed model responses. [[1]](diffhunk://#diff-18bfba6093bfee50abb0f7701d0e4bd6e3a10c5409b438a9d428a858a03ce521L42-R42) [[2]](diffhunk://#diff-18bfba6093bfee50abb0f7701d0e4bd6e3a10c5409b438a9d428a858a03ce521L52-R52) [[3]](diffhunk://#diff-40c7ac33cbe96dd363565f97903cf924d3fca9ed5554a296f63d3f92cdba80caL61-R68)
* Changed the default AI triage image and token limits (`ai_triage_max_expected_images` and `ai_triage_max_output_tokens`) from restrictive values to `null`, so they now inherit the main analysis settings unless explicitly overridden, prioritizing review quality by default. [[1]](diffhunk://#diff-18bfba6093bfee50abb0f7701d0e4bd6e3a10c5409b438a9d428a858a03ce521L161-R167) [[2]](diffhunk://#diff-40c7ac33cbe96dd363565f97903cf924d3fca9ed5554a296f63d3f92cdba80caL90-R91) [[3]](diffhunk://#diff-600f225c8367e59bfc1ffa68bd1f29665e172a0f1857b51a7b3ce1aa85283f4aL61-R62) [[4]](diffhunk://#diff-6890b21bf500eef3a4a219dc8a0be5b4073847c896eeea01149a299b5aaea8fcL61-R62)

**Logging and diagnostics:**

* Enhanced logging in the chat completion routines to include finish reasons, token usage, content length, and warnings when token limits are hit or when no usable text is returned. This will help with debugging and monitoring model behavior. [[1]](diffhunk://#diff-e823433dc0d5098240e8e58cf9b638e4fa2cef4d60765fb5007c1f5ee70d65bfL1795-R1847) [[2]](diffhunk://#diff-e823433dc0d5098240e8e58cf9b638e4fa2cef4d60765fb5007c1f5ee70d65bfR1862-R1867) [[3]](diffhunk://#diff-517b6ca99cb86fee6ccd63ff6e30051395507fecf513aebc74520b593ab94db6L1825-R1877) [[4]](diffhunk://#diff-517b6ca99cb86fee6ccd63ff6e30051395507fecf513aebc74520b593ab94db6R1892-R1897)

**Documentation updates:**

* Updated architecture documentation to clarify the default behavior for AI triage, emphasizing that quality is prioritized and overrides are only needed for explicit low-latency modes.

These changes collectively improve the reliability, transparency, and flexibility of the AI triage system for calibration tasks.<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
<!-- Link to the ticket / issue -->

## Summary
<!-- What and why (1–2 sentences) -->

## Changes
<!-- Bullet list of key changes -->
