### PR TITLE
fix(ui): reduce mobile CDF table overflow

### DIFF
--- a/ui/src/components/features/analysis/CDFView.tsx
+++ b/ui/src/components/features/analysis/CDFView.tsx
@@ -919,10 +919,11 @@ export function CDFView() {
 
       {/* Data Table */}
       <div className="card bg-base-100 shadow-md">
-        <div className="card-body">
+        <div className="card-body px-2 sm:px-8">
           <DataTable
             title="Data Points"
             data={combinedTableData}
+            className="px-2 sm:px-8"
             columns={[
               { key: "qid", label: "Entity ID", sortable: true },
               ...selectedParameters.map((param) => {


### PR DESCRIPTION
## Ticket
Closes #821

## Summary
Reduces the horizontal padding around the CDF data points table on small screens so the mobile view no longer needs a slight horizontal scroll.

## Changes
- Tighten the mobile padding around the CDF data table
- Keep the existing larger spacing on wider screens
