### PR TITLE
feat(infra): add lightweight Nix local dev flow

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -76,6 +76,48 @@ tasks:
       - bun run docs:dev --host
 
   # =============================================================================
+  # Lightweight local development (Nix shell + Docker services)
+  # =============================================================================
+
+  dev-services:
+    desc: Start only the services needed by host-side API/UI development
+    cmds:
+      - docker compose up -d mongo postgres prefect-server deployment-service
+
+  dev-api-local:
+    desc: Start the API on the host against Docker services
+    dotenv: [.env]
+    cmds:
+      - |
+        if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"${API_PORT:-5715}" -sTCP:LISTEN; then
+          echo "Port ${API_PORT:-5715} is already in use. Stop that process or set API_PORT to another port." >&2
+          exit 1
+        fi
+        export MONGO_HOST="${MONGO_HOST:-localhost}"
+        export DEPLOYMENT_SERVICE_URL="http://localhost:${DEPLOYMENT_SERVICE_PORT:-4006}"
+        uv run uvicorn src.qdash.api.main:app --reload --port "${API_PORT:-5715}"
+
+  dev-ui-local:
+    desc: Start the UI on the host against the local API
+    dir: ui
+    dotenv: [../.env]
+    cmds:
+      - |
+        if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"${UI_PORT:-5714}" -sTCP:LISTEN; then
+          echo "Port ${UI_PORT:-5714} is already in use. Stop that process or set UI_PORT to another port." >&2
+          exit 1
+        fi
+        export PORT="${UI_PORT:-5714}"
+        export INTERNAL_API_URL="http://localhost:${API_PORT:-5715}"
+        bun run dev
+
+  dev-local:
+    desc: Start lightweight local development services, API, and UI
+    cmds:
+      - task: dev-services
+      - task --parallel dev-api-local dev-ui-local
+
+  # =============================================================================
   # Python Tests (all tests run in-memory, no MongoDB required)
   # =============================================================================
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -94,9 +94,10 @@ nix develop
 ```
 
 The shell provides Python 3.11, uv, Bun, Node.js 20, go-task, Docker CLI/Compose, jq, PostgreSQL
-client tools, and the secret scanning tools used by the project. It does not start MongoDB,
-PostgreSQL, Prefect, API, or UI services by itself; use the existing Docker Compose tasks for
-those services.
+client tools, and the secret scanning tools used by the project. It also sets `UV_PYTHON` to the
+Nix-provided Python 3.11 so `uv sync` does not accidentally select Python 3.12 on macOS, where
+some workflow backend dependencies may fail to build. It does not start MongoDB, PostgreSQL,
+Prefect, API, or UI services by itself; use the existing Docker Compose tasks for those services.
 
 To load the shell automatically when entering the repository, install
 [direnv](https://direnv.net/) and run:
@@ -112,6 +113,15 @@ uv sync --locked --all-groups --all-packages
 
 cd ui && bun install --frozen-lockfile
 ```
+
+Then start the lightweight development stack:
+
+```shell
+task dev-local
+```
+
+This starts MongoDB, PostgreSQL, Prefect, and the deployment service with Docker Compose, then
+runs the API and UI on the host. The UI is available at <http://localhost:5714>.
 
 ### Install Dependencies
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -81,6 +81,38 @@ git config --global user.email
 
 Set them in the container if either command is empty.
 
+### Using Nix (Lightweight Local Shell)
+
+Nix can provide the local CLI toolchain without starting the DevContainer. This is useful when
+you want to run Python tests, UI checks, or Docker Compose tasks from the host shell while keeping
+the service stack in Docker.
+
+Install [Nix](https://nixos.org/download/) with flakes enabled, then enter the development shell:
+
+```shell
+nix develop
+```
+
+The shell provides Python 3.11, uv, Bun, Node.js 20, go-task, Docker CLI/Compose, jq, PostgreSQL
+client tools, and the secret scanning tools used by the project. It does not start MongoDB,
+PostgreSQL, Prefect, API, or UI services by itself; use the existing Docker Compose tasks for
+those services.
+
+To load the shell automatically when entering the repository, install
+[direnv](https://direnv.net/) and run:
+
+```shell
+direnv allow
+```
+
+After entering the Nix shell for the first time, install project dependencies:
+
+```shell
+uv sync --locked --all-groups --all-packages
+
+cd ui && bun install --frozen-lockfile
+```
+
 ### Install Dependencies
 
 The DevContainer installs Python, frontend, and Lefthook dependencies automatically during

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778458615,
+        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
             go-task
             jq
             lefthook
+            lsof
             nodejs_20
             pkg-config
             postgresql_14
@@ -54,11 +55,12 @@
 
           env = {
             UV_LINK_MODE = "copy";
+            UV_PYTHON = "${pkgs.python311}/bin/python";
             LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibs;
           };
 
           shellHook = ''
-            export PATH="$PWD/.venv/bin:$PWD/ui/node_modules/.bin:$PATH"
+            export PATH="$PWD/ui/node_modules/.bin:$PATH:$PWD/.venv/bin"
 
             if [ ! -d .venv ]; then
               echo "Run: uv sync --locked --all-groups --all-packages"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  description = "QDash development shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        runtimeLibs = with pkgs; [
+          cairo
+          glib
+          gtk3
+          hdf5
+          postgresql_14
+          stdenv.cc.cc.lib
+          zlib
+        ];
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            bashInteractive
+            bun
+            curl
+            docker-client
+            docker-compose
+            gcc
+            git
+            gitleaks
+            gnumake
+            go-task
+            jq
+            lefthook
+            nodejs_20
+            pkg-config
+            postgresql_14
+            python311
+            trufflehog
+            uv
+          ];
+
+          env = {
+            UV_LINK_MODE = "copy";
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibs;
+          };
+
+          shellHook = ''
+            export PATH="$PWD/.venv/bin:$PWD/ui/node_modules/.bin:$PATH"
+
+            if [ ! -d .venv ]; then
+              echo "Run: uv sync --locked --all-groups --all-packages"
+            fi
+
+            if [ ! -d ui/node_modules ]; then
+              echo "Run: cd ui && bun install --frozen-lockfile"
+            fi
+          '';
+        };
+      }
+    );
+}

--- a/src/qdash/api/db/session.py
+++ b/src/qdash/api/db/session.py
@@ -28,11 +28,13 @@ def get_mongo_client() -> MongoClient[Any]:
     """
     global _client
     if _client is None:
-        # Note: MONGO_PORT is for host-side port mapping, not container-to-container communication
-        # MongoDB always listens on 27017 inside the Docker network
+        mongo_host = os.getenv("MONGO_HOST", "mongo")
+        # MONGO_PORT is for host-side port mapping. Inside the Docker network,
+        # MongoDB always listens on 27017.
+        mongo_port = 27017 if mongo_host == "mongo" else int(os.getenv("MONGO_PORT", "27017"))
         _client = MongoClient(
-            os.getenv("MONGO_HOST", "mongo"),
-            port=27017,
+            mongo_host,
+            port=mongo_port,
             username=os.getenv("MONGO_INITDB_ROOT_USERNAME"),
             password=os.getenv("MONGO_INITDB_ROOT_PASSWORD"),
         )

--- a/src/qdash/common/infrastructure/logging.py
+++ b/src/qdash/common/infrastructure/logging.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import yaml
 
 _CONFIG_DIR = Path("/app/config/logging")
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_LOCAL_CONFIG_DIR = _REPO_ROOT / "config" / "logging"
 
 
 def setup_logging(
@@ -19,12 +21,20 @@ def setup_logging(
 ) -> None:
     """Load a YAML logging config and apply it via ``logging.config.dictConfig``."""
     config_dir = config_dir or _CONFIG_DIR
+    if not config_dir.exists() and config_dir == _CONFIG_DIR:
+        config_dir = _LOCAL_CONFIG_DIR
     yaml_path = config_dir / f"{config_name}.yaml"
 
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     log_file = log_file or f"/app/logs/{config_name}.log"
 
-    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    try:
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    except OSError:
+        if not log_file.startswith("/app/logs/"):
+            raise
+        log_file = str(_REPO_ROOT / "logs" / f"{config_name}.log")
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
 
     raw = yaml_path.read_text()
     raw = raw.replace("${LOG_LEVEL}", log_level)

--- a/src/qdash/dbmodel/initialize.py
+++ b/src/qdash/dbmodel/initialize.py
@@ -21,9 +21,11 @@ def _get_client() -> MongoClient[Any]:
     """Get or create MongoDB client (lazy initialization)."""
     global _client
     if _client is None:
+        mongo_host = os.getenv("MONGO_HOST", "mongo")
+        mongo_port = 27017 if mongo_host == "mongo" else int(os.getenv("MONGO_PORT", "27017"))
         _client = MongoClient(
-            "mongo",  # Docker service name
-            port=27017,  # Docker internal port
+            mongo_host,
+            port=mongo_port,
             username=os.getenv("MONGO_INITDB_ROOT_USERNAME"),
             password=os.getenv("MONGO_INITDB_ROOT_PASSWORD"),
         )


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add a lightweight host-side development path for API/UI work using Nix tooling plus Docker Compose services.
- Keeps the devcontainer/Docker flow intact while making MongoDB and logging paths work from host-side processes.

## Changes
- Add Nix dev shell updates for Python 3.11 selection, local tool paths, lsof, and the generated flake lock.
- Add Taskfile entries for local service startup, host-side API startup, host-side UI startup, and combined lightweight development.
- Allow API Mongo clients to use MONGO_HOST/MONGO_PORT for host-side development while preserving Docker defaults.
- Add host-side fallback paths for logging config and log output.
- Document the lightweight local development workflow in setup docs.