### PR TITLE
fix(workflow): sync changed params before github push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ POSTGRES_DB=prefect
 POSTGRES_DATA_PATH="./postgres_data"
 MONGO_DATA_PATH="./mongo_data/data/db"
 CALIB_DATA_PATH="./calib_data"
-CALTASKS_PATH="./src/qdash/workflow/calibtasks"
+CALIB_TASKS_PATH="./src/qdash/workflow/calibtasks"
 CONFIG_PATH="./config/qubex-config"
 
 QDASH_ADMIN_USERNAME="admin"

--- a/.env.example.qubex
+++ b/.env.example.qubex
@@ -34,7 +34,7 @@ POSTGRES_DB=prefect
 POSTGRES_DATA_PATH="./postgres_data"
 MONGO_DATA_PATH="./mongo_data/data/db"
 CALIB_DATA_PATH="./calib_data"
-CALTASKS_PATH="./src/qdash/workflow/calibtasks"
+CALIB_TASKS_PATH="./src/qdash/workflow/calibtasks"
 CONFIG_PATH="./config/qubex-config"
 
 QDASH_ADMIN_USERNAME="admin"

--- a/config/settings.local.yaml.template
+++ b/config/settings.local.yaml.template
@@ -8,3 +8,9 @@
 # ui:
 #   task_files:
 #     default_backend: fake
+
+# Example: Restrict params/*.yaml files pushed by workflow GitHub sync
+# workflow:
+#   github:
+#     params_file_names:
+#       - params.yaml

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -44,3 +44,28 @@ ui:
     # Task list sort order
     # Options: type_then_name, name_only, file_path
     sort_order: type_then_name
+
+# =============================================================================
+# Workflow Settings
+# =============================================================================
+workflow:
+  github:
+    # Optional allowlist for params/*.yaml files pushed by ALL_PARAMS.
+    # Leave empty to preserve the historical behavior of pushing all *.yaml files.
+    # Example:
+    # params_file_names:
+    #   - params.yaml
+    params_file_names:
+      - control_amplitude.yaml
+      - readout_amplitude.yaml
+      - control_frequency.yaml
+      - qubit_frequency.yaml
+      - readout_frequency.yaml
+      - resonator_frequency.yaml
+      - t1.yaml
+      - t2_star.yaml
+      - t2_echo.yaml
+      - x90_gate_fidelity.yaml
+      - zx90_gate_fidelity.yaml
+      - bell_state_fidelity.yaml
+      - readout_fidelity.yaml

--- a/docs/developer-guide/codebase.md
+++ b/docs/developer-guide/codebase.md
@@ -33,4 +33,4 @@ Important mounted paths:
 
 - `CALIB_DATA_PATH` ↔ `/app/calib_data`
 - `CONFIG_PATH` ↔ `/app/config/qubex-config`
-- `CALTASKS_PATH` ↔ `/app/qdash/workflow/calibtasks`
+- `CALIB_TASKS_PATH` ↔ `/app/qdash/workflow/calibtasks`

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -297,7 +297,7 @@ Key environment variables are configured in `.env`. See `.env.example` for avail
 | `PREFECT_PORT`            | 4200    | Prefect dashboard port      |
 | `DEPLOYMENT_SERVICE_PORT` | 4006    | Deployment service port     |
 | `CALIB_DATA_PATH`         | -       | Calibration data mount path |
-| `CALTASKS_PATH`           | -       | Calibration tasks path      |
+| `CALIB_TASKS_PATH`        | -       | Calibration tasks path      |
 | `CONFIG_PATH`             | -       | Qubex config path           |
 | `NEXT_PUBLIC_API_URL`     | -       | Public API URL for frontend |
 | `NEXT_PUBLIC_PREFECT_URL` | -       | Prefect dashboard URL       |

--- a/docs/operator-guide/operations.md
+++ b/docs/operator-guide/operations.md
@@ -49,4 +49,4 @@ If task figures do not render, confirm `CALIB_DATA_PATH` points at the directory
 `/app/calib_data` in Docker.
 
 If config or task file pages return missing-path errors, confirm `CONFIG_PATH` and
-`CALTASKS_PATH` in `.env`.
+`CALIB_TASKS_PATH` in `.env`.

--- a/src/qdash/common/config/path_resolver.py
+++ b/src/qdash/common/config/path_resolver.py
@@ -23,16 +23,25 @@ def _env_path(name: str) -> Path | None:
     return Path(value).expanduser().resolve() if value else None
 
 
+def _first_existing_env_path(*names: str) -> Path | None:
+    for name in names:
+        env_value = _env_path(name)
+        if env_value is not None and env_value.exists():
+            return env_value
+    return None
+
+
 def _resolve_runtime_base_path(
     *,
-    env_name: str | None,
+    env_name: str | tuple[str, ...] | None,
     container_path: Path,
     repo_local_path: Path | None = None,
 ) -> Path:
     """Resolve a base path with explicit env, container, then repo-local fallback."""
     if env_name:
-        env_value = _env_path(env_name)
-        if env_value is not None and env_value.exists():
+        env_names = (env_name,) if isinstance(env_name, str) else env_name
+        env_value = _first_existing_env_path(*env_names)
+        if env_value is not None:
             return env_value
     if container_path.exists():
         return container_path
@@ -53,7 +62,7 @@ def resolve_config_base_path() -> Path:
 def resolve_calibtasks_base_path() -> Path:
     """Resolve the calibration task directory for host and container execution."""
     return _resolve_runtime_base_path(
-        env_name="CALTASKS_PATH",
+        env_name=("CALIB_TASKS_PATH", "CALTASKS_PATH"),
         container_path=CALIBTASKS_DIR,
         repo_local_path=REPO_WORKFLOW_DIR / "calibtasks",
     )

--- a/src/qdash/workflow/calibtasks/fake/fake_check_rabi.py
+++ b/src/qdash/workflow/calibtasks/fake/fake_check_rabi.py
@@ -76,6 +76,10 @@ class FakeCheckRabi(FakeTask):
             unit="a.u.",
             description="Rabi oscillation offset",
         ),
+        "control_amplitude": ParameterModel(
+            unit="a.u.",
+            description="Control pulse amplitude",
+        ),
         "maximum_rabi_frequency": ParameterModel(
             unit="MHz/a.u.",
             description="Maximum Rabi frequency per unit control amplitude",
@@ -145,9 +149,10 @@ class FakeCheckRabi(FakeTask):
 
         # Maximum Rabi frequency = rabi_frequency / control_amplitude
         fake_control_amplitude = 0.0125  # Default control amplitude for fake backend
-        self.output_parameters["maximum_rabi_frequency"].value = (
-            result["rabi_frequency"] / fake_control_amplitude
-        )
+        maximum_rabi_frequency = result["rabi_frequency"] / fake_control_amplitude
+        self.output_parameters["maximum_rabi_frequency"].value = maximum_rabi_frequency
+        ratio = maximum_rabi_frequency / 1000
+        self.output_parameters["control_amplitude"].value = min(0.0125 / ratio, 0.99)
 
         output_parameters = self.attach_execution_id(execution_id)
 

--- a/src/qdash/workflow/engine/backend/fake.py
+++ b/src/qdash/workflow/engine/backend/fake.py
@@ -13,6 +13,11 @@ class FakeBackend(BaseBackend):
         self._config = config
         self._instance: Any | None = None
 
+    @property
+    def config(self) -> dict[str, Any]:
+        """Return the configuration dictionary for the Fake backend."""
+        return self._config
+
     def version(self) -> str:
         """Return the version of the Fake backend."""
         return "0.1.0"

--- a/src/qdash/workflow/engine/params_updater.py
+++ b/src/qdash/workflow/engine/params_updater.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class ParamsUpdater(Protocol):
     """Protocol for backend-specific parameter updaters."""
 
-    def update(self, qid: str, output_parameters: dict[str, Any]) -> None: ...
+    def update(self, qid: str, output_parameters: dict[str, Any]) -> set[str]: ...
 
 
 def get_params_updater(
@@ -36,6 +36,9 @@ def get_params_updater(
     qubex_updater = _resolve_qubex_updater(backend, chip_id)
     if qubex_updater is not None:
         return qubex_updater
+    fake_updater = _resolve_fake_updater(backend, chip_id)
+    if fake_updater is not None:
+        return fake_updater
     return None
 
 
@@ -46,6 +49,18 @@ def _resolve_qubex_updater(backend: BaseBackend, chip_id: str | None) -> ParamsU
         return None
 
     if not isinstance(backend, QubexBackend):
+        return None
+
+    return _QubexParamsUpdater(backend, chip_id)
+
+
+def _resolve_fake_updater(backend: BaseBackend, chip_id: str | None) -> ParamsUpdater | None:
+    try:
+        from qdash.workflow.engine.backend.fake import FakeBackend
+    except ImportError:
+        return None
+
+    if not isinstance(backend, FakeBackend):
         return None
 
     return _QubexParamsUpdater(backend, chip_id)
@@ -83,14 +98,15 @@ class _QubexParamsUpdater:
         self._yaml.indent(mapping=2, sequence=4, offset=2)
         self._yaml.representer.add_representer(type(None), represent_none)
 
-    def update(self, qid: str, output_parameters: dict[str, Any]) -> None:
+    def update(self, qid: str, output_parameters: dict[str, Any]) -> set[str]:
+        updated_files: set[str] = set()
         params_dir = self._resolve_params_dir()
         if params_dir is None:
-            return
+            return updated_files
 
         label = self._resolve_qubit_label(qid)
         if label is None:
-            return
+            return updated_files
 
         for key, param in output_parameters.items():
             file_name = self.PARAM_FILE_MAP.get(key)
@@ -102,11 +118,15 @@ class _QubexParamsUpdater:
                 continue
 
             file_path = params_dir / file_name
-            self._update_yaml(file_path, label, value)
+            if self._update_yaml(file_path, label, value):
+                updated_files.add(file_name)
 
             for extra_file in self.EXTRA_FILE_MAP.get(key, []):
                 extra_path = params_dir / extra_file
-                self._update_yaml(extra_path, label, value)
+                if self._update_yaml(extra_path, label, value):
+                    updated_files.add(extra_file)
+
+        return updated_files
 
     def _resolve_params_dir(self) -> Path | None:
         config_dir = getattr(self._backend, "config", {}).get("params_dir")
@@ -205,10 +225,10 @@ class _QubexParamsUpdater:
             return value
         return None
 
-    def _update_yaml(self, file_path: Path, qubit_label: str, value: float | int | str) -> None:
+    def _update_yaml(self, file_path: Path, qubit_label: str, value: float | int | str) -> bool:
         """Update YAML file with file locking and atomic write to prevent race conditions."""
         if not file_path.exists():
-            return
+            return False
 
         lock_path = file_path.with_suffix(file_path.suffix + ".lock")
         lock_path.touch(exist_ok=True)
@@ -231,7 +251,7 @@ class _QubexParamsUpdater:
 
             current_value = section.get(qubit_label)
             if self._values_equal(current_value, value):
-                return
+                return False
 
             if isinstance(section, CommentedMap):
                 self._set_ordered(section, qubit_label, value)
@@ -253,6 +273,7 @@ class _QubexParamsUpdater:
             os.replace(tmp_path, file_path)
 
         lock_path.touch(exist_ok=True)
+        return True
 
     @staticmethod
     def _values_equal(current: Any, new: Any) -> bool:

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -838,17 +838,97 @@ class CalibService:
     def _sync_backend_params_before_push(self, logger: Any) -> None:
         """Sync recent calibration results into backend YAML params prior to GitHub push."""
         assert self.execution_service is not None, "ExecutionService not initialized"
+        assert self.github_push_config is not None, "GitHubPushConfig not initialized"
+        self._merge_task_result_calib_data_before_push(logger)
         updater_instance = get_params_updater(self.backend, self.chip_id)
         if updater_instance is None:
             return
 
+        updated_param_files: set[str] = set()
         for qid, params in self.execution_service.calib_data.qubit.items():
             if "-" in qid or not params:
                 continue
             try:
-                updater_instance.update(qid, params)
+                updated_param_files.update(updater_instance.update(qid, params))
             except Exception as exc:
                 logger.warning(f"Failed to sync params for qid={qid}: {exc}")
+
+        configured_param_files = self.github_push_config.params_file_names
+        if configured_param_files is not None:
+            self.github_push_config.params_file_names = [
+                file_name for file_name in configured_param_files if file_name in updated_param_files
+            ]
+            skipped_files = sorted(set(configured_param_files) - updated_param_files)
+            if skipped_files:
+                logger.info(
+                    "Skipping unchanged params files from GitHub push: %s",
+                    ", ".join(skipped_files),
+                )
+
+    def _merge_task_result_calib_data_before_push(self, logger: Any) -> None:
+        """Reload completed task outputs into parent calib_data before GitHub push.
+
+        Parallel strategies run isolated child sessions. Those sessions persist
+        TaskResultHistoryDocument rows, but their in-memory calib_data does not
+        flow back to the parent process. Rebuild the parent in-memory calib_data
+        from completed task results before deciding which params YAML files changed.
+        """
+        assert self.execution_service is not None, "ExecutionService not initialized"
+        execution_id = getattr(self, "execution_id", None)
+        if not execution_id:
+            return
+
+        try:
+            from qdash.datamodel.task import CalibDataModel, ParameterModel, TaskTypes
+            from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
+
+            docs = (
+                TaskResultHistoryDocument.find(
+                    {
+                        "project_id": self.project_id,
+                        "execution_id": execution_id,
+                        "status": "completed",
+                    }
+                )
+                .sort([("end_at", 1)])
+                .run()
+            )
+
+            calib_data = CalibDataModel()
+            for doc in docs:
+                if not doc.qid or not doc.output_parameters:
+                    continue
+
+                for name, value in doc.output_parameters.items():
+                    try:
+                        parameter = (
+                            value
+                            if isinstance(value, ParameterModel)
+                            else ParameterModel.model_validate(value)
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Skipping invalid output parameter %s from task_id=%s",
+                            name,
+                            doc.task_id,
+                            exc_info=True,
+                        )
+                        continue
+
+                    if doc.task_type == TaskTypes.COUPLING or "-" in doc.qid:
+                        calib_data.put_coupling_data(doc.qid, name, parameter)
+                    else:
+                        calib_data.put_qubit_data(doc.qid, name, parameter)
+
+            if calib_data.qubit or calib_data.coupling:
+                self.execution_service.merge_calib_data(calib_data)
+                logger.info(
+                    "Merged task result calib_data before GitHub push: %d qubit(s), %d coupling(s)",
+                    len(calib_data.qubit),
+                    len(calib_data.coupling),
+                )
+        except Exception as exc:
+            logger.warning(f"Failed to merge task result calib_data before push: {exc}")
 
     def finish_calibration(
         self,

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -856,7 +856,9 @@ class CalibService:
         configured_param_files = self.github_push_config.params_file_names
         if configured_param_files is not None:
             self.github_push_config.params_file_names = [
-                file_name for file_name in configured_param_files if file_name in updated_param_files
+                file_name
+                for file_name in configured_param_files
+                if file_name in updated_param_files
             ]
             skipped_files = sorted(set(configured_param_files) - updated_param_files)
             if skipped_files:
@@ -879,6 +881,8 @@ class CalibService:
             return
 
         try:
+            from bunnet import SortDirection
+
             from qdash.datamodel.task import CalibDataModel, ParameterModel, TaskTypes
             from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 
@@ -890,7 +894,7 @@ class CalibService:
                         "status": "completed",
                     }
                 )
-                .sort([("end_at", 1)])
+                .sort([("end_at", SortDirection.ASCENDING)])
                 .run()
             )
 

--- a/src/qdash/workflow/service/github.py
+++ b/src/qdash/workflow/service/github.py
@@ -16,6 +16,7 @@ from typing import Any
 from prefect import get_run_logger
 from pydantic import BaseModel, Field
 
+from qdash.common.config.loader import ConfigLoader
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 
 
@@ -35,12 +36,32 @@ class ConfigFileType(Enum):
     ALL_PARAMS = "all_params"
 
 
+def _load_default_params_file_names() -> list[str] | None:
+    """Load default params batch allowlist from QDash settings."""
+    workflow_settings = ConfigLoader.load_settings().get("workflow", {})
+    if not isinstance(workflow_settings, dict):
+        return None
+    github_settings = workflow_settings.get("github", {})
+    if not isinstance(github_settings, dict):
+        return None
+    value = github_settings.get("params_file_names")
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError("workflow.github.params_file_names must be a list of strings")
+    return value
+
+
 class GitHubPushConfig(BaseModel):
     """Configuration for GitHub push operations.
 
     Attributes:
         enabled: Whether to push to GitHub on finish_calibration()
         file_types: List of file types to push (default: [CALIB_NOTE, ALL_PARAMS])
+        params_file_names: Optional allowlist for ALL_PARAMS, such as
+            ["params.yaml", "drag.yaml"]. If omitted, defaults to
+            workflow.github.params_file_names from QDash settings. If neither is
+            configured, all *.yaml files are pushed.
         commit_message: Custom commit message (default: auto-generated)
         branch: Target branch (default: "main")
         props_within_24hrs: For PROPS type, only include data from last 24 hours
@@ -59,6 +80,7 @@ class GitHubPushConfig(BaseModel):
     file_types: list[ConfigFileType] = Field(
         default_factory=lambda: [ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS]
     )
+    params_file_names: list[str] | None = Field(default_factory=_load_default_params_file_names)
     commit_message: str | None = None
     branch: str = "main"
     props_within_24hrs: bool = False
@@ -350,7 +372,7 @@ class GitHubIntegration:
         return str(commit_sha)
 
     def _push_all_params(self, config: GitHubPushConfig) -> dict[str, Any]:
-        """Push all yaml files in params directory in a single commit.
+        """Push configured yaml files in params directory in a single commit.
 
         Args:
             config: Push configuration
@@ -366,9 +388,11 @@ class GitHubIntegration:
             self.logger.warning(f"Params directory not found: {params_dir}")
             return {"error": f"Directory not found: {params_dir}"}
 
-        # Collect all yaml files
+        # Collect yaml files. By default this preserves the historical ALL_PARAMS
+        # behavior; params_file_names narrows the batch to an explicit allowlist.
         files: list[tuple[str, str]] = []
-        for yaml_file in params_dir.glob("*.yaml"):
+        yaml_files = self._select_param_yaml_files(params_dir, config.params_file_names)
+        for yaml_file in yaml_files:
             source_path = str(yaml_file)
             repo_subpath = f"{self.chip_id}/params/{yaml_file.name}"
             files.append((source_path, repo_subpath))
@@ -394,3 +418,29 @@ class GitHubIntegration:
         except Exception as e:
             self.logger.error(f"Failed to push params: {e}")
             return {"error": str(e)}
+
+    def _select_param_yaml_files(
+        self,
+        params_dir: Path,
+        params_file_names: list[str] | None,
+    ) -> list[Path]:
+        """Select params YAML files to push, optionally constrained by filename."""
+        if params_file_names is None:
+            return sorted(params_dir.glob("*.yaml"))
+
+        files: list[Path] = []
+        seen: set[str] = set()
+        for file_name in params_file_names:
+            normalized = file_name.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            path = Path(normalized)
+            if path.name != normalized or path.suffix != ".yaml":
+                raise ValueError(f"Invalid params file name: {file_name!r}")
+            yaml_file = params_dir / normalized
+            if yaml_file.exists():
+                files.append(yaml_file)
+            else:
+                self.logger.warning(f"Configured params file not found, skipping: {yaml_file}")
+        return files

--- a/src/qdash/workflow/service/single_task_flow.py
+++ b/src/qdash/workflow/service/single_task_flow.py
@@ -66,7 +66,7 @@ def single_task_executor(
         flow_name=flow_name or f"re-execute:{task_name}",
         tags=tags,
         project_id=project_id,
-        enable_github_pull=False,
+        enable_github_pull=True,
         enable_github=update_params,
         use_lock=False,
         parameter_overrides=parameter_overrides,

--- a/tests/qdash/api/services/test_task_file_service.py
+++ b/tests/qdash/api/services/test_task_file_service.py
@@ -6,11 +6,11 @@ from qdash.api.services.task_file_service import TaskFileService
 from qdash.common.config.backend import clear_cache as clear_backend_config_cache
 
 
-def test_uses_caltasks_path_from_environment(monkeypatch, tmp_path: Path) -> None:
+def test_uses_calib_tasks_path_from_environment(monkeypatch, tmp_path: Path) -> None:
     calibtasks_dir = tmp_path / "calibtasks"
     (calibtasks_dir / "fake").mkdir(parents=True)
     (calibtasks_dir / "qubex").mkdir()
-    monkeypatch.setenv("CALTASKS_PATH", str(calibtasks_dir))
+    monkeypatch.setenv("CALIB_TASKS_PATH", str(calibtasks_dir))
 
     service = TaskFileService()
 
@@ -18,7 +18,19 @@ def test_uses_caltasks_path_from_environment(monkeypatch, tmp_path: Path) -> Non
     assert [backend.name for backend in service.list_backends().backends] == ["fake", "qubex"]
 
 
+def test_uses_legacy_caltasks_path_from_environment(monkeypatch, tmp_path: Path) -> None:
+    calibtasks_dir = tmp_path / "calibtasks"
+    calibtasks_dir.mkdir()
+    monkeypatch.delenv("CALIB_TASKS_PATH", raising=False)
+    monkeypatch.setenv("CALTASKS_PATH", str(calibtasks_dir))
+
+    service = TaskFileService()
+
+    assert service._base_path == calibtasks_dir.resolve()
+
+
 def test_falls_back_to_container_calibtasks_path(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("CALIB_TASKS_PATH", raising=False)
     monkeypatch.delenv("CALTASKS_PATH", raising=False)
     calibtasks_dir = tmp_path / "calibtasks"
     calibtasks_dir.mkdir()
@@ -33,7 +45,8 @@ def test_falls_back_to_container_calibtasks_path(monkeypatch, tmp_path: Path) ->
 
 
 def test_ignores_nonexistent_caltasks_path_from_environment(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("CALTASKS_PATH", str(tmp_path / "missing"))
+    monkeypatch.setenv("CALIB_TASKS_PATH", str(tmp_path / "missing"))
+    monkeypatch.delenv("CALTASKS_PATH", raising=False)
     calibtasks_dir = tmp_path / "calibtasks"
     calibtasks_dir.mkdir()
     monkeypatch.setattr(
@@ -49,6 +62,7 @@ def test_ignores_nonexistent_caltasks_path_from_environment(monkeypatch, tmp_pat
 def test_falls_back_to_repo_local_calibtasks_path_when_container_path_is_missing(
     monkeypatch,
 ) -> None:
+    monkeypatch.delenv("CALIB_TASKS_PATH", raising=False)
     monkeypatch.delenv("CALTASKS_PATH", raising=False)
     monkeypatch.chdir(Path(__file__).parents[4])
     monkeypatch.setattr(
@@ -64,7 +78,7 @@ def test_falls_back_to_repo_local_calibtasks_path_when_container_path_is_missing
 def test_explicit_calibtasks_base_path_takes_precedence(monkeypatch, tmp_path: Path) -> None:
     explicit_dir = tmp_path / "explicit"
     explicit_dir.mkdir()
-    monkeypatch.setenv("CALTASKS_PATH", str(tmp_path / "from-env"))
+    monkeypatch.setenv("CALIB_TASKS_PATH", str(tmp_path / "from-env"))
 
     service = TaskFileService(calibtasks_base_path=explicit_dir)
 
@@ -76,7 +90,7 @@ def test_get_settings_uses_effective_default_backend_from_environment(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setenv("DEFAULT_BACKEND", "fake")
-    monkeypatch.setenv("CALTASKS_PATH", str(tmp_path))
+    monkeypatch.setenv("CALIB_TASKS_PATH", str(tmp_path))
     clear_backend_config_cache()
 
     service = TaskFileService()
@@ -101,7 +115,7 @@ def test_get_task_names_uses_effective_default_backend_and_resolved_calibtasks_p
         'class QubexTask:\n    name: str = "QubexOnlyTask"\n    task_type: str = "qubit"\n',
         encoding="utf-8",
     )
-    monkeypatch.setenv("CALTASKS_PATH", str(calibtasks_dir))
+    monkeypatch.setenv("CALIB_TASKS_PATH", str(calibtasks_dir))
     monkeypatch.setenv("DEFAULT_BACKEND", "fake")
     clear_backend_config_cache()
     get_task_file_service.cache_clear()

--- a/tests/qdash/workflow/calibtasks/test_fake_check_rabi.py
+++ b/tests/qdash/workflow/calibtasks/test_fake_check_rabi.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from qdash.workflow.calibtasks.base import RunResult
+from qdash.workflow.calibtasks.fake.fake_check_rabi import FakeCheckRabi
+from qdash.workflow.engine.backend.fake import FakeBackend
+
+
+def test_fake_check_rabi_outputs_control_amplitude():
+    """Fake CheckRabi should emit control_amplitude for params YAML verification."""
+    task = FakeCheckRabi()
+    backend = FakeBackend({})
+
+    result = task.postprocess(
+        backend,
+        execution_id="exec-1",
+        run_result=RunResult(
+            raw_result={
+                "rabi_amplitude": 0.45,
+                "rabi_frequency": 12.0,
+                "rabi_phase": 0.0,
+                "rabi_offset": 0.5,
+                "time": np.array([0, 8, 16]),
+                "signal": np.array([0.9, 0.8, 0.7]),
+            },
+            r2={"0": 0.98},
+        ),
+        qid="0",
+    )
+
+    control_amplitude = result.output_parameters["control_amplitude"]
+    maximum_rabi_frequency = result.output_parameters["maximum_rabi_frequency"]
+
+    assert maximum_rabi_frequency.value == 960.0
+    assert control_amplitude.value == 0.0125 / 0.96
+    assert control_amplitude.execution_id == "exec-1"

--- a/tests/qdash/workflow/engine/test_params_updater.py
+++ b/tests/qdash/workflow/engine/test_params_updater.py
@@ -9,7 +9,7 @@ import pytest
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
-from qdash.workflow.engine.params_updater import _QubexParamsUpdater
+from qdash.workflow.engine.params_updater import _QubexParamsUpdater, get_params_updater
 
 
 class TestParamsUpdaterNoneHandling:
@@ -131,9 +131,10 @@ data:
 
     def test_update_existing_value(self, updater, yaml_file):
         """Test updating an existing qubit value."""
-        updater._update_yaml(yaml_file, "Q00", 15.0)
+        updated = updater._update_yaml(yaml_file, "Q00", 15.0)
 
         content = yaml_file.read_text()
+        assert updated is True
         assert "Q00: 15.0" in content
         assert "meta:" in content  # meta section preserved
         assert "description: Test parameter file" in content
@@ -184,10 +185,11 @@ data:
         original_mtime = yaml_file.stat().st_mtime
 
         # Update with same value
-        updater._update_yaml(yaml_file, "Q00", 10.5)
+        updated = updater._update_yaml(yaml_file, "Q00", 10.5)
 
         # File should not be modified
         new_mtime = yaml_file.stat().st_mtime
+        assert updated is False
         assert original_mtime == new_mtime
 
     def test_nonexistent_file_is_skipped(self, updater, tmp_path):
@@ -195,7 +197,7 @@ data:
         nonexistent = tmp_path / "nonexistent.yaml"
 
         # Should not raise
-        updater._update_yaml(nonexistent, "Q00", 10.0)
+        assert updater._update_yaml(nonexistent, "Q00", 10.0) is False
 
     def test_extract_value_from_db_parameter_dict(self, updater):
         """Test DB calibration data dictionaries can be written to params files."""
@@ -220,8 +222,62 @@ data:
             "qdash.common.domain.qubit._get_chip_size",
             return_value=144,
         ):
-            updater.update("47", {"control_amplitude": {"value": 0.25}})
+            updated_files = updater.update("47", {"control_amplitude": {"value": 0.25}})
 
+        assert updated_files == {"control_amplitude.yaml"}
+        assert "Q047: 0.25" in (params_dir / "control_amplitude.yaml").read_text()
+
+    def test_update_returns_only_changed_yaml_file_names(self, tmp_path):
+        """Update should report the params files that were actually changed."""
+        params_dir = tmp_path / "params"
+        params_dir.mkdir()
+        (params_dir / "qubit_frequency.yaml").write_text("data:\n  Q047: 4.2\n")
+        (params_dir / "control_frequency.yaml").write_text("data:\n  Q047: 4.0\n")
+        (params_dir / "t1.yaml").write_text("data:\n  Q047: 10.0\n")
+
+        backend = MagicMock()
+        backend.config = {
+            "project_id": "project-1",
+            "chip_id": "144Qv1",
+            "params_dir": str(params_dir),
+        }
+        backend.get_instance.side_effect = AssertionError("should not connect")
+        updater = _QubexParamsUpdater(backend, chip_id="144Qv1")
+
+        with patch("qdash.common.domain.qubit._get_chip_size", return_value=144):
+            updated_files = updater.update(
+                "47",
+                {
+                    "qubit_frequency": {"value": 4.2},
+                    "t1": {"value": 12.0},
+                },
+            )
+
+        assert updated_files == {"control_frequency.yaml", "t1.yaml"}
+
+    def test_fake_backend_uses_yaml_params_updater(self, tmp_path):
+        """Fake backend should support params YAML updates for local verification."""
+        from qdash.workflow.engine.backend.fake import FakeBackend
+
+        params_dir = tmp_path / "params"
+        params_dir.mkdir()
+        (params_dir / "control_amplitude.yaml").write_text("data:\n  Q047: 0.1\n")
+
+        backend = FakeBackend(
+            {
+                "project_id": "project-1",
+                "chip_id": "144Qv1",
+                "params_dir": str(params_dir),
+            }
+        )
+
+        updater = get_params_updater(backend, chip_id="144Qv1")
+        assert updater is not None
+
+        with patch("qdash.common.domain.qubit._get_chip_size", return_value=144):
+            updated_files = updater.update("47", {"control_amplitude": {"value": 0.25}})
+
+        assert updated_files == {"control_amplitude.yaml"}
         assert "Q047: 0.25" in (params_dir / "control_amplitude.yaml").read_text()
 
     def test_insert_ordered_between_existing(self, updater, yaml_file):

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -356,7 +356,9 @@ class TestCalibServiceParameterManagement:
 
         session._merge_task_result_calib_data_before_push(MagicMock())
 
-        merged = session.execution_service.calib_data.qubit["0"]["control_amplitude"]
+        execution_service = session.execution_service
+        assert execution_service is not None
+        merged = execution_service.calib_data.qubit["0"]["control_amplitude"]
         assert isinstance(merged, ParameterModel)
         assert merged.value == 0.25
 

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -44,6 +44,13 @@ class MockExecutionService:
     def reload(self):
         return self
 
+    def merge_calib_data(self, calib_data):
+        for qid, params in calib_data.qubit.items():
+            self.calib_data.qubit.setdefault(qid, {}).update(params)
+        for qid, params in calib_data.coupling.items():
+            self.calib_data.coupling.setdefault(qid, {}).update(params)
+        return self
+
     @classmethod
     def create(cls, **kwargs):
         return cls(**kwargs)
@@ -274,6 +281,84 @@ class TestCalibServiceParameterManagement:
         # Get nonexistent parameter
         result = session.get_parameter("0", "nonexistent")
         assert result is None
+
+    def test_sync_backend_params_filters_configured_push_files_to_changed_files(
+        self,
+        monkeypatch,
+    ):
+        """Only configured params files changed by this calibration should be batch-pushed."""
+        from qdash.workflow.service.github import GitHubPushConfig
+
+        class FakeUpdater:
+            def update(self, qid, params):
+                assert qid == "0"
+                assert params == {"t1": {"value": 12.0}}
+                return {"t1.yaml"}
+
+        orchestrator = MagicMock()
+        orchestrator._execution_service = MockExecutionService()
+        orchestrator._execution_service.calib_data.qubit = {
+            "0": {"t1": {"value": 12.0}},
+        }
+        orchestrator._backend = MagicMock()
+
+        session = CalibService.__new__(CalibService)
+        session.chip_id = "chip_1"
+        session._orchestrator = orchestrator
+        session.github_push_config = GitHubPushConfig(
+            params_file_names=["t1.yaml", "t2_echo.yaml"],
+        )
+
+        monkeypatch.setattr(
+            "qdash.workflow.service.calib_service.get_params_updater",
+            lambda backend, chip_id: FakeUpdater(),
+        )
+        logger = MagicMock()
+
+        session._sync_backend_params_before_push(logger)
+
+        assert session.github_push_config.params_file_names == ["t1.yaml"]
+        logger.info.assert_called_once()
+
+    def test_merge_task_result_calib_data_before_push_loads_completed_outputs(
+        self,
+        monkeypatch,
+    ):
+        """Parent sessions should rebuild calib_data from isolated child task results."""
+        from qdash.datamodel.task import ParameterModel, TaskTypes
+
+        class FakeFinder:
+            def sort(self, sort):
+                return self
+
+            def run(self):
+                return [
+                    MagicMock(
+                        qid="0",
+                        task_type=TaskTypes.QUBIT,
+                        task_id="task-1",
+                        output_parameters={"control_amplitude": {"value": 0.25}},
+                    )
+                ]
+
+        monkeypatch.setattr(
+            "qdash.dbmodel.task_result_history.TaskResultHistoryDocument.find",
+            lambda query: FakeFinder(),
+        )
+
+        orchestrator = MagicMock()
+        orchestrator._execution_service = MockExecutionService()
+
+        session = CalibService.__new__(CalibService)
+        session.project_id = "test_project"
+        session.execution_id = "exec-1"
+        session._orchestrator = orchestrator
+
+        session._merge_task_result_calib_data_before_push(MagicMock())
+
+        merged = session.execution_service.calib_data.qubit["0"]["control_amplitude"]
+        assert isinstance(merged, ParameterModel)
+        assert merged.value == 0.25
 
 
 class TestGlobalSessionHelpers:

--- a/tests/qdash/workflow/service/test_single_task_flow.py
+++ b/tests/qdash/workflow/service/test_single_task_flow.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def test_single_task_executor_pulls_config_before_reexecute(monkeypatch):
+    """Re-execute must pull latest config before a possible params batch push."""
+    from qdash.workflow.service.single_task_flow import single_task_executor
+
+    captured: dict[str, Any] = {}
+
+    class FakeCalibService:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            captured["kwargs"] = kwargs
+
+        def execute_task(self, task_name: str, qid: str) -> dict[str, Any]:
+            return {"task_name": task_name, "qid": qid}
+
+        def finish_calibration(self) -> None:
+            captured["finished"] = True
+
+    monkeypatch.setattr(
+        "qdash.workflow.service.single_task_flow.CalibService",
+        FakeCalibService,
+    )
+
+    result = single_task_executor(
+        username="alice",
+        chip_id="chip-1",
+        qid="0",
+        task_name="CheckRabi",
+        source_execution_id="exec-001",
+        project_id="project-1",
+        update_params=True,
+    )
+
+    assert result == {"task_name": "CheckRabi", "qid": "0"}
+    assert captured["kwargs"]["enable_github_pull"] is True
+    assert captured["kwargs"]["enable_github"] is True
+    assert captured["finished"] is True

--- a/tests/qdash/workflow/worker/tasks/test_push_github.py
+++ b/tests/qdash/workflow/worker/tasks/test_push_github.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from git import Repo
 from git.exc import GitCommandError, InvalidGitRepositoryError
 
@@ -133,3 +134,104 @@ class TestGitHubPushConfigDefaults:
 
         config = GitHubPushConfig(file_types=[ConfigFileType.PROPS])
         assert config.file_types == [ConfigFileType.PROPS]
+
+    def test_params_file_names_defaults_to_none(self):
+        """Default params_file_names keeps the historical all-yaml behavior."""
+        from qdash.workflow.service.github import GitHubPushConfig
+
+        with patch("qdash.workflow.service.github.ConfigLoader.load_settings", return_value={}):
+            config = GitHubPushConfig()
+        assert config.params_file_names is None
+
+    def test_params_file_names_loads_from_qdash_settings(self):
+        """Default params_file_names can be managed in QDash settings."""
+        from qdash.workflow.service.github import GitHubPushConfig
+
+        with patch(
+            "qdash.workflow.service.github.ConfigLoader.load_settings",
+            return_value={"workflow": {"github": {"params_file_names": ["params.yaml"]}}},
+        ):
+            config = GitHubPushConfig()
+
+        assert config.params_file_names == ["params.yaml"]
+
+    def test_explicit_params_file_names_overrides_qdash_settings(self):
+        """An explicit config value should override the QDash settings default."""
+        from qdash.workflow.service.github import GitHubPushConfig
+
+        with patch(
+            "qdash.workflow.service.github.ConfigLoader.load_settings",
+            return_value={"workflow": {"github": {"params_file_names": ["params.yaml"]}}},
+        ):
+            config = GitHubPushConfig(params_file_names=["drag.yaml"])
+
+        assert config.params_file_names == ["drag.yaml"]
+
+    def test_invalid_qdash_settings_params_file_names_raises(self):
+        """Invalid QDash settings should fail during GitHubPushConfig creation."""
+        from qdash.workflow.service.github import GitHubPushConfig
+
+        with (
+            patch(
+                "qdash.workflow.service.github.ConfigLoader.load_settings",
+                return_value={"workflow": {"github": {"params_file_names": "params.yaml"}}},
+            ),
+            pytest.raises(ValueError, match=r"workflow\.github\.params_file_names"),
+        ):
+            GitHubPushConfig()
+
+
+class TestSelectParamYamlFiles:
+    """Tests for selecting params YAML files for ALL_PARAMS batch pushes."""
+
+    def _make_integration(self):
+        from qdash.workflow.service.github import GitHubIntegration
+
+        integration = GitHubIntegration.__new__(GitHubIntegration)
+        integration.logger = MagicMock()
+        return integration
+
+    def test_selects_all_yaml_files_by_default(self, tmp_path: Path):
+        """Should preserve ALL_PARAMS behavior when no allowlist is configured."""
+        integration = self._make_integration()
+        (tmp_path / "params.yaml").write_text("a: 1")
+        (tmp_path / "drag.yaml").write_text("a: 2")
+        (tmp_path / "README.md").write_text("ignored")
+
+        files = integration._select_param_yaml_files(tmp_path, None)
+
+        assert [path.name for path in files] == ["drag.yaml", "params.yaml"]
+
+    def test_selects_configured_yaml_files(self, tmp_path: Path):
+        """Should only include configured params file names."""
+        integration = self._make_integration()
+        (tmp_path / "params.yaml").write_text("a: 1")
+        (tmp_path / "drag.yaml").write_text("a: 2")
+
+        files = integration._select_param_yaml_files(tmp_path, ["params.yaml"])
+
+        assert [path.name for path in files] == ["params.yaml"]
+
+    def test_skips_missing_configured_files(self, tmp_path: Path):
+        """Missing allowlisted files should not fail the whole batch."""
+        integration = self._make_integration()
+        (tmp_path / "params.yaml").write_text("a: 1")
+
+        files = integration._select_param_yaml_files(tmp_path, ["params.yaml", "drag.yaml"])
+
+        assert [path.name for path in files] == ["params.yaml"]
+        integration.logger.warning.assert_called_once()
+
+    def test_rejects_subpaths(self, tmp_path: Path):
+        """Only simple file names are allowed in the params allowlist."""
+        integration = self._make_integration()
+
+        with pytest.raises(ValueError, match="Invalid params file name"):
+            integration._select_param_yaml_files(tmp_path, ["nested/params.yaml"])
+
+    def test_rejects_non_yaml_files(self, tmp_path: Path):
+        """Only .yaml files are valid params batch targets."""
+        integration = self._make_integration()
+
+        with pytest.raises(ValueError, match="Invalid params file name"):
+            integration._select_param_yaml_files(tmp_path, ["params.yml"])


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Sync calibration outputs into params YAML before GitHub push and restrict ALL_PARAMS commits to files that actually changed.
- Workflow-only change with config defaults for managed params YAML names; no API schema or generated client changes.

## Changes
- Enable GitHub pull for re-execute single-task flows so they do not push from stale local config.
- Add QDash settings support for workflow.github.params_file_names and apply it as the ALL_PARAMS allowlist.
- Return changed params YAML file names from the params updater and filter GitHub batch pushes to those files.
- Merge completed isolated task results back into parent calib_data before deciding params updates.
- Allow fake backend params YAML updates and emit control_amplitude from fake Rabi for local verification.
- Add focused tests for re-execute pull behavior, params file selection, changed-file filtering, fake Rabi output, and parent calib_data merge.