### PR TITLE
Send multiple target images to Copilot analysis

### DIFF
--- a/src/qdash/api/routers/copilot.py
+++ b/src/qdash/api/routers/copilot.py
@@ -168,6 +168,7 @@ async def analyze_task_result(
             config=analysis_config,
             image_base64=ctx.image_base64,
             expected_images=ctx.expected_images,
+            experiment_images=ctx.experiment_images,
             conversation_history=request.conversation_history,
             tool_executors=tool_executors,
         )
@@ -176,6 +177,7 @@ async def analyze_task_result(
             ctx.figure_paths,
             ctx.expected_images,
             request.task_name,
+            ctx.experiment_images,
         )
         return result
     except ImportError:
@@ -250,6 +252,7 @@ async def analyze_task_result_stream(
                 config=analysis_config,
                 image_base64=ctx.image_base64,
                 expected_images=ctx.expected_images,
+                experiment_images=ctx.experiment_images,
                 conversation_history=request.conversation_history,
                 tool_executors=tool_executors,
             )
@@ -280,6 +283,7 @@ async def analyze_task_result_stream(
             ctx.figure_paths,
             ctx.expected_images,
             request.task_name,
+            ctx.experiment_images,
         )
 
         # Complete

--- a/src/qdash/copilot/agent.py
+++ b/src/qdash/copilot/agent.py
@@ -122,6 +122,7 @@ def _build_input(
     image_base64: str | None,
     conversation_history: list[dict[str, str]] | None,
     expected_images: list[tuple[str, str]] | None = None,
+    experiment_images: list[tuple[str, str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Build the input items list for the OpenAI Responses API.
 
@@ -139,6 +140,8 @@ def _build_input(
         Previous conversation messages.
     expected_images : list[tuple[str, str]] | None
         List of (base64_data, alt_text) for expected reference images.
+    experiment_images : list[tuple[str, str]] | None
+        List of (base64_data, alt_text) for actual experiment result images.
 
     """
     items: list[dict[str, Any]] = []
@@ -172,15 +175,25 @@ def _build_input(
                 }
             )
 
-    # Add experiment result image (with label)
-    if image_base64:
-        content_parts.append({"type": "input_text", "text": "Actual experimental result:"})
-        content_parts.append(
-            {
-                "type": "input_image",
-                "image_url": f"data:image/png;base64,{image_base64}",
-            }
+    actual_images = experiment_images or (
+        [(image_base64, "result figure")] if image_base64 else []
+    )
+    if actual_images:
+        label = (
+            "Actual experimental result images:"
+            if len(actual_images) > 1
+            else "Actual experimental result:"
         )
+        content_parts.append({"type": "input_text", "text": label})
+        for b64_data, alt_text in actual_images:
+            if len(actual_images) > 1:
+                content_parts.append({"type": "input_text", "text": f"[Target: {alt_text}]"})
+            content_parts.append(
+                {
+                    "type": "input_image",
+                    "image_url": f"data:image/png;base64,{b64_data}",
+                }
+            )
 
     # Add the user message text
     content_parts.append({"type": "input_text", "text": user_message})
@@ -196,6 +209,7 @@ def _build_messages(
     image_base64: str | None,
     conversation_history: list[dict[str, str]] | None,
     expected_images: list[tuple[str, str]] | None = None,
+    experiment_images: list[tuple[str, str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Build the messages list for the Chat Completions API (Ollama fallback)."""
     messages: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
@@ -211,7 +225,10 @@ def _build_messages(
             )
 
     # Build the current user message
-    has_images = image_base64 or expected_images
+    actual_images = experiment_images or (
+        [(image_base64, "result figure")] if image_base64 else []
+    )
+    has_images = actual_images or expected_images
     if has_images:
         content_parts: list[dict[str, Any]] = []
 
@@ -227,15 +244,22 @@ def _build_messages(
                     }
                 )
 
-        # Add experiment result image
-        if image_base64:
-            content_parts.append({"type": "text", "text": "Actual experimental result:"})
-            content_parts.append(
-                {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:image/png;base64,{image_base64}"},
-                }
+        if actual_images:
+            label = (
+                "Actual experimental result images:"
+                if len(actual_images) > 1
+                else "Actual experimental result:"
             )
+            content_parts.append({"type": "text", "text": label})
+            for b64_data, alt_text in actual_images:
+                if len(actual_images) > 1:
+                    content_parts.append({"type": "text", "text": f"[Target: {alt_text}]"})
+                content_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{b64_data}"},
+                    }
+                )
 
         content_parts.append({"type": "text", "text": user_message})
         messages.append({"role": "user", "content": content_parts})
@@ -352,6 +376,7 @@ async def run_analysis(
     config: CopilotConfig,
     image_base64: str | None = None,
     expected_images: list[tuple[str, str]] | None = None,
+    experiment_images: list[tuple[str, str]] | None = None,
     conversation_history: list[dict[str, str]] | None = None,
     tool_executors: ToolExecutors | None = None,
     on_tool_call: OnToolCallHook = None,
@@ -376,6 +401,9 @@ async def run_analysis(
         Optional base64-encoded result figure.
     expected_images : list[tuple[str, str]] | None
         Optional list of (base64_data, alt_text) for expected reference images.
+    experiment_images : list[tuple[str, str]] | None
+        Optional list of actual experiment result images. When provided, this
+        supersedes image_base64 and preserves per-image target labels.
     conversation_history : list[dict[str, str]] | None
         Previous conversation messages.
     tool_executors : ToolExecutors | None
@@ -402,7 +430,7 @@ async def run_analysis(
     provider = config.model.provider
 
     has_expected = bool(expected_images)
-    has_experiment = bool(image_base64)
+    has_experiment = bool(experiment_images or image_base64)
 
     if provider == "ollama":
         # Ollama only supports Chat Completions API (no tool support)
@@ -414,7 +442,12 @@ async def run_analysis(
             has_experiment_image=has_experiment,
         )
         messages = _build_messages(
-            system_prompt, user_message, image_base64, conversation_history, expected_images
+            system_prompt,
+            user_message,
+            image_base64,
+            conversation_history,
+            expected_images,
+            experiment_images,
         )
         content = await _run_chat_completions(client, messages, config)
         # Ollama still uses legacy schema; convert to blocks
@@ -439,7 +472,11 @@ async def run_analysis(
             + CHART_SYSTEM_PROMPT
         )
         input_items = _build_input(
-            user_message, image_base64, conversation_history, expected_images
+            user_message,
+            image_base64,
+            conversation_history,
+            expected_images,
+            experiment_images,
         )
 
         # Wrap tools: data store + chart collection + rate limiting

--- a/src/qdash/copilot/agent.py
+++ b/src/qdash/copilot/agent.py
@@ -175,9 +175,7 @@ def _build_input(
                 }
             )
 
-    actual_images = experiment_images or (
-        [(image_base64, "result figure")] if image_base64 else []
-    )
+    actual_images = experiment_images or ([(image_base64, "result figure")] if image_base64 else [])
     if actual_images:
         label = (
             "Actual experimental result images:"
@@ -225,9 +223,7 @@ def _build_messages(
             )
 
     # Build the current user message
-    actual_images = experiment_images or (
-        [(image_base64, "result figure")] if image_base64 else []
-    )
+    actual_images = experiment_images or ([(image_base64, "result figure")] if image_base64 else [])
     has_images = actual_images or expected_images
     if has_images:
         content_parts: list[dict[str, Any]] = []

--- a/src/qdash/copilot/agent_runtime/rendering.py
+++ b/src/qdash/copilot/agent_runtime/rendering.py
@@ -55,7 +55,7 @@ def legacy_to_blocks(
     response: AnalysisResponse, config: CopilotConfig | None = None
 ) -> dict[str, Any]:
     """Convert a legacy analysis response into the frontend blocks format."""
-    lang_raw = (config.response_language if config else "en") or "en"
+    lang_raw = (config.response_language if config else "ja") or "ja"
     lang = "ja" if lang_raw.startswith("ja") else "en"
     labels = _SECTION_LABELS[lang]
 

--- a/src/qdash/copilot/bundle/exporters/ai_triage.py
+++ b/src/qdash/copilot/bundle/exporters/ai_triage.py
@@ -68,11 +68,18 @@ def _knowledge_ref(task_name: str) -> AITriageKnowledgeRef:
 def _figure_entries(figure_paths: list[str]) -> list[AITriageFigureEntry]:
     entries: list[AITriageFigureEntry] = []
     for index, source_path in enumerate(figure_paths):
-        suffix = Path(source_path).suffix or ".bin"
+        path = Path(source_path)
+        suffix = path.suffix or ".bin"
+        role = ""
+        stem = path.stem.lower()
+        if "marked" in stem:
+            role = "_marked"
+        elif "raw" in stem:
+            role = "_raw"
         entries.append(
             AITriageFigureEntry(
                 source_path=source_path,
-                archive_path=f"figures/{index:02d}{suffix}",
+                archive_path=f"figures/{index:02d}{role}{suffix}",
             )
         )
     return entries

--- a/src/qdash/copilot/bundle/exporters/ai_triage.py
+++ b/src/qdash/copilot/bundle/exporters/ai_triage.py
@@ -78,10 +78,27 @@ def _figure_entries(figure_paths: list[str]) -> list[AITriageFigureEntry]:
     return entries
 
 
+def _target_image_slug(alt_text: str) -> str:
+    text = alt_text.lower()
+    if "marked" in text:
+        return "marked"
+    if "raw" in text:
+        return "raw"
+    return "target"
+
+
 def _bundle_context(context_bundle: Any) -> AITriageBundleContext:
     return AITriageBundleContext(
         context=context_bundle.context,
         image_base64=context_bundle.image_base64,
+        experiment_images=[
+            AITriageImageEntry(
+                path=f"experiment_images/{index:02d}_{_target_image_slug(alt_text)}.png",
+                alt_text=alt_text,
+                base64_data=base64_data,
+            )
+            for index, (base64_data, alt_text) in enumerate(context_bundle.experiment_images)
+        ],
         expected_images=[
             AITriageImageEntry(
                 path=f"expected_images/{index:02d}.png",
@@ -143,7 +160,8 @@ def export_ai_triage_replay_bundle(
             copilot_config_path="copilot_config.json",
             expected_image_paths=[image.path for image in bundle_context.expected_images],
             experiment_image_paths=(
-                ["experiment_images/00.png"] if bundle_context.image_base64 else []
+                [image.path for image in bundle_context.experiment_images]
+                or (["experiment_images/00.png"] if bundle_context.image_base64 else [])
             ),
             figure_paths=[figure.archive_path for figure in bundle_context.figures],
             extra_paths=(

--- a/src/qdash/copilot/bundle/models.py
+++ b/src/qdash/copilot/bundle/models.py
@@ -88,6 +88,7 @@ class AITriageBundleContext(BaseModel):
 
     context: TaskAnalysisContext
     image_base64: str | None = None
+    experiment_images: list[AITriageImageEntry] = Field(default_factory=list)
     expected_images: list[AITriageImageEntry] = Field(default_factory=list)
     figures: list[AITriageFigureEntry] = Field(default_factory=list)
 

--- a/src/qdash/copilot/bundle/writer.py
+++ b/src/qdash/copilot/bundle/writer.py
@@ -50,7 +50,10 @@ def write_ai_triage_bundle(
         zf.writestr("copilot_config.json", _json_bytes(runtime_config.model_dump(mode="json")))
         zf.writestr("prompt.txt", prompt_text.rstrip() + "\n")
 
-        if bundle_context.image_base64:
+        if bundle_context.experiment_images:
+            for image in bundle_context.experiment_images:
+                zf.writestr(image.path, _decode_base64(image.base64_data))
+        elif bundle_context.image_base64:
             zf.writestr("experiment_images/00.png", _decode_base64(bundle_context.image_base64))
 
         for image in bundle_context.expected_images:

--- a/src/qdash/copilot/contracts/models.py
+++ b/src/qdash/copilot/contracts/models.py
@@ -21,6 +21,7 @@ class AnalysisContextResult:
     context: TaskAnalysisContext
     image_base64: str | None
     expected_images: list[tuple[str, str]]
+    experiment_images: list[tuple[str, str]] = field(default_factory=list)
     figure_paths: list[str] = field(default_factory=list)
 
 

--- a/src/qdash/copilot/runtime.py
+++ b/src/qdash/copilot/runtime.py
@@ -72,6 +72,7 @@ class CopilotRuntime:
             load_neighbor_qubit_params=self._analysis_load_neighbor_qubit_params,
             load_coupling_params=self._analysis_load_coupling_params,
             load_figure_as_base64=self._analysis_load_figure_as_base64,
+            load_figures_as_base64=self._analysis_load_figures_as_base64,
             collect_expected_images=self._analysis_collect_expected_images,
         )
         self._heatmap_loader = ChipHeatmapLoader(
@@ -141,6 +142,10 @@ class CopilotRuntime:
         """Forward figure loading for analysis context assembly."""
         return self.load_figure_as_base64(figure_paths)
 
+    def _analysis_load_figures_as_base64(self, figure_paths: list[str]) -> list[tuple[str, str]]:
+        """Forward target figure loading for analysis context assembly."""
+        return self.load_figures_as_base64(figure_paths)
+
     def _analysis_collect_expected_images(
         self,
         knowledge: Any,
@@ -172,6 +177,10 @@ class CopilotRuntime:
     def load_figure_as_base64(self, figure_paths: list[str]) -> str | None:
         """Read the first existing PNG file from figure_paths and return base64."""
         return self._support_service.load_figure_as_base64(figure_paths)
+
+    def load_figures_as_base64(self, figure_paths: list[str]) -> list[tuple[str, str]]:
+        """Read existing PNG figures and return labeled target images."""
+        return self._support_service.load_figures_as_base64(figure_paths)
 
     def collect_expected_images(
         self,
@@ -447,6 +456,7 @@ class CopilotRuntime:
         figure_paths: list[str],
         expected_images: list[tuple[str, str]],
         task_name: str,
+        experiment_images: list[tuple[str, str]] | None = None,
     ) -> dict[str, Any]:
         """Build the ``images_sent`` metadata dict for analysis responses."""
         return CopilotSupportService.build_images_sent_metadata(
@@ -454,6 +464,7 @@ class CopilotRuntime:
             figure_paths=figure_paths,
             expected_images=expected_images,
             task_name=task_name,
+            experiment_images=experiment_images,
         )
 
     def build_tool_executors(self) -> dict[str, Any]:

--- a/src/qdash/copilot/services/analysis_context_service.py
+++ b/src/qdash/copilot/services/analysis_context_service.py
@@ -25,6 +25,7 @@ class AnalysisContextBuilder:
         ],
         load_coupling_params: Callable[[str, str, list[str] | None], dict[str, dict[str, Any]]],
         load_figure_as_base64: Callable[[list[str]], str | None],
+        load_figures_as_base64: Callable[[list[str]], list[tuple[str, str]]],
         collect_expected_images: Callable[[Any, int | None], list[tuple[str, str]]],
     ) -> None:
         self._load_qubit_params = load_qubit_params
@@ -33,6 +34,7 @@ class AnalysisContextBuilder:
         self._load_neighbor_qubit_params = load_neighbor_qubit_params
         self._load_coupling_params = load_coupling_params
         self._load_figure_as_base64 = load_figure_as_base64
+        self._load_figures_as_base64 = load_figures_as_base64
         self._collect_expected_images = collect_expected_images
 
     def build_analysis_context(
@@ -67,7 +69,7 @@ class AnalysisContextBuilder:
                 knowledge=knowledge,
             )
         )
-        image_base64, expected_images = self._resolve_analysis_images(
+        image_base64, expected_images, experiment_images = self._resolve_analysis_images(
             knowledge=knowledge,
             task_result=task_result,
             figure_paths=figure_paths,
@@ -91,6 +93,7 @@ class AnalysisContextBuilder:
             context=context,
             image_base64=image_base64,
             expected_images=expected_images,
+            experiment_images=experiment_images,
             figure_paths=figure_paths,
         )
 
@@ -150,16 +153,19 @@ class AnalysisContextBuilder:
         figure_paths: list[str],
         image_base64: str | None,
         config: CopilotConfig,
-    ) -> tuple[str | None, list[tuple[str, str]]]:
+    ) -> tuple[str | None, list[tuple[str, str]], list[tuple[str, str]]]:
         """Resolve experiment and expected images for multimodal analysis."""
         expected_images: list[tuple[str, str]] = []
+        experiment_images: list[tuple[str, str]] = []
         if not config.analysis.multimodal:
-            return image_base64, expected_images
+            return image_base64, expected_images, experiment_images
 
-        if not image_base64 and task_result:
-            image_base64 = self._load_figure_as_base64(figure_paths)
+        if task_result:
+            experiment_images = self._load_figures_as_base64(figure_paths)
+        if not image_base64:
+            image_base64 = experiment_images[0][0] if experiment_images else None
         expected_images = self._collect_expected_images(
             knowledge,
             config.analysis.max_expected_images,
         )
-        return image_base64, expected_images
+        return image_base64, expected_images, experiment_images

--- a/src/qdash/copilot/services/analysis_context_service.py
+++ b/src/qdash/copilot/services/analysis_context_service.py
@@ -163,7 +163,7 @@ class AnalysisContextBuilder:
         if task_result:
             experiment_images = self._load_figures_as_base64(figure_paths)
         if not image_base64:
-            image_base64 = experiment_images[0][0] if experiment_images else None
+            image_base64 = self._load_figure_as_base64(figure_paths)
         expected_images = self._collect_expected_images(
             knowledge,
             config.analysis.max_expected_images,

--- a/src/qdash/copilot/services/support_service.py
+++ b/src/qdash/copilot/services/support_service.py
@@ -90,16 +90,12 @@ class CopilotSupportService:
 
     @staticmethod
     def _target_figure_role(path: Path, index: int) -> str:
-        """Infer the target figure role from filename suffixes, falling back to order."""
+        """Infer the target figure role from filename suffixes."""
         stem = path.stem.lower()
         if "marked" in stem:
             return "target marked result image; validate heuristic markers against the raw signal"
         if "raw" in stem:
             return "target raw result image; inspect the measured signal without overlays"
-        if index == 0:
-            return "target raw result image; inspect the measured signal without overlays"
-        if index == 1:
-            return "target marked result image; validate heuristic markers against the raw signal"
         return f"target supporting result image {index + 1}"
 
     @staticmethod

--- a/src/qdash/copilot/services/support_service.py
+++ b/src/qdash/copilot/services/support_service.py
@@ -72,14 +72,35 @@ class CopilotSupportService:
 
     def load_figure_as_base64(self, figure_paths: list[str]) -> str | None:
         """Read the first existing PNG file from figure_paths and return base64."""
+        images = self.load_figures_as_base64(figure_paths)
+        return images[0][0] if images else None
+
+    def load_figures_as_base64(self, figure_paths: list[str]) -> list[tuple[str, str]]:
+        """Read existing PNG figures and return labeled target images."""
+        images: list[tuple[str, str]] = []
         for figure_path in figure_paths:
             path = Path(figure_path)
             if path.is_file() and path.suffix.lower() == ".png":
                 if path.stat().st_size > self._max_figure_size:
                     self._logger.warning("Figure %s exceeds 5MB size limit, skipping", figure_path)
                     continue
-                return base64.b64encode(path.read_bytes()).decode("ascii")
-        return None
+                role = self._target_figure_role(path, len(images))
+                images.append((base64.b64encode(path.read_bytes()).decode("ascii"), role))
+        return images
+
+    @staticmethod
+    def _target_figure_role(path: Path, index: int) -> str:
+        """Infer the target figure role from filename suffixes, falling back to order."""
+        stem = path.stem.lower()
+        if "marked" in stem:
+            return "target marked result image; validate heuristic markers against the raw signal"
+        if "raw" in stem:
+            return "target raw result image; inspect the measured signal without overlays"
+        if index == 0:
+            return "target raw result image; inspect the measured signal without overlays"
+        if index == 1:
+            return "target marked result image; validate heuristic markers against the raw signal"
+        return f"target supporting result image {index + 1}"
 
     @staticmethod
     def collect_expected_images(
@@ -134,11 +155,16 @@ class CopilotSupportService:
         figure_paths: list[str],
         expected_images: list[tuple[str, str]],
         task_name: str,
+        experiment_images: list[tuple[str, str]] | None = None,
     ) -> dict[str, Any]:
         """Build the ``images_sent`` metadata dict for analysis responses."""
         return {
-            "experiment_figure": bool(image_base64),
-            "experiment_figure_paths": figure_paths if image_base64 else [],
+            "experiment_figure": bool(experiment_images or image_base64),
+            "experiment_figure_paths": figure_paths if experiment_images or image_base64 else [],
+            "experiment_images": [
+                {"alt_text": alt, "index": i}
+                for i, (_, alt) in enumerate(experiment_images or [])
+            ],
             "expected_images": [
                 {"alt_text": alt, "index": i} for i, (_, alt) in enumerate(expected_images)
             ],

--- a/src/qdash/copilot/services/support_service.py
+++ b/src/qdash/copilot/services/support_service.py
@@ -162,8 +162,7 @@ class CopilotSupportService:
             "experiment_figure": bool(experiment_images or image_base64),
             "experiment_figure_paths": figure_paths if experiment_images or image_base64 else [],
             "experiment_images": [
-                {"alt_text": alt, "index": i}
-                for i, (_, alt) in enumerate(experiment_images or [])
+                {"alt_text": alt, "index": i} for i, (_, alt) in enumerate(experiment_images or [])
             ],
             "expected_images": [
                 {"alt_text": alt, "index": i} for i, (_, alt) in enumerate(expected_images)

--- a/src/qdash/copilot/triage.py
+++ b/src/qdash/copilot/triage.py
@@ -144,6 +144,7 @@ def render_ai_triage_markdown(
             config=config,
             image_base64=context_bundle.image_base64,
             expected_images=context_bundle.expected_images,
+            experiment_images=context_bundle.experiment_images,
             conversation_history=[],
             tool_executors=None,
         )

--- a/src/qdash/figure_metadata.py
+++ b/src/qdash/figure_metadata.py
@@ -1,0 +1,31 @@
+"""Helpers for figure metadata shared by artifact producers and savers."""
+
+from typing import Any
+
+FIGURE_ROLE_META_KEY = "qdash_figure_role"
+ALLOWED_FIGURE_ROLES = {"raw", "marked"}
+
+
+def set_figure_role(fig: Any, role: str) -> Any:
+    """Annotate a Plotly figure with a stable artifact role."""
+    meta = getattr(getattr(fig, "layout", None), "meta", None)
+    next_meta = dict(meta) if isinstance(meta, dict) else {}
+    next_meta[FIGURE_ROLE_META_KEY] = role
+    fig.update_layout(meta=next_meta)
+    return fig
+
+
+def figure_role_suffix(fig: Any) -> str:
+    """Return a safe filename suffix from figure role metadata."""
+    meta = getattr(getattr(fig, "layout", None), "meta", None)
+    if not isinstance(meta, dict):
+        return ""
+
+    role = meta.get(FIGURE_ROLE_META_KEY)
+    if not isinstance(role, str):
+        return ""
+
+    normalized = role.strip().lower().replace(" ", "_")
+    if normalized in ALLOWED_FIGURE_ROLES:
+        return normalized
+    return ""

--- a/src/qdash/repository/filesystem.py
+++ b/src/qdash/repository/filesystem.py
@@ -13,6 +13,8 @@ import numpy as np
 import numpy.typing as npt
 import plotly.graph_objs as go
 
+from qdash.figure_metadata import figure_role_suffix
+
 logger = logging.getLogger(__name__)
 
 
@@ -152,14 +154,19 @@ class FilesystemCalibDataSaver:
         json_paths: list[str] = []
 
         for i, fig in enumerate(figures):
+            figure_suffix = figure_role_suffix(fig)
             # Save PNG
-            png_filename = self._build_filename(task_name, task_type, qid, "", "png", i)
+            png_filename = self._build_filename(
+                task_name, task_type, qid, figure_suffix, "png", i
+            )
             png_path = self._resolve_conflict(fig_dir / png_filename)
             fig.write_image(str(png_path))
             png_paths.append(str(png_path))
 
             # Save JSON
-            json_filename = self._build_filename(task_name, task_type, qid, "", "json", i)
+            json_filename = self._build_filename(
+                task_name, task_type, qid, figure_suffix, "json", i
+            )
             json_path = self._resolve_conflict(fig_dir / json_filename)
             fig.write_json(str(json_path))
             json_paths.append(str(json_path))

--- a/src/qdash/repository/filesystem.py
+++ b/src/qdash/repository/filesystem.py
@@ -156,9 +156,7 @@ class FilesystemCalibDataSaver:
         for i, fig in enumerate(figures):
             figure_suffix = figure_role_suffix(fig)
             # Save PNG
-            png_filename = self._build_filename(
-                task_name, task_type, qid, figure_suffix, "png", i
-            )
+            png_filename = self._build_filename(task_name, task_type, qid, figure_suffix, "png", i)
             png_path = self._resolve_conflict(fig_dir / png_filename)
             fig.write_image(str(png_path))
             png_paths.append(str(png_path))

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from qdash.datamodel.task import ParameterModel, RunParameterModel
+from qdash.figure_metadata import set_figure_role
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -233,6 +234,9 @@ class CheckQubitSpectroscopy(QubexTask):
             )
 
         # Return both raw and marked figures
+        set_figure_role(raw_fig, "raw")
+        if marked_fig is not None:
+            set_figure_role(marked_fig, "marked")
         figures: list[go.Figure] = [raw_fig]
         if marked_fig is not None:
             figures.append(marked_fig)

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
@@ -19,6 +19,7 @@ from qdash.analysis.spectroscopy import (
     remove_false_spike_from_figure,
 )
 from qdash.datamodel.task import ParameterModel, RunParameterModel
+from qdash.figure_metadata import set_figure_role
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
     RunResult,
@@ -273,6 +274,9 @@ class CheckResonatorSpectroscopy(QubexTask):
             )
 
         # Return both raw and marked figures
+        set_figure_role(raw_fig, "raw")
+        if marked_fig is not None:
+            set_figure_role(marked_fig, "marked")
         figures: list[go.Figure] = [raw_fig]
         if marked_fig is not None:
             figures.append(marked_fig)

--- a/tests/qdash/api/lib/test_copilot_agent.py
+++ b/tests/qdash/api/lib/test_copilot_agent.py
@@ -6,7 +6,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from qdash.copilot.agent import _run_chat_completions, _run_responses_api, run_analysis
+from qdash.copilot.agent import (
+    _build_messages,
+    _run_chat_completions,
+    _run_responses_api,
+    run_analysis,
+)
 from qdash.copilot.agent_runtime.execution import get_max_tool_rounds
 from qdash.copilot.agent_runtime.parsing import parse_response
 from qdash.copilot.config import CopilotConfig, ModelConfig
@@ -58,6 +63,26 @@ def test_parse_response_converts_plain_missing_triage_text_to_safe_review() -> N
     assert response.explanation.startswith("**Review triage**")
     assert "- Decision: `REVIEW`" in response.explanation
     assert "- Suggested labels: `model_format_error`" in response.explanation
+
+
+def test_build_messages_includes_multiple_target_images_with_labels() -> None:
+    messages = _build_messages(
+        "system",
+        "review",
+        image_base64="raw",
+        conversation_history=None,
+        expected_images=None,
+        experiment_images=[("raw", "target raw"), ("marked", "target marked")],
+    )
+
+    content = messages[-1]["content"]
+    texts = [part["text"] for part in content if part["type"] == "text"]
+    images = [part for part in content if part["type"] == "image_url"]
+
+    assert "Actual experimental result images:" in texts
+    assert "[Target: target raw]" in texts
+    assert "[Target: target marked]" in texts
+    assert len(images) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/qdash/copilot/test_ai_triage_bundle.py
+++ b/tests/qdash/copilot/test_ai_triage_bundle.py
@@ -134,9 +134,9 @@ def _bundle_context(tmp_path: Path) -> AITriageBundleContext:
 
 
 def _analysis_context_result(tmp_path: Path) -> AnalysisContextResult:
-    figure_png = tmp_path / "figure.png"
+    figure_png = tmp_path / "CheckQubitSpectroscopy_4_raw_0.png"
     figure_png.write_bytes(b"png-bytes")
-    figure_json = tmp_path / "figure.json"
+    figure_json = tmp_path / "CheckQubitSpectroscopy_4_marked_1.json"
     figure_json.write_text('{"value": 1}', encoding="utf-8")
     return AnalysisContextResult(
         context=_context(),
@@ -223,7 +223,7 @@ def test_export_ai_triage_replay_bundle_uses_shared_triage_inputs(tmp_path: Path
         "experiment_images/01_marked.png",
     ]
     assert manifest.inputs.expected_image_paths == ["expected_images/00.png"]
-    assert manifest.inputs.figure_paths == ["figures/00.png", "figures/01.json"]
+    assert manifest.inputs.figure_paths == ["figures/00_raw.png", "figures/01_marked.json"]
     assert bundle_context.context.qid == "4"
     assert runtime_config.analysis_model is not None
     assert runtime_config.analysis_model.name == "gpt-5.1"
@@ -244,3 +244,5 @@ def test_export_ai_triage_replay_bundle_uses_shared_triage_inputs(tmp_path: Path
         )
         assert "experiment_images/00_raw.png" in zf.namelist()
         assert "experiment_images/01_marked.png" in zf.namelist()
+        assert "figures/00_raw.png" in zf.namelist()
+        assert "figures/01_marked.json" in zf.namelist()

--- a/tests/qdash/copilot/test_ai_triage_bundle.py
+++ b/tests/qdash/copilot/test_ai_triage_bundle.py
@@ -141,6 +141,13 @@ def _analysis_context_result(tmp_path: Path) -> AnalysisContextResult:
     return AnalysisContextResult(
         context=_context(),
         image_base64=base64.b64encode(b"experiment").decode("utf-8"),
+        experiment_images=[
+            (base64.b64encode(b"experiment-raw").decode("utf-8"), "target raw result image"),
+            (
+                base64.b64encode(b"experiment-marked").decode("utf-8"),
+                "target marked result image",
+            ),
+        ],
         expected_images=[(base64.b64encode(b"expected").decode("utf-8"), "expected image")],
         figure_paths=[str(figure_png), str(figure_json)],
     )
@@ -211,6 +218,10 @@ def test_export_ai_triage_replay_bundle_uses_shared_triage_inputs(tmp_path: Path
     assert manifest.knowledge.repo_url == "https://github.com/example/qdash-task-knowledge.git"
     assert manifest.knowledge.commit == "abc123def456"
     assert manifest.selected_model.name == "gpt-5.1"
+    assert manifest.inputs.experiment_image_paths == [
+        "experiment_images/00_raw.png",
+        "experiment_images/01_marked.png",
+    ]
     assert manifest.inputs.expected_image_paths == ["expected_images/00.png"]
     assert manifest.inputs.figure_paths == ["figures/00.png", "figures/01.json"]
     assert bundle_context.context.qid == "4"
@@ -231,3 +242,5 @@ def test_export_ai_triage_replay_bundle_uses_shared_triage_inputs(tmp_path: Path
         assert json.loads(zf.read("manifest.json").decode("utf-8"))["bundle_type"] == (
             "ai_triage_replay"
         )
+        assert "experiment_images/00_raw.png" in zf.namelist()
+        assert "experiment_images/01_marked.png" in zf.namelist()

--- a/tests/qdash/workflow/engine/repository/test_filesystem_impl.py
+++ b/tests/qdash/workflow/engine/repository/test_filesystem_impl.py
@@ -52,9 +52,7 @@ class TestFilesystemCalibDataSaver:
             set_figure_role(go.Figure(data=[go.Scatter(x=[3], y=[4])]), "marked"),
         ]
 
-        png_paths, json_paths = saver.save_figures(
-            figs, "CheckQubitSpectroscopy", "qubit", "2"
-        )
+        png_paths, json_paths = saver.save_figures(figs, "CheckQubitSpectroscopy", "qubit", "2")
 
         assert Path(png_paths[0]).name == "CheckQubitSpectroscopy_2_raw_0.png"
         assert Path(png_paths[1]).name == "CheckQubitSpectroscopy_2_marked_1.png"

--- a/tests/qdash/workflow/engine/repository/test_filesystem_impl.py
+++ b/tests/qdash/workflow/engine/repository/test_filesystem_impl.py
@@ -7,6 +7,7 @@ import numpy as np
 import plotly.graph_objs as go
 import pytest
 
+from qdash.figure_metadata import set_figure_role
 from qdash.repository.filesystem import FilesystemCalibDataSaver
 
 
@@ -43,6 +44,22 @@ class TestFilesystemCalibDataSaver:
 
         assert len(png_paths) == 2
         assert len(json_paths) == 2
+
+    def test_save_figures_uses_figure_role_suffix(self, saver):
+        """Test save_figures includes raw/marked role suffixes when provided."""
+        figs = [
+            set_figure_role(go.Figure(data=[go.Scatter(x=[1], y=[2])]), "raw"),
+            set_figure_role(go.Figure(data=[go.Scatter(x=[3], y=[4])]), "marked"),
+        ]
+
+        png_paths, json_paths = saver.save_figures(
+            figs, "CheckQubitSpectroscopy", "qubit", "2"
+        )
+
+        assert Path(png_paths[0]).name == "CheckQubitSpectroscopy_2_raw_0.png"
+        assert Path(png_paths[1]).name == "CheckQubitSpectroscopy_2_marked_1.png"
+        assert Path(json_paths[0]).name == "CheckQubitSpectroscopy_2_raw_0.json"
+        assert Path(json_paths[1]).name == "CheckQubitSpectroscopy_2_marked_1.json"
 
     def test_save_figures_empty_list(self, saver):
         """Test save_figures with empty list returns empty lists."""


### PR DESCRIPTION
## Summary
- Add labeled multi-image target support to Copilot analysis inputs
- Collect all PNG task result figures as target candidates, with raw/marked role labels
- Export AI triage replay bundles with labeled target images such as raw and marked
- Pass experiment_images through API, streaming, and AI triage paths

## Benchmark
- raw-only target: 4/5 format failures caused by COR_RECT
- raw+marked target: 0/5 format failures with the same 5 CheckQubitSpectroscopy bundles

## Tests
- uv run --group api --group dev pytest tests/qdash/api/lib/test_copilot_agent.py::test_build_messages_includes_multiple_target_images_with_labels tests/qdash/api/lib/test_copilot_agent.py::test_run_analysis_translates_ollama_output_when_target_language_mismatches tests/qdash/copilot/test_ai_triage_bundle.py