### PR TITLE
fix(workflow): sync Qubex parameters before calibration

### DIFF
--- a/src/qdash/repository/calibration_note.py
+++ b/src/qdash/repository/calibration_note.py
@@ -240,6 +240,73 @@ class MongoCalibrationNoteRepository:
         )
         raise last_error  # type: ignore[misc]
 
+    def upsert_on_insert(
+        self, note: CalibrationNoteModel, max_retries: int = 3
+    ) -> CalibrationNoteModel:
+        """Create a calibration note if absent without replacing existing note content.
+
+        Workflow workers initialize the same master note in parallel. A normal
+        upsert would replace ``note`` wholesale and can erase fields that another
+        worker has already merged. This method only sets ``note`` on insert.
+        """
+        from pymongo import ReturnDocument
+
+        user_id = note.user_id or self._user_id_for_username(note.username)
+        query = {
+            "project_id": note.project_id,
+            "execution_id": note.execution_id,
+            "task_id": note.task_id,
+            "username": note.username,
+            "chip_id": note.chip_id,
+        }
+
+        timestamp = now()
+        update = {
+            "$set": {
+                "user_id": user_id,
+                "timestamp": timestamp,
+            },
+            "$inc": {"version": 1},
+            "$setOnInsert": {
+                "project_id": note.project_id,
+                "execution_id": note.execution_id,
+                "task_id": note.task_id,
+                "username": note.username,
+                "chip_id": note.chip_id,
+                "note": note.note,
+            },
+        }
+
+        collection = CalibrationNoteDocument.get_motor_collection()
+
+        last_error: DuplicateKeyError | None = None
+        for attempt in range(max_retries):
+            try:
+                result = collection.find_one_and_update(
+                    query,
+                    update,
+                    upsert=True,
+                    return_document=ReturnDocument.AFTER,
+                )
+                doc = CalibrationNoteDocument.model_validate(result)
+                return self._to_model(doc)
+            except DuplicateKeyError as e:  # noqa: PERF203
+                last_error = e
+                logger.warning(
+                    "DuplicateKeyError on upsert_on_insert attempt %d/%d for %s, retrying...",
+                    attempt + 1,
+                    max_retries,
+                    query,
+                )
+                time.sleep(0.1 * (2**attempt))
+
+        logger.error(
+            "Failed to upsert_on_insert calibration note after %d attempts: %s",
+            max_retries,
+            query,
+        )
+        raise last_error  # type: ignore[misc]
+
     def merge_note_fields(
         self,
         query_filter: dict[str, str],

--- a/src/qdash/repository/inmemory/calibration_note.py
+++ b/src/qdash/repository/inmemory/calibration_note.py
@@ -193,6 +193,31 @@ class InMemoryCalibrationNoteRepository:
         self._notes[key] = updated_note
         return updated_note
 
+    def upsert_on_insert(self, note: CalibrationNoteModel) -> CalibrationNoteModel:
+        """Create a calibration note if absent without replacing existing note content."""
+        key = self._make_key(
+            note.project_id,
+            note.username,
+            note.chip_id,
+            note.execution_id,
+            note.task_id,
+        )
+        if key in self._notes:
+            existing = self._notes[key]
+            updated_note = CalibrationNoteModel(
+                project_id=existing.project_id,
+                username=existing.username,
+                chip_id=existing.chip_id,
+                execution_id=existing.execution_id,
+                task_id=existing.task_id,
+                note=existing.note,
+                timestamp=now(),
+                system_info=existing.system_info,
+            )
+            self._notes[key] = updated_note
+            return updated_note
+        return self.upsert(note)
+
     def merge_note_fields(
         self,
         query_filter: dict[str, str],

--- a/src/qdash/repository/protocols.py
+++ b/src/qdash/repository/protocols.py
@@ -781,6 +781,15 @@ class CalibrationNoteRepository(Protocol):
         """
         ...
 
+    def upsert_on_insert(self, note: CalibrationNoteModel) -> CalibrationNoteModel:
+        """Create a calibration note if absent without replacing an existing note.
+
+        This is used when initializing workflow-local calibration note files.
+        Parallel workers may initialize the same master note, so existing note
+        content must not be overwritten by a stale snapshot.
+        """
+        ...
+
     def merge_note_fields(
         self,
         query_filter: dict[str, str],

--- a/src/qdash/workflow/engine/backend/qubex.py
+++ b/src/qdash/workflow/engine/backend/qubex.py
@@ -138,7 +138,7 @@ class QubexBackend(BaseBackend):
         existing_master = repo.find_latest_master(chip_id=chip_id, project_id=project_id)
         initial_note = existing_master.note if existing_master is not None else {}
 
-        master_note = repo.upsert(
+        master_note = repo.upsert_on_insert(
             CalibrationNoteModel(
                 project_id=project_id,
                 username=username,
@@ -150,6 +150,36 @@ class QubexBackend(BaseBackend):
         )
 
         note_path.write_text(json.dumps(master_note.note, indent=2))
+        self._sync_qubit_params_from_db(project_id=project_id, chip_id=chip_id)
+
+    def _sync_qubit_params_from_db(self, *, project_id: str, chip_id: str) -> None:
+        """Write latest QDash qubit calibration values to Qubex params files.
+
+        Qubex loads params YAML during Experiment construction. Keep those files
+        in sync before connect(), especially for two-qubit sessions that depend
+        on one-qubit calibration results from previous workflow steps.
+        """
+        qids = self._config.get("qids", [])
+        if not qids:
+            return
+
+        from qdash.repository.qubit import MongoQubitCalibrationRepository
+        from qdash.workflow.engine.params_updater import get_params_updater
+
+        updater = get_params_updater(self, chip_id)
+        if updater is None:
+            return
+
+        qubit_repo = MongoQubitCalibrationRepository()
+        qubit_ids = sorted({qubit for qid in qids for qubit in str(qid).split("-")})
+        for qid in qubit_ids:
+            calib_data = qubit_repo.get_calibration_data(
+                project_id=project_id,
+                chip_id=chip_id,
+                qid=qid,
+            )
+            if calib_data:
+                updater.update(qid, calib_data)
 
     def update_note(
         self,

--- a/src/qdash/workflow/engine/params_updater.py
+++ b/src/qdash/workflow/engine/params_updater.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -15,6 +16,8 @@ from ruamel.yaml.comments import CommentedMap
 
 if TYPE_CHECKING:
     from qdash.workflow.engine.backend.base import BaseBackend
+
+logger = logging.getLogger(__name__)
 
 
 class ParamsUpdater(Protocol):
@@ -146,6 +149,21 @@ class _QubexParamsUpdater:
         except ValueError:
             return qid
 
+        config = getattr(self._backend, "config", {})
+        project_id = config.get("project_id")
+        chip_id = config.get("chip_id") or self._chip_id
+        if project_id and chip_id:
+            try:
+                from qdash.common.qubit_utils import qid_to_label_from_chip
+
+                return qid_to_label_from_chip(qid, project_id=project_id, chip_id=chip_id)
+            except Exception:
+                logger.debug(
+                    "Failed to resolve qid label from chip metadata for qid=%s",
+                    qid,
+                    exc_info=True,
+                )
+
         try:
             experiment = self._backend.get_instance()
         except Exception:
@@ -160,6 +178,9 @@ class _QubexParamsUpdater:
     def _extract_value(param: Any) -> float | int | str | None:
         if isinstance(param, ParameterModel):
             return _QubexParamsUpdater._coerce_value(param.value)
+
+        if isinstance(param, dict) and "value" in param:
+            return _QubexParamsUpdater._coerce_value(param.get("value"))
 
         value = getattr(param, "value", param)
         return _QubexParamsUpdater._coerce_value(value)

--- a/tests/qdash/workflow/engine/repository/test_calibration_note_repository.py
+++ b/tests/qdash/workflow/engine/repository/test_calibration_note_repository.py
@@ -92,6 +92,24 @@ class TestInMemoryCalibrationNoteRepository:
 
         assert result.note == {"qubit_0": {"frequency": 6.0}}
 
+    def test_upsert_on_insert_preserves_existing_note(
+        self, repo: InMemoryCalibrationNoteRepository, sample_note: CalibrationNoteModel
+    ) -> None:
+        """Test insert-only upsert does not replace existing note."""
+        repo.upsert(sample_note)
+        stale_note = CalibrationNoteModel(
+            project_id=sample_note.project_id,
+            username=sample_note.username,
+            chip_id=sample_note.chip_id,
+            execution_id=sample_note.execution_id,
+            task_id=sample_note.task_id,
+            note={},
+        )
+
+        result = repo.upsert_on_insert(stale_note)
+
+        assert result.note == sample_note.note
+
     def test_find_one_returns_matching_note(
         self, repo: InMemoryCalibrationNoteRepository, sample_note: CalibrationNoteModel
     ) -> None:
@@ -288,6 +306,40 @@ class TestMongoCalibrationNoteRepository:
         assert collection.update is not None
         assert collection.update["$set"]["user_id"] == "usr_alice"
         assert "user_id" not in collection.update["$setOnInsert"]
+
+    def test_upsert_on_insert_does_not_replace_existing_note(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Parallel worker initialization must not overwrite merged note fields."""
+        collection = RecordingCollection()
+        monkeypatch.setattr(
+            CalibrationNoteDocument,
+            "get_motor_collection",
+            classmethod(lambda cls: collection),
+        )
+        monkeypatch.setattr(
+            MongoCalibrationNoteRepository,
+            "_user_id_for_username",
+            staticmethod(lambda username: "usr_alice"),
+        )
+
+        repo = MongoCalibrationNoteRepository()
+        repo.upsert_on_insert(
+            CalibrationNoteModel(
+                project_id="project-1",
+                username="alice",
+                chip_id="64Qv3",
+                execution_id="20240101-001",
+                task_id="master",
+                note={"rabi_params": {"Q00": {"amplitude": 0.1}}},
+            )
+        )
+
+        assert collection.update is not None
+        assert "note" not in collection.update["$set"]
+        assert collection.update["$setOnInsert"]["note"] == {
+            "rabi_params": {"Q00": {"amplitude": 0.1}}
+        }
 
     def test_document_upsert_note_does_not_set_user_id_in_conflicting_operators(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/qdash/workflow/engine/test_params_updater.py
+++ b/tests/qdash/workflow/engine/test_params_updater.py
@@ -3,7 +3,7 @@
 import io
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from qdash.workflow.engine.params_updater import _QubexParamsUpdater
@@ -195,6 +195,33 @@ data:
 
         # Should not raise
         updater._update_yaml(nonexistent, "Q00", 10.0)
+
+    def test_extract_value_from_db_parameter_dict(self, updater):
+        """Test DB calibration data dictionaries can be written to params files."""
+        assert updater._extract_value({"value": 0.125, "unit": "a.u."}) == 0.125
+
+    def test_preconnect_label_resolution_uses_chip_metadata(self, tmp_path):
+        """Test qid labels can be resolved before Qubex Experiment connects."""
+        params_dir = tmp_path / "params"
+        params_dir.mkdir()
+        (params_dir / "control_amplitude.yaml").write_text("data:\n  Q047: 0.1\n")
+
+        backend = MagicMock()
+        backend.config = {
+            "project_id": "project-1",
+            "chip_id": "144Qv1",
+            "params_dir": str(params_dir),
+        }
+        backend.get_instance.side_effect = AssertionError("should not connect")
+        updater = _QubexParamsUpdater(backend, chip_id="144Qv1")
+
+        with patch(
+            "qdash.common.qubit_utils._get_chip_size",
+            return_value=144,
+        ):
+            updater.update("47", {"control_amplitude": {"value": 0.25}})
+
+        assert "Q047: 0.25" in (params_dir / "control_amplitude.yaml").read_text()
 
     def test_insert_ordered_between_existing(self, updater, yaml_file):
         """Test that new qubit is inserted in correct order."""

--- a/tests/qdash/workflow/engine/test_qubex_backend_params_sync.py
+++ b/tests/qdash/workflow/engine/test_qubex_backend_params_sync.py
@@ -1,0 +1,66 @@
+"""Tests for QubexBackend parameter synchronization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from qdash.workflow.engine.backend.qubex import QubexBackend
+
+
+class FakeQubitRepo:
+    """Fake qubit repository returning DB-shaped calibration data."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def get_calibration_data(self, *, project_id: str, chip_id: str, qid: str) -> dict[str, Any]:
+        self.calls.append((project_id, chip_id, qid))
+        return {"control_amplitude": {"value": float(qid)}}
+
+
+class RecordingUpdater:
+    """Record params updates requested by the backend."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def update(self, qid: str, output_parameters: dict[str, Any]) -> None:
+        self.calls.append((qid, output_parameters))
+
+
+def test_sync_qubit_params_from_db_splits_coupling_qids(monkeypatch) -> None:
+    """Coupling sessions must sync each participating qubit before Qubex connects."""
+    repo = FakeQubitRepo()
+    updater = RecordingUpdater()
+
+    monkeypatch.setattr(
+        "qdash.repository.qubit.MongoQubitCalibrationRepository",
+        lambda: repo,
+    )
+    monkeypatch.setattr(
+        "qdash.workflow.engine.params_updater.get_params_updater",
+        lambda backend, chip_id: updater,
+    )
+
+    backend = QubexBackend(
+        {
+            "project_id": "project-1",
+            "chip_id": "64Qv2",
+            "qids": ["47-46", "44-45"],
+        }
+    )
+
+    backend._sync_qubit_params_from_db(project_id="project-1", chip_id="64Qv2")
+
+    assert repo.calls == [
+        ("project-1", "64Qv2", "44"),
+        ("project-1", "64Qv2", "45"),
+        ("project-1", "64Qv2", "46"),
+        ("project-1", "64Qv2", "47"),
+    ]
+    assert updater.calls == [
+        ("44", {"control_amplitude": {"value": 44.0}}),
+        ("45", {"control_amplitude": {"value": 45.0}}),
+        ("46", {"control_amplitude": {"value": 46.0}}),
+        ("47", {"control_amplitude": {"value": 47.0}}),
+    ]


### PR DESCRIPTION
<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
N/A

## Summary
- Introduce a method to synchronize Qubex calibration parameters before starting the calibration process to ensure accurate data usage.
- This change mitigates risks associated with stale calibration data affecting the workflow.

## Changes
- Added `upsert_on_insert` method to prevent overwriting existing calibration notes.
- Implemented `_sync_qubit_params_from_db` to update Qubex parameters from the database.
- Enhanced tests to validate the new synchronization functionality and ensure existing notes remain intact during parallel operations.

