### PR TITLE
feat(workflow): add ConfigureAll task for box configuration

### DIFF
--- a/config/backend.yaml
+++ b/config/backend.yaml
@@ -29,6 +29,7 @@ backends:
     tasks:
       # Box Setup
       - Configure
+      - ConfigureAll
       - LinkUp
       - CheckStatus
       - CheckNoise
@@ -111,6 +112,7 @@ backends:
 categories:
   "Box Setup":
     - Configure
+    - ConfigureAll
     - LinkUp
     - CheckStatus
     - CheckNoise

--- a/src/qdash/datamodel/task_knowledge.py
+++ b/src/qdash/datamodel/task_knowledge.py
@@ -415,6 +415,7 @@ _CATEGORIES: list[tuple[str, str, list[str]]] = [
             "DumpBox",
             "CheckNoise",
             "Configure",
+            "ConfigureAll",
             "ReadoutConfigure",
         ],
     ),

--- a/src/qdash/workflow/calibtasks/qubex/__init__.py
+++ b/src/qdash/workflow/calibtasks/qubex/__init__.py
@@ -19,6 +19,7 @@ from qdash.workflow.calibtasks.qubex.benchmark.zx90_interleaved_randoized_benchm
 from qdash.workflow.calibtasks.qubex.box_setup.check_noise import CheckNoise
 from qdash.workflow.calibtasks.qubex.box_setup.check_status import CheckStatus
 from qdash.workflow.calibtasks.qubex.box_setup.configure import Configure
+from qdash.workflow.calibtasks.qubex.box_setup.configure_all import ConfigureAll
 from qdash.workflow.calibtasks.qubex.box_setup.dump_box import DumpBox
 from qdash.workflow.calibtasks.qubex.box_setup.link_up import LinkUp
 from qdash.workflow.calibtasks.qubex.box_setup.readout_configure import ReadoutConfigure
@@ -84,6 +85,7 @@ __all__ = [
     "CheckNoise",
     "CheckStatus",
     "Configure",
+    "ConfigureAll",
     "ReadoutConfigure",
     "DumpBox",
     "LinkUp",

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/configure_all.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/configure_all.py
@@ -1,0 +1,66 @@
+from typing import ClassVar
+
+from qdash.datamodel.task import ParameterModel, RunParameterModel
+from qdash.workflow.calibtasks.base import (
+    PostProcessResult,
+    RunResult,
+)
+from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.engine.backend.qubex import QubexBackend
+from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
+
+
+class ConfigureAll(QubexTask):
+    """Task to configure all boxes for the selected MUXes."""
+
+    name: str = "ConfigureAll"
+    task_type: str = "system"
+    input_parameters: ClassVar[dict[str, ParameterModel | None]] = {}
+    run_parameters: ClassVar[dict[str, RunParameterModel]] = {
+        "mux_ids": RunParameterModel(
+            unit="a.u.",
+            value_type="list",
+            value=[],
+            description="List of MUX IDs to configure",
+        ),
+    }
+    output_parameters: ClassVar[dict[str, ParameterModel]] = {}
+
+    def postprocess(
+        self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
+    ) -> PostProcessResult:
+        return PostProcessResult(output_parameters={})
+
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
+        from qubex import Experiment
+
+        chip_id = backend.config.get("chip_id")
+        if chip_id is None:
+            msg = "chip_id must be provided to run ConfigureAll"
+            raise ValueError(msg)
+
+        mux_ids = self.run_parameters["mux_ids"].get_value()
+        if mux_ids is None:
+            mux_ids = []
+        mux_ids = list(mux_ids)
+
+        qubex_paths = get_qubex_paths()
+        config_dir = backend.config.get("config_dir", str(qubex_paths.config_dir(chip_id)))
+        params_dir = backend.config.get("params_dir", str(qubex_paths.params_dir(chip_id)))
+
+        print(f"[ConfigureAll] Loading system_manager for mux_ids={mux_ids}")
+        exp = Experiment(
+            chip_id=chip_id,
+            muxes=mux_ids,
+            config_dir=config_dir,
+            params_dir=params_dir,
+        )
+        exp.system_manager.load(
+            chip_id=exp.chip_id,
+            config_dir=exp.config_path,
+            params_dir=exp.params_path,
+        )
+        print(f"[ConfigureAll] Pushing system_manager (box_ids={exp.box_ids})")
+        exp.system_manager.push(box_ids=exp.box_ids, confirm=False)
+        print("[ConfigureAll] Done")
+        return RunResult(raw_result={"mux_ids": mux_ids, "box_ids": exp.box_ids})

--- a/src/qdash/workflow/engine/task/backend_saver.py
+++ b/src/qdash/workflow/engine/task/backend_saver.py
@@ -165,6 +165,7 @@ class BackendSaver:
 
         # Always update calibration note regardless of success/failure
         if backend.name == "qubex":
+            note_qid = qid if task.is_qubit_task() or task.is_coupling_task() else None
             backend.update_note(
                 username=self._username,
                 chip_id=execution_service.chip_id,
@@ -172,7 +173,7 @@ class BackendSaver:
                 execution_id=execution_service.execution_id,
                 task_manager_id=self._task_manager_id,
                 project_id=execution_service.project_id,
-                qid=qid,
+                qid=note_qid,
             )
 
         # Always save to database (even on R² failure)

--- a/src/qdash/workflow/engine/task_runner.py
+++ b/src/qdash/workflow/engine/task_runner.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from prefect import get_run_logger, task
 from qdash.dbmodel.initialize import initialize
+
+CACHE_POLICY_NO_CACHE: Any = None
+try:
+    from prefect.cache_policies import NO_CACHE
+except ModuleNotFoundError:
+    pass
+else:
+    CACHE_POLICY_NO_CACHE = NO_CACHE
 
 if TYPE_CHECKING:
     from qdash.workflow.calibtasks.base import BaseTask
@@ -52,7 +60,7 @@ def validate_task_name(
 initialize()
 
 
-@task(name="execute-dynamic-task-service")
+@task(name="execute-dynamic-task-service", cache_policy=CACHE_POLICY_NO_CACHE)
 def execute_dynamic_task_by_qid_service(
     backend: BaseBackend,
     execution_service: ExecutionService,
@@ -90,7 +98,7 @@ def execute_dynamic_task_by_qid_service(
     return execution_service, task_context
 
 
-@task(name="execute-dynamic-task-batch-service")
+@task(name="execute-dynamic-task-batch-service", cache_policy=CACHE_POLICY_NO_CACHE)
 def execute_dynamic_task_batch_service(
     backend: BaseBackend,
     execution_service: ExecutionService,

--- a/src/qdash/workflow/service/__init__.py
+++ b/src/qdash/workflow/service/__init__.py
@@ -67,6 +67,7 @@ from qdash.workflow.service.session_context import (
 from qdash.workflow.service.steps import (
     CalibrationStep,
     CheckSkew,
+    ConfigureAll,
     CustomOneQubit,
     CustomTwoQubit,
     FilterByMetric,
@@ -112,6 +113,7 @@ __all__ = [
     "Pipeline",
     "OneQubitCheck",
     "OneQubitFineTune",
+    "ConfigureAll",
     "CustomOneQubit",
     "CustomTwoQubit",
     "FilterByMetric",

--- a/src/qdash/workflow/service/steps/__init__.py
+++ b/src/qdash/workflow/service/steps/__init__.py
@@ -37,6 +37,11 @@ from qdash.workflow.service.steps.base import (
     TransformStep,
 )
 
+# Box setup steps
+from qdash.workflow.service.steps.box_setup import (
+    ConfigureAll,
+)
+
 # MUX-level bring-up steps
 from qdash.workflow.service.steps.bringup import (
     BringUp,
@@ -75,6 +80,8 @@ __all__ = [
     "Step",
     "CalibrationStep",
     "TransformStep",
+    # Box setup steps
+    "ConfigureAll",
     # Context and Pipeline
     "StepContext",
     "Pipeline",

--- a/src/qdash/workflow/service/steps/box_setup.py
+++ b/src/qdash/workflow/service/steps/box_setup.py
@@ -1,0 +1,87 @@
+"""Box setup steps for calibration pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from prefect import get_run_logger
+from qdash.workflow.service.steps.base import CalibrationStep
+from qdash.workflow.service.targets import MuxTargets
+
+if TYPE_CHECKING:
+    from qdash.workflow.service.calib_service import CalibService
+    from qdash.workflow.service.steps.pipeline import StepContext
+    from qdash.workflow.service.targets import Target
+
+
+@dataclass
+class ConfigureAll(CalibrationStep):
+    """Configure all boxes for the selected MUXes once as a pipeline step."""
+
+    mux_ids: list[int] | None = None
+
+    @property
+    def name(self) -> str:
+        return "configure_all"
+
+    @property
+    def provides(self) -> set[str]:
+        return {"configure_all"}
+
+    def execute(
+        self,
+        service: CalibService,
+        targets: Target,
+        ctx: StepContext,
+    ) -> StepContext:
+        logger = get_run_logger()
+        mux_ids = self._resolve_mux_ids(service, targets)
+
+        logger.info(f"[{self.name}] Configuring boxes for {len(mux_ids)} MUXes")
+        owns_session = not service._initialized
+        if owns_session:
+            service._initialize([])
+
+        try:
+            raw_result = service.execute_task(
+                "ConfigureAll",
+                qid="",
+                task_details={
+                    "ConfigureAll": {
+                        "run_parameters": {
+                            "mux_ids": {
+                                "value": mux_ids,
+                                "value_type": "list",
+                            },
+                        },
+                    },
+                },
+            )
+            ctx.metadata[self.name] = raw_result
+            if owns_session:
+                service.finish_calibration()
+        except BaseException as e:
+            from qdash.workflow.service.calib_service import _is_cancellation
+
+            if owns_session:
+                if _is_cancellation(e):
+                    logger.info(f"[{self.name}] Cancelled")
+                    service.cancel_calibration()
+                else:
+                    logger.error(f"[{self.name}] Failed: {e}")
+                    service.fail_calibration(str(e))
+            raise
+
+        logger.info(f"[{self.name}] Completed")
+        return ctx
+
+    def _resolve_mux_ids(self, service: CalibService, targets: Target) -> list[int]:
+        if self.mux_ids is not None:
+            return list(self.mux_ids)
+        if isinstance(targets, MuxTargets):
+            return list(targets.mux_ids)
+        if service.muxes is not None:
+            return list(service.muxes)
+        qids = targets.to_qids(service.chip_id)
+        return sorted({int(qid) // 4 for qid in qids})


### PR DESCRIPTION
<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
- N/A

## Summary
- Introduced a new task, `ConfigureAll`, to streamline the configuration of all boxes for selected MUXes. This enhances the workflow by allowing batch configuration in a single step, reducing complexity and potential errors.

## Changes
- Added `ConfigureAll` task class to handle configuration for multiple MUXes.
- Updated workflow configurations to include the new task.
- Integrated `ConfigureAll` into existing calibration pipelines and service steps.

