### PR TITLE
feat(repo): integrate triage markdown into task knowledge

### DIFF
--- a/docs/.vitepress/task-knowledge-sidebar.json
+++ b/docs/.vitepress/task-knowledge-sidebar.json
@@ -106,10 +106,6 @@
       {
         "text": "ReadoutClassification",
         "link": "/task-knowledge/td-characterization/ReadoutClassification"
-      },
-      {
-        "text": "ChevronPattern",
-        "link": "/task-knowledge/td-characterization/ChevronPattern"
       }
     ]
   },
@@ -196,6 +192,16 @@
       {
         "text": "ZX90InterleavedRandomizedBenchmarking",
         "link": "/task-knowledge/benchmarking/ZX90InterleavedRandomizedBenchmarking"
+      }
+    ]
+  },
+  {
+    "text": "Other",
+    "collapsed": true,
+    "items": [
+      {
+        "text": "ChevronPattern",
+        "link": "/task-knowledge/other/ChevronPattern"
       }
     ]
   }

--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -17612,6 +17612,14 @@
             "type": "string",
             "title": "Prompt Guidance",
             "default": ""
+          },
+          "images": {
+            "items": {
+              "$ref": "#/components/schemas/KnowledgeImageResponse"
+            },
+            "type": "array",
+            "title": "Images",
+            "default": []
           }
         },
         "type": "object",
@@ -22147,6 +22155,19 @@
             "title": "Images",
             "default": []
           },
+          "triage_markdown": {
+            "type": "string",
+            "title": "Triage Markdown",
+            "default": ""
+          },
+          "triage_images": {
+            "items": {
+              "$ref": "#/components/schemas/KnowledgeImageResponse"
+            },
+            "type": "array",
+            "title": "Triage Images",
+            "default": []
+          },
           "cases": {
             "items": {
               "$ref": "#/components/schemas/KnowledgeCaseResponse"
@@ -22158,6 +22179,11 @@
           "prompt_text": {
             "type": "string",
             "title": "Prompt Text"
+          },
+          "triage_prompt_text": {
+            "type": "string",
+            "title": "Triage Prompt Text",
+            "default": ""
           }
         },
         "type": "object",
@@ -22208,6 +22234,11 @@
           "has_analysis_guide": {
             "type": "boolean",
             "title": "Has Analysis Guide",
+            "default": false
+          },
+          "has_triage_guide": {
+            "type": "boolean",
+            "title": "Has Triage Guide",
             "default": false
           }
         },

--- a/docs/task-knowledge/cw-characterization/CheckResonatorSpectroscopy/triage.md
+++ b/docs/task-knowledge/cw-characterization/CheckResonatorSpectroscopy/triage.md
@@ -1,0 +1,32 @@
+# CheckResonatorSpectroscopy AI Triage Guide
+
+This guide helps the AI decide whether a resonator-spectroscopy result is operationally usable for automatic follow-up.
+
+## Decision focus
+
+- Judge the full MUX map first, then the assigned qubit frequency.
+- Prefer `PASS` only when all expected resonators are visible and the assigned `readout_frequency` is clearly supported by the annotated peak.
+- Prefer `REVIEW` when the map is partially usable but ambiguity remains around peak count, MUX ordering, or peak assignment.
+- Prefer `FAIL` when the scan does not support reliable readout-frequency assignment.
+
+## MUX-specific rules
+
+- This is a MUX-level task. The representative result can affect multiple qubits, so weak evidence should not be auto-approved.
+- A peak count below the expected `num_resonators` is usually a `FAIL` unless the task parameters intentionally reduced the expected count.
+- If peaks are present but one assignment is ambiguous because of overlap or crossing trajectories, prefer `REVIEW` instead of `PASS`.
+- Mild frequency drift can still be acceptable when the resonance structure is clean and the assigned qubit peak is unambiguous.
+
+## Typical review triggers
+
+- One or more resonators are missing from the annotated result.
+- Two resonators are so close that the assigned qubit frequency may map to the wrong MUX position.
+- High-power and low-power traces disagree strongly, suggesting unstable detection or a wrong peak family.
+- The assigned `readout_frequency` sits far from the visually strongest resonance for that qubit position.
+- The map shows no clear power dependence and the detected points look dominated by noise or artifacts.
+
+## Recommended labels
+
+- Use `NO_SIGNAL` when resonator dips are not clearly observable or most expected peaks are absent.
+- Use `BAD_FIT` when peaks exist but the detected/annotated assignment is inconsistent with the visible resonance structure.
+- Use `OUTLIER` when the map is readable but the resulting frequency placement is suspicious compared with the rest of the MUX.
+- Use `PASS` only when the figure supports the assigned frequency without material ambiguity.

--- a/docs/task-knowledge/index.md
+++ b/docs/task-knowledge/index.md
@@ -11,6 +11,7 @@ Calibration task knowledge base for QDash copilot analysis. Each page describes 
 | [DumpBox](./box-setup/DumpBox) | Dumps diagnostic information from all control boxes. |
 | [CheckNoise](./box-setup/CheckNoise) | Checks the noise levels in the control and readout system. |
 | [Configure](./box-setup/Configure) | Loads and applies the full calibration state configuration to the control boxes. |
+| [ConfigureAll](./box-setup/ConfigureAll) |  |
 | [ReadoutConfigure](./box-setup/ReadoutConfigure) | Configures readout parameters for a specified subset of qubits. |
 
 ## CW Characterization
@@ -39,7 +40,7 @@ Calibration task knowledge base for QDash copilot analysis. Each page describes 
 | [CheckDispersiveShift](./td-characterization/CheckDispersiveShift) | Measures dispersive shift (χ) between qubit and readout resonator. |
 | [CheckOptimalReadoutAmplitude](./td-characterization/CheckOptimalReadoutAmplitude) | Optimizes readout pulse amplitude for best state discrimination. |
 | [ReadoutClassification](./td-characterization/ReadoutClassification) | Calibrates and evaluates readout state discrimination (|0⟩ vs |1⟩ classification). |
-| [ChevronPattern](./td-characterization/ChevronPattern) | Measures qubit response vs frequency and time to map the chevron pattern. |
+| [CheckFineChevron](./td-characterization/CheckFineChevron) |  |
 
 ## One-Qubit Gate Calibration
 
@@ -73,6 +74,12 @@ Calibration task knowledge base for QDash copilot analysis. Each page describes 
 | [X180InterleavedRandomizedBenchmarking](./benchmarking/X180InterleavedRandomizedBenchmarking) | Measures X180 (π) gate-specific error rate via interleaved randomized benchmarking. |
 | [ZX90InterleavedRandomizedBenchmarking](./benchmarking/ZX90InterleavedRandomizedBenchmarking) | Measures ZX90 two-qubit gate error rate via interleaved randomized benchmarking. |
 
+## Other
+
+| Task | Description |
+|------|-------------|
+| [ChevronPattern](./ChevronPattern) | Measures qubit response vs frequency and time to map the chevron pattern. |
+
 ## Calibration Workflows
 
 Standard calibration workflows and their task composition. See [workflow task definitions](https://github.com/oqtopus-team/qdash/blob/develop/src/qdash/workflow/service/tasks.py) for the source of truth.
@@ -92,7 +99,7 @@ flowchart LR
 
 1. [CheckResonatorSpectroscopy](./cw-characterization/CheckResonatorSpectroscopy)
 2. [CheckQubitSpectroscopy](./cw-characterization/CheckQubitSpectroscopy)
-3. [ChevronPattern](./td-characterization/ChevronPattern)
+3. ChevronPattern
 
 ### 1Q Check
 

--- a/scripts/generate_task_knowledge.py
+++ b/scripts/generate_task_knowledge.py
@@ -426,6 +426,43 @@ def _parse_cases_dir(task_dir: Path) -> list[dict]:
     return cases
 
 
+def _parse_aux_markdown(path: Path) -> tuple[str, list[dict]]:
+    """Parse an auxiliary markdown file and inline any referenced images."""
+    if not path.is_file():
+        return "", []
+
+    raw = path.read_text(encoding="utf-8")
+    images: list[dict] = []
+    for m in _IMAGE_RE.finditer(raw):
+        rel = m.group(2)
+        img_path = (path.parent / rel).resolve()
+        b64 = ""
+        if img_path.is_file():
+            try:
+                data = img_path.read_bytes()
+                if len(data) > MAX_IMAGE_SIZE:
+                    print(f"  Warning: {img_path.name} ({len(data)} bytes) exceeds 1MB limit, skipping")
+                elif _detect_image_type(data) is None:
+                    print(f"  Warning: {img_path.name} is not a valid image format, skipping")
+                else:
+                    b64 = base64.b64encode(data).decode("ascii")
+                    print(f"  Encoded aux image {img_path.name} ({len(data)} bytes)")
+            except (OSError, MemoryError) as e:
+                print(f"  Error encoding {img_path.name}: {e}")
+        else:
+            print(f"  Warning: Aux image not found: {rel}")
+        images.append(
+            {
+                "alt_text": m.group(1),
+                "relative_path": rel,
+                "section": path.stem,
+                "base64_data": b64,
+            }
+        )
+
+    return raw, images
+
+
 def _parse_markdown_file(path: Path) -> dict | None:
     """Parse a Markdown knowledge file into a dict.
 
@@ -517,6 +554,9 @@ def _parse_markdown_file(path: Path) -> dict | None:
             ).strip()
             fields[field_name] = clean
 
+    # --- triage guide ---
+    triage_markdown, triage_images = _parse_aux_markdown(path.parent / "triage.md")
+
     # --- cases ---
     cases = _parse_cases_dir(path.parent)
 
@@ -540,6 +580,8 @@ def _parse_markdown_file(path: Path) -> dict | None:
         "output_parameters_info": fields.get("output_parameters_info", []),
         "analysis_guide": fields.get("analysis_guide", []),
         "images": images,
+        "triage_markdown": triage_markdown,
+        "triage_images": triage_images,
         "related_context": fields.get("related_context", []),
         "cases": cases,
     }

--- a/src/qdash/api/schemas/task.py
+++ b/src/qdash/api/schemas/task.py
@@ -97,6 +97,7 @@ class KnowledgeCaseResponse(BaseModel):
     applicability: str = ""
     counterexample: str = ""
     prompt_guidance: str = ""
+    images: list[KnowledgeImageResponse] = []
     model_config = ConfigDict(protected_namespaces=())
 
 
@@ -117,8 +118,11 @@ class TaskKnowledgeResponse(BaseModel):
     analysis_guide: list[str] = []
     prerequisites: list[str] = []
     images: list[KnowledgeImageResponse] = []
+    triage_markdown: str = ""
+    triage_images: list[KnowledgeImageResponse] = []
     cases: list[KnowledgeCaseResponse] = []
     prompt_text: str
+    triage_prompt_text: str = ""
 
 
 class TaskKnowledgeSummaryResponse(BaseModel):
@@ -131,6 +135,7 @@ class TaskKnowledgeSummaryResponse(BaseModel):
     case_count: int = 0
     image_count: int = 0
     has_analysis_guide: bool = False
+    has_triage_guide: bool = False
 
 
 class ListTaskKnowledgeResponse(BaseModel):

--- a/src/qdash/api/services/task_service.py
+++ b/src/qdash/api/services/task_service.py
@@ -227,6 +227,7 @@ class TaskService:
                 case_count=len(k.cases),
                 image_count=len(k.images),
                 has_analysis_guide=len(k.analysis_guide) > 0,
+                has_triage_guide=bool(k.triage_markdown.strip()),
             )
             for k in all_knowledge
         ]
@@ -276,6 +277,11 @@ class TaskService:
             analysis_guide=knowledge.analysis_guide,
             prerequisites=knowledge.prerequisites,
             images=[KnowledgeImageResponse(**img.model_dump()) for img in knowledge.images],
+            triage_markdown=knowledge.triage_markdown,
+            triage_images=[
+                KnowledgeImageResponse(**img.model_dump()) for img in knowledge.triage_images
+            ],
             cases=[KnowledgeCaseResponse(**case.model_dump()) for case in knowledge.cases],
             prompt_text=knowledge.to_prompt(),
+            triage_prompt_text=knowledge.to_triage_prompt(),
         )

--- a/src/qdash/copilot/runtime.py
+++ b/src/qdash/copilot/runtime.py
@@ -150,9 +150,17 @@ class CopilotRuntime:
         self,
         knowledge: Any,
         max_images: int | None,
+        *,
+        include_case_images: bool = True,
+        include_triage_images: bool = True,
     ) -> list[tuple[str, str]]:
         """Forward expected-image lookup for analysis context assembly."""
-        return self.collect_expected_images(knowledge, max_images=max_images)
+        return self.collect_expected_images(
+            knowledge,
+            max_images=max_images,
+            include_case_images=include_case_images,
+            include_triage_images=include_triage_images,
+        )
 
     def _provenance_resolve_project_id(self, chip_id: str) -> str | None:
         """Forward project-id lookup for provenance lineage assembly."""
@@ -186,13 +194,21 @@ class CopilotRuntime:
         self,
         knowledge: Any,
         max_images: int | None = None,
+        *,
+        include_case_images: bool = True,
+        include_triage_images: bool = True,
     ) -> list[tuple[str, str]]:
         """Collect expected reference images from TaskKnowledge.
 
         Returns list of (base64_data, alt_text) for images with embedded data.
         Includes both task-level images and case-level images.
         """
-        return self._support_service.collect_expected_images(knowledge, max_images=max_images)
+        return self._support_service.collect_expected_images(
+            knowledge,
+            max_images=max_images,
+            include_case_images=include_case_images,
+            include_triage_images=include_triage_images,
+        )
 
     def load_task_history(
         self, task_name: str, chip_id: str, qid: str, last_n: int = 5
@@ -434,6 +450,7 @@ class CopilotRuntime:
         task_id: str,
         image_base64: str | None,
         config: CopilotConfig,
+        use_triage_knowledge: bool = False,
     ) -> AnalysisContextResult:
         """Build a full analysis context from DB data and TaskKnowledge.
 
@@ -448,6 +465,7 @@ class CopilotRuntime:
             task_id=task_id,
             image_base64=image_base64,
             config=config,
+            use_triage_knowledge=use_triage_knowledge,
         )
 
     @staticmethod

--- a/src/qdash/copilot/services/analysis_context_service.py
+++ b/src/qdash/copilot/services/analysis_context_service.py
@@ -26,7 +26,7 @@ class AnalysisContextBuilder:
         load_coupling_params: Callable[[str, str, list[str] | None], dict[str, dict[str, Any]]],
         load_figure_as_base64: Callable[[list[str]], str | None],
         load_figures_as_base64: Callable[[list[str]], list[tuple[str, str]]],
-        collect_expected_images: Callable[[Any, int | None], list[tuple[str, str]]],
+        collect_expected_images: Callable[..., list[tuple[str, str]]],
     ) -> None:
         self._load_qubit_params = load_qubit_params
         self._load_task_result = load_task_result
@@ -46,6 +46,7 @@ class AnalysisContextBuilder:
         task_id: str,
         image_base64: str | None,
         config: CopilotConfig,
+        use_triage_knowledge: bool = False,
     ) -> AnalysisContextResult:
         """Build the full analysis context consumed by Copilot review flows."""
         from qdash.copilot.contracts import (
@@ -55,7 +56,11 @@ class AnalysisContextBuilder:
         from qdash.datamodel.task_knowledge import get_task_knowledge
 
         knowledge = get_task_knowledge(task_name)
-        knowledge_prompt = self._build_task_knowledge_prompt(task_name, knowledge)
+        knowledge_prompt = self._build_task_knowledge_prompt(
+            task_name,
+            knowledge,
+            use_triage_knowledge=use_triage_knowledge,
+        )
         qubit_params = self._load_qubit_params(chip_id, qid)
         task_result = self._load_task_result(task_id)
         input_params, output_params, run_params, figure_paths = self._extract_task_result_payload(
@@ -75,6 +80,7 @@ class AnalysisContextBuilder:
             figure_paths=figure_paths,
             image_base64=image_base64,
             config=config,
+            use_triage_knowledge=use_triage_knowledge,
         )
 
         context = TaskAnalysisContext(
@@ -98,9 +104,18 @@ class AnalysisContextBuilder:
         )
 
     @staticmethod
-    def _build_task_knowledge_prompt(task_name: str, knowledge: Any) -> str:
+    def _build_task_knowledge_prompt(
+        task_name: str,
+        knowledge: Any,
+        *,
+        use_triage_knowledge: bool,
+    ) -> str:
         """Build the prompt prefix from task knowledge or fall back to the task name."""
-        return knowledge.to_prompt() if knowledge else f"Task: {task_name}"
+        if not knowledge:
+            return f"Task: {task_name}"
+        if use_triage_knowledge:
+            return knowledge.to_triage_prompt()
+        return knowledge.to_prompt()
 
     @staticmethod
     def _extract_task_result_payload(
@@ -153,6 +168,7 @@ class AnalysisContextBuilder:
         figure_paths: list[str],
         image_base64: str | None,
         config: CopilotConfig,
+        use_triage_knowledge: bool,
     ) -> tuple[str | None, list[tuple[str, str]], list[tuple[str, str]]]:
         """Resolve experiment and expected images for multimodal analysis."""
         expected_images: list[tuple[str, str]] = []
@@ -167,5 +183,7 @@ class AnalysisContextBuilder:
         expected_images = self._collect_expected_images(
             knowledge,
             config.analysis.max_expected_images,
+            include_case_images=not use_triage_knowledge,
+            include_triage_images=use_triage_knowledge,
         )
         return image_base64, expected_images, experiment_images

--- a/src/qdash/copilot/services/support_service.py
+++ b/src/qdash/copilot/services/support_service.py
@@ -102,15 +102,23 @@ class CopilotSupportService:
     def collect_expected_images(
         knowledge: Any,
         max_images: int | None = None,
+        *,
+        include_case_images: bool = True,
+        include_triage_images: bool = True,
     ) -> list[tuple[str, str]]:
         """Collect expected reference images from TaskKnowledge."""
         if knowledge is None:
             return []
         result = [(img.base64_data, img.alt_text) for img in knowledge.images if img.base64_data]
-        for case in knowledge.cases:
-            for img in case.images:
+        if include_triage_images:
+            for img in getattr(knowledge, "triage_images", []):
                 if img.base64_data:
-                    result.append((img.base64_data, f"[Case: {case.title}] {img.alt_text}"))
+                    result.append((img.base64_data, f"[Triage guide] {img.alt_text}"))
+        if include_case_images:
+            for case in knowledge.cases:
+                for img in case.images:
+                    if img.base64_data:
+                        result.append((img.base64_data, f"[Case: {case.title}] {img.alt_text}"))
         if max_images is not None and max_images >= 0:
             return result[:max_images]
         return result

--- a/src/qdash/copilot/triage.py
+++ b/src/qdash/copilot/triage.py
@@ -74,6 +74,7 @@ def build_ai_triage_context(
         task_id=task_id,
         image_base64=None,
         config=config,
+        use_triage_knowledge=True,
     )
     context_bundle.context = context_bundle.context.model_copy(
         update={"recent_values": [], "history_results": []}

--- a/src/qdash/datamodel/task_knowledge.py
+++ b/src/qdash/datamodel/task_knowledge.py
@@ -187,6 +187,14 @@ class TaskKnowledge(BaseModel):
         default_factory=list,
         description="Image references from the markdown file",
     )
+    triage_markdown: str = Field(
+        default="",
+        description="Optional AI-triage-specific markdown guidance",
+    )
+    triage_images: list[TaskKnowledgeImage] = Field(
+        default_factory=list,
+        description="Image references from the triage markdown file",
+    )
     related_context: list[RelatedContextItem] = Field(
         default_factory=list,
         description="Additional data sources to load during analysis",
@@ -333,6 +341,59 @@ class TaskKnowledge(BaseModel):
                 if case.images:
                     for img in case.images:
                         lines.append(f"   - Image: {img.alt_text} ({img.relative_path})")
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _normalize_markdown_block(markdown: str) -> str:
+        """Strip top-level heading and image lines from a markdown block."""
+        normalized_lines: list[str] = []
+        for line in markdown.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# "):
+                continue
+            if stripped.startswith("!["):
+                continue
+            normalized_lines.append(line)
+        return "\n".join(normalized_lines).strip()
+
+    def to_triage_prompt(self) -> str:
+        """Build a compact prompt focused on AI triage decisions."""
+        lines = [
+            f"## Experiment: {self.name}",
+            self.summary,
+            "",
+            "### What it measures",
+            self.what_it_measures,
+            "",
+            "### Expected result",
+            self.expected_result.description,
+        ]
+
+        if self.expected_result.good_visual:
+            lines += ["", f"- Good result looks like: {self.expected_result.good_visual}"]
+
+        if self.check_questions:
+            lines += ["", "### Review questions"]
+            lines += [f"- {question}" for question in self.check_questions]
+
+        if self.failure_modes:
+            lines += ["", "### Common failure patterns"]
+            for failure in self.failure_modes:
+                lines.append(f"- [{failure.severity}] {failure.description}")
+                if failure.visual:
+                    lines.append(f"  - Visual: {failure.visual}")
+                if failure.next_action:
+                    lines.append(f"  - Next: {failure.next_action}")
+
+        if self.analysis_guide:
+            lines += ["", "### Analysis guide"]
+            for index, step in enumerate(self.analysis_guide, 1):
+                lines.append(f"{index}. {step}")
+
+        triage_markdown = self._normalize_markdown_block(self.triage_markdown)
+        if triage_markdown:
+            lines += ["", "### AI triage guidance", triage_markdown]
 
         return "\n".join(lines)
 

--- a/tests/qdash/api/services/test_copilot_data_service.py
+++ b/tests/qdash/api/services/test_copilot_data_service.py
@@ -455,6 +455,60 @@ class TestBuildAnalysisContext:
             )
 
         load_fig.assert_called_once_with(["/tmp/figure.png"])
-        collect_expected.assert_called_once_with(knowledge, max_images=2)
+        collect_expected.assert_called_once_with(
+            knowledge,
+            max_images=2,
+            include_case_images=True,
+            include_triage_images=False,
+        )
         assert result.image_base64 == "encoded-image"
         assert result.expected_images == [("img-1", "expected alt")]
+
+    def test_triage_context_uses_triage_prompt_and_triage_images(self):
+        service = CopilotRuntime(data_access=MagicMock())
+        knowledge = MagicMock()
+        knowledge.to_triage_prompt.return_value = "Triage prompt body"
+        knowledge.related_context = []
+
+        with (
+            patch.object(service, "load_qubit_params", return_value={}),
+            patch.object(
+                service,
+                "load_task_result",
+                return_value={
+                    "input_parameters": {},
+                    "output_parameters": {},
+                    "run_parameters": {},
+                    "figure_path": ["/tmp/figure.png"],
+                },
+            ),
+            patch.object(
+                service, "load_figure_as_base64", return_value="encoded-image"
+            ) as load_fig,
+            patch.object(
+                service,
+                "collect_expected_images",
+                return_value=[("triage-img", "triage alt")],
+            ) as collect_expected,
+            patch("qdash.datamodel.task_knowledge.get_task_knowledge", return_value=knowledge),
+        ):
+            result = service.build_analysis_context(
+                task_name="CheckResonatorSpectroscopy",
+                chip_id="chip-1",
+                qid="16",
+                task_id="task-1",
+                image_base64=None,
+                config=self._config(multimodal=True),
+                use_triage_knowledge=True,
+            )
+
+        load_fig.assert_called_once_with(["/tmp/figure.png"])
+        collect_expected.assert_called_once_with(
+            knowledge,
+            max_images=2,
+            include_case_images=False,
+            include_triage_images=True,
+        )
+        assert result.context.task_knowledge_prompt == "Triage prompt body"
+        assert result.image_base64 == "encoded-image"
+        assert result.expected_images == [("triage-img", "triage alt")]

--- a/tests/qdash/api/services/test_task_service.py
+++ b/tests/qdash/api/services/test_task_service.py
@@ -1,0 +1,115 @@
+from unittest.mock import MagicMock, patch
+
+from qdash.api.services.task_service import TaskService
+from qdash.datamodel.task_knowledge import (
+    ExpectedResult,
+    FailureMode,
+    KnowledgeCase,
+    OutputParameterInfo,
+    TaskKnowledge,
+    TaskKnowledgeImage,
+)
+
+
+def _service() -> TaskService:
+    return TaskService(task_definition_repository=MagicMock())
+
+
+def _knowledge() -> TaskKnowledge:
+    return TaskKnowledge(
+        name="CheckResonatorSpectroscopy",
+        category="cw-characterization",
+        summary="High-resolution 2D spectroscopy of all resonators in a readout multiplexer.",
+        what_it_measures="Readout resonator frequencies within one MUX.",
+        physical_principle="Resonator response is swept across frequency and power.",
+        expected_result=ExpectedResult(
+            description="A 2D map with annotated resonator peaks.",
+            good_visual="Four clean resonator trajectories with stable peak assignment.",
+        ),
+        evaluation_criteria="All expected resonators should be visible and separable.",
+        check_questions=["Are all expected resonators detected?"],
+        failure_modes=[
+            FailureMode(
+                severity="critical",
+                description="Missing resonator peaks",
+                visual="Fewer peaks than expected",
+                next_action="Widen the scan range",
+            )
+        ],
+        output_parameters_info=[
+            OutputParameterInfo(
+                name="readout_frequency",
+                description="Assigned resonator frequency for the qubit under review.",
+            )
+        ],
+        analysis_guide=["Review the annotated 2D map."],
+        images=[
+            TaskKnowledgeImage(
+                alt_text="Expected resonator map",
+                relative_path="expected-map.png",
+                section="expected_result",
+                base64_data="task-image-b64",
+            )
+        ],
+        triage_markdown=(
+            "# CheckResonatorSpectroscopy AI Triage Guide\n\n"
+            "Use REVIEW when peak assignment is ambiguous.\n\n"
+            "![Triage example](triage.png)"
+        ),
+        triage_images=[
+            TaskKnowledgeImage(
+                alt_text="Triage example",
+                relative_path="triage.png",
+                section="triage",
+                base64_data="triage-image-b64",
+            )
+        ],
+        cases=[
+            KnowledgeCase(
+                title="Overlapping resonators in one MUX",
+                severity="warning",
+                human_review_decision="Escalate for human review.",
+                boundary_criteria="Two resonators overlap near the assigned slot.",
+                lesson_learned=["Peak overlap should block auto-pass."],
+                images=[
+                    TaskKnowledgeImage(
+                        alt_text="Case overlap map",
+                        relative_path="cases/overlap.png",
+                        section="cases",
+                        base64_data="case-image-b64",
+                    )
+                ],
+            )
+        ],
+    )
+
+
+def test_list_task_knowledge_sets_has_triage_guide_from_markdown() -> None:
+    knowledge = _knowledge()
+    service = _service()
+
+    with patch("qdash.api.services.task_service._list_all_knowledge", return_value=[knowledge]):
+        response = service.list_task_knowledge()
+
+    assert len(response.items) == 1
+    assert response.items[0].name == "CheckResonatorSpectroscopy"
+    assert response.items[0].has_analysis_guide is True
+    assert response.items[0].has_triage_guide is True
+    assert response.items[0].case_count == 1
+    assert response.items[0].image_count == 1
+
+
+def test_get_task_knowledge_includes_triage_prompt_and_case_images() -> None:
+    knowledge = _knowledge()
+    service = _service()
+
+    with patch("qdash.api.services.task_service._lookup_knowledge", return_value=knowledge):
+        response = service.get_task_knowledge("CheckResonatorSpectroscopy")
+
+    assert response.triage_markdown == knowledge.triage_markdown
+    assert response.triage_images[0].base64_data == "triage-image-b64"
+    assert response.cases[0].images[0].base64_data == "case-image-b64"
+    assert response.prompt_text
+    assert "### AI triage guidance" in response.triage_prompt_text
+    assert "Use REVIEW when peak assignment is ambiguous." in response.triage_prompt_text
+    assert "![Triage example]" not in response.triage_prompt_text

--- a/ui/src/components/features/task-knowledge/TaskKnowledgeDetailPage.tsx
+++ b/ui/src/components/features/task-knowledge/TaskKnowledgeDetailPage.tsx
@@ -1,10 +1,32 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Image as ImageIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";
 import { AXIOS_INSTANCE } from "@/lib/api/custom-instance";
+
+type KnowledgeImage = {
+  alt_text: string;
+  relative_path: string;
+  base64_data?: string;
+};
+
+type KnowledgeCase = {
+  title: string;
+  date?: string;
+  severity?: string;
+  human_review_decision?: string;
+  boundary_criteria?: string;
+  lesson_learned?: string[];
+  images?: KnowledgeImage[];
+};
+
+type TaskKnowledgeDetail = {
+  triage_markdown?: string;
+  triage_images?: KnowledgeImage[];
+  cases?: KnowledgeCase[];
+};
 
 function useTaskKnowledgeMarkdown(taskName: string) {
   return useQuery({
@@ -18,11 +40,22 @@ function useTaskKnowledgeMarkdown(taskName: string) {
   });
 }
 
+function useTaskKnowledgeDetail(taskName: string) {
+  return useQuery({
+    queryKey: ["task-knowledge-detail", taskName],
+    queryFn: async () => {
+      const resp = await AXIOS_INSTANCE.get(`/tasks/${taskName}/knowledge`);
+      return resp.data as TaskKnowledgeDetail;
+    },
+  });
+}
+
 export function TaskKnowledgeDetailPage({ taskName }: { taskName: string }) {
   const router = useRouter();
-  const { data: markdown, isLoading, error } = useTaskKnowledgeMarkdown(taskName);
+  const { data: markdown, isLoading: markdownLoading, error } = useTaskKnowledgeMarkdown(taskName);
+  const { data: detail, isLoading: detailLoading } = useTaskKnowledgeDetail(taskName);
 
-  if (isLoading) {
+  if (markdownLoading || detailLoading) {
     return (
       <div className="flex justify-center py-16">
         <span className="loading loading-spinner loading-lg"></span>
@@ -59,6 +92,117 @@ export function TaskKnowledgeDetailPage({ taskName }: { taskName: string }) {
         <h1 className="text-xl font-bold font-mono">{taskName}</h1>
       </div>
       <MarkdownContent content={markdown} />
+
+      {detail?.triage_markdown?.trim() && (
+        <section className="mt-10">
+          <div className="mb-3">
+            <h2 className="text-lg font-semibold">AI Triage Guide</h2>
+            <p className="text-sm text-base-content/60">
+              Operational guidance used for automatic review decisions.
+            </p>
+          </div>
+          <div className="rounded-xl border border-base-300 bg-base-100 p-5">
+            <MarkdownContent content={detail.triage_markdown} />
+          </div>
+        </section>
+      )}
+
+      {(detail?.cases?.length ?? 0) > 0 && (
+        <section className="mt-10">
+          <div className="mb-3">
+            <h2 className="text-lg font-semibold">Cases</h2>
+            <p className="text-sm text-base-content/60">
+              Operational cases and counterexamples linked to this task.
+            </p>
+          </div>
+          <div className="space-y-4">
+            {detail?.cases?.map((knowledgeCase) => (
+              <article
+                key={`${knowledgeCase.title}-${knowledgeCase.date ?? ""}`}
+                className="rounded-xl border border-base-300 bg-base-100 p-5"
+              >
+                <div className="flex flex-wrap items-center gap-2 mb-3">
+                  <h3 className="text-base font-semibold">{knowledgeCase.title}</h3>
+                  {knowledgeCase.severity && (
+                    <span className="badge badge-outline badge-sm">{knowledgeCase.severity}</span>
+                  )}
+                  {knowledgeCase.date && (
+                    <span className="text-xs text-base-content/50">{knowledgeCase.date}</span>
+                  )}
+                </div>
+
+                {knowledgeCase.human_review_decision && (
+                  <div className="mb-3">
+                    <div className="text-xs font-medium uppercase tracking-wide text-base-content/50 mb-1">
+                      Human Review Decision
+                    </div>
+                    <p className="text-sm text-base-content/80">
+                      {knowledgeCase.human_review_decision}
+                    </p>
+                  </div>
+                )}
+
+                {knowledgeCase.boundary_criteria && (
+                  <div className="mb-3">
+                    <div className="text-xs font-medium uppercase tracking-wide text-base-content/50 mb-1">
+                      Boundary Criteria
+                    </div>
+                    <p className="text-sm text-base-content/80">
+                      {knowledgeCase.boundary_criteria}
+                    </p>
+                  </div>
+                )}
+
+                {(knowledgeCase.lesson_learned?.length ?? 0) > 0 && (
+                  <div className="mb-3">
+                    <div className="text-xs font-medium uppercase tracking-wide text-base-content/50 mb-1">
+                      Lessons
+                    </div>
+                    <ul className="list-disc pl-5 text-sm text-base-content/80 space-y-1">
+                      {knowledgeCase.lesson_learned?.map((lesson) => (
+                        <li key={lesson}>{lesson}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {(knowledgeCase.images?.length ?? 0) > 0 && (
+                  <div>
+                    <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-base-content/50 mb-2">
+                      <ImageIcon className="h-3.5 w-3.5" />
+                      Case Figures
+                    </div>
+                    <div className="grid gap-3 md:grid-cols-2">
+                      {knowledgeCase.images?.map((image) => (
+                        <figure
+                          key={`${knowledgeCase.title}-${image.relative_path}`}
+                          className="rounded-lg border border-base-300 bg-base-200/40 p-3"
+                        >
+                          {image.base64_data ? (
+                            /* eslint-disable-next-line @next/next/no-img-element -- task knowledge images are API-provided base64 assets */
+                            <img
+                              src={`data:image/png;base64,${image.base64_data}`}
+                              alt={image.alt_text}
+                              className="w-full h-auto rounded"
+                            />
+                          ) : (
+                            <div className="flex items-center justify-center rounded border border-dashed border-base-300 bg-base-100 px-3 py-8 text-sm text-base-content/50">
+                              Image asset unavailable
+                            </div>
+                          )}
+                          <figcaption className="mt-2 text-xs text-base-content/60">
+                            {image.alt_text}
+                          </figcaption>
+                        </figure>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </article>
+            ))}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/ui/src/schemas/knowledgeCaseResponse.ts
+++ b/ui/src/schemas/knowledgeCaseResponse.ts
@@ -5,6 +5,7 @@
  * API for QDash
  * OpenAPI spec version: 0.0.1
  */
+import type { KnowledgeImageResponse } from './knowledgeImageResponse';
 
 /**
  * Response model for a knowledge case (postmortem).
@@ -31,4 +32,5 @@ export interface KnowledgeCaseResponse {
   applicability?: string;
   counterexample?: string;
   prompt_guidance?: string;
+  images?: KnowledgeImageResponse[];
 }

--- a/ui/src/schemas/taskKnowledgeResponse.ts
+++ b/ui/src/schemas/taskKnowledgeResponse.ts
@@ -29,6 +29,9 @@ export interface TaskKnowledgeResponse {
   analysis_guide?: string[];
   prerequisites?: string[];
   images?: KnowledgeImageResponse[];
+  triage_markdown?: string;
+  triage_images?: KnowledgeImageResponse[];
   cases?: KnowledgeCaseResponse[];
   prompt_text: string;
+  triage_prompt_text?: string;
 }

--- a/ui/src/schemas/taskKnowledgeSummaryResponse.ts
+++ b/ui/src/schemas/taskKnowledgeSummaryResponse.ts
@@ -17,4 +17,5 @@ export interface TaskKnowledgeSummaryResponse {
   case_count?: number;
   image_count?: number;
   has_analysis_guide?: boolean;
+  has_triage_guide?: boolean;
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add AI triage-specific task knowledge for `CheckResonatorSpectroscopy` and expose it through the task-knowledge API/UI flow.
- Update Copilot context assembly to switch between analysis knowledge and triage knowledge, including the correct reference-image set.
- Impact: API, Copilot context shaping, task-knowledge docs/UI. No runtime contract change for calibration tasks.

## Changes
- Add `docs/task-knowledge/cw-characterization/CheckResonatorSpectroscopy/triage.md` as the task-knowledge source for resonator-spectroscopy triage guidance.
- Extend task-knowledge parsing and models with `triage_markdown`, `triage_images`, case images, and `triage_prompt_text` support.
- Return triage-related fields from task-knowledge API responses and surface triage/case content in `TaskKnowledgeDetailPage`.
- Update Copilot analysis-context assembly so AI triage uses `to_triage_prompt()` and triage images while normal analysis keeps case images.
- Regenerate tracked task-knowledge docs artifacts (`docs/task-knowledge/index.md`, `docs/.vitepress/task-knowledge-sidebar.json`) after the new source file was added.
- Add focused API service tests for triage prompt/image selection and task-knowledge response coverage.
- Verification: `pytest tests/qdash/api/services/test_copilot_data_service.py tests/qdash/api/services/test_task_service.py -q`
