### PR TITLE
feat(api, ui): add image upload functionality for forum posts

### DIFF
--- a/src/qdash/api/main.py
+++ b/src/qdash/api/main.py
@@ -100,6 +100,7 @@ app.include_router(execution.router, tags=["execution"])
 app.include_router(file.router, tags=["file"])
 app.include_router(copilot.public_router, prefix="/copilot", tags=["copilot"])
 app.include_router(issue.public_router, tags=["issue"])
+app.include_router(forum.public_router, tags=["forum"])
 
 # All other routers with global auth dependency
 auth_dependency = [Depends(get_current_active_user)]

--- a/src/qdash/api/routers/forum.py
+++ b/src/qdash/api/routers/forum.py
@@ -7,8 +7,8 @@ import logging
 from functools import partial
 from typing import TYPE_CHECKING, Annotated, Any
 
-from fastapi import APIRouter, Depends, Query
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, Query, UploadFile
+from fastapi.responses import FileResponse, StreamingResponse
 from qdash.api.dependencies import get_forum_service  # noqa: TCH002
 from qdash.api.lib.ai_labels import STATUS_LABELS as _AI_STATUS_LABELS
 from qdash.api.lib.ai_labels import TOOL_LABELS as _AI_TOOL_LABELS
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
 router = APIRouter()
+public_router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
@@ -214,6 +215,33 @@ def get_forum_post_replies(
 ) -> list[ForumPostResponse]:
     """List replies for a forum thread."""
     return service.get_replies(project_id=ctx.project_id, post_id=post_id, skip=skip, limit=limit)
+
+
+@router.post(
+    "/forum/upload-image",
+    summary="Upload an image for a forum post",
+    operation_id="uploadForumImage",
+    include_in_schema=False,
+)
+async def upload_forum_image(
+    file: UploadFile,
+    ctx: Annotated[ProjectContext, Depends(get_project_context)],
+) -> dict[str, str]:
+    """Upload an image to attach to a forum post. Returns the image URL."""
+    data = await file.read()
+    url = ForumService.upload_image(data, file.content_type or "")
+    return {"url": url}
+
+
+@public_router.get(
+    "/forum/images/{filename}",
+    summary="Serve a forum image",
+    include_in_schema=False,
+)
+def get_forum_image(filename: str) -> FileResponse:
+    """Serve an uploaded forum image."""
+    filepath, media_type = ForumService.get_image_path(filename)
+    return FileResponse(filepath, media_type=media_type)
 
 
 @router.post("/forum/posts/{post_id}/ai-reply/stream", include_in_schema=False)

--- a/src/qdash/api/services/forum_service.py
+++ b/src/qdash/api/services/forum_service.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import logging
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from bson import ObjectId
 from bunnet import SortDirection
@@ -16,6 +18,7 @@ from qdash.api.schemas.forum import (
     ListForumPostsResponse,
 )
 from qdash.api.schemas.success import SuccessResponse
+from qdash.common.paths import CALIB_DATA_BASE
 from qdash.datamodel.project import ProjectRole
 from qdash.dbmodel.forum import ForumCategoryDocument, ForumPostDocument
 from qdash.dbmodel.user import UserDocument
@@ -68,6 +71,21 @@ DEFAULT_FORUM_CATEGORIES = [
 ]
 
 CATEGORY_KEY_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+FORUM_IMAGE_DIR = CALIB_DATA_BASE / "forum"
+ALLOWED_CONTENT_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+}
+CONTENT_TYPE_TO_EXT: dict[str, str] = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+MAX_IMAGE_SIZE = 5 * 1024 * 1024
+FILENAME_PATTERN = re.compile(r"^[0-9a-f\-]{36}\.(png|jpg|gif|webp)$")
 logger = logging.getLogger(__name__)
 
 
@@ -536,6 +554,50 @@ class ForumService:
         )
         ai_doc.insert()
         return self._to_response(ai_doc)
+
+    @staticmethod
+    def upload_image(data: bytes, content_type: str) -> str:
+        """Validate and save an uploaded forum image."""
+        if content_type not in ALLOWED_CONTENT_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unsupported image type: {content_type}. " "Allowed: png, jpeg, gif, webp"
+                ),
+            )
+
+        if len(data) > MAX_IMAGE_SIZE:
+            raise HTTPException(status_code=400, detail="Image exceeds 5MB size limit")
+
+        ext = CONTENT_TYPE_TO_EXT[content_type]
+        filename = f"{uuid4()}{ext}"
+        dest = FORUM_IMAGE_DIR / filename
+
+        FORUM_IMAGE_DIR.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+
+        return f"/api/forum/images/{filename}"
+
+    @staticmethod
+    def get_image_path(filename: str) -> tuple[Path, str]:
+        """Resolve and validate a forum image filename."""
+        if not FILENAME_PATTERN.match(filename):
+            raise HTTPException(status_code=400, detail="Invalid filename")
+
+        filepath = FORUM_IMAGE_DIR / filename
+        if not filepath.is_file():
+            raise HTTPException(status_code=404, detail="Image not found")
+
+        ext = Path(filename).suffix.lstrip(".")
+        media_types = {
+            "png": "image/png",
+            "jpg": "image/jpeg",
+            "gif": "image/gif",
+            "webp": "image/webp",
+        }
+        media_type = media_types.get(ext, "application/octet-stream")
+
+        return filepath, media_type
 
     def update_post(
         self,

--- a/tests/qdash/api/routers/test_forum.py
+++ b/tests/qdash/api/routers/test_forum.py
@@ -1,5 +1,6 @@
 """Tests for forum router endpoints."""
 
+from qdash.api.services import forum_service
 from qdash.datamodel.project import ProjectRole
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.notification import NotificationDocument
@@ -256,3 +257,24 @@ def test_close_forum_thread_requires_author_or_owner(test_client, init_db):
     response = test_client.patch(f"/forum/posts/{root_id}/close", headers=_headers("member_token"))
 
     assert response.status_code == 403
+
+
+def test_upload_and_serve_forum_image(test_client, init_db, tmp_path, monkeypatch):
+    """Forum images can be uploaded by members and served for markdown rendering."""
+    monkeypatch.setattr(forum_service, "FORUM_IMAGE_DIR", tmp_path / "forum")
+    _create_user("owner", "owner_token", ProjectRole.OWNER)
+    _create_project()
+
+    upload = test_client.post(
+        "/forum/upload-image",
+        headers=_headers("owner_token"),
+        files={"file": ("image.png", b"\x89PNG\r\n\x1a\n", "image/png")},
+    )
+
+    assert upload.status_code == 200
+    url = upload.json()["url"]
+    assert url.startswith("/api/forum/images/")
+
+    image = test_client.get(url.removeprefix("/api"))
+    assert image.status_code == 200
+    assert image.headers["content-type"] == "image/png"

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -33,6 +33,7 @@ import { QdashBotAvatar, UserAvatar } from "@/components/ui/UserAvatar";
 import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
 import { useForumAiReply } from "@/hooks/useForumAiReply";
+import { useImageUpload } from "@/hooks/useImageUpload";
 import { formatRelativeTime } from "@/lib/utils/datetime";
 import type { ForumPostResponse } from "@/schemas";
 
@@ -60,6 +61,7 @@ function PostBody({
   onCancel,
   onSave,
   saving,
+  onImageUpload,
 }: {
   post: ForumPostResponse;
   currentUsername?: string;
@@ -73,6 +75,7 @@ function PostBody({
   onCancel: () => void;
   onSave: () => void;
   saving: boolean;
+  onImageUpload?: (file: File) => Promise<string>;
 }) {
   const canEdit = currentUsername === post.username;
   const isAi = post.is_ai_reply || post.username === "qdash";
@@ -143,6 +146,7 @@ function PostBody({
             onSubmit={onSave}
             rows={4}
             placeholder="Edit post..."
+            onImageUpload={onImageUpload}
           />
           <div className="flex justify-end gap-2">
             <button className="btn btn-ghost btn-sm" onClick={onCancel}>
@@ -176,6 +180,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const { isOwner, projectId } = useProject();
+  const { uploadImage } = useImageUpload("forum");
   const currentUsername = user?.username;
   const [replyText, setReplyText] = useState("");
   const [editingRoot, setEditingRoot] = useState(false);
@@ -406,6 +411,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
         onCancel={() => setEditingRoot(false)}
         onSave={handleSaveRoot}
         saving={updateMutation.isPending}
+        onImageUpload={uploadImage}
       />
 
       <div className="divider text-xs text-base-content/40">
@@ -433,6 +439,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                 onCancel={() => setEditingReplyId(null)}
                 onSave={handleSaveReply}
                 saving={updateMutation.isPending}
+                onImageUpload={uploadImage}
               />
             ))}
             {replies.length >= replyLimit && (
@@ -481,6 +488,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
             submitLabel="Reply"
             isSubmitting={createMutation.isPending}
             mentionCandidates={mentionCandidates}
+            onImageUpload={uploadImage}
           />
         )}
       </div>

--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -34,6 +34,7 @@ import { UserAvatar } from "@/components/ui/UserAvatar";
 import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
 import { useForumAiReply } from "@/hooks/useForumAiReply";
+import { useImageUpload } from "@/hooks/useImageUpload";
 import { formatRelativeTime } from "@/lib/utils/datetime";
 import type { ForumPostResponse, ListForumPostsParams } from "@/schemas";
 
@@ -154,6 +155,7 @@ export function ForumPageContent() {
   const [categoryDescription, setCategoryDescription] = useState("");
   const [categoryColor, setCategoryColor] = useState("neutral");
   const [categoryIcon, setCategoryIcon] = useState("message-square");
+  const { uploadImage } = useImageUpload("forum");
 
   const params: ListForumPostsParams = {
     skip,
@@ -516,6 +518,7 @@ export function ForumPageContent() {
               submitLabel="Post"
               isSubmitting={createMutation.isPending}
               mentionCandidates={mentionCandidates}
+              onImageUpload={uploadImage}
             />
           </div>
         </div>

--- a/ui/src/hooks/useImageUpload.ts
+++ b/ui/src/hooks/useImageUpload.ts
@@ -3,7 +3,14 @@
 import { useState, useCallback } from "react";
 import { AXIOS_INSTANCE } from "@/lib/api/custom-instance";
 
-export function useImageUpload() {
+type ImageUploadTarget = "issues" | "forum";
+
+const UPLOAD_PATHS: Record<ImageUploadTarget, string> = {
+  issues: "/issues/upload-image",
+  forum: "/forum/upload-image",
+};
+
+export function useImageUpload(target: ImageUploadTarget = "issues") {
   const [isUploading, setIsUploading] = useState(false);
 
   const uploadImage = useCallback(async (file: File): Promise<string> => {
@@ -12,14 +19,14 @@ export function useImageUpload() {
       const formData = new FormData();
       formData.append("file", file);
       const response = await AXIOS_INSTANCE.post<{ url: string }>(
-        "/issues/upload-image",
+        UPLOAD_PATHS[target],
         formData,
       );
       return response.data.url;
     } finally {
       setIsUploading(false);
     }
-  }, []);
+  }, [target]);
 
   return { uploadImage, isUploading };
 }

--- a/ui/src/hooks/useImageUpload.ts
+++ b/ui/src/hooks/useImageUpload.ts
@@ -13,20 +13,23 @@ const UPLOAD_PATHS: Record<ImageUploadTarget, string> = {
 export function useImageUpload(target: ImageUploadTarget = "issues") {
   const [isUploading, setIsUploading] = useState(false);
 
-  const uploadImage = useCallback(async (file: File): Promise<string> => {
-    setIsUploading(true);
-    try {
-      const formData = new FormData();
-      formData.append("file", file);
-      const response = await AXIOS_INSTANCE.post<{ url: string }>(
-        UPLOAD_PATHS[target],
-        formData,
-      );
-      return response.data.url;
-    } finally {
-      setIsUploading(false);
-    }
-  }, [target]);
+  const uploadImage = useCallback(
+    async (file: File): Promise<string> => {
+      setIsUploading(true);
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+        const response = await AXIOS_INSTANCE.post<{ url: string }>(
+          UPLOAD_PATHS[target],
+          formData,
+        );
+        return response.data.url;
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [target],
+  );
 
   return { uploadImage, isUploading };
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced image upload functionality for forum posts to enhance user engagement and content sharing.
- This change impacts the API and UI, allowing users to upload images directly to forum posts.

## Changes
- Added a new API endpoint for uploading images to forum posts.
- Implemented image serving functionality for uploaded images.
- Updated the UI components to support image uploads in forum posts. 
- Enhanced the `useImageUpload` hook to accommodate the new upload path for forum images.

