### PR TITLE
docs: update setup instructions for UID and GID in DevContainer

### DIFF
--- a/compose.devcontainer.yaml
+++ b/compose.devcontainer.yaml
@@ -4,6 +4,9 @@ services:
     build:
       context: .
       dockerfile: ./.devcontainer/Dockerfile
+      args:
+        USER_UID: ${LOCAL_UID:-1000}
+        USER_GID: ${LOCAL_GID:-1000}
     env_file:
       - path: .env
         required: false

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -51,6 +51,15 @@ docker compose -f compose.devcontainer.yaml up -d
 ```
 
 The DevContainer can start without a local `.env`; Docker Compose uses `.env` when present.
+When starting it with Docker Compose directly on Linux, pass the host UID and GID so files
+generated in the mounted workspace remain writable from both the host and the container:
+
+```shell
+LOCAL_UID=$(id -u) LOCAL_GID=$(id -g) docker compose -f compose.devcontainer.yaml up -d --build
+```
+
+VS Code's Dev Containers extension also aligns the remote user's UID with the host by using
+`updateRemoteUserUID`.
 The container mounts `/var/run/docker.sock` so devcontainer users can run the local Docker
 Compose tasks from inside the workspace. User-level tools installed under `/home/vscode/.local`
 and Claude Code configuration under `/home/vscode/.claude` are persisted in Docker volumes, so
@@ -61,6 +70,16 @@ Then attach to the container using VS Code's DevContainer extension or:
 ```shell
 docker compose -f compose.devcontainer.yaml exec --user vscode devcontainer zsh
 ```
+
+Check the Git identity inside the container before committing because host-level Git settings are
+not copied into the DevContainer automatically:
+
+```shell
+git config --global user.name
+git config --global user.email
+```
+
+Set them in the container if either command is empty.
 
 ### Install Dependencies
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updated setup instructions for the DevContainer to include user UID and GID configuration for better file permissions.
- Ensures files generated in the mounted workspace remain writable from both the host and the container.

## Changes
- Added instructions for passing host UID and GID when starting the DevContainer with Docker Compose.
- Included guidance on checking and setting Git identity within the container.

