### PR TITLE
test(spectroscopy): add test for optimal powers rounding behavior

### DIFF
--- a/src/qdash/analysis/spectroscopy/estimate_resonator_frequency.py
+++ b/src/qdash/analysis/spectroscopy/estimate_resonator_frequency.py
@@ -810,7 +810,7 @@ def estimate_optimal_powers(
 
     def compute_mid(y: float) -> float:
         y_idx_1 = _arg_closest(ys, y)
-        y_idx_mid = (y_idx_0 + y_idx_1) // 2
+        y_idx_mid = (y_idx_0 + y_idx_1 + 1) // 2
         return float(ys[y_idx_mid])
 
     return [compute_mid(boundary.low_power) for boundary in local_boundaries]

--- a/tests/qdash/analysis/spectroscopy/test_estimate_resonator_frequency.py
+++ b/tests/qdash/analysis/spectroscopy/test_estimate_resonator_frequency.py
@@ -1,3 +1,4 @@
+from qdash.analysis.spectroscopy import BareShiftBoundary
 from qdash.analysis.spectroscopy.estimate_resonator_frequency import (
     ComposeResonancesConfig,
     EstimateResonatorFrequencyConfig,
@@ -26,6 +27,23 @@ def test_estimate_optimal_powers_uses_midpoint_between_minimum_and_local_low_pow
 
     assert local_boundary.low_power == -30.0
     assert optimal_powers == [-35.0]
+
+
+def test_estimate_optimal_powers_rounds_midpoint_up_when_between_grid_points() -> None:
+    ys = [-60.0, -55.0, -50.0, -45.0, -40.0, -35.0, -30.0, -25.0]
+    local_boundary = BareShiftBoundary(
+        high_power_min=-20.0,
+        high_power_max=0.0,
+        low_power=-25.0,
+    )
+
+    optimal_powers = estimate_optimal_powers(
+        ys,
+        [local_boundary],
+        minimum_usable_power=-40.0,
+    )
+
+    assert optimal_powers == [-30.0]
 
 
 def test_resonance_score_prefers_wider_high_power_x_span() -> None:


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduce a test to verify that the optimal powers calculation correctly rounds midpoints up when they fall between grid points. This ensures accurate power estimations in spectroscopy analysis.

## Changes
- Added a new test case for rounding behavior in the `estimate_optimal_powers` function. 
- Verified that the function returns the expected optimal power when given specific input values.

