### PR TITLE
Rename task knowledge review fields

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -22155,17 +22155,17 @@
             "title": "Images",
             "default": []
           },
-          "triage_markdown": {
+          "review_markdown": {
             "type": "string",
-            "title": "Triage Markdown",
+            "title": "Review Markdown",
             "default": ""
           },
-          "triage_images": {
+          "review_images": {
             "items": {
               "$ref": "#/components/schemas/KnowledgeImageResponse"
             },
             "type": "array",
-            "title": "Triage Images",
+            "title": "Review Images",
             "default": []
           },
           "cases": {
@@ -22180,9 +22180,9 @@
             "type": "string",
             "title": "Prompt Text"
           },
-          "triage_prompt_text": {
+          "review_prompt_text": {
             "type": "string",
-            "title": "Triage Prompt Text",
+            "title": "Review Prompt Text",
             "default": ""
           }
         },
@@ -22236,9 +22236,9 @@
             "title": "Has Analysis Guide",
             "default": false
           },
-          "has_triage_guide": {
+          "has_review_guide": {
             "type": "boolean",
-            "title": "Has Triage Guide",
+            "title": "Has Review Guide",
             "default": false
           }
         },

--- a/scripts/generate_task_knowledge.py
+++ b/scripts/generate_task_knowledge.py
@@ -463,6 +463,11 @@ def _parse_aux_markdown(path: Path) -> tuple[str, list[dict]]:
     return raw, images
 
 
+def _review_markdown_path(task_dir: Path) -> Path:
+    """Return the AI review guide path."""
+    return task_dir / "review.md"
+
+
 def _parse_markdown_file(path: Path) -> dict | None:
     """Parse a Markdown knowledge file into a dict.
 
@@ -555,7 +560,7 @@ def _parse_markdown_file(path: Path) -> dict | None:
             fields[field_name] = clean
 
     # --- AI review guide ---
-    triage_markdown, triage_images = _parse_aux_markdown(path.parent / "review.md")
+    review_markdown, review_images = _parse_aux_markdown(_review_markdown_path(path.parent))
 
     # --- cases ---
     cases = _parse_cases_dir(path.parent)
@@ -580,8 +585,8 @@ def _parse_markdown_file(path: Path) -> dict | None:
         "output_parameters_info": fields.get("output_parameters_info", []),
         "analysis_guide": fields.get("analysis_guide", []),
         "images": images,
-        "triage_markdown": triage_markdown,
-        "triage_images": triage_images,
+        "review_markdown": review_markdown,
+        "review_images": review_images,
         "related_context": fields.get("related_context", []),
         "cases": cases,
     }

--- a/src/qdash/api/schemas/task.py
+++ b/src/qdash/api/schemas/task.py
@@ -118,11 +118,11 @@ class TaskKnowledgeResponse(BaseModel):
     analysis_guide: list[str] = []
     prerequisites: list[str] = []
     images: list[KnowledgeImageResponse] = []
-    triage_markdown: str = ""
-    triage_images: list[KnowledgeImageResponse] = []
+    review_markdown: str = ""
+    review_images: list[KnowledgeImageResponse] = []
     cases: list[KnowledgeCaseResponse] = []
     prompt_text: str
-    triage_prompt_text: str = ""
+    review_prompt_text: str = ""
 
 
 class TaskKnowledgeSummaryResponse(BaseModel):
@@ -135,7 +135,7 @@ class TaskKnowledgeSummaryResponse(BaseModel):
     case_count: int = 0
     image_count: int = 0
     has_analysis_guide: bool = False
-    has_triage_guide: bool = False
+    has_review_guide: bool = False
 
 
 class ListTaskKnowledgeResponse(BaseModel):

--- a/src/qdash/api/services/task_service.py
+++ b/src/qdash/api/services/task_service.py
@@ -294,7 +294,7 @@ class TaskService:
                 case_count=len(k.cases),
                 image_count=len(k.images),
                 has_analysis_guide=len(k.analysis_guide) > 0,
-                has_triage_guide=bool(k.triage_markdown.strip()),
+                has_review_guide=bool(k.review_markdown.strip()),
             )
             for k in all_knowledge
         ]
@@ -344,11 +344,11 @@ class TaskService:
             analysis_guide=knowledge.analysis_guide,
             prerequisites=knowledge.prerequisites,
             images=[KnowledgeImageResponse(**img.model_dump()) for img in knowledge.images],
-            triage_markdown=knowledge.triage_markdown,
-            triage_images=[
-                KnowledgeImageResponse(**img.model_dump()) for img in knowledge.triage_images
+            review_markdown=knowledge.review_markdown,
+            review_images=[
+                KnowledgeImageResponse(**img.model_dump()) for img in knowledge.review_images
             ],
             cases=[KnowledgeCaseResponse(**case.model_dump()) for case in knowledge.cases],
             prompt_text=knowledge.to_prompt(),
-            triage_prompt_text=knowledge.to_triage_prompt(),
+            review_prompt_text=knowledge.to_review_prompt(),
         )

--- a/src/qdash/copilot/review.py
+++ b/src/qdash/copilot/review.py
@@ -74,7 +74,7 @@ def build_ai_review_context(
         task_id=task_id,
         image_base64=None,
         config=config,
-        use_triage_knowledge=True,
+        use_review_knowledge=True,
     )
     context_bundle.context = context_bundle.context.model_copy(
         update={"recent_values": [], "history_results": []}

--- a/src/qdash/copilot/runtime.py
+++ b/src/qdash/copilot/runtime.py
@@ -152,14 +152,14 @@ class CopilotRuntime:
         max_images: int | None,
         *,
         include_case_images: bool = True,
-        include_triage_images: bool = True,
+        include_review_images: bool = True,
     ) -> list[tuple[str, str]]:
         """Forward expected-image lookup for analysis context assembly."""
         return self.collect_expected_images(
             knowledge,
             max_images=max_images,
             include_case_images=include_case_images,
-            include_triage_images=include_triage_images,
+            include_review_images=include_review_images,
         )
 
     def _provenance_resolve_project_id(self, chip_id: str) -> str | None:
@@ -196,7 +196,7 @@ class CopilotRuntime:
         max_images: int | None = None,
         *,
         include_case_images: bool = True,
-        include_triage_images: bool = True,
+        include_review_images: bool = True,
     ) -> list[tuple[str, str]]:
         """Collect expected reference images from TaskKnowledge.
 
@@ -207,7 +207,7 @@ class CopilotRuntime:
             knowledge,
             max_images=max_images,
             include_case_images=include_case_images,
-            include_triage_images=include_triage_images,
+            include_review_images=include_review_images,
         )
 
     def load_task_history(
@@ -450,7 +450,7 @@ class CopilotRuntime:
         task_id: str,
         image_base64: str | None,
         config: CopilotConfig,
-        use_triage_knowledge: bool = False,
+        use_review_knowledge: bool = False,
     ) -> AnalysisContextResult:
         """Build a full analysis context from DB data and TaskKnowledge.
 
@@ -465,7 +465,7 @@ class CopilotRuntime:
             task_id=task_id,
             image_base64=image_base64,
             config=config,
-            use_triage_knowledge=use_triage_knowledge,
+            use_review_knowledge=use_review_knowledge,
         )
 
     @staticmethod

--- a/src/qdash/copilot/services/analysis_context_service.py
+++ b/src/qdash/copilot/services/analysis_context_service.py
@@ -46,7 +46,7 @@ class AnalysisContextBuilder:
         task_id: str,
         image_base64: str | None,
         config: CopilotConfig,
-        use_triage_knowledge: bool = False,
+        use_review_knowledge: bool = False,
     ) -> AnalysisContextResult:
         """Build the full analysis context consumed by Copilot review flows."""
         from qdash.copilot.contracts import (
@@ -59,7 +59,7 @@ class AnalysisContextBuilder:
         knowledge_prompt = self._build_task_knowledge_prompt(
             task_name,
             knowledge,
-            use_triage_knowledge=use_triage_knowledge,
+            use_review_knowledge=use_review_knowledge,
         )
         qubit_params = self._load_qubit_params(chip_id, qid)
         task_result = self._load_task_result(task_id)
@@ -80,7 +80,7 @@ class AnalysisContextBuilder:
             figure_paths=figure_paths,
             image_base64=image_base64,
             config=config,
-            use_triage_knowledge=use_triage_knowledge,
+            use_review_knowledge=use_review_knowledge,
         )
 
         context = TaskAnalysisContext(
@@ -108,13 +108,13 @@ class AnalysisContextBuilder:
         task_name: str,
         knowledge: Any,
         *,
-        use_triage_knowledge: bool,
+        use_review_knowledge: bool,
     ) -> str:
         """Build the prompt prefix from task knowledge or fall back to the task name."""
         if not knowledge:
             return f"Task: {task_name}"
-        if use_triage_knowledge:
-            return knowledge.to_triage_prompt()
+        if use_review_knowledge:
+            return knowledge.to_review_prompt()
         return knowledge.to_prompt()
 
     @staticmethod
@@ -168,7 +168,7 @@ class AnalysisContextBuilder:
         figure_paths: list[str],
         image_base64: str | None,
         config: CopilotConfig,
-        use_triage_knowledge: bool,
+        use_review_knowledge: bool,
     ) -> tuple[str | None, list[tuple[str, str]], list[tuple[str, str]]]:
         """Resolve experiment and expected images for multimodal analysis."""
         expected_images: list[tuple[str, str]] = []
@@ -183,7 +183,7 @@ class AnalysisContextBuilder:
         expected_images = self._collect_expected_images(
             knowledge,
             config.analysis.max_expected_images,
-            include_case_images=not use_triage_knowledge,
-            include_triage_images=use_triage_knowledge,
+            include_case_images=not use_review_knowledge,
+            include_review_images=use_review_knowledge,
         )
         return image_base64, expected_images, experiment_images

--- a/src/qdash/copilot/services/support_service.py
+++ b/src/qdash/copilot/services/support_service.py
@@ -104,14 +104,14 @@ class CopilotSupportService:
         max_images: int | None = None,
         *,
         include_case_images: bool = True,
-        include_triage_images: bool = True,
+        include_review_images: bool = True,
     ) -> list[tuple[str, str]]:
         """Collect expected reference images from TaskKnowledge."""
         if knowledge is None:
             return []
         result = [(img.base64_data, img.alt_text) for img in knowledge.images if img.base64_data]
-        if include_triage_images:
-            for img in getattr(knowledge, "triage_images", []):
+        if include_review_images:
+            for img in getattr(knowledge, "review_images", []):
                 if img.base64_data:
                     result.append((img.base64_data, f"[AI review guide] {img.alt_text}"))
         if include_case_images:

--- a/src/qdash/datamodel/task_knowledge.py
+++ b/src/qdash/datamodel/task_knowledge.py
@@ -187,11 +187,11 @@ class TaskKnowledge(BaseModel):
         default_factory=list,
         description="Image references from the markdown file",
     )
-    triage_markdown: str = Field(
+    review_markdown: str = Field(
         default="",
         description="Optional AI-review-specific markdown guidance",
     )
-    triage_images: list[TaskKnowledgeImage] = Field(
+    review_images: list[TaskKnowledgeImage] = Field(
         default_factory=list,
         description="Image references from the review markdown file",
     )
@@ -357,7 +357,7 @@ class TaskKnowledge(BaseModel):
             normalized_lines.append(line)
         return "\n".join(normalized_lines).strip()
 
-    def to_triage_prompt(self) -> str:
+    def to_review_prompt(self) -> str:
         """Build a compact prompt focused on AI review decisions."""
         lines = [
             f"## Experiment: {self.name}",
@@ -391,9 +391,9 @@ class TaskKnowledge(BaseModel):
             for index, step in enumerate(self.analysis_guide, 1):
                 lines.append(f"{index}. {step}")
 
-        triage_markdown = self._normalize_markdown_block(self.triage_markdown)
-        if triage_markdown:
-            lines += ["", "### AI review guidance", triage_markdown]
+        review_markdown = self._normalize_markdown_block(self.review_markdown)
+        if review_markdown:
+            lines += ["", "### AI review guidance", review_markdown]
 
         return "\n".join(lines)
 

--- a/tests/qdash/api/services/test_copilot_data_service.py
+++ b/tests/qdash/api/services/test_copilot_data_service.py
@@ -459,15 +459,15 @@ class TestBuildAnalysisContext:
             knowledge,
             max_images=2,
             include_case_images=True,
-            include_triage_images=False,
+            include_review_images=False,
         )
         assert result.image_base64 == "encoded-image"
         assert result.expected_images == [("img-1", "expected alt")]
 
-    def test_triage_context_uses_triage_prompt_and_triage_images(self):
+    def test_review_context_uses_review_prompt_and_review_images(self):
         service = CopilotRuntime(data_access=MagicMock())
         knowledge = MagicMock()
-        knowledge.to_triage_prompt.return_value = "Triage prompt body"
+        knowledge.to_review_prompt.return_value = "AI review prompt body"
         knowledge.related_context = []
 
         with (
@@ -488,7 +488,7 @@ class TestBuildAnalysisContext:
             patch.object(
                 service,
                 "collect_expected_images",
-                return_value=[("triage-img", "triage alt")],
+                return_value=[("review-img", "review alt")],
             ) as collect_expected,
             patch("qdash.datamodel.task_knowledge.get_task_knowledge", return_value=knowledge),
         ):
@@ -499,7 +499,7 @@ class TestBuildAnalysisContext:
                 task_id="task-1",
                 image_base64=None,
                 config=self._config(multimodal=True),
-                use_triage_knowledge=True,
+                use_review_knowledge=True,
             )
 
         load_fig.assert_called_once_with(["/tmp/figure.png"])
@@ -507,8 +507,8 @@ class TestBuildAnalysisContext:
             knowledge,
             max_images=2,
             include_case_images=False,
-            include_triage_images=True,
+            include_review_images=True,
         )
-        assert result.context.task_knowledge_prompt == "Triage prompt body"
+        assert result.context.task_knowledge_prompt == "AI review prompt body"
         assert result.image_base64 == "encoded-image"
-        assert result.expected_images == [("triage-img", "triage alt")]
+        assert result.expected_images == [("review-img", "review alt")]

--- a/tests/qdash/api/services/test_task_service.py
+++ b/tests/qdash/api/services/test_task_service.py
@@ -91,17 +91,17 @@ def _resonator_knowledge() -> TaskKnowledge:
                 base64_data="task-image-b64",
             )
         ],
-        triage_markdown=(
+        review_markdown=(
             "# CheckResonatorSpectroscopy AI Review Guide\n\n"
             "Use REVIEW when peak assignment is ambiguous.\n\n"
-            "![Triage example](triage.png)"
+            "![AI review example](review.png)"
         ),
-        triage_images=[
+        review_images=[
             TaskKnowledgeImage(
-                alt_text="Triage example",
-                relative_path="triage.png",
-                section="triage",
-                base64_data="triage-image-b64",
+                alt_text="AI review example",
+                relative_path="review.png",
+                section="review",
+                base64_data="review-image-b64",
             )
         ],
         cases=[
@@ -170,7 +170,7 @@ def test_get_task_knowledge_markdown_falls_back_to_registry_prompt(tmp_path: Pat
     assert markdown.count("data:image/") == 3
 
 
-def test_list_task_knowledge_sets_has_triage_guide_from_markdown() -> None:
+def test_list_task_knowledge_sets_has_review_guide_from_markdown() -> None:
     knowledge = _resonator_knowledge()
     service = _service()
 
@@ -180,22 +180,22 @@ def test_list_task_knowledge_sets_has_triage_guide_from_markdown() -> None:
     assert len(response.items) == 1
     assert response.items[0].name == "CheckResonatorSpectroscopy"
     assert response.items[0].has_analysis_guide is True
-    assert response.items[0].has_triage_guide is True
+    assert response.items[0].has_review_guide is True
     assert response.items[0].case_count == 1
     assert response.items[0].image_count == 1
 
 
-def test_get_task_knowledge_includes_triage_prompt_and_case_images() -> None:
+def test_get_task_knowledge_includes_review_prompt_and_case_images() -> None:
     knowledge = _resonator_knowledge()
     service = _service()
 
     with patch("qdash.api.services.task_service._lookup_knowledge", return_value=knowledge):
         response = service.get_task_knowledge("CheckResonatorSpectroscopy")
 
-    assert response.triage_markdown == knowledge.triage_markdown
-    assert response.triage_images[0].base64_data == "triage-image-b64"
+    assert response.review_markdown == knowledge.review_markdown
+    assert response.review_images[0].base64_data == "review-image-b64"
     assert response.cases[0].images[0].base64_data == "case-image-b64"
     assert response.prompt_text
-    assert "### AI review guidance" in response.triage_prompt_text
-    assert "Use REVIEW when peak assignment is ambiguous." in response.triage_prompt_text
-    assert "![Triage example]" not in response.triage_prompt_text
+    assert "### AI review guidance" in response.review_prompt_text
+    assert "Use REVIEW when peak assignment is ambiguous." in response.review_prompt_text
+    assert "![AI review example]" not in response.review_prompt_text

--- a/tests/scripts/test_generate_task_knowledge.py
+++ b/tests/scripts/test_generate_task_knowledge.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "generate_task_knowledge.py"
+SPEC = importlib.util.spec_from_file_location("generate_task_knowledge", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+generate_task_knowledge = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(generate_task_knowledge)
+
+
+def _write_index(task_dir: Path) -> Path:
+    index_path = task_dir / "index.md"
+    index_path.write_text(
+        "# CheckExample\n\n"
+        "Summary.\n\n"
+        "## Evaluation criteria\n\n"
+        "- The output is readable.\n",
+        encoding="utf-8",
+    )
+    return index_path
+
+
+def test_parse_markdown_file_reads_review_md(tmp_path: Path) -> None:
+    task_dir = tmp_path / "category" / "CheckExample"
+    task_dir.mkdir(parents=True)
+    index_path = _write_index(task_dir)
+    (task_dir / "review.md").write_text("# AI review guide\n", encoding="utf-8")
+
+    parsed = generate_task_knowledge._parse_markdown_file(index_path)
+
+    assert parsed is not None
+    assert parsed["review_markdown"] == "# AI review guide\n"
+
+
+def test_parse_markdown_file_without_review_md_has_empty_review_markdown(
+    tmp_path: Path,
+) -> None:
+    task_dir = tmp_path / "category" / "CheckExample"
+    task_dir.mkdir(parents=True)
+    index_path = _write_index(task_dir)
+
+    parsed = generate_task_knowledge._parse_markdown_file(index_path)
+
+    assert parsed is not None
+    assert parsed["review_markdown"] == ""

--- a/ui/src/components/features/task-knowledge/TaskKnowledgeDetailPage.tsx
+++ b/ui/src/components/features/task-knowledge/TaskKnowledgeDetailPage.tsx
@@ -23,8 +23,8 @@ type KnowledgeCase = {
 };
 
 type TaskKnowledgeDetail = {
-  triage_markdown?: string;
-  triage_images?: KnowledgeImage[];
+  review_markdown?: string;
+  review_images?: KnowledgeImage[];
   cases?: KnowledgeCase[];
 };
 
@@ -93,7 +93,7 @@ export function TaskKnowledgeDetailPage({ taskName }: { taskName: string }) {
       </div>
       <MarkdownContent content={markdown} />
 
-      {detail?.triage_markdown?.trim() && (
+      {detail?.review_markdown?.trim() && (
         <section className="mt-10">
           <div className="mb-3">
             <h2 className="text-lg font-semibold">AI Review Guide</h2>
@@ -102,7 +102,7 @@ export function TaskKnowledgeDetailPage({ taskName }: { taskName: string }) {
             </p>
           </div>
           <div className="rounded-xl border border-base-300 bg-base-100 p-5">
-            <MarkdownContent content={detail.triage_markdown} />
+            <MarkdownContent content={detail.review_markdown} />
           </div>
         </section>
       )}

--- a/ui/src/schemas/taskKnowledgeResponse.ts
+++ b/ui/src/schemas/taskKnowledgeResponse.ts
@@ -29,9 +29,9 @@ export interface TaskKnowledgeResponse {
   analysis_guide?: string[];
   prerequisites?: string[];
   images?: KnowledgeImageResponse[];
-  triage_markdown?: string;
-  triage_images?: KnowledgeImageResponse[];
+  review_markdown?: string;
+  review_images?: KnowledgeImageResponse[];
   cases?: KnowledgeCaseResponse[];
   prompt_text: string;
-  triage_prompt_text?: string;
+  review_prompt_text?: string;
 }

--- a/ui/src/schemas/taskKnowledgeSummaryResponse.ts
+++ b/ui/src/schemas/taskKnowledgeSummaryResponse.ts
@@ -17,5 +17,5 @@ export interface TaskKnowledgeSummaryResponse {
   case_count?: number;
   image_count?: number;
   has_analysis_guide?: boolean;
-  has_triage_guide?: boolean;
+  has_review_guide?: boolean;
 }


### PR DESCRIPTION
## Summary
- rename task knowledge AI review fields from triage_* to review_*
- read review.md directly and remove triage.md fallback
- pass review guide images into AI Review with review naming
- update OpenAPI/UI schemas and task knowledge UI references

## Verification
- uv run pytest tests/scripts/test_generate_task_knowledge.py tests/qdash/api/services/test_copilot_data_service.py tests/qdash/api/services/test_task_service.py
- uv run pytest tests/qdash/api/services/test_task_result_service.py tests/qdash/api/routers/test_copilot.py tests/qdash/api/lib/test_copilot_agent.py

Note: tests/qdash/workflow/engine/task/test_ai_review.py could not be collected locally because qubex is not installed in this environment.