### PR TITLE
test(qubex): add test for propagating spectroscopy coarse values

### DIFF
--- a/src/qdash/workflow/calibtasks/qubex/cw/check_control_amplitude.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_control_amplitude.py
@@ -137,13 +137,19 @@ class CheckControlAmplitude(QubexTask):
             figures.append(fig)
 
         output_params_copy = copy.deepcopy(self.output_parameters)
+        coarse_input_param = self.input_parameters["coarse_control_amplitude"]
+        coarse_floor = (
+            float(coarse_input_param.value)
+            if coarse_input_param is not None and coarse_input_param.value is not None
+            else None
+        )
+        coarse_frequency_param = self.input_parameters["coarse_qubit_frequency"]
+        coarse_frequency = (
+            float(coarse_frequency_param.value)
+            if coarse_frequency_param is not None and coarse_frequency_param.value is not None
+            else None
+        )
         if estimated_amplitude is not None:
-            coarse_input_param = self.input_parameters["coarse_control_amplitude"]
-            coarse_floor = (
-                float(coarse_input_param.value)
-                if coarse_input_param is not None and coarse_input_param.value is not None
-                else None
-            )
             calibrated_amplitude = float(estimated_amplitude)
             if coarse_floor is not None and calibrated_amplitude < coarse_floor:
                 print(
@@ -164,8 +170,13 @@ class CheckControlAmplitude(QubexTask):
         else:
             print(
                 f"[WARNING] Failed to estimate control amplitude for qid={qid}: "
-                "sqrt-Lorentzian fit did not converge"
+                "sqrt-Lorentzian fit did not converge; propagating spectroscopy coarse values"
             )
+            if coarse_floor is not None:
+                output_params_copy["control_amplitude"].value = coarse_floor
+                output_params_copy["coarse_control_amplitude"].value = coarse_floor
+            if coarse_frequency is not None:
+                output_params_copy["coarse_qubit_frequency"].value = coarse_frequency
 
         # Refine coarse_qubit_frequency from the bounded sqrt-Lorentzian fit center.
         # The fit's f0 is constrained to [sweep_min, sweep_max] (see
@@ -178,15 +189,6 @@ class CheckControlAmplitude(QubexTask):
 
         for value in output_params_copy.values():
             value.execution_id = execution_id
-
-        if estimated_amplitude is None:
-            return PostProcessResult(
-                output_parameters=output_params_copy,
-                figures=figures,
-                validation_error=(
-                    f"Failed to estimate control amplitude for qid={qid}: no Rabi rate fit"
-                ),
-            )
 
         return PostProcessResult(
             output_parameters=output_params_copy,

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_control_amplitude.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_control_amplitude.py
@@ -67,6 +67,28 @@ def test_check_control_amplitude_updates_refined_coarse_seed(monkeypatch) -> Non
     assert result.output_parameters["coarse_control_amplitude"].value == 0.035
 
 
+def test_check_control_amplitude_propagates_spectroscopy_coarse_values_when_fit_is_missing(
+    monkeypatch,
+) -> None:
+    task = CheckControlAmplitude()
+    task.input_parameters["coarse_qubit_frequency"] = ParameterModel(value=4.25, unit="GHz")
+    task.input_parameters["coarse_control_amplitude"] = ParameterModel(value=0.02, unit="a.u.")
+
+    monkeypatch.setattr(task, "get_qubit_label", lambda _backend, _qid: "Q00")
+
+    result = task.postprocess(
+        backend=cast("QubexBackend", object()),
+        execution_id="exec-1",
+        run_result=RunResult(raw_result={"Q00": {"estimated_amplitude": None, "fig": go.Figure()}}),
+        qid="0",
+    )
+
+    assert result.validation_error is None
+    assert result.output_parameters["control_amplitude"].value == 0.02
+    assert result.output_parameters["coarse_control_amplitude"].value == 0.02
+    assert result.output_parameters["coarse_qubit_frequency"].value == 4.25
+
+
 def test_check_control_amplitude_run_uses_coarse_control_amplitude_without_extra_uplift(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced a test to ensure that the system correctly propagates spectroscopy coarse values when the fit is missing. This change enhances the robustness of the control amplitude estimation process.

## Changes
- Added a test case for propagating spectroscopy coarse values in the `CheckControlAmplitude` class.
- Updated the `postprocess` method to handle cases where estimated amplitude is not available, ensuring proper value propagation.

