### PR TITLE
feat(api): add support for multiple chat models and Ollama responses API

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -234,6 +234,7 @@ tasks:
       - bun run test:run
       - bunx eslint . -c eslint.config.mjs
       - bunx prettier . --check
+      - bun run knip
 
   ci-ui-build:
     desc: Build UI for production

--- a/config/copilot.yaml
+++ b/config/copilot.yaml
@@ -11,11 +11,13 @@ thinking_language: en
 response_language: ja
 
 # Model configuration
-# `model` is used for general chat (side-panel Q&A, tool use, explanations).
-# `analysis_models` lists selectable models for task result analysis.
-# The first entry is the default. If omitted, QDash falls back to the general
-# `model` below. The older single `analysis_model` key is still supported for
-# local overrides.
+# `model` is used as the default for general chat (side-panel Q&A, tool use, explanations).
+# `chat_models` lists selectable models for general chat. The first entry is the
+# default. If omitted, QDash falls back to the general `model` below.
+# `analysis_models` lists selectable models for task result analysis. The first
+# entry is the default. If omitted, QDash falls back to the general `model`
+# below. The older single `analysis_model` key is still supported for local
+# overrides.
 model:
   # Provider: "openai", "anthropic", or "ollama"
   provider: openai
@@ -25,6 +27,39 @@ model:
   temperature: 0.7
   # Maximum tokens for response
   max_output_tokens: 4096
+
+# Selectable models for general chat (UI shows a dropdown). The first entry is
+# the default. The configured `model` above is also offered as a fallback.
+chat_models:
+  - provider: ollama
+    name: gemma4:26b
+    # Ollama endpoint. Set GEMMA_BASE_URL to your Ollama server URL,
+    # e.g. http://localhost:11434. QDash appends /v1 automatically.
+    base_url: env:GEMMA_BASE_URL
+    # Optional. If unset or missing, Ollama uses a dummy "ollama" API key.
+    api_key_env: GEMMA_API_KEY
+    keep_alive: 30m
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
+    reasoning_effort: none
+    disable_thinking_instruction: true
+    max_output_tokens: 4096
+  - provider: ollama
+    name: gemma4:31b
+    base_url: env:GEMMA_BASE_URL
+    api_key_env: GEMMA_API_KEY
+    keep_alive: 30m
+    temperature: 1.0
+    top_p: 0.95
+    top_k: 64
+    reasoning_effort: none
+    disable_thinking_instruction: true
+    max_output_tokens: 4096
+  - provider: openai
+    name: gpt-5.4
+    temperature: 0.7
+    max_output_tokens: 4096
 
 # Specialized models for task result analysis (chevron patterns, Rabi, etc.).
 analysis_models:

--- a/src/qdash/api/lib/copilot_agent.py
+++ b/src/qdash/api/lib/copilot_agent.py
@@ -2220,7 +2220,6 @@ async def run_chat(
 
     """
     client = _build_client(config)
-    provider = config.model.provider
 
     system_prompt = _build_chat_system_prompt(
         config=config,
@@ -2229,37 +2228,27 @@ async def run_chat(
         qubit_params=qubit_params,
     )
 
-    if provider == "ollama":
-        messages = _build_messages(
-            system_prompt + RESPONSE_FORMAT_INSTRUCTION,
-            user_message,
-            image_base64,
-            conversation_history,
-        )
-        content = await _run_chat_completions(client, messages, config)
-        response = _parse_response(content)
-        return _legacy_to_blocks(response, config)
+    # Ollama 0.13.3+ exposes `/v1/responses` with the same tool-call,
+    # function_call_output, and `text.format: json_schema` semantics as OpenAI,
+    # so chat uses one unified Responses API path regardless of provider.
+    input_items = _build_input(user_message, image_base64, conversation_history)
+
+    if tool_executors:
+        data_store: dict[str, Any] = {}
+        rate_limited = _wrap_rate_limited_executors(tool_executors)
+        wrapped_executors, collected_charts = _wrap_tool_executors(rate_limited, data_store)
     else:
-        input_items = _build_input(user_message, image_base64, conversation_history)
+        wrapped_executors, collected_charts = None, []
 
-        # Wrap tools: data store + chart collection + rate limiting
-        if tool_executors:
-            wrapped_executors: ToolExecutors | None = None
-            data_store: dict[str, Any] = {}
-            rate_limited = _wrap_rate_limited_executors(tool_executors)
-            wrapped_executors, collected_charts = _wrap_tool_executors(rate_limited, data_store)
-        else:
-            wrapped_executors, collected_charts = None, []
-
-        content = await _run_responses_api(
-            client,
-            system_prompt,
-            input_items,
-            config,
-            wrapped_executors,
-            response_schema=BLOCKS_RESPONSE_SCHEMA,
-            strict_schema=False,
-            on_tool_call=on_tool_call,
-            on_status=on_status,
-        )
-        return _inject_collected_charts(_parse_blocks_response(content, config), collected_charts)
+    content = await _run_responses_api(
+        client,
+        system_prompt,
+        input_items,
+        config,
+        wrapped_executors,
+        response_schema=BLOCKS_RESPONSE_SCHEMA,
+        strict_schema=False,
+        on_tool_call=on_tool_call,
+        on_status=on_status,
+    )
+    return _inject_collected_charts(_parse_blocks_response(content, config), collected_charts)

--- a/src/qdash/api/lib/copilot_analysis.py
+++ b/src/qdash/api/lib/copilot_analysis.py
@@ -164,3 +164,11 @@ class ChatRequest(BaseModel):
         description="Previous conversation messages [{role, content}, ...]",
     )
     image_base64: str | None = None
+    chat_model_override: ModelConfig | None = Field(
+        default=None,
+        alias="model_override",
+        description=(
+            "Optional per-request model override for general chat. "
+            "When unset, the configured chat_models[0]/model selection is used."
+        ),
+    )

--- a/src/qdash/api/lib/copilot_config.py
+++ b/src/qdash/api/lib/copilot_config.py
@@ -84,6 +84,9 @@ class CopilotConfig(BaseModel):
     # is used as the default when `analysis_model` is unset. `analysis_model`
     # remains for backward compatibility with existing copilot.yaml files.
     analysis_models: list[ModelConfig] = []
+    # Optional list of selectable models for general chat. The first entry is
+    # used as the default. When unset, the configured `model` above is used.
+    chat_models: list[ModelConfig] = []
     evaluation_metrics: EvaluationMetrics = EvaluationMetrics()
     scoring: dict[str, ScoringThreshold] = {}
     system_prompt: str = ""

--- a/src/qdash/api/routers/copilot.py
+++ b/src/qdash/api/routers/copilot.py
@@ -25,7 +25,7 @@ from qdash.api.lib.copilot_analysis import (
     AnalyzeRequest,
     ChatRequest,
 )
-from qdash.api.lib.copilot_config import CopilotConfig, load_copilot_config
+from qdash.api.lib.copilot_config import CopilotConfig, ModelConfig, load_copilot_config
 from qdash.api.lib.sse import SSETaskBridge, sse_event
 from qdash.api.services.copilot_data_service import CopilotDataService
 from qdash.datamodel.task_knowledge import get_task_knowledge
@@ -40,6 +40,27 @@ def _config_with_request_model(config: CopilotConfig, request: AnalyzeRequest) -
     if request.analysis_model_override is None:
         return config
     return config.model_copy(update={"analysis_model": request.analysis_model_override})
+
+
+def _resolve_chat_model(config: CopilotConfig, override: ModelConfig | None) -> ModelConfig | None:
+    """Pick the chat model to use for a request.
+
+    Priority: per-request override > first entry of `chat_models` > None (caller
+    uses ``config.model`` as-is).
+    """
+    if override is not None:
+        return override
+    if config.chat_models:
+        return config.chat_models[0]
+    return None
+
+
+def _config_with_chat_model(config: CopilotConfig, request: ChatRequest) -> CopilotConfig:
+    """Apply the resolved chat model to ``config.model`` for this request."""
+    resolved = _resolve_chat_model(config, request.chat_model_override)
+    if resolved is None:
+        return config
+    return config.model_copy(update={"model": resolved})
 
 
 @router.get(
@@ -273,6 +294,7 @@ async def chat_stream(
         if not config.enabled:
             yield sse_event("error", {"step": "init", "detail": "Copilot is not enabled"})
             return
+        chat_config = _config_with_chat_model(config, request)
 
         # Load config and resolve default chip_id
         yield sse_event("status", {"step": "load_config", "message": "設定を読み込み中..."})
@@ -306,7 +328,7 @@ async def chat_stream(
             coro = partial(
                 run_chat,
                 user_message=request.message,
-                config=config,
+                config=chat_config,
                 chip_id=chip_id,
                 qid=qid,
                 qubit_params=qubit_params if qubit_params else None,

--- a/ui/src/components/features/chat/CopilotChatPage.tsx
+++ b/ui/src/components/features/chat/CopilotChatPage.tsx
@@ -23,6 +23,7 @@ import {
   Loader2,
   Sparkles,
   ArrowRight,
+  Cpu,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -33,6 +34,13 @@ import {
 } from "@/hooks/useCopilotChat";
 import { ChatPlotlyChart } from "@/components/features/chat/ChatPlotlyChart";
 import { CodeBlock } from "@/components/features/chat/CodeBlock";
+import { useGetCopilotConfig } from "@/client/copilot/copilot";
+import {
+  buildChatModelOptions,
+  getStoredChatModelKey,
+  resolveChatModelOption,
+  setStoredChatModelKey,
+} from "@/lib/copilotModels";
 import { formatDateTime, formatDateTimeCompact } from "@/lib/utils/datetime";
 import type { BlocksResult } from "@/hooks/useAnalysisChat";
 
@@ -366,6 +374,22 @@ const SUGGESTED_QUESTIONS = [
 // ---------------------------------------------------------------------------
 
 export function CopilotChatPage() {
+  const [selectedModelKey, setSelectedModelKey] = useState(
+    getStoredChatModelKey,
+  );
+  const { data: copilotConfigResponse } = useGetCopilotConfig();
+  const modelOptions = useMemo(
+    () => buildChatModelOptions(copilotConfigResponse?.data ?? null),
+    [copilotConfigResponse?.data],
+  );
+  const selectedModel = resolveChatModelOption(modelOptions, selectedModelKey);
+  const modelOverride = selectedModel?.model ?? null;
+
+  const handleModelChange = (key: string) => {
+    setSelectedModelKey(key);
+    setStoredChatModelKey(key);
+  };
+
   const {
     sessions,
     activeSession,
@@ -379,7 +403,7 @@ export function CopilotChatPage() {
     deleteSession,
     sendMessage,
     clearActiveSession,
-  } = useCopilotChat();
+  } = useCopilotChat({ modelOverride });
 
   const [input, setInput] = useState("");
   const [showSessionSidebar, setShowSessionSidebar] = useState(true);
@@ -493,6 +517,23 @@ export function CopilotChatPage() {
               {activeSession?.title || "AI Chat"}
             </h2>
           </div>
+          {modelOptions.length > 1 && (
+            <label className="flex items-center gap-1 mr-1" title="Chat model">
+              <Cpu className="w-3.5 h-3.5 text-base-content/40" />
+              <select
+                className="select select-bordered select-xs w-44 text-xs"
+                value={selectedModel.key}
+                onChange={(event) => handleModelChange(event.target.value)}
+                disabled={isLoading}
+              >
+                {modelOptions.map((option) => (
+                  <option key={option.key} value={option.key}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
           {messages.length > 0 && (
             <button
               onClick={clearActiveSession}

--- a/ui/src/hooks/useCopilotChat.ts
+++ b/ui/src/hooks/useCopilotChat.ts
@@ -13,7 +13,7 @@ import { buildHeaders, consumeSSEEvents } from "@/lib/sse-utils";
 export type CopilotMessage = ChatMessage;
 export type CopilotSession = ChatSession;
 
-export interface UseCopilotChatOptions {
+interface UseCopilotChatOptions {
   modelOverride?: ModelOverride | null;
 }
 

--- a/ui/src/hooks/useCopilotChat.ts
+++ b/ui/src/hooks/useCopilotChat.ts
@@ -6,13 +6,19 @@ import {
   type ChatSession,
 } from "@/contexts/AnalysisChatContext";
 import type { ChatMessage } from "@/hooks/useAnalysisChat";
+import type { ModelOverride } from "@/lib/copilotModels";
 import { buildHeaders, consumeSSEEvents } from "@/lib/sse-utils";
 
 // Re-export for backward compat
 export type CopilotMessage = ChatMessage;
 export type CopilotSession = ChatSession;
 
-export function useCopilotChat() {
+export interface UseCopilotChatOptions {
+  modelOverride?: ModelOverride | null;
+}
+
+export function useCopilotChat(options?: UseCopilotChatOptions) {
+  const modelOverride = options?.modelOverride ?? null;
   const {
     sessions,
     activeSessionId,
@@ -91,6 +97,7 @@ export function useCopilotChat() {
               role: m.role,
               content: m.content,
             })),
+            model_override: modelOverride,
           }),
           signal: controller.signal,
         });
@@ -175,6 +182,7 @@ export function useCopilotChat() {
       createNewSession,
       updateSessionMessages,
       autoTitleSession,
+      modelOverride,
     ],
   );
 

--- a/ui/src/lib/copilotModels.ts
+++ b/ui/src/lib/copilotModels.ts
@@ -15,6 +15,7 @@ interface ModelOption {
 }
 
 const ANALYSIS_MODEL_STORAGE_KEY = "qdash_analysis_model_key";
+const CHAT_MODEL_STORAGE_KEY = "qdash_chat_model_key";
 
 function readModel(value: unknown): ModelOverride | null {
   if (!value || typeof value !== "object") return null;
@@ -117,6 +118,81 @@ export function setStoredAnalysisModelKey(key: string) {
 }
 
 export function resolveAnalysisModelOption(
+  options: ModelOption[],
+  key: string,
+): ModelOption {
+  return (
+    options.find((option) => option.key === key) ??
+    options.find((option) => option.isConfiguredDefault) ??
+    options[0]
+  );
+}
+
+export function buildChatModelOptions(
+  config: Record<string, unknown> | null,
+): ModelOption[] {
+  if (!config) {
+    return [
+      {
+        key: "default",
+        label: "Configured model",
+        model: null,
+        isConfiguredDefault: true,
+      },
+    ];
+  }
+
+  const chatModels = Array.isArray(config.chat_models)
+    ? config.chat_models
+    : [];
+  const configuredModel = readModel(chatModels[0]) ?? readModel(config.model);
+  const options: ModelOption[] = [
+    {
+      key: "default",
+      label: configuredModel
+        ? `Configured: ${configuredModel.name}`
+        : "Configured model",
+      model: null,
+      isConfiguredDefault: true,
+    },
+  ];
+  const seen = new Set<string>();
+  if (configuredModel) {
+    seen.add(modelIdentity(configuredModel));
+  }
+
+  const addOption = (key: string, label: string, value: unknown) => {
+    const model = readModel(value);
+    if (!model) return;
+    const identity = modelIdentity(model);
+    if (seen.has(identity)) return;
+    seen.add(identity);
+    options.push({
+      key,
+      label: `${label}: ${model.name}`,
+      model,
+    });
+  };
+
+  chatModels.forEach((model, index) => {
+    addOption(`chat-${index}`, `Chat ${index + 1}`, model);
+  });
+  addOption("general", "General", config.model);
+
+  return options;
+}
+
+export function getStoredChatModelKey(): string {
+  if (typeof window === "undefined") return "default";
+  return localStorage.getItem(CHAT_MODEL_STORAGE_KEY) || "default";
+}
+
+export function setStoredChatModelKey(key: string) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(CHAT_MODEL_STORAGE_KEY, key);
+}
+
+export function resolveChatModelOption(
   options: ModelOption[],
   key: string,
 ): ModelOption {


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced support for multiple chat models and configuration options to enhance flexibility in chat interactions.
- Updated the API to utilize a unified responses API path for different providers, improving compatibility and performance.

## Changes
- Added `chat_models` configuration to allow selection of multiple chat models.
- Implemented per-request model override functionality.
- Modified the chat request handling to resolve and apply the appropriate chat model.
- Updated relevant components to support the new chat model options and storage mechanisms.

