### PR TITLE
feat(ui): enhance notification icons and labels for forum interactions

### DIFF
--- a/ui/src/components/features/notifications/NotificationsPageContent.tsx
+++ b/ui/src/components/features/notifications/NotificationsPageContent.tsx
@@ -20,12 +20,17 @@ import { formatRelativeTime } from "@/lib/utils/datetime";
 import type { NotificationResponse } from "@/schemas";
 
 function kindIcon(kind: string) {
+  if (kind === "forum_reply" || kind === "forum_mention") {
+    return <MessageSquare className="h-4 w-4" />;
+  }
   if (kind === "issue_reply") return <MessageSquare className="h-4 w-4" />;
   if (kind === "note_mention") return <StickyNote className="h-4 w-4" />;
   return <AtSign className="h-4 w-4" />;
 }
 
 function kindLabel(kind: string) {
+  if (kind === "forum_reply") return "Forum reply";
+  if (kind === "forum_mention") return "Forum mention";
   if (kind === "issue_reply") return "Reply";
   if (kind === "note_mention") return "Note mention";
   if (kind === "mention") return "Mention";

--- a/ui/src/components/layout/Sidebar/index.tsx
+++ b/ui/src/components/layout/Sidebar/index.tsx
@@ -43,7 +43,10 @@ import { UserAvatar } from "@/components/ui/UserAvatar";
 import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
 import { useSidebar } from "@/contexts/SidebarContext";
-import { useUnreadNotificationCount } from "@/hooks/useNotifications";
+import {
+  useNotifications,
+  useUnreadNotificationCount,
+} from "@/hooks/useNotifications";
 import { DARK_THEMES } from "@/constants/themes";
 
 const PREFECT_URL =
@@ -176,8 +179,15 @@ export function Sidebar() {
   const { user, logout: authLogout } = useAuth();
   const { theme, setTheme } = useTheme();
   const { data: unreadNotificationsResponse } = useUnreadNotificationCount();
+  const { data: unreadForumNotificationsResponse } = useNotifications(true);
   const unreadNotifications =
     unreadNotificationsResponse?.data.unread_count ?? 0;
+  const unreadForumNotifications =
+    unreadForumNotificationsResponse?.data.notifications.filter(
+      (notification) =>
+        notification.kind === "forum_mention" ||
+        notification.kind === "forum_reply",
+    ).length ?? 0;
   const isAdmin = user?.system_role === "admin";
   const isDarkTheme = DARK_THEMES.includes(
     theme as (typeof DARK_THEMES)[number],
@@ -293,6 +303,7 @@ export function Sidebar() {
           label: "Forum",
           icon: MessagesSquare,
           match: "prefix",
+          badge: unreadForumNotifications,
         },
         {
           href: "/issue-knowledge",

--- a/ui/src/hooks/useNotifications.ts
+++ b/ui/src/hooks/useNotifications.ts
@@ -15,6 +15,7 @@ export function useNotifications(unreadOnly = false) {
     {
       query: {
         staleTime: 15_000,
+        refetchInterval: 60_000,
       },
     },
   );


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Improved notification icons and labels for forum interactions to enhance user experience and clarity.
- This change impacts the UI, specifically the sidebar notifications.

## Changes
- Added icons for "forum_reply" and "forum_mention" notifications.
- Updated labels for "forum_reply" and "forum_mention" notifications.
- Introduced a badge for unread forum notifications in the sidebar.

