### PR TITLE
fix(docs): update OpenAPI theme import and usage in VitePress setup

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,7 +1,7 @@
 import type { Theme } from "vitepress";
 import DefaultTheme from "vitepress/theme";
 
-import { theme, useOpenapi } from "vitepress-openapi";
+import * as OpenApiTheme from "vitepress-openapi";
 import "vitepress-openapi/dist/style.css";
 
 import "./custom.css";
@@ -11,9 +11,9 @@ import spec from "../../oas/openapi.json" assert { type: "json" };
 export default {
   extends: DefaultTheme,
   async enhanceApp({ app, router, siteData }) {
-    const openapi = useOpenapi({
+    const openapi = OpenApiTheme.useOpenapi({
       spec,
     });
-    theme.enhanceApp({ app, openapi });
+    OpenApiTheme.theme?.enhanceApp?.({ app, openapi });
   },
 } satisfies Theme;


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updated the import and usage of the OpenAPI theme in the VitePress setup to ensure compatibility with the latest changes in the `vitepress-openapi` package.
- This change improves the integration of OpenAPI specifications within the documentation workflow.

## Changes
- Replaced the import statement for the OpenAPI theme to use a namespace import.
- Updated the usage of `useOpenapi` and `theme.enhanceApp` to reflect the new import structure.

