### PR TITLE
refactor(workflow): configure params file mapping

### DIFF
--- a/config/settings.local.yaml.template
+++ b/config/settings.local.yaml.template
@@ -14,3 +14,12 @@
 #   github:
 #     params_file_names:
 #       - params.yaml
+
+# Example: Override params YAML update mapping
+# workflow:
+#   params_updater:
+#     parameter_file_map:
+#       control_amplitude: control_amplitude.yaml
+#     extra_file_map:
+#       qubit_frequency:
+#         - control_frequency.yaml

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -49,6 +49,29 @@ ui:
 # Workflow Settings
 # =============================================================================
 workflow:
+  params_updater:
+    # Map calibration output parameter names to params/*.yaml files.
+    # These files are updated before GitHub ALL_PARAMS push.
+    parameter_file_map:
+      t1: t1.yaml
+      t2_echo: t2_echo.yaml
+      t2_star: t2_star.yaml
+      readout_amplitude: readout_amplitude.yaml
+      resonator_frequency: readout_frequency.yaml
+      readout_frequency: readout_frequency.yaml
+      control_amplitude: control_amplitude.yaml
+      qubit_frequency: qubit_frequency.yaml
+      x90_gate_fidelity: x90_gate_fidelity.yaml
+      x180_gate_fidelity: x180_gate_fidelity.yaml
+      zx90_gate_fidelity: zx90_gate_fidelity.yaml
+      average_gate_fidelity: average_gate_fidelity.yaml
+      average_readout_fidelity: average_readout_fidelity.yaml
+
+    # Additional params/*.yaml files to update from the same output parameter.
+    extra_file_map:
+      qubit_frequency:
+        - control_frequency.yaml
+
   github:
     # Optional allowlist for params/*.yaml files pushed by ALL_PARAMS.
     # Leave empty to preserve the historical behavior of pushing all *.yaml files.

--- a/src/qdash/workflow/engine/params_updater.py
+++ b/src/qdash/workflow/engine/params_updater.py
@@ -11,6 +11,7 @@ from filelock import FileLock
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
+from qdash.common.config.loader import ConfigLoader
 from qdash.datamodel.task import ParameterModel
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
 from qdash.workflow.worker.flows.push_props.formatter import represent_none
@@ -19,6 +20,60 @@ if TYPE_CHECKING:
     from qdash.workflow.engine.backend.base import BaseBackend
 
 logger = logging.getLogger(__name__)
+
+
+def _load_params_updater_settings() -> dict[str, Any]:
+    workflow_settings = ConfigLoader.load_settings().get("workflow", {})
+    if not isinstance(workflow_settings, dict):
+        return {}
+    settings = workflow_settings.get("params_updater", {})
+    if not isinstance(settings, dict):
+        return {}
+    return settings
+
+
+def _validate_yaml_file_name(file_name: str) -> str:
+    normalized = file_name.strip()
+    path = Path(normalized)
+    if not normalized or path.name != normalized or path.suffix != ".yaml":
+        raise ValueError(f"Invalid params updater YAML file name: {file_name!r}")
+    return normalized
+
+
+def _load_param_file_map() -> dict[str, str]:
+    settings = _load_params_updater_settings()
+    value = settings.get("parameter_file_map")
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("workflow.params_updater.parameter_file_map must be a mapping")
+
+    result: dict[str, str] = {}
+    for parameter_name, file_name in value.items():
+        if not isinstance(parameter_name, str) or not isinstance(file_name, str):
+            raise ValueError(
+                "workflow.params_updater.parameter_file_map must map strings to strings"
+            )
+        result[parameter_name] = _validate_yaml_file_name(file_name)
+    return result
+
+
+def _load_extra_file_map() -> dict[str, list[str]]:
+    settings = _load_params_updater_settings()
+    value = settings.get("extra_file_map")
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("workflow.params_updater.extra_file_map must be a mapping")
+
+    result: dict[str, list[str]] = {}
+    for parameter_name, file_names in value.items():
+        if not isinstance(parameter_name, str) or not isinstance(file_names, list):
+            raise ValueError("workflow.params_updater.extra_file_map must map strings to lists")
+        if not all(isinstance(file_name, str) for file_name in file_names):
+            raise ValueError("workflow.params_updater.extra_file_map values must be string lists")
+        result[parameter_name] = [_validate_yaml_file_name(file_name) for file_name in file_names]
+    return result
 
 
 class ParamsUpdater(Protocol):
@@ -69,29 +124,11 @@ def _resolve_fake_updater(backend: BaseBackend, chip_id: str | None) -> ParamsUp
 class _QubexParamsUpdater:
     """Synchronize calibration results with Qubex params YAML files."""
 
-    PARAM_FILE_MAP: dict[str, str] = {
-        "t1": "t1.yaml",
-        "t2_echo": "t2_echo.yaml",
-        "t2_star": "t2_star.yaml",
-        "readout_amplitude": "readout_amplitude.yaml",
-        "resonator_frequency": "readout_frequency.yaml",
-        "readout_frequency": "readout_frequency.yaml",
-        "control_amplitude": "control_amplitude.yaml",
-        "qubit_frequency": "qubit_frequency.yaml",
-        "x90_gate_fidelity": "x90_gate_fidelity.yaml",
-        "x180_gate_fidelity": "x180_gate_fidelity.yaml",
-        "zx90_gate_fidelity": "zx90_gate_fidelity.yaml",
-        "average_gate_fidelity": "average_gate_fidelity.yaml",
-        "average_readout_fidelity": "average_readout_fidelity.yaml",
-    }
-
-    EXTRA_FILE_MAP: dict[str, list[str]] = {
-        "qubit_frequency": ["control_frequency.yaml"],
-    }
-
     def __init__(self, backend: Any, chip_id: str | None) -> None:
         self._backend = backend
         self._chip_id = chip_id
+        self._param_file_map = _load_param_file_map()
+        self._extra_file_map = _load_extra_file_map()
         self._yaml = YAML(typ="rt")
         self._yaml.preserve_quotes = True
         self._yaml.width = None
@@ -109,7 +146,7 @@ class _QubexParamsUpdater:
             return updated_files
 
         for key, param in output_parameters.items():
-            file_name = self.PARAM_FILE_MAP.get(key)
+            file_name = self._param_file_map.get(key)
             if file_name is None:
                 continue
 
@@ -121,7 +158,7 @@ class _QubexParamsUpdater:
             if self._update_yaml(file_path, label, value):
                 updated_files.add(file_name)
 
-            for extra_file in self.EXTRA_FILE_MAP.get(key, []):
+            for extra_file in self._extra_file_map.get(key, []):
                 extra_path = params_dir / extra_file
                 if self._update_yaml(extra_path, label, value):
                     updated_files.add(extra_file)

--- a/tests/qdash/workflow/engine/test_params_updater.py
+++ b/tests/qdash/workflow/engine/test_params_updater.py
@@ -9,7 +9,12 @@ import pytest
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
 
-from qdash.workflow.engine.params_updater import _QubexParamsUpdater, get_params_updater
+from qdash.workflow.engine.params_updater import (
+    _load_extra_file_map,
+    _load_param_file_map,
+    _QubexParamsUpdater,
+    get_params_updater,
+)
 
 
 class TestParamsUpdaterNoneHandling:
@@ -254,6 +259,110 @@ data:
             )
 
         assert updated_files == {"control_frequency.yaml", "t1.yaml"}
+
+    def test_update_uses_params_mapping_from_qdash_settings(self, tmp_path):
+        """Parameter-to-YAML mapping should be configurable through QDash settings."""
+        params_dir = tmp_path / "params"
+        params_dir.mkdir()
+        (params_dir / "custom_amplitude.yaml").write_text("data:\n  Q047: 0.1\n")
+        (params_dir / "mirrored_amplitude.yaml").write_text("data:\n  Q047: 0.1\n")
+
+        backend = MagicMock()
+        backend.config = {
+            "project_id": "project-1",
+            "chip_id": "144Qv1",
+            "params_dir": str(params_dir),
+        }
+        backend.get_instance.side_effect = AssertionError("should not connect")
+
+        with patch(
+            "qdash.workflow.engine.params_updater.ConfigLoader.load_settings",
+            return_value={
+                "workflow": {
+                    "params_updater": {
+                        "parameter_file_map": {
+                            "control_amplitude": "custom_amplitude.yaml",
+                        },
+                        "extra_file_map": {
+                            "control_amplitude": ["mirrored_amplitude.yaml"],
+                        },
+                    }
+                }
+            },
+        ):
+            updater = _QubexParamsUpdater(backend, chip_id="144Qv1")
+
+        with patch("qdash.common.domain.qubit._get_chip_size", return_value=144):
+            updated_files = updater.update("47", {"control_amplitude": {"value": 0.25}})
+
+        assert updated_files == {"custom_amplitude.yaml", "mirrored_amplitude.yaml"}
+        assert "Q047: 0.25" in (params_dir / "custom_amplitude.yaml").read_text()
+        assert "Q047: 0.25" in (params_dir / "mirrored_amplitude.yaml").read_text()
+
+    def test_missing_params_mapping_does_not_update_yaml(self, tmp_path):
+        """Without YAML settings, there should be no code-side fallback mapping."""
+        params_dir = tmp_path / "params"
+        params_dir.mkdir()
+        yaml_file = params_dir / "control_amplitude.yaml"
+        yaml_file.write_text("data:\n  Q047: 0.1\n")
+
+        backend = MagicMock()
+        backend.config = {
+            "project_id": "project-1",
+            "chip_id": "144Qv1",
+            "params_dir": str(params_dir),
+        }
+        backend.get_instance.side_effect = AssertionError("should not connect")
+
+        with patch(
+            "qdash.workflow.engine.params_updater.ConfigLoader.load_settings",
+            return_value={},
+        ):
+            updater = _QubexParamsUpdater(backend, chip_id="144Qv1")
+
+        with patch("qdash.common.domain.qubit._get_chip_size", return_value=144):
+            updated_files = updater.update("47", {"control_amplitude": {"value": 0.25}})
+
+        assert updated_files == set()
+        assert "Q047: 0.1" in yaml_file.read_text()
+
+    def test_invalid_params_mapping_file_name_raises(self):
+        """Configured mapping should reject paths outside params/*.yaml filenames."""
+        with (
+            patch(
+                "qdash.workflow.engine.params_updater.ConfigLoader.load_settings",
+                return_value={
+                    "workflow": {
+                        "params_updater": {
+                            "parameter_file_map": {
+                                "control_amplitude": "../control_amplitude.yaml",
+                            },
+                        }
+                    }
+                },
+            ),
+            pytest.raises(ValueError, match="Invalid params updater YAML file name"),
+        ):
+            _load_param_file_map()
+
+    def test_invalid_extra_file_map_shape_raises(self):
+        """Extra file mapping values must be YAML filename lists."""
+        with (
+            patch(
+                "qdash.workflow.engine.params_updater.ConfigLoader.load_settings",
+                return_value={
+                    "workflow": {
+                        "params_updater": {
+                            "extra_file_map": {
+                                "qubit_frequency": "control_frequency.yaml",
+                            },
+                        }
+                    }
+                },
+            ),
+            pytest.raises(ValueError, match="workflow\\.params_updater\\.extra_file_map"),
+        ):
+            _load_extra_file_map()
 
     def test_fake_backend_uses_yaml_params_updater(self, tmp_path):
         """Fake backend should support params YAML updates for local verification."""


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Move params updater parameter-to-YAML mapping into QDash settings so operations can manage mappings without code changes.
- Workflow-only change; no API schema or generated client changes.

## Changes
- Add workflow.params_updater.parameter_file_map and extra_file_map defaults to config/settings.yaml.
- Add settings.local.yaml.template examples for overriding params update mapping.
- Load params updater mappings from settings and remove code-side hardcoded mapping defaults.
- Validate configured params YAML targets as simple *.yaml file names.
- Add tests for configured mapping, missing mapping behavior, and invalid mapping shapes.