### PR TITLE
feat(workflow): prefix config commit environment

### DIFF
--- a/src/qdash/api/services/file_service.py
+++ b/src/qdash/api/services/file_service.py
@@ -18,6 +18,7 @@ from git.exc import GitCommandError
 from qdash.api.lib.file_utils import validate_relative_path
 from qdash.api.schemas.file import FileTreeNode
 from qdash.common.config.path_resolver import resolve_config_base_path
+from qdash.common.utils.commit_message import format_machine_commit_message
 from qdash.common.utils.datetime import now_iso
 
 logger = logging.getLogger(__name__)
@@ -481,7 +482,7 @@ class FileService:
                 repo.git.config("user.email", "github-actions[bot]@users.noreply.github.com")
 
                 now_jst = now_iso()
-                commit_msg = f"{commit_message} at {now_jst}"
+                commit_msg = format_machine_commit_message(commit_message, now_jst)
                 repo.index.commit(commit_msg)
 
                 logger.info(f"Pushing branch {branch_name} to remote")

--- a/src/qdash/common/utils/commit_message.py
+++ b/src/qdash/common/utils/commit_message.py
@@ -1,0 +1,25 @@
+"""Helpers for machine-generated commit messages."""
+
+from __future__ import annotations
+
+import os
+import re
+
+_UNSAFE_TOKEN_CHARS = re.compile(r"[\s\[\]]+")
+
+
+def _sanitize_commit_token(value: str) -> str:
+    """Convert an environment value into a safe single-line commit token."""
+    token = _UNSAFE_TOKEN_CHARS.sub("-", value.strip()).strip("-")
+    return token or "unknown"
+
+
+def format_machine_commit_message(
+    message: str,
+    committed_at: str,
+    *,
+    env: str | None = None,
+) -> str:
+    """Format a machine-generated commit message with the runtime environment first."""
+    env_name = os.getenv("ENV", "unknown") if env is None else env
+    return f"[ENV={_sanitize_commit_token(env_name)}] {message} at {committed_at}"

--- a/src/qdash/workflow/worker/tasks/push_github.py
+++ b/src/qdash/workflow/worker/tasks/push_github.py
@@ -12,6 +12,7 @@ from git.exc import GitCommandError, InvalidGitRepositoryError
 from prefect import get_run_logger, task
 
 from qdash.common.config.paths import QUBEX_CONFIG_BASE
+from qdash.common.utils.commit_message import format_machine_commit_message
 from qdash.common.utils.datetime import now_iso
 
 if TYPE_CHECKING:
@@ -111,7 +112,7 @@ def push_github(
         now_jst = now_iso()
         repo.git.config("user.name", "github-actions[bot]")
         repo.git.config("user.email", "github-actions[bot]@users.noreply.github.com")
-        repo.index.commit(f"{commit_message} at {now_jst}")
+        repo.index.commit(format_machine_commit_message(commit_message, now_jst))
 
         repo.remotes.origin.push()
 
@@ -199,7 +200,7 @@ def push_github_batch(
         now_jst = now_iso()
         repo.git.config("user.name", "github-actions[bot]")
         repo.git.config("user.email", "github-actions[bot]@users.noreply.github.com")
-        repo.index.commit(f"{commit_message} at {now_jst}")
+        repo.index.commit(format_machine_commit_message(commit_message, now_jst))
 
         repo.remotes.origin.push()
 

--- a/tests/qdash/common/test_commit_message_utils.py
+++ b/tests/qdash/common/test_commit_message_utils.py
@@ -1,0 +1,29 @@
+from qdash.common.utils.commit_message import format_machine_commit_message
+
+
+def test_format_machine_commit_message_prefixes_env(monkeypatch):
+    monkeypatch.setenv("ENV", "prod-osaka")
+
+    message = format_machine_commit_message("Update params", "2026-05-22T12:00:00+00:00")
+
+    assert message == "[ENV=prod-osaka] Update params at 2026-05-22T12:00:00+00:00"
+
+
+def test_format_machine_commit_message_sanitizes_env_token():
+    message = format_machine_commit_message(
+        "Update params",
+        "2026-05-22T12:00:00+00:00",
+        env=" staging env ",
+    )
+
+    assert message == "[ENV=staging-env] Update params at 2026-05-22T12:00:00+00:00"
+
+
+def test_format_machine_commit_message_uses_unknown_for_empty_env():
+    message = format_machine_commit_message(
+        "Update params",
+        "2026-05-22T12:00:00+00:00",
+        env=" ",
+    )
+
+    assert message == "[ENV=unknown] Update params at 2026-05-22T12:00:00+00:00"


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Prefixes machine-generated config commit messages with the runtime `ENV` value so operators can identify which platform produced a qubex-config update.
- Applies to workflow-driven config pushes and UI/API config push commits without changing the pushed file contents.

## Changes
- Added a shared commit message helper that formats messages as `[ENV=<value>] <message> at <timestamp>`.
- Updated workflow GitHub push tasks to use the new ENV-prefixed format for single-file and batch commits.
- Updated UI/API config push commits to use the same ENV-prefixed format.
- Added unit coverage for ENV prefixing, sanitization, and empty ENV fallback.

Verification:
- `uv run ruff check src/qdash/common/utils/commit_message.py src/qdash/workflow/worker/tasks/push_github.py src/qdash/api/services/file_service.py tests/qdash/common/test_commit_message_utils.py tests/qdash/workflow/worker/tasks/test_push_github.py`
- `uv run pytest tests/qdash/common/test_commit_message_utils.py tests/qdash/workflow/worker/tasks/test_push_github.py`