### PR TITLE
feat(workflow): update full calibration template to include ConfigureAll

### DIFF
--- a/src/qdash/workflow/templates/full_calibration.py
+++ b/src/qdash/workflow/templates/full_calibration.py
@@ -3,12 +3,13 @@
 This template demonstrates the step-based calibration API.
 
 Execution flow:
-    1. OneQubitCheck: Basic 1Q characterization (Rabi, HPI, T1, T2, Ramsey)
-    2. FilterByStatus: Filter to only successful qubits
-    3. OneQubitFineTune: Advanced 1Q calibration (DRAG, RB, X90 IRB)
-    4. FilterByMetric: Filter by X90 fidelity threshold
-    5. GenerateCRSchedule: Generate 2Q execution schedule
-    6. TwoQubitCalibration: 2Q coupling calibration
+    1. ConfigureAll: Push the current full-chip configuration to the selected MUXes
+    2. OneQubitCheck: Basic 1Q characterization (Rabi, HPI, T1, T2, Ramsey)
+    3. FilterByStatus: Filter to only successful qubits
+    4. OneQubitFineTune: Advanced 1Q calibration (DRAG, RB, X90 IRB)
+    5. FilterByMetric: Filter by X90 fidelity threshold
+    6. GenerateCRSchedule: Generate 2Q execution schedule
+    7. TwoQubitCalibration: 2Q coupling calibration
 
 Example:
     full_calibration(
@@ -26,6 +27,7 @@ from prefect import flow
 from qdash.workflow.service import CalibService
 from qdash.workflow.service.calib_service import on_flow_cancellation
 from qdash.workflow.service.steps import (
+    ConfigureAll,
     FilterByMetric,
     FilterByStatus,
     GenerateCRSchedule,
@@ -91,6 +93,8 @@ def full_calibration(
     # =========================================================================
 
     steps = [
+        # Stage 0: Push current configuration to all selected MUXes
+        ConfigureAll(),
         # Stage 1: Basic 1Q characterization
         OneQubitCheck(mode="synchronized"),
         FilterByStatus(),  # Only proceed with successful qubits

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -26,7 +26,7 @@
   {
     "id": "full_calibration",
     "name": "Full Calibration",
-    "description": "Complete calibration using step-based pipeline: 1Q Check -> 1Q Fine-tune -> Filter -> CR Schedule (forward/reverse) -> 2Q.",
+    "description": "Complete calibration using step-based pipeline: ConfigureAll -> 1Q Check -> 1Q Fine-tune -> Filter -> CR Schedule (forward/reverse) -> 2Q.",
     "category": "production",
     "filename": "full_calibration.py",
     "function_name": "full_calibration"

--- a/tests/qdash/api/routers/test_flow.py
+++ b/tests/qdash/api/routers/test_flow.py
@@ -1,6 +1,7 @@
 """Tests for flow router endpoints."""
 
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -340,3 +341,29 @@ class TestFlowExecution:
         parameters = call_args.kwargs.get("parameters", {})
         assert parameters["username"] == "editor_user"
         assert parameters["project_id"] == "test_project"
+
+
+class TestFlowTemplates:
+    """Tests for flow template endpoints."""
+
+    def test_get_full_calibration_template_includes_configure_all(
+        self, test_client, test_project, auth_headers
+    ):
+        """Test that the full calibration template starts with ConfigureAll."""
+        repo_root = Path(__file__).resolve().parents[4]
+        templates_dir = repo_root / "src/qdash/workflow/templates"
+
+        with (
+            patch("qdash.api.services.flow_service.TEMPLATES_DIR", templates_dir),
+            patch(
+                "qdash.api.services.flow_service.TEMPLATES_METADATA_FILE",
+                templates_dir / "templates.json",
+            ),
+        ):
+            response = test_client.get("/flows/templates/full_calibration", headers=auth_headers)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == "full_calibration"
+        assert "ConfigureAll -> 1Q Check" in data["description"]
+        assert "ConfigureAll()," in data["code"]


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updated the full calibration template to include the `ConfigureAll` step, enhancing the execution flow for calibration processes.
- This change improves the workflow by ensuring the current full-chip configuration is pushed to selected MUXes before proceeding with other calibration steps.

## Changes
- Added `ConfigureAll` as the first step in the full calibration execution flow.
- Updated the description of the full calibration template to reflect the new step.
- Included a test to verify that the full calibration template starts with `ConfigureAll`.

