### PR TITLE
chore(devcontainer): restore root-based devcontainer user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -119,7 +119,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     node -v && npm -v
 
-# Install bun in a shared location so the non-root dev user can run it.
+# Install bun in a shared location so either root or a dev user can run it.
 ENV BUN_INSTALL=/usr/local/bun
 COPY --from=bun-bin /usr/local/bin/bun /usr/local/bin/bun
 RUN mkdir -p "${BUN_INSTALL}/bin" \
@@ -139,8 +139,8 @@ ARG CODEX_VERSION
 RUN echo "umask 022" >> /etc/profile && \
     echo "umask 022" >> /etc/bash.bashrc
 
-ENV HOME=/home/vscode
-ENV PATH="/home/vscode/.local/bin:${PATH}"
+ENV HOME=/root
+ENV PATH="/root/.local/bin:${PATH}"
 
 # Install OpenAI Codex CLI
 RUN npm install -g "@openai/codex@${CODEX_VERSION}" && \
@@ -153,20 +153,19 @@ ENV SHELL=/bin/zsh
 RUN mkdir -p \
         /workspace/qdash/ui \
         /commandhistory \
-        /home/vscode/.cache/pip \
-        /home/vscode/.cache/uv \
-        /home/vscode/.claude \
-        /home/vscode/.codex \
-        /home/vscode/.vscode-server/extensions \
+        /root/.cache/pip \
+        /root/.cache/uv \
+        /root/.claude \
+        /root/.codex \
+        /root/.vscode-server/extensions \
     && touch /workspace/qdash/ui/.bunfig.toml \
-    && touch /home/vscode/.bashrc /home/vscode/.zshrc \
-    && echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/vscode/.bashrc \
-    && echo 'export PATH="$HOME/.local/bin:$PATH"' >> /home/vscode/.zshrc \
-    && echo 'export HISTFILE=/commandhistory/.zsh_history' >> /home/vscode/.zshrc \
-    && echo 'setopt APPEND_HISTORY' >> /home/vscode/.zshrc \
-    && echo 'setopt HIST_IGNORE_DUPS' >> /home/vscode/.zshrc \
-    && chsh -s /bin/zsh vscode \
-    && chown -R vscode:vscode /workspace /commandhistory /home/vscode
+    && touch /root/.bashrc /root/.zshrc \
+    && echo 'export PATH="$HOME/.local/bin:$PATH"' >> /root/.bashrc \
+    && echo 'export PATH="$HOME/.local/bin:$PATH"' >> /root/.zshrc \
+    && echo 'export HISTFILE=/commandhistory/.zsh_history' >> /root/.zshrc \
+    && echo 'setopt APPEND_HISTORY' >> /root/.zshrc \
+    && echo 'setopt HIST_IGNORE_DUPS' >> /root/.zshrc \
+    && chsh -s /bin/zsh root
 
 COPY ./.devcontainer/update-docker-socket-group.sh /usr/local/bin/update-docker-socket-group
 COPY ./.devcontainer/start-container.sh /usr/local/bin/start-container

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,26 +41,26 @@
     }
   },
 
-  "remoteUser": "vscode",
-  "updateRemoteUserUID": true,
+  "remoteUser": "root",
+  "updateRemoteUserUID": false,
 
   // Volume mounts (persistence configuration)
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/vscode/.claude,type=volume",
-    "source=codex-config-${devcontainerId},target=/home/vscode/.codex,type=volume",
-    "source=qdash-local-bin-${devcontainerId},target=/home/vscode/.local,type=volume",
-    "source=qdash-vscode-extensions-${devcontainerId},target=/home/vscode/.vscode-server/extensions,type=volume",
-    "source=qdash-pip-cache,target=/home/vscode/.cache/pip,type=volume",
-    "source=qdash-uv-cache,target=/home/vscode/.cache/uv,type=volume"
+    "source=claude-code-config-${devcontainerId},target=/root/.claude,type=volume",
+    "source=codex-config-${devcontainerId},target=/root/.codex,type=volume",
+    "source=qdash-local-bin-${devcontainerId},target=/root/.local,type=volume",
+    "source=qdash-vscode-extensions-${devcontainerId},target=/root/.vscode-server/extensions,type=volume",
+    "source=qdash-pip-cache,target=/root/.cache/pip,type=volume",
+    "source=qdash-uv-cache,target=/root/.cache/uv,type=volume"
   ],
 
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
-    "CLAUDE_CONFIG_DIR": "/home/vscode/.claude",
+    "CLAUDE_CONFIG_DIR": "/root/.claude",
     "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
-    "PIP_CACHE_DIR": "/home/vscode/.cache/pip",
-    "UV_CACHE_DIR": "/home/vscode/.cache/uv",
+    "PIP_CACHE_DIR": "/root/.cache/pip",
+    "UV_CACHE_DIR": "/root/.cache/uv",
     "UV_LINK_MODE": "copy"
   },
   // Startup optimization settings

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sudo mkdir -p /home/vscode/.cache/pip /home/vscode/.cache/uv /workspace/qdash/ui/node_modules
-sudo chown -R vscode:vscode \
-  /home/vscode/.cache/pip \
-  /home/vscode/.cache/uv \
-  /workspace/qdash/ui/node_modules
-chmod -R u+rwX /home/vscode/.cache/pip /home/vscode/.cache/uv /workspace/qdash/ui/node_modules
+mkdir -p /root/.cache/pip /root/.cache/uv /workspace/qdash/ui/node_modules
+chmod -R u+rwX /root/.cache/pip /root/.cache/uv /workspace/qdash/ui/node_modules
 
 cd /workspace/qdash
 

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,19 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-sudo mkdir -p /home/vscode/.codex /home/vscode/.local
-sudo mkdir -p /home/vscode/.cache/pip /home/vscode/.cache/uv /workspace/qdash/ui/node_modules
-sudo chown -R vscode:vscode \
-  /home/vscode/.codex \
-  /home/vscode/.local \
-  /home/vscode/.cache/pip \
-  /home/vscode/.cache/uv \
-  /workspace/qdash/ui/node_modules
+mkdir -p /root/.codex /root/.local
+mkdir -p /root/.cache/pip /root/.cache/uv /workspace/qdash/ui/node_modules
 chmod -R u+rwX \
-  /home/vscode/.codex \
-  /home/vscode/.local \
-  /home/vscode/.cache/pip \
-  /home/vscode/.cache/uv \
+  /root/.codex \
+  /root/.local \
+  /root/.cache/pip \
+  /root/.cache/uv \
   /workspace/qdash/ui/node_modules
 
 git config --global --add safe.directory /workspace/qdash

--- a/.devcontainer/start-container.sh
+++ b/.devcontainer/start-container.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mkdir -p /home/vscode/.codex /home/vscode/.local
-chown -R vscode:vscode /home/vscode/.codex /home/vscode/.local
-chmod -R u+rwX /home/vscode/.codex /home/vscode/.local
-
-update-docker-socket-group vscode
+mkdir -p /root/.codex /root/.local
+chmod -R u+rwX /root/.codex /root/.local
 
 exec sleep infinity


### PR DESCRIPTION
## Summary
- restore the devcontainer remote user to root
- switch devcontainer home-mounted paths back to /root
- remove the vscode-specific startup handling added for the non-root setup

## Testing
- not run
- confirmed the devcontainer revert is isolated from the chevron worktree changes locally