### PR TITLE
ci(repo): sync all workspace packages in backend CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --all-packages --all-groups
 
       - name: Run lint check
         run: task ci-lint
@@ -73,7 +73,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --all-packages --all-groups
 
       - name: Run type check
         run: task ci-typecheck
@@ -106,7 +106,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --all-packages --all-groups
 
       - name: Run tests with coverage
         run: task ci-test


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updates backend CI dependency installation so workspace member dependencies are installed before lint, typecheck, and test jobs.
- Fixes Python 3.12 task ci-test collection failures caused by missing API/workflow dependencies such as fastapi, scipy, openai, and pydantic-settings.

## Changes
- Replaced uv sync --all-groups with uv sync --all-packages --all-groups in backend CI jobs.
- Verified task ci-test passes after syncing all workspace packages under Python 3.12.