### PR TITLE
feat(agent): apply gemma4 best-practice triage settings

### DIFF
--- a/config/copilot.yaml
+++ b/config/copilot.yaml
@@ -29,7 +29,7 @@ model:
 # Specialized models for task result analysis (chevron patterns, Rabi, etc.).
 analysis_models:
   - provider: ollama
-    name: gemma4:31b
+    name: gemma4:26b
     # Ollama endpoint. Set GEMMA_BASE_URL to your Ollama server URL,
     # e.g. http://localhost:11434. QDash appends /v1 automatically.
     base_url: env:GEMMA_BASE_URL
@@ -38,17 +38,25 @@ analysis_models:
     # Keep the local VLM resident between automatic triage requests and avoid
     # repeated cold model loads between short qdash reviews.
     keep_alive: 30m
-    temperature: 0.2
+    # Gemma 4 best-practice sampling for stable local VLM triage.
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
+    reasoning_effort: none
+    disable_thinking_instruction: true
     max_output_tokens: 4096
   - provider: ollama
-    name: gemma4:26b
-    # Faster local VLM option. Some Ollama/OpenAI-compatible deployments place
-    # its generated text in reasoning fields, so QDash keeps a parser fallback
-    # for this model but does not make it the default.
+    name: gemma4:31b
+    # Higher-stability local VLM fallback. It is slower than 26B but showed
+    # fewer format failures in qdash triage spot checks.
     base_url: env:GEMMA_BASE_URL
     api_key_env: GEMMA_API_KEY
     keep_alive: 30m
-    temperature: 0.2
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
+    reasoning_effort: none
+    disable_thinking_instruction: true
     max_output_tokens: 4096
   - provider: ollama
     name: nvidia/Ising-Calibration-1-35B-A3B

--- a/docs/development/copilot/architecture.md
+++ b/docs/development/copilot/architecture.md
@@ -53,18 +53,26 @@ model:
 
 analysis_models:
   - provider: ollama
-    name: gemma4:31b
-    base_url: env:GEMMA_BASE_URL
-    api_key_env: GEMMA_API_KEY
-    keep_alive: 30m
-    temperature: 0.2
-    max_output_tokens: 4096
-  - provider: ollama
     name: gemma4:26b
     base_url: env:GEMMA_BASE_URL
     api_key_env: GEMMA_API_KEY
     keep_alive: 30m
-    temperature: 0.2
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
+    reasoning_effort: none
+    disable_thinking_instruction: true
+    max_output_tokens: 4096
+  - provider: ollama
+    name: gemma4:31b
+    base_url: env:GEMMA_BASE_URL
+    api_key_env: GEMMA_API_KEY
+    keep_alive: 30m
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
+    reasoning_effort: none
+    disable_thinking_instruction: true
     max_output_tokens: 4096
 
 # Metrics for chip health evaluation

--- a/src/qdash/api/lib/copilot_agent.py
+++ b/src/qdash/api/lib/copilot_agent.py
@@ -771,7 +771,7 @@ def _build_language_instruction(config: CopilotConfig | None) -> str:
 
     parts: list[str] = []
 
-    if thinking_lang != response_lang:
+    if thinking_lang != response_lang and not config.model.disable_thinking_instruction:
         parts.append(f"Think and reason internally in {thinking_lang} for technical precision.")
 
     if response_lang == "ja":
@@ -1787,6 +1787,8 @@ async def _run_chat_completions(
             extra_body["keep_alive"] = config.model.keep_alive
         if config.model.num_ctx is not None:
             options["num_ctx"] = config.model.num_ctx
+        if config.model.top_k is not None:
+            options["top_k"] = config.model.top_k
         if options:
             extra_body["options"] = options
 
@@ -1800,12 +1802,24 @@ async def _run_chat_completions(
         kwargs["extra_body"] = extra_body
     if config.model.temperature is not None:
         kwargs["temperature"] = config.model.temperature
+    if config.model.top_p is not None:
+        kwargs["top_p"] = config.model.top_p
+    if config.model.reasoning_effort:
+        kwargs["reasoning_effort"] = config.model.reasoning_effort
     try:
         response = await client.chat.completions.create(**kwargs)
     except BadRequestError as exc:
         if "temperature" in str(exc) and "temperature" in kwargs:
             logger.info("Model does not support temperature, retrying without it")
             kwargs.pop("temperature")
+            response = await client.chat.completions.create(**kwargs)
+        elif "top_p" in str(exc) and "top_p" in kwargs:
+            logger.info("Model does not support top_p, retrying without it")
+            kwargs.pop("top_p")
+            response = await client.chat.completions.create(**kwargs)
+        elif "reasoning_effort" in str(exc) and "reasoning_effort" in kwargs:
+            logger.info("Model does not support reasoning_effort, retrying without it")
+            kwargs.pop("reasoning_effort")
             response = await client.chat.completions.create(**kwargs)
         else:
             raise

--- a/src/qdash/api/lib/copilot_config.py
+++ b/src/qdash/api/lib/copilot_config.py
@@ -42,6 +42,10 @@ class ModelConfig(BaseModel):
     api_key_env: str | None = None
     keep_alive: str | None = None
     num_ctx: int | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    reasoning_effort: str | None = None
+    disable_thinking_instruction: bool = False
 
 
 class Suggestion(BaseModel):

--- a/src/qdash/common/copilot/agent.py
+++ b/src/qdash/common/copilot/agent.py
@@ -797,7 +797,7 @@ def _build_language_instruction(config: CopilotConfig | None) -> str:
 
     parts: list[str] = []
 
-    if thinking_lang != response_lang:
+    if thinking_lang != response_lang and not config.model.disable_thinking_instruction:
         parts.append(f"Think and reason internally in {thinking_lang} for technical precision.")
 
     if response_lang == "ja":
@@ -1817,6 +1817,8 @@ async def _run_chat_completions(
             extra_body["keep_alive"] = config.model.keep_alive
         if config.model.num_ctx is not None:
             options["num_ctx"] = config.model.num_ctx
+        if config.model.top_k is not None:
+            options["top_k"] = config.model.top_k
         if options:
             extra_body["options"] = options
 
@@ -1830,12 +1832,24 @@ async def _run_chat_completions(
         kwargs["extra_body"] = extra_body
     if config.model.temperature is not None:
         kwargs["temperature"] = config.model.temperature
+    if config.model.top_p is not None:
+        kwargs["top_p"] = config.model.top_p
+    if config.model.reasoning_effort:
+        kwargs["reasoning_effort"] = config.model.reasoning_effort
     try:
         response = await client.chat.completions.create(**kwargs)
     except BadRequestError as exc:
         if "temperature" in str(exc) and "temperature" in kwargs:
             logger.info("Model does not support temperature, retrying without it")
             kwargs.pop("temperature")
+            response = await client.chat.completions.create(**kwargs)
+        elif "top_p" in str(exc) and "top_p" in kwargs:
+            logger.info("Model does not support top_p, retrying without it")
+            kwargs.pop("top_p")
+            response = await client.chat.completions.create(**kwargs)
+        elif "reasoning_effort" in str(exc) and "reasoning_effort" in kwargs:
+            logger.info("Model does not support reasoning_effort, retrying without it")
+            kwargs.pop("reasoning_effort")
             response = await client.chat.completions.create(**kwargs)
         else:
             raise

--- a/src/qdash/common/copilot/config.py
+++ b/src/qdash/common/copilot/config.py
@@ -42,6 +42,10 @@ class ModelConfig(BaseModel):
     api_key_env: str | None = None
     keep_alive: str | None = None
     num_ctx: int | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    reasoning_effort: str | None = None
+    disable_thinking_instruction: bool = False
 
 
 class Suggestion(BaseModel):

--- a/tests/qdash/api/lib/test_copilot_agent.py
+++ b/tests/qdash/api/lib/test_copilot_agent.py
@@ -56,7 +56,7 @@ def test_parse_response_converts_plain_missing_triage_text_to_safe_review() -> N
 
 
 @pytest.mark.asyncio
-async def test_run_chat_completions_passes_ollama_keep_alive_and_num_ctx() -> None:
+async def test_run_chat_completions_passes_ollama_options() -> None:
     captured = {}
 
     class _Completions:
@@ -72,7 +72,10 @@ async def test_run_chat_completions_passes_ollama_keep_alive_and_num_ctx() -> No
             name="gemma4:26b",
             keep_alive="30m",
             num_ctx=8192,
-            temperature=0,
+            temperature=1.0,
+            top_p=0.95,
+            top_k=64,
+            reasoning_effort="none",
         )
     )
 
@@ -80,8 +83,11 @@ async def test_run_chat_completions_passes_ollama_keep_alive_and_num_ctx() -> No
 
     assert captured["extra_body"] == {
         "keep_alive": "30m",
-        "options": {"num_ctx": 8192},
+        "options": {"num_ctx": 8192, "top_k": 64},
     }
+    assert captured["temperature"] == 1.0
+    assert captured["top_p"] == 0.95
+    assert captured["reasoning_effort"] == "none"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request updates the configuration and codebase to support new model parameters and improve the stability and flexibility of model selection for local VLM (Vision-Language Model) triage. The main changes include switching the default and fallback Gemma model assignments, updating best-practice sampling parameters, extending the model config and agent code to handle new parameters, and enhancing error handling for unsupported parameters.

**Model configuration and selection improvements:**

* Swapped the default and fallback Gemma models in `config/copilot.yaml` and `docs/development/copilot/architecture.md`, making `gemma4:26b` the default and `gemma4:31b` the higher-stability fallback. Updated documentation and comments to match. [[1]](diffhunk://#diff-18bfba6093bfee50abb0f7701d0e4bd6e3a10c5409b438a9d428a858a03ce521L32-R32) [[2]](diffhunk://#diff-18bfba6093bfee50abb0f7701d0e4bd6e3a10c5409b438a9d428a858a03ce521L41-R59) [[3]](diffhunk://#diff-40c7ac33cbe96dd363565f97903cf924d3fca9ed5554a296f63d3f92cdba80caL56-R75)
* Updated model sampling parameters for both Gemma models: set `temperature` to 1.0, added `top_p: 0.95`, `top_k: 64`, `reasoning_effort: none`, and `disable_thinking_instruction: true` for improved stability and best practices. [[1]](diffhunk://#diff-18bfba6093bfee50abb0f7701d0e4bd6e3a10c5409b438a9d428a858a03ce521L41-R59) [[2]](diffhunk://#diff-40c7ac33cbe96dd363565f97903cf924d3fca9ed5554a296f63d3f92cdba80caL56-R75)

**Agent and config code enhancements:**

* Extended `ModelConfig` in both `src/qdash/api/lib/copilot_config.py` and `src/qdash/common/copilot/config.py` to include `top_p`, `top_k`, `reasoning_effort`, and `disable_thinking_instruction` fields. [[1]](diffhunk://#diff-600f225c8367e59bfc1ffa68bd1f29665e172a0f1857b51a7b3ce1aa85283f4aR45-R48) [[2]](diffhunk://#diff-6890b21bf500eef3a4a219dc8a0be5b4073847c896eeea01149a299b5aaea8fcR45-R48)
* Updated `_run_chat_completions` in both agent modules to pass the new parameters to the model, and to retry requests without unsupported parameters if the model returns an error. [[1]](diffhunk://#diff-e823433dc0d5098240e8e58cf9b638e4fa2cef4d60765fb5007c1f5ee70d65bfR1790-R1791) [[2]](diffhunk://#diff-e823433dc0d5098240e8e58cf9b638e4fa2cef4d60765fb5007c1f5ee70d65bfR1805-R1823) [[3]](diffhunk://#diff-517b6ca99cb86fee6ccd63ff6e30051395507fecf513aebc74520b593ab94db6R1820-R1821) [[4]](diffhunk://#diff-517b6ca99cb86fee6ccd63ff6e30051395507fecf513aebc74520b593ab94db6R1835-R1853)
* Modified `_build_language_instruction` in both agent modules to respect `disable_thinking_instruction`, suppressing the internal reasoning language prompt if set. [[1]](diffhunk://#diff-e823433dc0d5098240e8e58cf9b638e4fa2cef4d60765fb5007c1f5ee70d65bfL774-R774) [[2]](diffhunk://#diff-517b6ca99cb86fee6ccd63ff6e30051395507fecf513aebc74520b593ab94db6L800-R800)

**Testing:**

* Updated tests to verify that all new model parameters are passed through correctly and that the options dictionary is constructed as expected. [[1]](diffhunk://#diff-9979a8d3ae11994d09d99f47dbe87ff3159b311a2fa191eefaa0243bfc495d46L59-R59) [[2]](diffhunk://#diff-9979a8d3ae11994d09d99f47dbe87ff3159b311a2fa191eefaa0243bfc495d46L75-R90)<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
<!-- Link to the ticket / issue -->

## Summary
<!-- What and why (1–2 sentences) -->

## Changes
<!-- Bullet list of key changes -->
