### PR TITLE
style(workflow): add min-w-0 class to editor container

### DIFF
--- a/ui/src/app/(auth)/workflow/new/page.tsx
+++ b/ui/src/app/(auth)/workflow/new/page.tsx
@@ -229,7 +229,7 @@ export default function NewFlowPage() {
         {/* Main Editor Area */}
         <div className="flex-1 flex overflow-hidden">
           {/* Editor */}
-          <div className="flex-1 flex flex-col">
+          <div className="flex-1 flex flex-col min-w-0">
             <Editor
               height="100%"
               language="python"


### PR DESCRIPTION
## Ticket

close #818

## Summary

The properties sidebar on the new workflow page gets pushed off-screen when the browser window is resized narrower, because the editor's flex item cannot shrink below its intrinsic content width. Adding `min-w-0` allows the editor to shrink properly, keeping the sidebar visible.

## Changes

- Add `min-w-0` to the editor container div in `workflow/new/page.tsx` to override the default `min-width: auto` behavior of flex items, allowing the editor to shrink below the Monaco Editor's intrinsic width on viewport resize
