### PR TITLE
feat(api): update project member management to restrict actions to owners

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -1179,7 +1179,7 @@
           "projects"
         ],
         "summary": "Invite a member",
-        "description": "Invite a user to the project. Admin only.",
+        "description": "Invite a user to the project. Owner only.",
         "operationId": "inviteProjectMember",
         "security": [
           {
@@ -1193,8 +1193,10 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "Project identifier",
               "title": "Project Id"
-            }
+            },
+            "description": "Project identifier"
           }
         ],
         "requestBody": {
@@ -1241,7 +1243,7 @@
           "projects"
         ],
         "summary": "Update member role",
-        "description": "Update a member's role. Admin only.",
+        "description": "Update a member's role. Owner only.",
         "operationId": "updateProjectMember",
         "security": [
           {
@@ -1250,15 +1252,6 @@
         ],
         "parameters": [
           {
-            "name": "project_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Project Id"
-            }
-          },
-          {
             "name": "username",
             "in": "path",
             "required": true,
@@ -1266,6 +1259,17 @@
               "type": "string",
               "title": "Username"
             }
+          },
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Project identifier",
+              "title": "Project Id"
+            },
+            "description": "Project identifier"
           }
         ],
         "requestBody": {
@@ -1310,7 +1314,7 @@
           "projects"
         ],
         "summary": "Remove member",
-        "description": "Remove a member from the project. Admin only.",
+        "description": "Remove a member from the project. Owner only.",
         "operationId": "removeProjectMember",
         "security": [
           {
@@ -1319,15 +1323,6 @@
         ],
         "parameters": [
           {
-            "name": "project_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Project Id"
-            }
-          },
-          {
             "name": "username",
             "in": "path",
             "required": true,
@@ -1335,6 +1330,17 @@
               "type": "string",
               "title": "Username"
             }
+          },
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Project identifier",
+              "title": "Project Id"
+            },
+            "description": "Project identifier"
           }
         ],
         "responses": {

--- a/src/qdash/api/routers/project.py
+++ b/src/qdash/api/routers/project.py
@@ -171,17 +171,16 @@ def list_members(
     operation_id="inviteProjectMember",
 )
 def invite_member(
-    project_id: str,
     invite_data: MemberInvite,
-    admin: Annotated[User, Depends(get_admin_user)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_owner_from_path)],
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> MemberResponse:
-    """Invite a user to the project. Admin only."""
+    """Invite a user to the project. Owner only."""
     membership = service.invite_member(
-        project_id=project_id,
+        project_id=ctx.project_id,
         username=invite_data.username,
         role=invite_data.role,
-        admin_username=admin.username,
+        admin_username=ctx.user.username,
     )
     return ProjectService.to_member_response(membership)
 
@@ -193,15 +192,14 @@ def invite_member(
     operation_id="updateProjectMember",
 )
 def update_member(
-    project_id: str,
     username: str,
     update_data: MemberUpdate,
-    admin: Annotated[User, Depends(get_admin_user)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_owner_from_path)],
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> MemberResponse:
-    """Update a member's role. Admin only."""
+    """Update a member's role. Owner only."""
     membership = service.update_member(
-        project_id=project_id,
+        project_id=ctx.project_id,
         username=username,
         role=update_data.role,
     )
@@ -215,16 +213,15 @@ def update_member(
     operation_id="removeProjectMember",
 )
 def remove_member(
-    project_id: str,
     username: str,
-    admin: Annotated[User, Depends(get_admin_user)],
+    ctx: Annotated[ProjectContext, Depends(get_project_context_owner_from_path)],
     service: Annotated[ProjectService, Depends(get_project_service)],
 ) -> None:
-    """Remove a member from the project. Admin only."""
+    """Remove a member from the project. Owner only."""
     service.remove_member(
-        project_id=project_id,
+        project_id=ctx.project_id,
         username=username,
-        admin_username=admin.username,
+        admin_username=ctx.user.username,
     )
 
 

--- a/src/qdash/api/services/project_service.py
+++ b/src/qdash/api/services/project_service.py
@@ -283,6 +283,12 @@ class ProjectService:
                 detail=f"Project '{project_id}' not found",
             )
 
+        if role == ProjectRole.OWNER:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Use ownership transfer to assign the owner role",
+            )
+
         target_user = self._user_repo.find_one({"username": username})
         if not target_user:
             raise HTTPException(
@@ -356,6 +362,12 @@ class ProjectService:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Cannot change the owner's role",
+            )
+
+        if role == ProjectRole.OWNER:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Use ownership transfer to assign the owner role",
             )
 
         membership = self._membership_repo.find_one(

--- a/tests/qdash/api/routers/test_project_members.py
+++ b/tests/qdash/api/routers/test_project_members.py
@@ -1,0 +1,131 @@
+"""Tests for project member management endpoints."""
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from pymongo.database import Database as PyMongoDatabase
+from qdash.datamodel.project import ProjectRole
+from qdash.datamodel.system_info import SystemInfoModel
+from qdash.dbmodel.project import ProjectDocument
+from qdash.dbmodel.project_membership import ProjectMembershipDocument
+from qdash.dbmodel.user import UserDocument
+
+
+@pytest.fixture
+def project_with_members(init_db: PyMongoDatabase[Any]) -> ProjectDocument:
+    """Create a project with owner, editor, viewer, and candidate users."""
+    users = [
+        ("owner", "owner-token"),
+        ("editor", "editor-token"),
+        ("viewer", "viewer-token"),
+        ("candidate", "candidate-token"),
+    ]
+    for username, token in users:
+        UserDocument(
+            username=username,
+            hashed_password="hashed",
+            access_token=token,
+            default_project_id="project-1",
+            system_info=SystemInfoModel(),
+        ).insert()
+
+    project = ProjectDocument(
+        project_id="project-1",
+        name="Project 1",
+        owner_username="owner",
+    )
+    project.insert()
+
+    for username, role in [
+        ("owner", ProjectRole.OWNER),
+        ("editor", ProjectRole.EDITOR),
+        ("viewer", ProjectRole.VIEWER),
+    ]:
+        ProjectMembershipDocument(
+            project_id="project-1",
+            username=username,
+            role=role,
+            status="active",
+            invited_by="owner",
+        ).insert()
+
+    return project
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_owner_can_invite_project_member_as_editor(
+    test_client: TestClient,
+    project_with_members: ProjectDocument,
+) -> None:
+    """Project owners can add editors to their project."""
+    response = test_client.post(
+        "/projects/project-1/members",
+        headers=_headers("owner-token"),
+        json={"username": "candidate", "role": "editor"},
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["username"] == "candidate"
+    assert data["role"] == "editor"
+
+
+def test_owner_cannot_invite_member_as_owner(
+    test_client: TestClient,
+    project_with_members: ProjectDocument,
+) -> None:
+    """Owner role assignment must use ownership transfer."""
+    response = test_client.post(
+        "/projects/project-1/members",
+        headers=_headers("owner-token"),
+        json={"username": "candidate", "role": "owner"},
+    )
+
+    assert response.status_code == 400
+    assert "ownership transfer" in response.json()["detail"]
+
+
+def test_owner_can_update_viewer_to_editor(
+    test_client: TestClient,
+    project_with_members: ProjectDocument,
+) -> None:
+    """Project owners can change non-owner members between viewer and editor."""
+    response = test_client.patch(
+        "/projects/project-1/members/viewer",
+        headers=_headers("owner-token"),
+        json={"role": "editor"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["role"] == "editor"
+
+
+def test_editor_cannot_update_project_member_role(
+    test_client: TestClient,
+    project_with_members: ProjectDocument,
+) -> None:
+    """Editors cannot manage project membership."""
+    response = test_client.patch(
+        "/projects/project-1/members/viewer",
+        headers=_headers("editor-token"),
+        json={"role": "editor"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_owner_can_remove_project_member(
+    test_client: TestClient,
+    project_with_members: ProjectDocument,
+) -> None:
+    """Project owners can remove non-owner members."""
+    response = test_client.delete(
+        "/projects/project-1/members/viewer",
+        headers=_headers("owner-token"),
+    )
+
+    assert response.status_code == 204

--- a/ui/src/app/(auth)/settings/page.tsx
+++ b/ui/src/app/(auth)/settings/page.tsx
@@ -2,22 +2,45 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Cpu } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useTheme } from "@/contexts/ThemeContext";
 import { PasswordChangeCard } from "@/components/features/settings/PasswordChangeCard";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { useAuth } from "@/contexts/AuthContext";
+import { useProject } from "@/contexts/ProjectContext";
 import { AVAILABLE_THEMES, DEV_THEMES } from "@/constants/themes";
 import { useGetCopilotConfig } from "@/client/copilot/copilot";
+import {
+  getListProjectMembersQueryKey,
+  useInviteProjectMember,
+  useListProjectMembers,
+  useRemoveProjectMember,
+  useUpdateProjectMember,
+} from "@/client/projects/projects";
 import {
   buildAnalysisModelOptions,
   getStoredAnalysisModelKey,
   resolveAnalysisModelOption,
   setStoredAnalysisModelKey,
 } from "@/lib/copilotModels";
+import type { MemberResponse, ProjectRole } from "@/schemas";
 
-type Tab = "appearance" | "copilot" | "account" | "api";
+type Tab = "appearance" | "project" | "copilot" | "account" | "api";
+
+const editableProjectRoles: ProjectRole[] = ["viewer", "editor"];
+
+function roleBadgeClass(role: ProjectRole) {
+  if (role === "owner") return "badge-secondary";
+  if (role === "editor") return "badge-primary";
+  return "badge-ghost";
+}
+
+function mutationErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return "Failed to update project members";
+}
 
 function CopilotSettingsPanel() {
   const [selectedModelKey, setSelectedModelKey] = useState(
@@ -88,6 +111,265 @@ function CopilotSettingsPanel() {
   );
 }
 
+function ProjectMembersPanel() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { currentProject, projectId, isOwner } = useProject();
+  const [inviteUsername, setInviteUsername] = useState("");
+  const [inviteRole, setInviteRole] = useState<ProjectRole>("viewer");
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const membersQuery = useListProjectMembers(projectId ?? "", {
+    query: {
+      enabled: !!projectId,
+      retry: false,
+    },
+  });
+  const inviteMutation = useInviteProjectMember();
+  const updateMutation = useUpdateProjectMember();
+  const removeMutation = useRemoveProjectMember();
+  const members = membersQuery.data?.data.members ?? [];
+  const isMutating =
+    inviteMutation.isPending ||
+    updateMutation.isPending ||
+    removeMutation.isPending;
+  const memberError =
+    localError ||
+    (inviteMutation.error || updateMutation.error || removeMutation.error
+      ? mutationErrorMessage(
+          inviteMutation.error || updateMutation.error || removeMutation.error,
+        )
+      : null);
+
+  const refreshMembers = () => {
+    if (!projectId) return;
+    queryClient.invalidateQueries({
+      queryKey: getListProjectMembersQueryKey(projectId),
+    });
+  };
+
+  const handleInvite = async () => {
+    if (!projectId) return;
+    const username = inviteUsername.trim();
+    if (!username) {
+      setLocalError("Enter a username.");
+      return;
+    }
+    setLocalError(null);
+    try {
+      await inviteMutation.mutateAsync({
+        projectId,
+        data: { username, role: inviteRole },
+      });
+      setInviteUsername("");
+      setInviteRole("viewer");
+      refreshMembers();
+    } catch {
+      // The mutation error is rendered from TanStack Query state.
+    }
+  };
+
+  const handleRoleChange = async (
+    member: MemberResponse,
+    role: ProjectRole,
+  ) => {
+    if (!projectId || member.role === role) return;
+    setLocalError(null);
+    try {
+      await updateMutation.mutateAsync({
+        projectId,
+        username: member.username,
+        data: { role },
+      });
+      refreshMembers();
+    } catch {
+      // The mutation error is rendered from TanStack Query state.
+    }
+  };
+
+  const handleRemove = async (member: MemberResponse) => {
+    if (!projectId) return;
+    setLocalError(null);
+    try {
+      await removeMutation.mutateAsync({
+        projectId,
+        username: member.username,
+      });
+      refreshMembers();
+    } catch {
+      // The mutation error is rendered from TanStack Query state.
+    }
+  };
+
+  return (
+    <div className="space-y-4" key="project">
+      <div className="card bg-base-200 shadow-lg">
+        <div className="card-body">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="card-title text-xl">Project Members</h2>
+              <p className="text-sm text-base-content/60">
+                {currentProject?.name ?? "Current project"}
+              </p>
+            </div>
+            <div
+              className={`badge ${isOwner ? "badge-secondary" : "badge-ghost"} w-fit`}
+            >
+              {isOwner ? "Owner controls" : "Read only"}
+            </div>
+          </div>
+
+          {!isOwner && (
+            <div className="alert alert-info mt-4">
+              <span>
+                Only the project owner can invite members, remove members, or
+                change Viewer and Editor roles.
+              </span>
+            </div>
+          )}
+
+          {isOwner && (
+            <div className="mt-4 grid gap-3 rounded-lg bg-base-100 p-4 md:grid-cols-[1fr_160px_auto]">
+              <input
+                className="input input-bordered w-full"
+                value={inviteUsername}
+                onChange={(event) => setInviteUsername(event.target.value)}
+                placeholder="Username"
+              />
+              <select
+                className="select select-bordered w-full"
+                value={inviteRole}
+                onChange={(event) =>
+                  setInviteRole(event.target.value as ProjectRole)
+                }
+              >
+                <option value="viewer">Viewer</option>
+                <option value="editor">Editor</option>
+              </select>
+              <button
+                className="btn btn-primary"
+                onClick={handleInvite}
+                disabled={isMutating || !inviteUsername.trim()}
+              >
+                Add Member
+              </button>
+            </div>
+          )}
+
+          {memberError && (
+            <div className="alert alert-error mt-4">
+              <span>{memberError}</span>
+            </div>
+          )}
+
+          <div className="mt-4 overflow-x-auto rounded-lg border border-base-300 bg-base-100">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Username</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                  <th className="text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {membersQuery.isLoading ? (
+                  <tr>
+                    <td colSpan={4} className="py-8 text-center">
+                      <span className="loading loading-spinner" />
+                    </td>
+                  </tr>
+                ) : members.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={4}
+                      className="py-8 text-center text-base-content/60"
+                    >
+                      No members found
+                    </td>
+                  </tr>
+                ) : (
+                  members.map((member) => {
+                    const isProjectOwner = member.role === "owner";
+                    const isCurrentUser = member.username === user?.username;
+                    return (
+                      <tr key={member.username}>
+                        <td className="font-mono">{member.username}</td>
+                        <td>
+                          {isOwner && !isProjectOwner ? (
+                            <select
+                              className="select select-bordered select-sm w-32"
+                              value={member.role}
+                              disabled={isMutating}
+                              onChange={(event) =>
+                                handleRoleChange(
+                                  member,
+                                  event.target.value as ProjectRole,
+                                )
+                              }
+                            >
+                              {editableProjectRoles.map((role) => (
+                                <option key={role} value={role}>
+                                  {role.charAt(0).toUpperCase() + role.slice(1)}
+                                </option>
+                              ))}
+                            </select>
+                          ) : (
+                            <span
+                              className={`badge ${roleBadgeClass(member.role)}`}
+                            >
+                              {member.role}
+                            </span>
+                          )}
+                        </td>
+                        <td>
+                          <span className="badge badge-ghost">
+                            {member.status}
+                          </span>
+                        </td>
+                        <td className="text-right">
+                          {isOwner && !isProjectOwner ? (
+                            <button
+                              className="btn btn-error btn-ghost btn-sm"
+                              disabled={isMutating || isCurrentUser}
+                              onClick={() => handleRemove(member)}
+                            >
+                              Remove
+                            </button>
+                          ) : (
+                            <span className="text-xs text-base-content/50">
+                              {isProjectOwner ? "Owner" : "-"}
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mt-3 grid gap-2 text-sm text-base-content/60 md:grid-cols-3">
+            <p>
+              <span className="font-medium text-base-content">Viewer</span> can
+              read project data.
+            </p>
+            <p>
+              <span className="font-medium text-base-content">Editor</span> can
+              run workflows and update operational data.
+            </p>
+            <p>
+              <span className="font-medium text-base-content">Owner</span>{" "}
+              manages project settings and membership.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   const { theme, setTheme, isDevEnv } = useTheme();
   const { accessToken, user } = useAuth();
@@ -135,6 +417,12 @@ export default function SettingsPage() {
             onClick={() => setActiveTab("appearance")}
           >
             Appearance
+          </a>
+          <a
+            className={`tab ${activeTab === "project" ? "tab-active" : ""}`}
+            onClick={() => setActiveTab("project")}
+          >
+            Project
           </a>
           <a
             className={`tab ${activeTab === "copilot" ? "tab-active" : ""}`}
@@ -282,6 +570,8 @@ export default function SettingsPage() {
                 </div>
               </div>
             </div>
+          ) : activeTab === "project" ? (
+            <ProjectMembersPanel />
           ) : activeTab === "copilot" ? (
             <CopilotSettingsPanel />
           ) : activeTab === "account" ? (

--- a/ui/src/client/projects/projects.ts
+++ b/ui/src/client/projects/projects.ts
@@ -740,7 +740,7 @@ export function useListProjectMembers<
 }
 
 /**
- * Invite a user to the project. Admin only.
+ * Invite a user to the project. Owner only.
  * @summary Invite a member
  */
 export const inviteProjectMember = (
@@ -833,7 +833,7 @@ export const useInviteProjectMember = <
   return useMutation(mutationOptions, queryClient);
 };
 /**
- * Update a member's role. Admin only.
+ * Update a member's role. Owner only.
  * @summary Update member role
  */
 export const updateProjectMember = (
@@ -925,7 +925,7 @@ export const useUpdateProjectMember = <
   return useMutation(mutationOptions, queryClient);
 };
 /**
- * Remove a member from the project. Admin only.
+ * Remove a member from the project. Owner only.
  * @summary Remove member
  */
 export const removeProjectMember = (


### PR DESCRIPTION
<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
- N/A

## Summary
- Updated project member management to restrict actions such as inviting, updating, and removing members to project owners only. This change enhances security and ensures that only authorized users can manage project memberships.

## Changes
- Changed API and internal logic to enforce owner-only restrictions for inviting, updating, and removing project members.
- Updated relevant documentation and tests to reflect the new ownership requirements. 
- Added tests to verify that only owners can perform membership management actions.

