### PR TITLE
fix(api): read ai review task notes from ai_review_note

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -23530,6 +23530,10 @@
               }
             ],
             "title": "Elapsed Time"
+          },
+          "ai_review_note": {
+            "$ref": "#/components/schemas/NoteModel",
+            "description": "AI-generated review note for this task result"
           }
         },
         "type": "object",

--- a/docs/reference/database-indexes.md
+++ b/docs/reference/database-indexes.md
@@ -138,13 +138,17 @@ db.task_result_history.create_index([
     ("project_id", 1), ("chip_id", 1), ("name", 1), ("qid", 1), ("start_at", -1)
 ])  # Latest task result queries
 
-# Partial sparse index for the dashboard notes summary — only indexes rows
-# that have a user note, so chip_notes_summary doesn't scan the entire
-# task_result_history collection.
+# Partial sparse indexes for the dashboard notes summary — only index rows
+# that have a user-authored note or an AI review note.
 db.task_result_history.create_index(
     [("project_id", 1), ("chip_id", 1), ("user_note.updated_at", -1)],
     name="project_chip_user_note_idx",
     partialFilterExpression={"user_note.updated_at": {"$type": "date"}},
+)
+db.task_result_history.create_index(
+    [("project_id", 1), ("chip_id", 1), ("ai_review_note.updated_at", -1)],
+    name="project_chip_ai_review_note_idx",
+    partialFilterExpression={"ai_review_note.updated_at": {"$type": "date"}},
 )
 
 # Cool-down filter — list task results for a specific cool-down cycle.

--- a/src/qdash/api/routers/dashboard.py
+++ b/src/qdash/api/routers/dashboard.py
@@ -15,6 +15,7 @@ from qdash.api.schemas.dashboard import (
     DashboardInsight,
     DashboardInsightSuppressed,
 )
+from qdash.datamodel.note import NoteModel
 from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 
 router = APIRouter()
@@ -94,6 +95,7 @@ def _load_reviewed_task_results(
         "chip_id": chip_id,
         "$or": [
             {"ai_review.status": {"$exists": True, "$ne": ""}},
+            {"ai_review_note.content": {"$regex": "^## AI review"}},
             {"user_note.content": {"$regex": "^## AI review"}},
         ],
     }
@@ -119,7 +121,7 @@ def _load_reviewed_task_results(
 
 
 def _has_terminal_review_signal(doc: TaskResultHistoryDocument) -> bool:
-    content = doc.user_note.content or ""
+    content = _ai_review_note_content(doc)
     return bool(
         AI_REVIEW_RE.search(content)
         or getattr(doc.ai_review, "status", "") in {"completed", "failed"}
@@ -127,7 +129,7 @@ def _has_terminal_review_signal(doc: TaskResultHistoryDocument) -> bool:
 
 
 def _parse_review_record(doc: TaskResultHistoryDocument) -> dict[str, Any]:
-    content = doc.user_note.content or ""
+    content = _ai_review_note_content(doc)
     match = AI_REVIEW_RE.search(content)
     body = match.group("body") if match else content
     decision = _field(body, "Decision")
@@ -158,6 +160,11 @@ def _parse_review_record(doc: TaskResultHistoryDocument) -> dict[str, Any]:
         or ("no_signal" in labels.lower() and "Deterministic safety guard" in body),
         "is_format_error": decision == "FORMAT_ERROR" or "model_format_error" in body,
     }
+
+
+def _ai_review_note_content(doc: TaskResultHistoryDocument) -> str:
+    ai_review_note = getattr(doc, "ai_review_note", NoteModel())
+    return ai_review_note.content or doc.user_note.content or ""
 
 
 def _field(text: str, name: str) -> str:

--- a/src/qdash/api/schemas/task.py
+++ b/src/qdash/api/schemas/task.py
@@ -3,9 +3,10 @@
 from datetime import datetime, timedelta
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_serializer, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 from qdash.common.utils.datetime import format_elapsed_time, parse_elapsed_time
+from qdash.datamodel.note import NoteModel
 
 
 class InputParameterModel(BaseModel):
@@ -197,6 +198,10 @@ class TaskResultResponse(BaseModel):
     start_at: datetime | None = None
     end_at: datetime | None = None
     elapsed_time: timedelta | None = None
+    ai_review_note: NoteModel = Field(
+        default_factory=NoteModel,
+        description="AI-generated review note for this task result",
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/qdash/api/services/note_service.py
+++ b/src/qdash/api/services/note_service.py
@@ -788,14 +788,17 @@ class NoteService:
                 CouplingDocument.chip_id == chip_id,
             ).run()
         )
-        # Use the partial sparse index on user_note.updated_at so we only scan
-        # the small subset of task results that actually have a note set.
+        # Use partial sparse note indexes so the dashboard only scans task
+        # results with user-authored notes or AI review notes.
         task_docs = list(
             TaskResultHistoryDocument.find(
                 {
                     "project_id": project_id,
                     "chip_id": chip_id,
-                    "user_note.updated_at": {"$ne": None},
+                    "$or": [
+                        {"user_note.updated_at": {"$ne": None}},
+                        {"ai_review_note.updated_at": {"$ne": None}},
+                    ],
                 }
             ).run()
         )

--- a/src/qdash/api/services/task_result_service.py
+++ b/src/qdash/api/services/task_result_service.py
@@ -217,6 +217,7 @@ class TaskResultService:
             "project_id": project_id,
             "$or": [
                 {"ai_review.status": {"$exists": True, "$ne": ""}},
+                {"ai_review_note.content": {"$regex": "^## AI review"}},
                 {"user_note.content": {"$regex": "^## AI review"}},
             ],
         }

--- a/src/qdash/api/services/task_service.py
+++ b/src/qdash/api/services/task_service.py
@@ -187,6 +187,7 @@ class TaskService:
             start_at=task_result.start_at,
             end_at=task_result.end_at,
             elapsed_time=task_result.elapsed_time,
+            ai_review_note=task_result.ai_review_note,
         )
 
     def get_task_knowledge_markdown(self, task_name: str) -> str:

--- a/src/qdash/dbmodel/task_result_history.py
+++ b/src/qdash/dbmodel/task_result_history.py
@@ -208,6 +208,15 @@ class TaskResultHistoryDocument(Document):
                 # docs whose user_note.updated_at is an actual date (i.e. set).
                 partialFilterExpression={"user_note.updated_at": {"$type": "date"}},
             ),
+            IndexModel(
+                [
+                    ("project_id", ASCENDING),
+                    ("chip_id", ASCENDING),
+                    ("ai_review_note.updated_at", DESCENDING),
+                ],
+                name="project_chip_ai_review_note_idx",
+                partialFilterExpression={"ai_review_note.updated_at": {"$type": "date"}},
+            ),
             # Cool-down filter: list task results that ran in a specific
             # cool-down. Sparse so empty (legacy) rows are not indexed.
             IndexModel(

--- a/tests/qdash/api/routers/test_note.py
+++ b/tests/qdash/api/routers/test_note.py
@@ -58,7 +58,8 @@ def _create_task_result(
     *,
     task_id: str,
     qid: str = "63",
-    note: NoteModel,
+    note: NoteModel | None = None,
+    ai_review_note: NoteModel | None = None,
 ) -> None:
     TaskResultHistoryDocument(
         project_id="note_project",
@@ -72,7 +73,8 @@ def _create_task_result(
         output_parameters={},
         output_parameter_names=[],
         note={},
-        user_note=note,
+        user_note=note or NoteModel(),
+        ai_review_note=ai_review_note or NoteModel(),
         figure_path=[],
         json_figure_path=[],
         raw_data_path=[],
@@ -330,4 +332,25 @@ def test_notes_summary_keeps_user_part_when_ai_review_prefix_exists(test_client,
     assert response.status_code == 200
     task_note = response.json()["task_notes"][0]
     assert task_note["note"]["content"] == "operator follow-up"
+    assert task_note["ai_review_note"]["content"].startswith("## AI review")
+
+
+def test_notes_summary_includes_task_results_with_only_ai_review_note(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+    _create_task_result(
+        task_id="task-ai-review-note",
+        ai_review_note=NoteModel(
+            content="## AI review\n\n- Decision: `REVIEW`\n",
+            updated_by="qdash-ai",
+            updated_at=datetime(2026, 5, 19, tzinfo=UTC),
+        ),
+    )
+
+    response = test_client.get("/chips/chip-1/notes-summary", headers=headers)
+
+    assert response.status_code == 200
+    task_note = response.json()["task_notes"][0]
+    assert task_note["task_id"] == "task-ai-review-note"
+    assert task_note["note"]["content"] == ""
     assert task_note["ai_review_note"]["content"].startswith("## AI review")

--- a/tests/qdash/api/services/test_task_result_service.py
+++ b/tests/qdash/api/services/test_task_result_service.py
@@ -83,6 +83,7 @@ def _doc(task_id: str, qid: str, end_at: datetime) -> _TaskResultDoc:
         chip_id="chip-1",
         ai_review=AiReviewModel(),
         user_note=NoteModel(),
+        ai_review_note=NoteModel(),
     )
 
 
@@ -460,7 +461,7 @@ def test_create_figures_zip_includes_ai_review_replay_bundle(tmp_path) -> None:
 
 def test_load_reviewed_task_results_prefers_latest_completed_review_over_newer_pending() -> None:
     completed_doc = _doc("done-q0", "0", datetime(2026, 5, 5, 10, tzinfo=timezone.utc))
-    completed_doc.user_note = NoteModel(content="## AI review\n\n- Decision: `PASS`\n")
+    completed_doc.ai_review_note = NoteModel(content="## AI review\n\n- Decision: `PASS`\n")
     completed_doc.ai_review = AiReviewModel(status="completed")
 
     pending_doc = _doc("pending-q0", "0", datetime(2026, 5, 5, 11, tzinfo=timezone.utc))
@@ -492,7 +493,7 @@ def test_list_ai_reviews_extracts_decision_and_paginates() -> None:
     first_doc.name = "CheckQubitSpectroscopy"
     first_doc.figure_path = ["/tmp/task-1.png"]
     first_doc.json_figure_path = ["/tmp/task-1.json"]
-    first_doc.user_note = NoteModel(
+    first_doc.ai_review_note = NoteModel(
         content=(
             "## AI review\n\n"
             "- Decision: `REVIEW`\n"
@@ -511,7 +512,7 @@ def test_list_ai_reviews_extracts_decision_and_paginates() -> None:
     )
 
     second_doc = _doc("task-2", "1", datetime(2026, 5, 5, 10, tzinfo=timezone.utc))
-    second_doc.user_note = NoteModel(content="## AI review\n\n- Decision: `PASS`\n")
+    second_doc.ai_review_note = NoteModel(content="## AI review\n\n- Decision: `PASS`\n")
     second_doc.ai_review = AiReviewModel(status="completed")
 
     class _Finder:
@@ -549,7 +550,7 @@ def test_list_ai_reviews_extracts_decision_and_paginates() -> None:
 
 def test_get_ai_review_run_groups_reviews_by_run_id() -> None:
     first_doc = _doc("task-1", "0", datetime(2026, 5, 5, 11, tzinfo=timezone.utc))
-    first_doc.user_note = NoteModel(content="## AI review\n\n- Decision: `REVIEW`\n")
+    first_doc.ai_review_note = NoteModel(content="## AI review\n\n- Decision: `REVIEW`\n")
     first_doc.ai_review = AiReviewModel(
         status="completed",
         requested_by="bob",
@@ -561,7 +562,7 @@ def test_get_ai_review_run_groups_reviews_by_run_id() -> None:
     )
 
     second_doc = _doc("task-2", "1", datetime(2026, 5, 5, 11, tzinfo=timezone.utc))
-    second_doc.user_note = NoteModel(content="## AI review\n\n- Decision: `PASS`\n")
+    second_doc.ai_review_note = NoteModel(content="## AI review\n\n- Decision: `PASS`\n")
     second_doc.ai_review = AiReviewModel(
         status="running",
         requested_by="bob",

--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -122,7 +122,7 @@ export function ChipPageContent() {
   const aiReviewBadgesByTaskId = useMemo(() => {
     const badges = new Map<string, AiReviewBadgeState>();
     for (const entry of notesSummaryData?.data?.task_notes ?? []) {
-      const content = entry.note?.content ?? "";
+      const content = entry.ai_review_note?.content || entry.note?.content || "";
       const badge = getAiReviewBadgeState(content);
       if (badge) {
         badges.set(entry.task_id, badge);

--- a/ui/src/components/features/chip/modals/CouplingTaskHistoryModal.tsx
+++ b/ui/src/components/features/chip/modals/CouplingTaskHistoryModal.tsx
@@ -16,6 +16,7 @@ import { useUpdateCalibrationParameters } from "@/client/calibration/calibration
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { ParametersTable } from "@/components/features/metrics/ParametersTable";
 import { useManualOverrides } from "@/hooks/useManualOverrides";
+import { TaskResultAiReviewNote } from "@/components/features/metrics/TaskResultAiReviewNote";
 import { TaskResultIssues } from "@/components/features/metrics/TaskResultIssues";
 import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
 import type { AnalysisContext } from "@/hooks/useAnalysisChat";
@@ -396,6 +397,9 @@ export function CouplingTaskHistoryModal({
         </div>
       )}
 
+      {selectedTask?.task_id && (
+        <TaskResultAiReviewNote taskId={selectedTask.task_id} hideWhenEmpty />
+      )}
       {selectedTask?.task_id && (
         <TaskResultMemo taskId={selectedTask.task_id} chipId={chipId} hideWhenEmpty />
       )}

--- a/ui/src/components/features/chip/modals/TaskDetailModal.tsx
+++ b/ui/src/components/features/chip/modals/TaskDetailModal.tsx
@@ -9,6 +9,7 @@ import type { Task } from "@/schemas";
 import { useGetTaskResult } from "@/client/task/task";
 import { InteractiveFigureContent } from "@/components/charts/InteractiveFigureContent";
 import { TaskFigure } from "@/components/charts/TaskFigure";
+import { TaskResultAiReviewNote } from "@/components/features/metrics/TaskResultAiReviewNote";
 import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
 import { ReanalysisPanel } from "@/components/features/qubit/ReanalysisPanel";
 import {
@@ -111,7 +112,7 @@ export function TaskDetailModal({
     error: fetchError,
   } = useGetTaskResult(taskId!, {
     query: {
-      enabled: isOpen && !!taskId && !taskProp,
+      enabled: isOpen && !!taskId,
     },
   });
 
@@ -135,12 +136,12 @@ export function TaskDetailModal({
     : null;
 
   const task = taskProp || fetchedTask;
-  const error = (fetchError as Error)?.message || null;
+  const error = taskProp ? null : (fetchError as Error)?.message || null;
 
   if (!isOpen) return null;
 
   // Loading state
-  if (loading) {
+  if (loading && !taskProp) {
     return (
       <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 backdrop-blur-sm">
         <div className="bg-base-100 rounded-xl p-8">
@@ -483,6 +484,9 @@ export function TaskDetailModal({
               </div>
             )}
 
+            {noteTaskId && (
+              <TaskResultAiReviewNote note={fetchedTaskData?.ai_review_note} hideWhenEmpty />
+            )}
             {noteTaskId && <TaskResultMemo taskId={noteTaskId} chipId={chipId} hideWhenEmpty />}
 
             {/* Parameters Tables (detailed variant only) */}

--- a/ui/src/components/features/chip/modals/TaskHistoryModal.tsx
+++ b/ui/src/components/features/chip/modals/TaskHistoryModal.tsx
@@ -15,6 +15,7 @@ import { useUpdateCalibrationParameters } from "@/client/calibration/calibration
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { ParametersTable } from "@/components/features/metrics/ParametersTable";
 import { useManualOverrides } from "@/hooks/useManualOverrides";
+import { TaskResultAiReviewNote } from "@/components/features/metrics/TaskResultAiReviewNote";
 import { TaskResultIssues } from "@/components/features/metrics/TaskResultIssues";
 import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
 import type { AnalysisContext } from "@/hooks/useAnalysisChat";
@@ -376,6 +377,9 @@ export function TaskHistoryModal({
         </div>
       )}
 
+      {selectedTask?.task_id && (
+        <TaskResultAiReviewNote taskId={selectedTask.task_id} hideWhenEmpty />
+      )}
       {selectedTask?.task_id && (
         <TaskResultMemo taskId={selectedTask.task_id} chipId={chipId} hideWhenEmpty />
       )}

--- a/ui/src/components/features/metrics/QubitMetricHistoryModal.tsx
+++ b/ui/src/components/features/metrics/QubitMetricHistoryModal.tsx
@@ -15,6 +15,7 @@ import { isChipMetricsQuery } from "@/lib/utils/queryInvalidation";
 import { useManualOverrides } from "@/hooks/useManualOverrides";
 
 import { ParametersTable } from "./ParametersTable";
+import { TaskResultAiReviewNote } from "./TaskResultAiReviewNote";
 import { TaskResultIssues } from "./TaskResultIssues";
 import { TaskResultMemo } from "./TaskResultMemo";
 import { TaskResultExcludeButton } from "./TaskResultExcludeButton";
@@ -615,7 +616,10 @@ export function QubitMetricHistoryModal({
         </div>
       )}
 
-      {/* Memo (above issues) */}
+      {/* Notes (above issues) */}
+      {selectedTask?.task_id && (
+        <TaskResultAiReviewNote taskId={selectedTask.task_id} hideWhenEmpty />
+      )}
       {selectedTask?.task_id && <TaskResultMemo taskId={selectedTask.task_id} chipId={chipId} />}
 
       {/* Issues */}

--- a/ui/src/components/features/metrics/TaskResultAiReviewNote.tsx
+++ b/ui/src/components/features/metrics/TaskResultAiReviewNote.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Bot } from "lucide-react";
+
+import type { NoteModel } from "@/schemas";
+
+import { useGetTaskResult } from "@/client/task/task";
+import { MarkdownContent } from "@/components/ui/MarkdownContent";
+import { formatDateTime } from "@/lib/utils/datetime";
+
+interface TaskResultAiReviewNoteProps {
+  note?: NoteModel | null;
+  taskId?: string;
+  hideWhenEmpty?: boolean;
+}
+
+export function TaskResultAiReviewNote({
+  note,
+  taskId,
+  hideWhenEmpty = false,
+}: TaskResultAiReviewNoteProps) {
+  const shouldFetch = Boolean(taskId && !note?.content?.trim());
+  const { data, isLoading } = useGetTaskResult(taskId ?? "", {
+    query: {
+      enabled: shouldFetch,
+      retry: false,
+      staleTime: 30_000,
+    },
+  });
+  const aiReviewNote = note?.content?.trim() ? note : data?.data.ai_review_note;
+  const content = aiReviewNote?.content?.trim() ?? "";
+  if (!content && hideWhenEmpty) return null;
+
+  return (
+    <div className="mt-6 mb-3 rounded-lg border border-base-300 bg-base-200/40">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-base-300">
+        <h3 className="text-sm font-semibold flex items-center gap-2">
+          <Bot className="h-4 w-4" />
+          AI Review
+          {content && aiReviewNote?.updated_by && (
+            <span className="text-xs font-normal text-base-content/60">
+              · by {aiReviewNote.updated_by}
+              {aiReviewNote.updated_at && <> · {formatDateTime(aiReviewNote.updated_at)}</>}
+            </span>
+          )}
+        </h3>
+      </div>
+
+      <div className="p-3 text-sm">
+        {isLoading ? (
+          <div className="text-xs text-base-content/50 italic">Loading…</div>
+        ) : content ? (
+          <MarkdownContent
+            content={content}
+            className="break-words [&>:first-child]:mt-0 [&>:last-child]:mb-0 [&_ul]:my-1.5 [&_ol]:my-1.5 [&_li]:my-0.5 [&_li>p]:my-0"
+          />
+        ) : (
+          <p className="text-xs text-base-content/50 italic">No AI review note yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -22,6 +22,7 @@ import { useCreateIssue, getGetTaskResultIssuesQueryKey } from "@/client/issue/i
 import { useQueryClient } from "@tanstack/react-query";
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { ParametersTable } from "@/components/features/metrics/ParametersTable";
+import { TaskResultAiReviewNote } from "@/components/features/metrics/TaskResultAiReviewNote";
 import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
 import { ReanalysisPanel } from "@/components/features/qubit/ReanalysisPanel";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";
@@ -653,6 +654,7 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
         )}
       </div>
 
+      <TaskResultAiReviewNote note={taskResult.ai_review_note} hideWhenEmpty />
       <TaskResultMemo taskId={taskId} chipId={taskResult.chip_id} />
 
       {/* Divider: Issues */}

--- a/ui/src/schemas/taskResultResponse.ts
+++ b/ui/src/schemas/taskResultResponse.ts
@@ -13,6 +13,7 @@ import type { ReExecutionEntry } from './reExecutionEntry';
 import type { TaskResultResponseStartAt } from './taskResultResponseStartAt';
 import type { TaskResultResponseEndAt } from './taskResultResponseEndAt';
 import type { TaskResultResponseElapsedTime } from './taskResultResponseElapsedTime';
+import type { NoteModel } from './noteModel';
 
 /**
  * Response model for task result by task_id.
@@ -55,4 +56,6 @@ export interface TaskResultResponse {
   start_at?: TaskResultResponseStartAt;
   end_at?: TaskResultResponseEndAt;
   elapsed_time?: TaskResultResponseElapsedTime;
+  /** AI-generated review note for this task result */
+  ai_review_note?: NoteModel;
 }


### PR DESCRIPTION
## Ticket
N/A

## Summary
- Align AI review task-result note handling with the new `ai_review_note` storage field while preserving legacy `user_note` fallback behavior.
- Affects API note summaries, dashboard AI insights, chip-page badges, task-result detail views, and the task-result note indexes.

## Changes
- Read AI review markdown from `ai_review_note` first in AI review listing and dashboard insight parsing.
- Include task results that only have `ai_review_note` in chip notes summary, and add the matching Mongo index documentation.
- Update `ChipPageContent` badge lookup to use `ai_review_note` before legacy note content.
- Add `ai_review_note` to `TaskResultResponse`, regenerate OpenAPI/client schema, and show AI review notes in task result pages and task-result modals.
- Add/update focused tests for note summary and task-result AI review parsing.

## Verification
- `pytest tests/qdash/api/routers/test_note.py tests/qdash/api/services/test_task_result_service.py`
- `bun run test:run src/components/features/chip/__tests__/aiReviewBadge.test.ts`
- `ruff check src/qdash/api/services/task_result_service.py src/qdash/api/services/note_service.py src/qdash/api/routers/dashboard.py src/qdash/dbmodel/task_result_history.py tests/qdash/api/routers/test_note.py tests/qdash/api/services/test_task_result_service.py`
- `ruff check src/qdash/api/schemas/task.py src/qdash/api/services/task_service.py`
- `bun run lint`
- `bun run build`
