### PR TITLE
feat(api): implement role-based permissions for project members

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -709,7 +709,7 @@
           "admin"
         ],
         "summary": "Add member to project",
-        "description": "Add a member to a project as viewer (admin only).",
+        "description": "Add a member to a project (admin only).",
         "operationId": "addProjectMemberAdmin",
         "security": [
           {
@@ -2714,7 +2714,7 @@
           "chip"
         ],
         "summary": "Create a new chip",
-        "description": "Create a new chip in the current project.\n\nParameters\n----------\nrequest : CreateChipRequest\n    Chip creation request containing chip_id and size\nctx : ProjectContext\n    Project context with owner permission\n\nReturns\n-------\nChipResponse\n    Created chip information\n\nRaises\n------\nHTTPException\n    If chip_id already exists or size is invalid",
+        "description": "Create a new chip in the current project.\n\nParameters\n----------\nrequest : CreateChipRequest\n    Chip creation request containing chip_id and size\nctx : ProjectContext\n    Project context with editor permission\n\nReturns\n-------\nChipResponse\n    Created chip information\n\nRaises\n------\nHTTPException\n    If chip_id already exists or size is invalid",
         "operationId": "createChip",
         "security": [
           {
@@ -5239,7 +5239,7 @@
           "task-result"
         ],
         "summary": "Toggle exclusion of a task result from metrics aggregations",
-        "description": "Toggle the excluded flag on a task result.\n\nExcluded measurements are skipped when aggregating metrics for the\ndashboard / metrics screens. Raw data is preserved. Any project member\ncan toggle exclusion; the most recent toggler is recorded.",
+        "description": "Toggle the excluded flag on a task result.\n\nExcluded measurements are skipped when aggregating metrics for the\ndashboard / metrics screens. Raw data is preserved.",
         "operationId": "setTaskResultExcluded",
         "security": [
           {
@@ -12809,6 +12809,10 @@
           "username": {
             "type": "string",
             "title": "Username"
+          },
+          "role": {
+            "$ref": "#/components/schemas/ProjectRole",
+            "default": "viewer"
           }
         },
         "type": "object",
@@ -12816,7 +12820,7 @@
           "username"
         ],
         "title": "AddMemberRequest",
-        "description": "Request to add a member to a project (always as viewer)."
+        "description": "Request to add a member to a project."
       },
       "AiTriageReviewModel": {
         "properties": {
@@ -19101,10 +19105,11 @@
         "type": "string",
         "enum": [
           "owner",
+          "editor",
           "viewer"
         ],
         "title": "ProjectRole",
-        "description": "Role of a member inside a project.\n\nSimplified model:\n- OWNER: Full access to project (read, write, admin)\n- VIEWER: Read-only access (for invited members)"
+        "description": "Role of a member inside a project.\n\nRoles intentionally stay coarse-grained:\n- OWNER: Project administration plus write access\n- EDITOR: Operational write access\n- VIEWER: Read-only access"
       },
       "ProjectUpdate": {
         "properties": {

--- a/src/qdash/api/lib/project.py
+++ b/src/qdash/api/lib/project.py
@@ -7,7 +7,7 @@ from typing import Annotated, cast
 from fastapi import Depends, Header, HTTPException, Path, status
 from qdash.api.lib.auth import get_current_active_user
 from qdash.api.schemas.auth import User
-from qdash.datamodel.project import ProjectRole
+from qdash.datamodel.project import ProjectPermission, ProjectRole, role_has_permission
 from qdash.dbmodel.project import ProjectDocument
 from qdash.dbmodel.project_membership import ProjectMembershipDocument
 
@@ -80,14 +80,14 @@ def _get_membership(project_id: str, username: str) -> ProjectMembershipDocument
 def _check_permission(
     project_id: str,
     user: User,
-    required_roles: list[ProjectRole] | None = None,
+    required_permission: ProjectPermission = ProjectPermission.READ,
 ) -> tuple[ProjectDocument, ProjectRole]:
     """Check if user has permission to access project.
 
     Args:
         project_id: The project identifier
         user: The authenticated user
-        required_roles: List of roles that are allowed. If None, any role is accepted.
+        required_permission: Coarse project permission required for this endpoint.
 
     Returns:
         Tuple of (ProjectDocument, user's role)
@@ -109,17 +109,21 @@ def _check_permission(
         # Check if user is the owner (fallback for legacy data)
         if project.owner_username == user.username:
             logger.debug(f"User {user.username} is owner of project {project_id}")
+            if not role_has_permission(ProjectRole.OWNER, required_permission):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Insufficient permissions. Required: {required_permission.value}",
+                )
             return project, ProjectRole.OWNER
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"You do not have access to project '{project_id}'",
         )
 
-    # Check role if required
-    if required_roles and membership.role not in required_roles:
+    if not role_has_permission(membership.role, required_permission):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Insufficient permissions. Required: {[r.value for r in required_roles]}",
+            detail=f"Insufficient permissions. Required: {required_permission.value}",
         )
 
     return project, membership.role
@@ -147,7 +151,20 @@ def get_project_context_owner(
     Use this dependency for admin endpoints (e.g., project settings, member management).
     """
     project_id = _resolve_project_id(user, project_id_header)
-    project, role = _check_permission(project_id, user, required_roles=[ProjectRole.OWNER])
+    project, role = _check_permission(project_id, user, required_permission=ProjectPermission.ADMIN)
+    return ProjectContext(project_id=project_id, project=project, user=user, role=role)
+
+
+def get_project_context_editor(
+    user: Annotated[User, Depends(get_current_active_user)],
+    project_id_header: Annotated[str | None, Depends(get_project_id_from_header)] = None,
+) -> ProjectContext:
+    """Get project context with editor or owner permission.
+
+    Use this dependency for operational write endpoints.
+    """
+    project_id = _resolve_project_id(user, project_id_header)
+    project, role = _check_permission(project_id, user, required_permission=ProjectPermission.WRITE)
     return ProjectContext(project_id=project_id, project=project, user=user, role=role)
 
 
@@ -174,5 +191,14 @@ def get_project_context_owner_from_path(
 
     Use this dependency for project router admin endpoints with /{project_id}.
     """
-    project, role = _check_permission(project_id, user, required_roles=[ProjectRole.OWNER])
+    project, role = _check_permission(project_id, user, required_permission=ProjectPermission.ADMIN)
+    return ProjectContext(project_id=project_id, project=project, user=user, role=role)
+
+
+def get_project_context_editor_from_path(
+    project_id: Annotated[str, Path(description="Project identifier")],
+    user: Annotated[User, Depends(get_current_active_user)],
+) -> ProjectContext:
+    """Get project context from path parameter with editor or owner permission."""
+    project, role = _check_permission(project_id, user, required_permission=ProjectPermission.WRITE)
     return ProjectContext(project_id=project_id, project=project, user=user, role=role)

--- a/src/qdash/api/routers/admin.py
+++ b/src/qdash/api/routers/admin.py
@@ -195,11 +195,12 @@ def add_project_member_admin(
     admin: Annotated[User, Depends(get_admin_user)],
     service: Annotated[AdminService, Depends(get_admin_service)],
 ) -> MemberItem:
-    """Add a member to a project as viewer (admin only)."""
+    """Add a member to a project (admin only)."""
     logger.debug(f"Admin {admin.username} adding {request.username} to project {project_id}")
     return service.add_project_member(
         project_id=project_id,
         username=request.username,
+        role=request.role,
         admin_username=admin.username,
     )
 

--- a/src/qdash/api/routers/calibration.py
+++ b/src/qdash/api/routers/calibration.py
@@ -9,7 +9,7 @@ from qdash.api.dependencies import (
     get_manual_update_service,
     get_seed_import_service,
 )
-from qdash.api.lib.project import ProjectContext, get_project_context
+from qdash.api.lib.project import ProjectContext, get_project_context, get_project_context_editor
 from qdash.api.schemas.calibration import (
     CalibrationNoteResponse,
     ManualEditsResponse,
@@ -75,7 +75,7 @@ def get_calibration_note(
     operation_id="importSeedParameters",
 )
 def import_seed_parameters(
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[SeedImportService, Depends(get_seed_import_service)],
     request: SeedImportRequest,
 ) -> SeedImportResponse:
@@ -228,7 +228,7 @@ def compare_seed_values(
     operation_id="updateCalibrationParameters",
 )
 def update_calibration_parameters(
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[ManualUpdateService, Depends(get_manual_update_service)],
     request: ManualParameterUpdateRequest,
 ) -> ManualParameterUpdateResponse:

--- a/src/qdash/api/routers/chip.py
+++ b/src/qdash/api/routers/chip.py
@@ -17,7 +17,7 @@ from qdash.api.dependencies import (  # noqa: TCH002
 from qdash.api.lib.project import (  # noqa: TCH002
     ProjectContext,
     get_project_context,
-    get_project_context_owner,
+    get_project_context_editor,
 )
 from qdash.api.schemas.chip import (
     ChipDatesResponse,
@@ -80,7 +80,7 @@ def list_chips(
 )
 def create_chip(
     request: CreateChipRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context_owner)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
 ) -> ChipResponse:
     """Create a new chip in the current project.
 
@@ -89,7 +89,7 @@ def create_chip(
     request : CreateChipRequest
         Chip creation request containing chip_id and size
     ctx : ProjectContext
-        Project context with owner permission
+        Project context with editor permission
 
     Returns
     -------
@@ -142,7 +142,7 @@ def create_chip(
 def update_chip(
     chip_id: str,
     body: UpdateChipRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[ChipService, Depends(get_chip_service)],
 ) -> ChipResponse:
     return service.update_chip(
@@ -175,7 +175,7 @@ def get_chip_deletion_impact(
 )
 def delete_chip(
     chip_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[ChipService, Depends(get_chip_service)],
     force: Annotated[
         bool,

--- a/src/qdash/api/routers/cooldown.py
+++ b/src/qdash/api/routers/cooldown.py
@@ -10,6 +10,7 @@ from qdash.api.dependencies import get_cooldown_service  # noqa: TCH002
 from qdash.api.lib.project import (  # noqa: TCH002
     ProjectContext,
     get_project_context,
+    get_project_context_editor,
 )
 from qdash.api.schemas.cooldown import (
     CooldownCreateRequest,
@@ -62,7 +63,7 @@ def get_cooldown(
 )
 def create_cooldown(
     body: CooldownCreateRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CooldownService, Depends(get_cooldown_service)],
 ) -> CooldownResponse:
     return service.create(project_id=ctx.project_id, body=body)
@@ -77,7 +78,7 @@ def create_cooldown(
 def update_cooldown(
     cooldown_id: str,
     body: CooldownUpdateRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CooldownService, Depends(get_cooldown_service)],
 ) -> CooldownResponse:
     return service.update(project_id=ctx.project_id, cooldown_id=cooldown_id, body=body)
@@ -91,7 +92,7 @@ def update_cooldown(
 )
 def delete_cooldown(
     cooldown_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CooldownService, Depends(get_cooldown_service)],
 ) -> SuccessResponse:
     return service.delete(project_id=ctx.project_id, cooldown_id=cooldown_id)
@@ -106,7 +107,7 @@ def delete_cooldown(
 def assign_chip(
     cooldown_id: str,
     chip_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CooldownService, Depends(get_cooldown_service)],
 ) -> CooldownResponse:
     return service.assign_chip(project_id=ctx.project_id, cooldown_id=cooldown_id, chip_id=chip_id)
@@ -121,7 +122,7 @@ def assign_chip(
 def unassign_chip(
     cooldown_id: str,
     chip_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CooldownService, Depends(get_cooldown_service)],
 ) -> CooldownResponse:
     return service.unassign_chip(

--- a/src/qdash/api/routers/cooldown_wiring_event.py
+++ b/src/qdash/api/routers/cooldown_wiring_event.py
@@ -15,6 +15,7 @@ from qdash.api.dependencies import get_cooldown_wiring_event_service  # noqa: TC
 from qdash.api.lib.project import (  # noqa: TCH002
     ProjectContext,
     get_project_context,
+    get_project_context_editor,
 )
 from qdash.api.schemas.cooldown_wiring_event import (
     CooldownWiringCheckpointRequest,
@@ -38,7 +39,7 @@ router = APIRouter()
 def create_wiring_checkpoint(
     cooldown_id: str,
     body: CooldownWiringCheckpointRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CooldownWiringEventService, Depends(get_cooldown_wiring_event_service)],
 ) -> CooldownWiringEventResponse:
     return service.create_checkpoint(

--- a/src/qdash/api/routers/cryostat.py
+++ b/src/qdash/api/routers/cryostat.py
@@ -10,6 +10,7 @@ from qdash.api.dependencies import get_cryostat_service  # noqa: TCH002
 from qdash.api.lib.project import (  # noqa: TCH002
     ProjectContext,
     get_project_context,
+    get_project_context_editor,
 )
 from qdash.api.schemas.cryostat import (
     CryostatCreateRequest,
@@ -60,7 +61,7 @@ def get_cryostat(
 )
 def create_cryostat(
     body: CryostatCreateRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CryostatService, Depends(get_cryostat_service)],
 ) -> CryostatResponse:
     return service.create(project_id=ctx.project_id, body=body)
@@ -75,7 +76,7 @@ def create_cryostat(
 def update_cryostat(
     cryo_id: str,
     body: CryostatUpdateRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CryostatService, Depends(get_cryostat_service)],
 ) -> CryostatResponse:
     return service.update(project_id=ctx.project_id, cryo_id=cryo_id, body=body)
@@ -89,7 +90,7 @@ def update_cryostat(
 )
 def delete_cryostat(
     cryo_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[CryostatService, Depends(get_cryostat_service)],
 ) -> SuccessResponse:
     return service.delete(project_id=ctx.project_id, cryo_id=cryo_id)

--- a/src/qdash/api/routers/execution.py
+++ b/src/qdash/api/routers/execution.py
@@ -16,7 +16,7 @@ from qdash.api.dependencies import get_execution_service, get_flow_service  # no
 from qdash.api.lib.project import (  # noqa: TCH002
     ProjectContext,
     get_project_context,
-    get_project_context_owner,
+    get_project_context_editor,
 )
 from qdash.api.schemas.error import Detail
 from qdash.api.schemas.execution import (
@@ -202,7 +202,7 @@ def get_execution(
 )
 async def cancel_execution(
     flow_run_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     execution_service: Annotated[ExecutionService, Depends(get_execution_service)],
 ) -> CancelExecutionResponse:
     """Cancel a running or scheduled execution via Prefect.
@@ -242,7 +242,7 @@ async def cancel_execution(
 async def re_execute_from_snapshot(
     execution_id: str,
     request: ReExecuteRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context_owner)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     execution_service: Annotated[ExecutionService, Depends(get_execution_service)],
     flow_service: Annotated[FlowService, Depends(get_flow_service)],
 ) -> ExecuteFlowResponse:

--- a/src/qdash/api/routers/flow.py
+++ b/src/qdash/api/routers/flow.py
@@ -8,7 +8,7 @@ from qdash.api.dependencies import (
     get_flow_schedule_service,
     get_flow_service,
 )
-from qdash.api.lib.project import ProjectContext, get_project_context
+from qdash.api.lib.project import ProjectContext, get_project_context, get_project_context_editor
 from qdash.api.schemas.flow import (
     DeleteScheduleResponse,
     ExecuteFlowRequest,
@@ -45,7 +45,7 @@ logger = getLogger("uvicorn.app")
 )
 async def save_flow(
     request: SaveFlowRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[FlowService, Depends(get_flow_service)],
 ) -> SaveFlowResponse:
     """Save a Flow to file system and MongoDB."""
@@ -161,7 +161,7 @@ async def list_all_flow_schedules(
 )
 async def delete_flow_schedule(
     schedule_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     schedule_service: Annotated[FlowScheduleService, Depends(get_flow_schedule_service)],
 ) -> DeleteScheduleResponse:
     """Delete a Flow schedule (cron or one-time)."""
@@ -177,7 +177,7 @@ async def delete_flow_schedule(
 async def update_flow_schedule(
     schedule_id: str,
     request: UpdateScheduleRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     schedule_service: Annotated[FlowScheduleService, Depends(get_flow_schedule_service)],
 ) -> UpdateScheduleResponse:
     """Update a Flow schedule (cron schedules only)."""
@@ -215,7 +215,7 @@ async def get_flow(
 async def execute_flow(
     name: str,
     request: ExecuteFlowRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[FlowService, Depends(get_flow_service)],
 ) -> ExecuteFlowResponse:
     """Execute a Flow via Prefect deployment."""
@@ -229,7 +229,7 @@ async def execute_flow(
 )
 async def delete_flow(
     name: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[FlowService, Depends(get_flow_service)],
 ) -> dict[str, str]:
     """Delete a Flow."""
@@ -245,7 +245,7 @@ async def delete_flow(
 async def schedule_flow(
     name: str,
     request: ScheduleFlowRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     schedule_service: Annotated[FlowScheduleService, Depends(get_flow_schedule_service)],
 ) -> ScheduleFlowResponse:
     """Schedule a Flow execution with cron or one-time schedule."""

--- a/src/qdash/api/routers/issue_knowledge.py
+++ b/src/qdash/api/routers/issue_knowledge.py
@@ -9,6 +9,7 @@ from qdash.api.dependencies import get_issue_knowledge_service, get_issue_servic
 from qdash.api.lib.project import (  # noqa: TCH002
     ProjectContext,
     get_project_context,
+    get_project_context_editor,
 )
 from qdash.api.schemas.issue_knowledge import (
     IssueKnowledgeResponse,
@@ -29,7 +30,7 @@ router = APIRouter()
     response_model=ListIssueKnowledgeResponse,
 )
 def list_issue_knowledge(
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[IssueKnowledgeService, Depends(get_issue_knowledge_service)],
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
@@ -56,7 +57,7 @@ def list_issue_knowledge(
 )
 def get_issue_knowledge(
     knowledge_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[IssueKnowledgeService, Depends(get_issue_knowledge_service)],
 ) -> IssueKnowledgeResponse:
     """Get a single knowledge case by ID."""
@@ -72,7 +73,7 @@ def get_issue_knowledge(
 )
 async def extract_issue_knowledge(
     issue_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[IssueKnowledgeService, Depends(get_issue_knowledge_service)],
     issue_service: Annotated[IssueService, Depends(get_issue_service)],
 ) -> IssueKnowledgeResponse:
@@ -93,7 +94,7 @@ async def extract_issue_knowledge(
 def update_issue_knowledge(
     knowledge_id: str,
     body: IssueKnowledgeUpdate,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[IssueKnowledgeService, Depends(get_issue_knowledge_service)],
 ) -> IssueKnowledgeResponse:
     """Update a knowledge draft's content. Only drafts can be edited."""
@@ -128,7 +129,7 @@ def update_issue_knowledge(
 )
 def approve_issue_knowledge(
     knowledge_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[IssueKnowledgeService, Depends(get_issue_knowledge_service)],
 ) -> IssueKnowledgeResponse:
     """Approve a knowledge draft for inclusion in task knowledge."""

--- a/src/qdash/api/routers/note.py
+++ b/src/qdash/api/routers/note.py
@@ -10,6 +10,7 @@ from qdash.api.dependencies import get_note_service  # noqa: TCH002
 from qdash.api.lib.project import (  # noqa: TCH002
     ProjectContext,
     get_project_context,
+    get_project_context_editor,
 )
 from qdash.api.schemas.note import (
     ChipNotesSummaryResponse,
@@ -39,7 +40,7 @@ def upsert_qubit_note(
     chip_id: str,
     qid: str,
     body: NoteUpsertRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> NoteModel:
     return service.upsert_qubit_note(
@@ -60,7 +61,7 @@ def upsert_qubit_note(
 def delete_qubit_note(
     chip_id: str,
     qid: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> SuccessResponse:
     return service.delete_qubit_note(
@@ -82,7 +83,7 @@ def upsert_qubit_metric_note(
     qid: str,
     metric_key: str,
     body: NoteUpsertRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> NoteModel:
     return service.upsert_qubit_metric_note(
@@ -105,7 +106,7 @@ def delete_qubit_metric_note(
     chip_id: str,
     qid: str,
     metric_key: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> SuccessResponse:
     return service.delete_qubit_metric_note(
@@ -132,7 +133,7 @@ def upsert_coupling_note(
     chip_id: str,
     coupling_id: str,
     body: NoteUpsertRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> NoteModel:
     return service.upsert_coupling_note(
@@ -153,7 +154,7 @@ def upsert_coupling_note(
 def delete_coupling_note(
     chip_id: str,
     coupling_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> SuccessResponse:
     return service.delete_coupling_note(
@@ -175,7 +176,7 @@ def upsert_coupling_metric_note(
     coupling_id: str,
     metric_key: str,
     body: NoteUpsertRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> NoteModel:
     return service.upsert_coupling_metric_note(
@@ -198,7 +199,7 @@ def delete_coupling_metric_note(
     chip_id: str,
     coupling_id: str,
     metric_key: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> SuccessResponse:
     return service.delete_coupling_metric_note(
@@ -241,7 +242,7 @@ def get_task_note(
 def upsert_task_note(
     task_id: str,
     body: NoteUpsertRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> NoteModel:
     return service.upsert_task_note(
@@ -260,7 +261,7 @@ def upsert_task_note(
 )
 def delete_task_note(
     task_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[NoteService, Depends(get_note_service)],
 ) -> SuccessResponse:
     return service.delete_task_note(

--- a/src/qdash/api/routers/task_result.py
+++ b/src/qdash/api/routers/task_result.py
@@ -11,7 +11,7 @@ from qdash.api.dependencies import get_flow_service, get_task_result_service  # 
 from qdash.api.lib.project import (  # noqa: TCH002
     ProjectContext,
     get_project_context,
-    get_project_context_owner,
+    get_project_context_editor,
 )
 from qdash.api.schemas.flow import ExecuteFlowResponse
 from qdash.api.schemas.task_result import (
@@ -414,7 +414,7 @@ def get_timeseries_task_results(
 )
 def request_bulk_ai_triage_review(
     body: BulkAiTriageRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[TaskResultService, Depends(get_task_result_service)],
 ) -> BulkAiTriageResponse:
     """Enqueue AI triage review for the current latest task result per entity."""
@@ -443,7 +443,7 @@ def request_bulk_ai_triage_review(
 )
 async def re_execute_task_result(
     task_id: str,
-    ctx: Annotated[ProjectContext, Depends(get_project_context_owner)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
     service: Annotated[TaskResultService, Depends(get_task_result_service)],
     flow_service: Annotated[FlowService, Depends(get_flow_service)],
     parameter_overrides: Annotated[
@@ -540,13 +540,12 @@ async def re_execute_task_result(
 def set_task_result_excluded(
     task_id: str,
     body: TaskResultExcludeRequest,
-    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_editor)],
 ) -> TaskResultExcludeResponse:
     """Toggle the excluded flag on a task result.
 
     Excluded measurements are skipped when aggregating metrics for the
-    dashboard / metrics screens. Raw data is preserved. Any project member
-    can toggle exclusion; the most recent toggler is recorded.
+    dashboard / metrics screens. Raw data is preserved.
     """
     from qdash.common.datetime_utils import now
     from qdash.dbmodel.task_result_history import TaskResultHistoryDocument

--- a/src/qdash/api/schemas/admin.py
+++ b/src/qdash/api/schemas/admin.py
@@ -90,6 +90,7 @@ class MemberListResponse(BaseModel):
 
 
 class AddMemberRequest(BaseModel):
-    """Request to add a member to a project (always as viewer)."""
+    """Request to add a member to a project."""
 
     username: str
+    role: ProjectRole = ProjectRole.VIEWER

--- a/src/qdash/api/services/admin_service.py
+++ b/src/qdash/api/services/admin_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 from qdash.api.schemas.admin import (
@@ -15,7 +16,6 @@ from qdash.api.schemas.admin import (
     UserListItem,
     UserListResponse,
 )
-from qdash.datamodel.project import ProjectRole
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.datamodel.user import SystemRole
 from qdash.dbmodel.project import ProjectDocument
@@ -23,6 +23,9 @@ from qdash.dbmodel.project_membership import ProjectMembershipDocument
 from qdash.dbmodel.user import UserDocument
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from qdash.datamodel.project import ProjectRole
 
 
 class AdminService:
@@ -228,8 +231,10 @@ class AdminService:
 
         return MemberListResponse(members=members, total=len(members))
 
-    def add_project_member(self, project_id: str, username: str, admin_username: str) -> MemberItem:
-        """Add a member to a project as viewer."""
+    def add_project_member(
+        self, project_id: str, username: str, role: ProjectRole, admin_username: str
+    ) -> MemberItem:
+        """Add a member to a project."""
         project = ProjectDocument.find_one({"project_id": project_id}).run()
         if not project:
             raise HTTPException(
@@ -254,12 +259,12 @@ class AdminService:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"User '{username}' is already a member",
                 )
-            existing.role = ProjectRole.VIEWER
+            existing.role = role
             existing.status = "active"
             existing.invited_by = admin_username
             existing.system_info.update_time()
             existing.save()
-            logger.info(f"Reactivated {username} in project {project_id} as viewer")
+            logger.info("Reactivated %s in project %s as %s", username, project_id, role.value)
             return MemberItem(
                 username=existing.username,
                 full_name=user.full_name,
@@ -270,14 +275,14 @@ class AdminService:
         membership = ProjectMembershipDocument(
             project_id=project_id,
             username=username,
-            role=ProjectRole.VIEWER,
+            role=role,
             status="active",
             invited_by=admin_username,
             system_info=SystemInfoModel(),
         )
         membership.insert()
 
-        logger.info(f"Added {username} to project {project_id} as viewer")
+        logger.info("Added %s to project %s as %s", username, project_id, role.value)
         return MemberItem(
             username=membership.username,
             full_name=user.full_name,

--- a/src/qdash/api/services/project_service.py
+++ b/src/qdash/api/services/project_service.py
@@ -473,12 +473,12 @@ class ProjectService:
                 detail=f"User '{new_owner_username}' not found",
             )
 
-        # Update old owner membership to viewer
+        # Keep the previous owner as an editor after transferring administration.
         old_owner_membership = self._membership_repo.find_one(
             {"project_id": project_id, "username": project.owner_username}
         )
         if old_owner_membership:
-            old_owner_membership.role = ProjectRole.VIEWER
+            old_owner_membership.role = ProjectRole.EDITOR
             old_owner_membership.system_info.update_time()
             self._membership_repo.save(old_owner_membership)
 

--- a/src/qdash/datamodel/__init__.py
+++ b/src/qdash/datamodel/__init__.py
@@ -10,11 +10,17 @@ Related modules:
 """
 
 from qdash.datamodel.calibration_note import CalibrationNoteModel
-from qdash.datamodel.project import ProjectMembershipModel, ProjectModel, ProjectRole
+from qdash.datamodel.project import (
+    ProjectMembershipModel,
+    ProjectModel,
+    ProjectPermission,
+    ProjectRole,
+)
 
 __all__ = [
     "CalibrationNoteModel",
     "ProjectMembershipModel",
     "ProjectModel",
+    "ProjectPermission",
     "ProjectRole",
 ]

--- a/src/qdash/datamodel/project.py
+++ b/src/qdash/datamodel/project.py
@@ -7,13 +7,43 @@ from qdash.datamodel.system_info import SystemInfoModel
 class ProjectRole(str, Enum):
     """Role of a member inside a project.
 
-    Simplified model:
-    - OWNER: Full access to project (read, write, admin)
-    - VIEWER: Read-only access (for invited members)
+    Roles intentionally stay coarse-grained:
+    - OWNER: Project administration plus write access
+    - EDITOR: Operational write access
+    - VIEWER: Read-only access
     """
 
     OWNER = "owner"
+    EDITOR = "editor"
     VIEWER = "viewer"
+
+
+class ProjectPermission(str, Enum):
+    """Coarse project permissions shared by API dependencies and UI."""
+
+    READ = "read"
+    WRITE = "write"
+    ADMIN = "admin"
+
+
+ROLE_PERMISSIONS: dict[ProjectRole, frozenset[ProjectPermission]] = {
+    ProjectRole.OWNER: frozenset(
+        {
+            ProjectPermission.READ,
+            ProjectPermission.WRITE,
+            ProjectPermission.ADMIN,
+        }
+    ),
+    ProjectRole.EDITOR: frozenset({ProjectPermission.READ, ProjectPermission.WRITE}),
+    ProjectRole.VIEWER: frozenset({ProjectPermission.READ}),
+}
+
+
+def role_has_permission(role: ProjectRole | None, permission: ProjectPermission) -> bool:
+    """Return whether a project role includes the requested coarse permission."""
+    if role is None:
+        return False
+    return permission in ROLE_PERMISSIONS[role]
 
 
 class ProjectModel(BaseModel):

--- a/tests/qdash/api/routers/test_execution.py
+++ b/tests/qdash/api/routers/test_execution.py
@@ -70,6 +70,30 @@ def viewer_user(init_db: PyMongoDatabase[Any]) -> UserDocument:
 
 
 @pytest.fixture
+def editor_user(init_db: PyMongoDatabase[Any]) -> UserDocument:
+    """Create an editor user."""
+    user = UserDocument(
+        username="editor_user",
+        hashed_password="hashed",
+        access_token="editor_token",
+        default_project_id="test_project",
+        system_info=SystemInfoModel(),
+    )
+    user.insert()
+
+    membership = ProjectMembershipDocument(
+        project_id="test_project",
+        username="editor_user",
+        role=ProjectRole.EDITOR,
+        status="active",
+        invited_by="test_user",
+    )
+    membership.insert()
+
+    return user
+
+
+@pytest.fixture
 def auth_headers() -> dict[str, str]:
     """Owner authentication headers."""
     return {
@@ -83,6 +107,15 @@ def viewer_headers() -> dict[str, str]:
     """Viewer authentication headers."""
     return {
         "Authorization": "Bearer viewer_token",
+        "X-Project-Id": "test_project",
+    }
+
+
+@pytest.fixture
+def editor_headers() -> dict[str, str]:
+    """Editor authentication headers."""
+    return {
+        "Authorization": "Bearer editor_token",
         "X-Project-Id": "test_project",
     }
 
@@ -379,7 +412,7 @@ class TestReExecuteFromSnapshot:
         )
         assert response.status_code == 401
 
-    def test_re_execute_requires_owner_role(
+    def test_re_execute_rejects_viewer_role(
         self,
         test_client: TestClient,
         test_project: ProjectDocument,
@@ -397,6 +430,51 @@ class TestReExecuteFromSnapshot:
             },
         )
         assert response.status_code == 403
+
+    @patch("qdash.api.services.flow_service.FlowService.re_execute_from_snapshot")
+    def test_re_execute_allows_editor_for_own_execution(
+        self,
+        mock_re_execute: AsyncMock,
+        test_client: TestClient,
+        test_project: ProjectDocument,
+        editor_user: UserDocument,
+        editor_headers: dict[str, str],
+    ) -> None:
+        """Test editors can re-execute their own executions."""
+        execution = ExecutionHistoryDocument(
+            project_id="test_project",
+            execution_id="exec-editor",
+            name="test_flow",
+            status="completed",
+            chip_id="chip-1",
+            username="editor_user",
+            tags=["test"],
+            note={},
+            calib_data_path="/tmp/calib",
+            message="completed",
+            system_info=SystemInfoModel(),
+            start_at=datetime.now(tz=timezone.utc),
+            end_at=datetime.now(tz=timezone.utc),
+            elapsed_time=10.0,
+        )
+        execution.insert()
+        mock_re_execute.return_value = {
+            "execution_id": "exec-new",
+            "flow_run_url": "http://prefect.local/runs/run-123",
+            "qdash_ui_url": "http://qdash.local/executions/exec-new",
+            "message": "Flow re-execution started",
+        }
+
+        response = test_client.post(
+            "/executions/exec-editor/re-execute",
+            headers=editor_headers,
+            json={
+                "flow_name": "test_flow",
+                "parameter_overrides": {},
+            },
+        )
+
+        assert response.status_code == 200
 
 
 class TestListExecutions:

--- a/ui/src/client/admin/admin.ts
+++ b/ui/src/client/admin/admin.ts
@@ -988,7 +988,7 @@ export function useListProjectMembersAdmin<
 }
 
 /**
- * Add a member to a project as viewer (admin only).
+ * Add a member to a project (admin only).
  * @summary Add member to project
  */
 export const addProjectMemberAdmin = (

--- a/ui/src/client/chip/chip.ts
+++ b/ui/src/client/chip/chip.ts
@@ -190,7 +190,7 @@ Parameters
 request : CreateChipRequest
     Chip creation request containing chip_id and size
 ctx : ProjectContext
-    Project context with owner permission
+    Project context with editor permission
 
 Returns
 -------

--- a/ui/src/client/task-result/task-result.ts
+++ b/ui/src/client/task-result/task-result.ts
@@ -1628,8 +1628,7 @@ export const useReExecuteTaskResult = <
  * Toggle the excluded flag on a task result.
 
 Excluded measurements are skipped when aggregating metrics for the
-dashboard / metrics screens. Raw data is preserved. Any project member
-can toggle exclusion; the most recent toggler is recorded.
+dashboard / metrics screens. Raw data is preserved.
  * @summary Toggle exclusion of a task result from metrics aggregations
  */
 export const setTaskResultExcluded = (

--- a/ui/src/components/features/admin/AdminPageContent.tsx
+++ b/ui/src/components/features/admin/AdminPageContent.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import type {
   UserListItem,
   SystemRole,
+  ProjectRole,
   ProjectListItem,
   MemberItem,
 } from "@/schemas";
@@ -180,12 +181,12 @@ export function AdminPageContent() {
     }
   };
 
-  const handleAddMember = async (username: string) => {
+  const handleAddMember = async (username: string, role: ProjectRole) => {
     if (!selectedProject) return;
 
     await addMemberMutation.mutateAsync({
       projectId: selectedProject.project_id,
-      data: { username },
+      data: { username, role },
     });
     queryClient.invalidateQueries({ queryKey: getListAllProjectsQueryKey() });
   };
@@ -1132,7 +1133,7 @@ function MembersModal({
   project: ProjectListItem;
   users: UserListItem[];
   onClose: () => void;
-  onAddMember: (username: string) => Promise<void>;
+  onAddMember: (username: string, role: ProjectRole) => Promise<void>;
   onRemoveMember: (username: string) => Promise<void>;
   isAddingMember: boolean;
   isRemovingMember: boolean;
@@ -1140,6 +1141,7 @@ function MembersModal({
 }) {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [selectedUsername, setSelectedUsername] = useState("");
+  const [selectedRole, setSelectedRole] = useState<ProjectRole>("viewer");
   const [removingUsername, setRemovingUsername] = useState<string | null>(null);
   const [localError, setLocalError] = useState<string | null>(null);
 
@@ -1166,8 +1168,9 @@ function MembersModal({
     }
 
     try {
-      await onAddMember(selectedUsername);
+      await onAddMember(selectedUsername, selectedRole);
       setSelectedUsername("");
+      setSelectedRole("viewer");
       setIsAddModalOpen(false);
       refetch();
     } catch {
@@ -1186,6 +1189,8 @@ function MembersModal({
     switch (role) {
       case "owner":
         return "badge-secondary";
+      case "editor":
+        return "badge-primary";
       case "viewer":
         return "badge-ghost";
       default:
@@ -1289,7 +1294,7 @@ function MembersModal({
         {isAddModalOpen && (
           <dialog className="modal modal-open" style={{ zIndex: 100 }}>
             <div className="modal-box">
-              <h3 className="font-bold text-lg mb-4">Add Member as Viewer</h3>
+              <h3 className="font-bold text-lg mb-4">Add Member</h3>
 
               {(localError || !!addMemberError) && (
                 <div className="alert alert-error mb-4">
@@ -1321,6 +1326,22 @@ function MembersModal({
                   </select>
                 </div>
 
+                <div className="form-control">
+                  <label className="label">
+                    <span className="label-text font-medium">Role</span>
+                  </label>
+                  <select
+                    className="select select-bordered ml-2"
+                    value={selectedRole}
+                    onChange={(e) =>
+                      setSelectedRole(e.target.value as ProjectRole)
+                    }
+                  >
+                    <option value="viewer">Viewer</option>
+                    <option value="editor">Editor</option>
+                  </select>
+                </div>
+
                 <div className="alert alert-info">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -1336,7 +1357,8 @@ function MembersModal({
                     ></path>
                   </svg>
                   <span className="text-sm">
-                    Members are added as viewers with read-only access.
+                    Viewers can read project data. Editors can also operate
+                    workflows, notes, chips, and calibration data.
                   </span>
                 </div>
               </div>
@@ -1356,7 +1378,7 @@ function MembersModal({
                   {isAddingMember ? (
                     <span className="loading loading-spinner loading-sm"></span>
                   ) : (
-                    "Add as Viewer"
+                    "Add Member"
                   )}
                 </button>
               </div>

--- a/ui/src/contexts/ProjectContext.tsx
+++ b/ui/src/contexts/ProjectContext.tsx
@@ -27,12 +27,22 @@ interface ProjectContextType {
   projectId: string | null;
   role: ProjectRole | null;
   isOwner: boolean;
+  isEditor: boolean;
   isViewer: boolean;
-  canEdit: boolean; // Only owner can edit (simplified permission model)
+  canEdit: boolean;
+  can: (permission: ProjectPermission) => boolean;
   loading: boolean;
   switchProject: (projectId: string) => void;
   refreshProjects: () => void;
 }
+
+type ProjectPermission = "read" | "write" | "admin";
+
+const ROLE_PERMISSIONS: Record<ProjectRole, ProjectPermission[]> = {
+  owner: ["read", "write", "admin"],
+  editor: ["read", "write"],
+  viewer: ["read"],
+};
 
 const ProjectContext = createContext<ProjectContextType | undefined>(undefined);
 
@@ -136,8 +146,14 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
   }, [refetch]);
 
   const isOwner = role === "owner";
+  const isEditor = role === "editor";
   const isViewer = role === "viewer";
-  const canEdit = isOwner; // Only owner can edit (simplified permission model)
+  const can = useCallback(
+    (permission: ProjectPermission) =>
+      role ? ROLE_PERMISSIONS[role].includes(permission) : false,
+    [role],
+  );
+  const canEdit = can("write");
 
   return (
     <ProjectContext.Provider
@@ -147,8 +163,10 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
         projectId,
         role,
         isOwner,
+        isEditor,
         isViewer,
         canEdit,
+        can,
         loading: isLoading,
         switchProject,
         refreshProjects,

--- a/ui/src/schemas/addMemberRequest.ts
+++ b/ui/src/schemas/addMemberRequest.ts
@@ -5,10 +5,12 @@
  * API for QDash
  * OpenAPI spec version: 0.0.1
  */
+import type { ProjectRole } from "./projectRole";
 
 /**
- * Request to add a member to a project (always as viewer).
+ * Request to add a member to a project.
  */
 export interface AddMemberRequest {
   username: string;
+  role?: ProjectRole;
 }

--- a/ui/src/schemas/projectRole.ts
+++ b/ui/src/schemas/projectRole.ts
@@ -9,14 +9,16 @@
 /**
  * Role of a member inside a project.
 
-Simplified model:
-- OWNER: Full access to project (read, write, admin)
-- VIEWER: Read-only access (for invited members)
+Roles intentionally stay coarse-grained:
+- OWNER: Project administration plus write access
+- EDITOR: Operational write access
+- VIEWER: Read-only access
  */
 export type ProjectRole = (typeof ProjectRole)[keyof typeof ProjectRole];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ProjectRole = {
   owner: "owner",
+  editor: "editor",
   viewer: "viewer",
 } as const;


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced role-based permissions for project members to enhance access control and functionality.
- This change impacts the API, allowing for more granular permission management among project members.

## Changes
- Added `EDITOR` role alongside `OWNER` and `VIEWER`.
- Updated member addition logic to accommodate different roles.
- Modified project context to reflect new permissions.
- Adjusted various API endpoints to utilize the new role-based permission system.

