### PR TITLE
Default Copilot responses to English

### DIFF
--- a/config/copilot.yaml
+++ b/config/copilot.yaml
@@ -8,7 +8,7 @@ enabled: true
 # thinking_language: Language for internal reasoning (en recommended for technical accuracy)
 # response_language: Language for user-facing responses (ja or en)
 thinking_language: en
-response_language: ja
+response_language: en
 
 # Model configuration
 # `model` is used as the default for general chat (side-panel Q&A, tool use, explanations).

--- a/docs/development/copilot/architecture.md
+++ b/docs/development/copilot/architecture.md
@@ -42,7 +42,7 @@ enabled: true
 
 # Language settings
 thinking_language: en      # Internal reasoning language
-response_language: ja      # User-facing response language
+response_language: en      # User-facing response language
 
 # Model settings
 model:

--- a/src/qdash/copilot/agent_runtime/rendering.py
+++ b/src/qdash/copilot/agent_runtime/rendering.py
@@ -55,7 +55,7 @@ def legacy_to_blocks(
     response: AnalysisResponse, config: CopilotConfig | None = None
 ) -> dict[str, Any]:
     """Convert a legacy analysis response into the frontend blocks format."""
-    lang_raw = (config.response_language if config else "ja") or "ja"
+    lang_raw = (config.response_language if config else "en") or "en"
     lang = "ja" if lang_raw.startswith("ja") else "en"
     labels = _SECTION_LABELS[lang]
 


### PR DESCRIPTION
<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
<!-- Link to the ticket / issue -->

## Summary
<!-- What and why (1–2 sentences) -->

## Changes
<!-- Bullet list of key changes -->
This pull request standardizes the default user-facing response language from Japanese to English across configuration, documentation, and code. The main goal is to ensure consistency and clarity for users by aligning the default language settings.

**Configuration and Documentation Updates:**
* Changed the `response_language` setting from `ja` to `en` in `config/copilot.yaml`, making English the default for user-facing responses.
* Updated the example configuration in the documentation (`docs/development/copilot/architecture.md`) to reflect English as the default `response_language`.

**Code Logic Update:**
* Updated the fallback logic in `legacy_to_blocks` within `src/qdash/copilot/agent_runtime/rendering.py` so that, if no configuration is provided, English (`en`) is used as the default response language instead of Japanese (`ja`).
