### PR TITLE
fix(api): resolve calibtasks path consistently

### DIFF
--- a/src/qdash/api/services/chip_service.py
+++ b/src/qdash/api/services/chip_service.py
@@ -48,24 +48,19 @@ def _get_task_names_cached() -> tuple[str, ...]:
     Returns a tuple for cache compatibility.
     """
     from qdash.api.dependencies import get_task_file_service
-    from qdash.common.config.loader import ConfigLoader
-    from qdash.common.config.paths import CALIBTASKS_DIR
+    from qdash.common.config.backend import get_default_backend
 
-    default_backend = "qubex"
     try:
-        settings = ConfigLoader.load_settings()
-        ui_settings = settings.get("ui", {})
-        task_files_settings = ui_settings.get("task_files", {})
-        default_backend = task_files_settings.get("default_backend", "qubex")
+        default_backend = get_default_backend()
     except Exception as e:
-        logger.warning(f"Failed to load settings: {e}")
+        logger.warning(f"Failed to load default backend: {e}")
+        default_backend = "qubex"
 
-    backend_path = CALIBTASKS_DIR / default_backend
+    service = get_task_file_service()
+    backend_path = service._base_path / default_backend
     if not backend_path.exists() or not backend_path.is_dir():
         logger.warning(f"Backend directory not found: {backend_path}")
         return ()
-
-    service = get_task_file_service()
     tasks = service._collect_tasks_from_directory(backend_path, backend_path)
     return tuple(task.name for task in tasks)
 

--- a/src/qdash/api/services/task_file_service.py
+++ b/src/qdash/api/services/task_file_service.py
@@ -23,6 +23,7 @@ from qdash.api.schemas.task_file import (
     TaskInfo,
 )
 from qdash.common.config.backend import (
+    get_default_backend,
     get_task_category,
     get_tasks,
     load_backend_config,
@@ -65,7 +66,7 @@ class TaskFileService:
             ui_settings = settings.get("ui", {})
             task_files_settings = ui_settings.get("task_files", {})
             return TaskFileSettings(
-                default_backend=task_files_settings.get("default_backend"),
+                default_backend=get_default_backend(),
                 default_view_mode=task_files_settings.get("default_view_mode"),
                 sort_order=task_files_settings.get("sort_order"),
             )
@@ -215,7 +216,7 @@ class TaskFileService:
         try:
             config = load_backend_config()
             return BackendConfigResponse(
-                default_backend=config.default_backend,
+                default_backend=get_default_backend(),
                 backends={
                     name: {"description": b.description, "tasks": b.tasks}
                     for name, b in config.backends.items()

--- a/src/qdash/common/config/path_resolver.py
+++ b/src/qdash/common/config/path_resolver.py
@@ -32,7 +32,7 @@ def _resolve_runtime_base_path(
     """Resolve a base path with explicit env, container, then repo-local fallback."""
     if env_name:
         env_value = _env_path(env_name)
-        if env_value is not None:
+        if env_value is not None and env_value.exists():
             return env_value
     if container_path.exists():
         return container_path

--- a/tests/qdash/api/services/test_task_file_service.py
+++ b/tests/qdash/api/services/test_task_file_service.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
+from qdash.api.dependencies import get_task_file_service
+from qdash.api.services.chip_service import _get_task_names_cached, get_task_names
 from qdash.api.services.task_file_service import TaskFileService
+from qdash.common.config.backend import clear_cache as clear_backend_config_cache
 
 
 def test_uses_caltasks_path_from_environment(monkeypatch, tmp_path: Path) -> None:
@@ -17,6 +20,22 @@ def test_uses_caltasks_path_from_environment(monkeypatch, tmp_path: Path) -> Non
 
 def test_falls_back_to_container_calibtasks_path(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.delenv("CALTASKS_PATH", raising=False)
+    calibtasks_dir = tmp_path / "calibtasks"
+    calibtasks_dir.mkdir()
+    monkeypatch.setattr(
+        "qdash.common.config.path_resolver.CALIBTASKS_DIR",
+        calibtasks_dir,
+    )
+
+    service = TaskFileService()
+
+    assert service._base_path == calibtasks_dir
+
+
+def test_ignores_nonexistent_caltasks_path_from_environment(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("CALTASKS_PATH", str(tmp_path / "missing"))
     calibtasks_dir = tmp_path / "calibtasks"
     calibtasks_dir.mkdir()
     monkeypatch.setattr(
@@ -52,3 +71,49 @@ def test_explicit_calibtasks_base_path_takes_precedence(monkeypatch, tmp_path: P
     service = TaskFileService(calibtasks_base_path=explicit_dir)
 
     assert service._base_path == explicit_dir
+
+
+def test_get_settings_uses_effective_default_backend_from_environment(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("DEFAULT_BACKEND", "fake")
+    monkeypatch.setenv("CALTASKS_PATH", str(tmp_path))
+    clear_backend_config_cache()
+
+    service = TaskFileService()
+
+    assert service.get_settings().default_backend == "fake"
+
+
+def test_get_task_names_uses_effective_default_backend_and_resolved_calibtasks_path(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    calibtasks_dir = tmp_path / "calibtasks"
+    fake_dir = calibtasks_dir / "fake"
+    qubex_dir = calibtasks_dir / "qubex"
+    fake_dir.mkdir(parents=True)
+    qubex_dir.mkdir()
+    (fake_dir / "fake_task.py").write_text(
+        "class FakeTask:\n"
+        "    name: str = \"FakeOnlyTask\"\n"
+        "    task_type: str = \"qubit\"\n",
+        encoding="utf-8",
+    )
+    (qubex_dir / "qubex_task.py").write_text(
+        "class QubexTask:\n"
+        "    name: str = \"QubexOnlyTask\"\n"
+        "    task_type: str = \"qubit\"\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CALTASKS_PATH", str(calibtasks_dir))
+    monkeypatch.setenv("DEFAULT_BACKEND", "fake")
+    clear_backend_config_cache()
+    get_task_file_service.cache_clear()
+    _get_task_names_cached.cache_clear()
+
+    assert get_task_names() == ["FakeOnlyTask"]
+
+    get_task_file_service.cache_clear()
+    _get_task_names_cached.cache_clear()

--- a/tests/qdash/api/services/test_task_file_service.py
+++ b/tests/qdash/api/services/test_task_file_service.py
@@ -32,9 +32,7 @@ def test_falls_back_to_container_calibtasks_path(monkeypatch, tmp_path: Path) ->
     assert service._base_path == calibtasks_dir
 
 
-def test_ignores_nonexistent_caltasks_path_from_environment(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_ignores_nonexistent_caltasks_path_from_environment(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("CALTASKS_PATH", str(tmp_path / "missing"))
     calibtasks_dir = tmp_path / "calibtasks"
     calibtasks_dir.mkdir()
@@ -96,15 +94,11 @@ def test_get_task_names_uses_effective_default_backend_and_resolved_calibtasks_p
     fake_dir.mkdir(parents=True)
     qubex_dir.mkdir()
     (fake_dir / "fake_task.py").write_text(
-        "class FakeTask:\n"
-        "    name: str = \"FakeOnlyTask\"\n"
-        "    task_type: str = \"qubit\"\n",
+        'class FakeTask:\n    name: str = "FakeOnlyTask"\n    task_type: str = "qubit"\n',
         encoding="utf-8",
     )
     (qubex_dir / "qubex_task.py").write_text(
-        "class QubexTask:\n"
-        "    name: str = \"QubexOnlyTask\"\n"
-        "    task_type: str = \"qubit\"\n",
+        'class QubexTask:\n    name: str = "QubexOnlyTask"\n    task_type: str = "qubit"\n',
         encoding="utf-8",
     )
     monkeypatch.setenv("CALTASKS_PATH", str(calibtasks_dir))


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Fixes calibration task path resolution so API services do not use a container-invalid relative CALTASKS_PATH when listing chip tasks.
- Aligns task-file default backend reporting and chip task discovery with the effective DEFAULT_BACKEND used by runtime services.

## Changes
- Ignore non-existent environment-provided runtime paths and fall back to container or repo-local defaults.
- Resolve chip task names through TaskFileService's resolved calibtasks base path instead of a fixed path.
- Return the effective default backend from task-file settings and backend config endpoints.
- Add API service regression tests for CALTASKS_PATH fallback and effective backend behavior.