### PR TITLE
chore(repo): add .direnv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -251,3 +251,4 @@ docs/papers/*
 config/qubex-config
 scripts/estimate_qubit_frequency
 scripts/estimate-resonator-frequency
+.direnv


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Added `.direnv` to the `.gitignore` file to prevent environment configuration files from being tracked in the repository. This change helps maintain a cleaner repository and avoids potential conflicts with local development environments.

## Changes
- Updated `.gitignore` to include `.direnv`

