### PR TITLE
fix(analysis): sync resonator selection logic

### DIFF
--- a/src/qdash/analysis/spectroscopy/__init__.py
+++ b/src/qdash/analysis/spectroscopy/__init__.py
@@ -39,7 +39,12 @@ from qdash.analysis.spectroscopy.estimate_resonator_frequency import (
     estimate_resonator_frequency,
     estimate_resonator_frequency_from_figure,
 )
-from qdash.analysis.spectroscopy.mux import NUM_RESONATORS, PEAK_POSITIONS
+from qdash.analysis.spectroscopy.mux import (
+    NUM_RESONATORS,
+    PEAK_POSITIONS,
+    guess_sorted_slots_for_partial_mux,
+    qid_for_sorted_slot,
+)
 from qdash.analysis.spectroscopy.remove_false_spike import (
     RemoveFalseSpikeRange,
     remove_false_spike,
@@ -53,23 +58,18 @@ from qdash.analysis.spectroscopy.representative_y import (
 )
 
 __all__ = [
-    # MUX layout
     "NUM_RESONATORS",
     "PEAK_POSITIONS",
-    # Bare-shift boundary estimation
     "BareShiftBoundary",
     "BareShiftBoundaryEstimator",
     "BareShiftDebugOptions",
-    # Resonator frequency estimation
     "ComposeResonancesConfig",
     "ConfigBareShiftBoundaryEstimator",
-    # Qubit frequency estimation
     "EstimateQubitFrequencyConfig",
     "EstimateResonatorFrequencyConfig",
     "F01Result",
     "F12Result",
     "FindPeaksConfig",
-    # Representative-y strategies
     "FirstPointMeetingWidthFromTipStrategy",
     "GroupPeaksConfig",
     "GroupResonancesConfig",
@@ -79,7 +79,6 @@ __all__ = [
     "PeakRepresentativeYStrategy",
     "QubitFrequencyResult",
     "QubitResponse",
-    # Remove false spike
     "RemoveFalseSpikeRange",
     "Resonance",
     "WidthEstimator",
@@ -95,6 +94,8 @@ __all__ = [
     "estimate_qubit_frequency_from_figure",
     "estimate_resonator_frequency",
     "estimate_resonator_frequency_from_figure",
+    "guess_sorted_slots_for_partial_mux",
+    "qid_for_sorted_slot",
     "remove_false_spike",
     "remove_false_spike_from_figure",
 ]

--- a/src/qdash/analysis/spectroscopy/estimate_resonator_frequency.py
+++ b/src/qdash/analysis/spectroscopy/estimate_resonator_frequency.py
@@ -528,7 +528,9 @@ def _nearby_resonance_score(resonance: Resonance) -> tuple[bool, float, bool, fl
     )
 
 
-def _refill_resonance_score(resonance: Resonance) -> tuple[bool, float, float, bool, float, float]:
+def _refill_resonance_score(
+    resonance: Resonance,
+) -> tuple[bool, float, float | bool, bool | float, float, float]:
     if resonance.high_power_x_span == 0:
         return (
             resonance.has_high_power_peaks,
@@ -538,14 +540,7 @@ def _refill_resonance_score(resonance: Resonance) -> tuple[bool, float, float, b
             resonance.high_power_grad,
             resonance.max_prominence,
         )
-    return (
-        resonance.has_high_power_peaks,
-        resonance.high_power_x_span,
-        resonance.has_low_power_peak,
-        resonance.high_power_grad,
-        resonance.max_prominence,
-        float("-inf"),
-    )
+    return resonance.score
 
 
 def _deduplicate_nearby_resonances(
@@ -553,12 +548,6 @@ def _deduplicate_nearby_resonances(
 ) -> tuple[list[Resonance], list[Resonance]]:
     if not resonances:
         return [], []
-
-    max_x_span = max(
-        (resonance.high_power_x_span for resonance in resonances if resonance.has_high_power_peaks),
-        default=0,
-    )
-    x_distance_max += int(max_x_span)
 
     clusters: list[list[Resonance]] = []
     for resonance in sorted(resonances, key=attrgetter("x")):
@@ -575,6 +564,111 @@ def _deduplicate_nearby_resonances(
         rejected.extend(sorted_cluster[1:])
 
     return selected, rejected
+
+
+def _diverse_resonance_score(
+    resonance: Resonance,
+) -> tuple[bool, bool, bool, float, float, float]:
+    high_power_prominence = (
+        resonance.high_power_prominence if resonance.has_high_power_peaks else 0.0
+    )
+    high_power_x_span_capped = (
+        min(max(resonance.high_power_x_span, 0), 12) if resonance.has_high_power_peaks else 0.0
+    )
+    return (
+        resonance.has_high_power_peaks,
+        resonance.has_adjacent_low_power_peak,
+        resonance.has_low_power_peak,
+        high_power_prominence,
+        high_power_x_span_capped,
+        resonance.max_prominence,
+    )
+
+
+def _rebalance_edge_resonances(
+    selected: Sequence[Resonance],
+    resonances: Sequence[Resonance],
+) -> list[Resonance]:
+    selected_ids = {id(resonance) for resonance in selected}
+    selected = sorted(selected, key=attrgetter("x"))
+    rejected = [resonance for resonance in resonances if id(resonance) not in selected_ids]
+
+    if not selected:
+        return list(selected)
+
+    left_edge_candidates = [
+        resonance
+        for resonance in rejected
+        if resonance.x < selected[0].x
+        and resonance.has_high_power_peaks
+        and resonance.has_low_power_peak
+        and not resonance.has_adjacent_low_power_peak
+        and resonance.high_power_x_span >= 12
+        and resonance.max_prominence >= 0.2
+    ]
+    if not left_edge_candidates:
+        return list(selected)
+
+    right_edge = selected[-1]
+    if (
+        not right_edge.has_high_power_peaks
+        or right_edge.high_power_x_span > 2
+        or right_edge.max_prominence >= 0.8
+    ):
+        return list(selected)
+
+    left_edge = sorted(
+        left_edge_candidates,
+        key=lambda resonance: (resonance.high_power_x_span, resonance.max_prominence),
+        reverse=True,
+    )[0]
+
+    return [left_edge, *selected[:-1]]
+
+
+def _select_diverse_resonances(
+    resonances: Sequence[Resonance], num_resonators: int, x_distance_max: int
+) -> tuple[list[Resonance], list[Resonance]]:
+    if len(resonances) <= num_resonators:
+        return list(resonances), []
+
+    x_distance_max = min(x_distance_max, 15)
+    best_score: tuple[float, ...] | None = None
+    best_resonances: tuple[Resonance, ...] | None = None
+
+    for candidates in itertools.combinations(resonances, num_resonators):
+        xs = sorted(resonance.x for resonance in candidates)
+        if any(x1 - x0 <= x_distance_max for x0, x1 in itertools.pairwise(xs)):
+            continue
+
+        score = tuple(
+            sum(score_part for score_part in score_parts)
+            for score_parts in zip(
+                *(_diverse_resonance_score(resonance) for resonance in candidates),
+                strict=False,
+            )
+        )
+        if best_score is None or score > best_score:
+            best_score = score
+            best_resonances = candidates
+
+    if best_resonances is None:
+        best_resonances = tuple(
+            sorted(resonances, key=_diverse_resonance_score, reverse=True)[:num_resonators]
+        )
+
+    best_resonances = tuple(_rebalance_edge_resonances(best_resonances, resonances))
+    selected_ids = {id(resonance) for resonance in best_resonances}
+    rejected = [resonance for resonance in resonances if id(resonance) not in selected_ids]
+    return list(best_resonances), rejected
+
+
+def _needs_diverse_reselection(resonances: Sequence[Resonance]) -> bool:
+    return any(
+        not resonance.has_high_power_peaks
+        or (not resonance.has_adjacent_low_power_peak and resonance.max_prominence < 0.8)
+        for resonance in resonances
+    )
 
 
 def _select_local_resonance(resonances: Sequence[Resonance]) -> tuple[Resonance, list[Resonance]]:
@@ -616,18 +710,20 @@ def _select_resonances(
 
     selected: list[Resonance] = []
     rejected: list[Resonance] = []
+    candidates: list[Resonance] = []
     for res_group in _group_resonances(composed, config.group_resonances_conf.x_distance_max):
+        candidates.extend(res_group)
         resonance, rest = _select_local_resonance(res_group)
         selected.append(resonance)
         rejected.extend(rest)
 
-    candidates = sorted(selected, key=attrgetter("score"), reverse=True)
+    ranked_selected = sorted(selected, key=attrgetter("score"), reverse=True)
     selected, additional_rejected = _deduplicate_nearby_resonances(
-        candidates[: config.num_resonators],
+        ranked_selected[: config.num_resonators],
         config.group_resonances_conf.x_distance_max,
     )
     rejected.extend(additional_rejected)
-    rejected.extend(candidates[config.num_resonators :])
+    rejected.extend(ranked_selected[config.num_resonators :])
 
     if len(selected) < config.num_resonators:
         refill_candidates = sorted(rejected, key=_refill_resonance_score, reverse=True)
@@ -659,6 +755,13 @@ def _select_resonances(
     selected = sorted(selected, key=attrgetter("score"), reverse=True)[: config.num_resonators]
     selected_ids = {id(resonance) for resonance in selected}
     rejected = [resonance for resonance in composed if id(resonance) not in selected_ids]
+
+    if _needs_diverse_reselection(selected):
+        selected, rejected = _select_diverse_resonances(
+            candidates,
+            config.num_resonators,
+            config.group_resonances_conf.x_distance_max,
+        )
 
     selected = sorted(selected, key=attrgetter("x"))
     rejected = sorted(rejected, key=attrgetter("x"))

--- a/src/qdash/analysis/spectroscopy/mux.py
+++ b/src/qdash/analysis/spectroscopy/mux.py
@@ -18,3 +18,39 @@ PEAK_POSITIONS: dict[int, int] = {
     2: 2,
     3: 0,
 }
+
+
+def guess_sorted_slots_for_partial_mux(
+    xs: list[float],
+    frequencies: list[float],
+) -> tuple[list[int | None], str]:
+    """Guess sorted-slot assignment when fewer than four resonator peaks are found."""
+    count = len(frequencies)
+    if count >= NUM_RESONATORS:
+        return list(range(count)), "full"
+    if count != 3:
+        return [None] * count, "unassigned"
+
+    left_gap = float(frequencies[1] - frequencies[0])
+    right_gap = float(frequencies[2] - frequencies[1])
+    min_gap = max(min(left_gap, right_gap), 1e-12)
+    gap_ratio = max(left_gap, right_gap) / min_gap
+
+    if gap_ratio >= 1.6:
+        if left_gap > right_gap:
+            return [0, 2, 3], "slot1-missing-large-left-gap"
+        return [0, 1, 3], "slot2-missing-large-right-gap"
+
+    scan_min = float(min(xs))
+    scan_max = float(max(xs))
+    scan_center = (scan_min + scan_max) / 2.0
+    cluster_center = sum(frequencies) / len(frequencies)
+    if cluster_center < scan_center:
+        return [0, 1, 2], "right-edge-missing-cluster-left"
+    return [1, 2, 3], "left-edge-missing-cluster-right"
+
+
+def qid_for_sorted_slot(mux_index: int, sorted_slot: int) -> int:
+    """Return the qubit id for a MUX index and sorted resonator slot."""
+    inverse_peak_positions = {slot: pos for pos, slot in PEAK_POSITIONS.items()}
+    return mux_index * NUM_RESONATORS + inverse_peak_positions[sorted_slot]

--- a/src/qdash/api/services/reanalysis_service.py
+++ b/src/qdash/api/services/reanalysis_service.py
@@ -25,6 +25,7 @@ from qdash.analysis.spectroscopy import (
     create_marked_figure,
     estimate_and_mark_qubit_figure,
     estimate_resonator_frequency_from_figure,
+    guess_sorted_slots_for_partial_mux,
 )
 from qdash.api.schemas.reanalysis import (
     ReanalyzeOutputParameter,
@@ -95,7 +96,8 @@ class ReanalysisService:
         )
         marked_fig = create_marked_figure(raw_fig, resonances, rejected_resonances=rejected)
 
-        readout_frequency = self._pick_resonator_for_qid(qid, frequencies)
+        trace = raw_fig.data[0]
+        readout_frequency = self._pick_resonator_for_qid(qid, list(trace.x), frequencies)
         outputs = [
             ReanalyzeOutputParameter(
                 name="readout_frequency",
@@ -330,30 +332,33 @@ class ReanalysisService:
         )
 
     @staticmethod
-    def _pick_resonator_for_qid(qid: str, frequencies: list[float]) -> float:
-        """Map the requested qid to one of the four resonator frequencies in the MUX.
-
-        Mirrors the logic in CheckResonatorSpectroscopy.postprocess so the
-        re-analysis preview matches what the workflow would have stored.
-        """
+    def _pick_resonator_for_qid(qid: str, xs: list[float], frequencies: list[float]) -> float:
+        """Map the requested qid to the workflow-equivalent resonator frequency."""
         if not frequencies:
             return 0.0
-        if len(frequencies) != NUM_RESONATORS:
-            logger.warning(
-                "Resonator reanalysis for qid=%s produced %d frequencies (expected %d); "
-                "using order-preserved fallback.",
-                qid,
-                len(frequencies),
-                NUM_RESONATORS,
-            )
-            try:
-                return float(frequencies[int(qid) % len(frequencies)])
-            except ValueError:
-                return float(frequencies[0])
         try:
-            id_in_mux = int(qid) % 4
+            qid_int = int(qid)
         except ValueError as exc:
             raise HTTPException(
                 status_code=400, detail=f"qid {qid!r} is not a valid integer qubit id."
             ) from exc
-        return float(frequencies[PEAK_POSITIONS[id_in_mux]])
+
+        id_in_mux = qid_int % NUM_RESONATORS
+        assigned_slot = PEAK_POSITIONS[id_in_mux]
+        sorted_slots, assignment_mode = guess_sorted_slots_for_partial_mux(xs, frequencies)
+        resonance_index = (
+            sorted_slots.index(assigned_slot) if assigned_slot in sorted_slots else None
+        )
+        if resonance_index is not None and resonance_index < len(frequencies):
+            return float(frequencies[resonance_index])
+
+        logger.warning(
+            "Resonator reanalysis for qid=%s produced %d frequencies (expected %d); "
+            "assigned slot %d unavailable in mode %s.",
+            qid,
+            len(frequencies),
+            NUM_RESONATORS,
+            assigned_slot,
+            assignment_mode,
+        )
+        return 0.0

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
@@ -17,6 +17,8 @@ from qdash.analysis.spectroscopy import (
     estimate_minimum_usable_power,
     estimate_optimal_powers,
     estimate_resonator_frequency_from_figure,
+    guess_sorted_slots_for_partial_mux,
+    qid_for_sorted_slot,
     remove_false_spike_from_figure,
 )
 from qdash.common.visualization.figure_metadata import set_figure_role
@@ -34,40 +36,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-def _guess_sorted_slots_for_partial_mux(
-    xs: list[float],
-    frequencies: list[float],
-) -> tuple[list[int | None], str]:
-    """Guess sorted-slot assignment when fewer than 4 resonator peaks are found."""
-    count = len(frequencies)
-    if count >= NUM_RESONATORS:
-        return list(range(count)), "full"
-    if count != 3:
-        return [None] * count, "unassigned"
-
-    left_gap = float(frequencies[1] - frequencies[0])
-    right_gap = float(frequencies[2] - frequencies[1])
-    min_gap = max(min(left_gap, right_gap), 1e-12)
-    gap_ratio = max(left_gap, right_gap) / min_gap
-
-    if gap_ratio >= 1.6:
-        if left_gap > right_gap:
-            return [0, 2, 3], "slot1-missing-large-left-gap"
-        return [0, 1, 3], "slot2-missing-large-right-gap"
-
-    scan_min = float(min(xs))
-    scan_max = float(max(xs))
-    scan_center = (scan_min + scan_max) / 2.0
-    cluster_center = sum(frequencies) / len(frequencies)
-    if cluster_center < scan_center:
-        return [0, 1, 2], "right-edge-missing-cluster-left"
-    return [1, 2, 3], "left-edge-missing-cluster-right"
-
-
-def _qid_for_sorted_slot(mux_index: int, sorted_slot: int) -> int:
-    inverse_peak_positions = {slot: pos for pos, slot in PEAK_POSITIONS.items()}
-    return mux_index * NUM_RESONATORS + inverse_peak_positions[sorted_slot]
+_guess_sorted_slots_for_partial_mux = guess_sorted_slots_for_partial_mux
+_qid_for_sorted_slot = qid_for_sorted_slot
 
 
 class CheckResonatorSpectroscopy(QubexTask):
@@ -283,7 +253,7 @@ class CheckResonatorSpectroscopy(QubexTask):
             )
 
             id_in_mux = int(qid) % 4
-            sorted_slots, assignment_mode = _guess_sorted_slots_for_partial_mux(
+            sorted_slots, assignment_mode = guess_sorted_slots_for_partial_mux(
                 list(trace.x),
                 frequencies,
             )
@@ -295,7 +265,7 @@ class CheckResonatorSpectroscopy(QubexTask):
                         x=frequency,
                         y=1.02,
                         yref="paper",
-                        text=f"Q{_qid_for_sorted_slot(int(qid) // NUM_RESONATORS, sorted_slot):02d} / s{sorted_slot}",
+                        text=f"Q{qid_for_sorted_slot(int(qid) // NUM_RESONATORS, sorted_slot):02d} / s{sorted_slot}",
                         showarrow=False,
                         font={"color": "red", "size": 11},
                         align="center",

--- a/tests/qdash/analysis/spectroscopy/test_estimate_resonator_frequency.py
+++ b/tests/qdash/analysis/spectroscopy/test_estimate_resonator_frequency.py
@@ -6,12 +6,15 @@ from qdash.analysis.spectroscopy.estimate_resonator_frequency import (
     Peak,
     PeakGroup,
     Resonance,
+    _needs_diverse_reselection,
     _refine_high_power_only_resonance_x,
+    _select_diverse_resonances,
     _select_local_resonance,
     _select_resonances,
     estimate_local_bare_shift_boundary,
     estimate_optimal_powers,
 )
+from qdash.analysis.spectroscopy.mux import guess_sorted_slots_for_partial_mux
 
 
 def test_estimate_optimal_powers_uses_midpoint_between_minimum_and_local_low_power() -> None:
@@ -145,3 +148,55 @@ def test_refine_high_power_only_resonance_x_sets_representative_x_from_stronger_
     assert refined.representative_x == 4
     assert refined.x == 4
     assert refined.complementary_peaks[-1] == Peak(x=4, y=0, prominence=8.0)
+
+
+def test_select_diverse_resonances_rebalances_weak_right_edge_with_left_candidate() -> None:
+    left_edge = Resonance(
+        high_power_peaks=PeakGroup(
+            [Peak(x=10, y=4, prominence=0.2), Peak(x=22, y=5, prominence=0.3)]
+        ),
+        low_power_peak=Peak(x=10, y=2, prominence=0.1),
+    )
+    middle_a = Resonance(
+        high_power_peaks=PeakGroup([Peak(x=40, y=4, prominence=0.9)]),
+        low_power_peak=Peak(x=40, y=3, prominence=0.4),
+    )
+    middle_b = Resonance(
+        high_power_peaks=PeakGroup([Peak(x=60, y=4, prominence=0.9)]),
+        low_power_peak=Peak(x=60, y=3, prominence=0.4),
+    )
+    middle_c = Resonance(
+        high_power_peaks=PeakGroup([Peak(x=80, y=4, prominence=0.9)]),
+        low_power_peak=Peak(x=80, y=3, prominence=0.4),
+    )
+    weak_right_edge = Resonance(
+        high_power_peaks=PeakGroup([Peak(x=100, y=4, prominence=0.7)]),
+        low_power_peak=Peak(x=100, y=3, prominence=0.4),
+    )
+
+    selected, rejected = _select_diverse_resonances(
+        [left_edge, middle_a, middle_b, middle_c, weak_right_edge],
+        num_resonators=4,
+        x_distance_max=25,
+    )
+
+    assert [resonance.x for resonance in selected] == [10, 40, 60, 80]
+    assert rejected == [weak_right_edge]
+
+
+def test_needs_diverse_reselection_for_weak_non_adjacent_resonance() -> None:
+    weak_non_adjacent = Resonance(
+        high_power_peaks=PeakGroup([Peak(x=10, y=5, prominence=0.3)]),
+        low_power_peak=Peak(x=20, y=2, prominence=0.2),
+    )
+
+    assert _needs_diverse_reselection([weak_non_adjacent])
+
+
+def test_guess_sorted_slots_for_partial_mux_assigns_large_gap_missing_slot() -> None:
+    xs = [float(i) for i in range(100)]
+
+    slots, mode = guess_sorted_slots_for_partial_mux(xs, [10.0, 50.0, 60.0])
+
+    assert slots == [0, 2, 3]
+    assert mode == "slot1-missing-large-left-gap"


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Sync resonator spectroscopy analysis with recent updates from scripts/estimate-resonator-frequency.
- Affects analysis, workflow postprocessing, and API reanalysis; no OpenAPI/schema or generated client changes.

## Changes
- Add diverse resonance reselection and edge rebalancing to resonator frequency estimation.
- Share partial MUX sorted-slot assignment helpers between workflow and API reanalysis.
- Update reanalysis qid-to-frequency selection to match workflow behavior for partial detections.
- Add regression coverage for diverse reselection and partial MUX slot assignment.