### PR TITLE
refactor(config): remove legacy fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -230,17 +230,9 @@ src/qdash/workflow/.calibration/*.json
 src/qdash/workflow/.classifier/*/*
 # Ignore all files in config directory except committed configs
 config/qubex/*
-!config/metrics.yaml
-!config/settings.yaml
-!config/copilot.yaml
-!config/topologies/
 !config/qubex/qubex.example/
 config/qubex-config/*
 config/task-knowledge/
-# Local settings overrides (not committed)
-# These allow per-developer customization without modifying committed files
-config/*.local.yaml
-config/**/*.local.yaml
 src/tools/schedule/*
 .serena/
 .mcp.json

--- a/docs/development/copilot/architecture.md
+++ b/docs/development/copilot/architecture.md
@@ -93,11 +93,9 @@ analysis:
 ```
 
 Configuration is loaded via `ConfigLoader` by deep-merging `config.yaml`, `chat.yaml`, and
-`review.yaml`. Each file supports a `.local.yaml` overlay, and legacy root-level
-`copilot.yaml` remains a fallback during migration. YAML string values support shell-style
-environment variable references such as `${OPENAI_API_KEY}`, so environment-specific or
-sensitive values should be supplied through environment variables instead of committed
-template files.
+`review.yaml`. YAML string values support shell-style environment variable references such
+as `${OPENAI_API_KEY}`, so environment-specific or sensitive values should be supplied
+through environment variables instead of committed template files.
 
 ### Environment Variables
 

--- a/src/qdash/api/lib/policy_config.py
+++ b/src/qdash/api/lib/policy_config.py
@@ -40,9 +40,7 @@ class PolicyConfig(BaseModel):
 def load_policy_config() -> PolicyConfig:
     """Load policy configuration from YAML.
 
-    Uses ConfigLoader for unified loading with local override support.
-    Configuration is loaded from domain/policy.yaml with optional
-    domain/policy.local.yaml overlay.
+    Uses ConfigLoader for unified loading from domain/policy.yaml.
     """
     data: dict[str, Any] = ConfigLoader.load_policy()
     try:

--- a/src/qdash/common/config/loader.py
+++ b/src/qdash/common/config/loader.py
@@ -35,7 +35,7 @@ def _expand_env_vars(value: Any) -> Any:
 
 
 class ConfigLoader:
-    """Unified configuration loader with local override support."""
+    """Unified configuration loader."""
 
     _CONFIG_DIR: Path = CONFIG_DIR
     LOCAL_CONFIG_DIR: Path = Path(__file__).resolve().parents[4] / "config"
@@ -58,45 +58,21 @@ class ConfigLoader:
         return expanded if isinstance(expanded, dict) else {}
 
     @classmethod
-    def _load_with_local(cls, filename: str) -> dict[str, Any]:
-        """Load a YAML file with local override support."""
-        config_dir = cls.get_config_dir()
-        base_path = config_dir / filename
-        local_path = config_dir / filename.replace(".yaml", ".local.yaml")
-
-        config = cls._load_yaml(base_path)
-        if local_path.exists():
-            local_config = cls._load_yaml(local_path)
-            config = _deep_merge(config, local_config)
-        return config
-
-    @classmethod
-    def _load_domain_with_local(cls, filename: str) -> dict[str, Any]:
-        """Load a domain YAML file, falling back to the legacy config root."""
-        config = cls._load_with_local(f"domain/{filename}")
-        if config:
-            return config
-        return cls._load_with_local(filename)
-
-    @classmethod
-    def _load_app_with_local(cls, filename: str) -> dict[str, Any]:
-        """Load an app YAML file, falling back to the legacy config root."""
-        config = cls._load_with_local(f"app/{filename}")
-        if config:
-            return config
-        return cls._load_with_local(filename)
+    def _load_config(cls, filename: str) -> dict[str, Any]:
+        """Load a YAML file relative to the configuration directory."""
+        return cls._load_yaml(cls.get_config_dir() / filename)
 
     @classmethod
     @lru_cache(maxsize=1)
     def load_settings(cls) -> dict[str, Any]:
         """Load settings configuration."""
-        return cls._load_app_with_local("settings.yaml")
+        return cls._load_config("app/settings.yaml")
 
     @classmethod
     @lru_cache(maxsize=1)
     def load_metrics(cls) -> dict[str, Any]:
         """Load metrics configuration."""
-        return cls._load_domain_with_local("metrics.yaml")
+        return cls._load_config("domain/metrics.yaml")
 
     @classmethod
     @lru_cache(maxsize=1)
@@ -108,37 +84,25 @@ class ConfigLoader:
             "copilot/chat.yaml",
             "copilot/review.yaml",
         ):
-            config = _deep_merge(config, cls._load_with_local(filename))
-        if config:
-            return config
-        return cls._load_with_local("copilot.yaml")
+            config = _deep_merge(config, cls._load_config(filename))
+        return config
 
     @classmethod
     @lru_cache(maxsize=1)
     def load_backend(cls) -> dict[str, Any]:
         """Load backend configuration."""
-        return cls._load_app_with_local("backend.yaml")
+        return cls._load_config("app/backend.yaml")
 
     @classmethod
     @lru_cache(maxsize=1)
     def load_workflow(cls) -> dict[str, Any]:
-        """Load workflow configuration.
-
-        Workflow settings used to live under ``settings.yaml``. Keep that path
-        as a fallback so local overrides continue to work during migration.
-        """
-        workflow_config = cls._load_app_with_local("workflow.yaml")
-        if workflow_config:
-            return workflow_config
-
-        settings = cls.load_settings()
-        workflow_settings = settings.get("workflow", {})
-        return workflow_settings if isinstance(workflow_settings, dict) else {}
+        """Load workflow configuration."""
+        return cls._load_config("app/workflow.yaml")
 
     @classmethod
     def load_policy(cls) -> dict[str, Any]:
         """Load provenance policy configuration."""
-        return cls._load_domain_with_local("policy.yaml")
+        return cls._load_config("domain/policy.yaml")
 
     @classmethod
     def clear_cache(cls) -> None:

--- a/src/qdash/common/infrastructure/logging.py
+++ b/src/qdash/common/infrastructure/logging.py
@@ -9,21 +9,15 @@ from pathlib import Path
 import yaml
 
 _CONFIG_DIR = Path("/app/config/app/logging")
-_LEGACY_CONFIG_DIR = Path("/app/config/logging")
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _LOCAL_CONFIG_DIR = _REPO_ROOT / "config" / "app" / "logging"
-_LEGACY_LOCAL_CONFIG_DIR = _REPO_ROOT / "config" / "logging"
 
 
 def _resolve_config_dir(config_dir: Path) -> Path:
     if config_dir.exists():
         return config_dir
-    if config_dir == _CONFIG_DIR and _LEGACY_CONFIG_DIR.exists():
-        return _LEGACY_CONFIG_DIR
     if config_dir == _CONFIG_DIR and _LOCAL_CONFIG_DIR.exists():
         return _LOCAL_CONFIG_DIR
-    if config_dir == _CONFIG_DIR and _LEGACY_LOCAL_CONFIG_DIR.exists():
-        return _LEGACY_LOCAL_CONFIG_DIR
     return config_dir
 
 

--- a/src/qdash/workflow/start_worker.py
+++ b/src/qdash/workflow/start_worker.py
@@ -9,13 +9,7 @@ from qdash.workflow.logging_config import setup_logging
 
 
 def _prefect_logging_yaml_path() -> Path:
-    path = Path("/app/config/app/logging/prefect.yaml")
-    if path.exists():
-        return path
-    legacy_path = Path("/app/config/logging/prefect.yaml")
-    if legacy_path.exists():
-        return legacy_path
-    return path
+    return Path("/app/config/app/logging/prefect.yaml")
 
 
 if __name__ == "__main__":

--- a/tests/qdash/common/config/test_loader.py
+++ b/tests/qdash/common/config/test_loader.py
@@ -18,16 +18,6 @@ def test_load_settings_reads_app_yaml(monkeypatch, tmp_path):
     ConfigLoader.clear_cache()
 
 
-def test_load_settings_falls_back_to_legacy_root_yaml(monkeypatch, tmp_path):
-    _write_yaml(tmp_path / "settings.yaml", "ui:\n  task_files:\n    sort_order: name\n")
-    monkeypatch.setattr(ConfigLoader, "_CONFIG_DIR", tmp_path)
-    ConfigLoader.clear_cache()
-
-    assert ConfigLoader.load_settings() == {"ui": {"task_files": {"sort_order": "name"}}}
-
-    ConfigLoader.clear_cache()
-
-
 def test_load_settings_expands_environment_variables(monkeypatch, tmp_path):
     monkeypatch.setenv("QDASH_TASK_FILE_SORT_ORDER", "updated_at")
     _write_yaml(
@@ -65,42 +55,12 @@ def test_load_workflow_reads_workflow_yaml(monkeypatch, tmp_path):
     ConfigLoader.clear_cache()
 
 
-def test_load_workflow_falls_back_to_legacy_root_yaml(monkeypatch, tmp_path):
-    _write_yaml(tmp_path / "workflow.yaml", "github:\n  params_file_names:\n    - params.yaml\n")
-    monkeypatch.setattr(ConfigLoader, "_CONFIG_DIR", tmp_path)
-    ConfigLoader.clear_cache()
-
-    assert ConfigLoader.load_workflow() == {"github": {"params_file_names": ["params.yaml"]}}
-
-    ConfigLoader.clear_cache()
-
-
-def test_load_workflow_falls_back_to_settings_yaml_workflow(monkeypatch, tmp_path):
-    _write_yaml(tmp_path / "settings.yaml", "workflow:\n  github:\n    params_file_names: []\n")
-    monkeypatch.setattr(ConfigLoader, "_CONFIG_DIR", tmp_path)
-    ConfigLoader.clear_cache()
-
-    assert ConfigLoader.load_workflow() == {"github": {"params_file_names": []}}
-
-    ConfigLoader.clear_cache()
-
-
 def test_load_metrics_reads_domain_yaml(monkeypatch, tmp_path):
     _write_yaml(tmp_path / "domain" / "metrics.yaml", "qubit_metrics:\n  t1:\n    title: T1\n")
     monkeypatch.setattr(ConfigLoader, "_CONFIG_DIR", tmp_path)
     ConfigLoader.clear_cache()
 
     assert ConfigLoader.load_metrics() == {"qubit_metrics": {"t1": {"title": "T1"}}}
-
-    ConfigLoader.clear_cache()
-
-
-def test_load_metrics_falls_back_to_legacy_root_yaml(monkeypatch, tmp_path):
-    _write_yaml(tmp_path / "metrics.yaml", "qubit_metrics:\n  t2_echo:\n    title: T2 Echo\n")
-    monkeypatch.setattr(ConfigLoader, "_CONFIG_DIR", tmp_path)
-    ConfigLoader.clear_cache()
-
-    assert ConfigLoader.load_metrics() == {"qubit_metrics": {"t2_echo": {"title": "T2 Echo"}}}
 
     ConfigLoader.clear_cache()
 
@@ -143,15 +103,5 @@ def test_load_copilot_merges_chat_and_review_yaml(monkeypatch, tmp_path):
         "chat_models": [{"provider": "openai", "name": "gpt-5.4"}],
         "analysis": {"ai_review_tasks": ["CheckQubitSpectroscopy"]},
     }
-
-    ConfigLoader.clear_cache()
-
-
-def test_load_copilot_falls_back_to_legacy_root_yaml(monkeypatch, tmp_path):
-    _write_yaml(tmp_path / "copilot.yaml", "enabled: false\n")
-    monkeypatch.setattr(ConfigLoader, "_CONFIG_DIR", tmp_path)
-    ConfigLoader.clear_cache()
-
-    assert ConfigLoader.load_copilot() == {"enabled": False}
 
     ConfigLoader.clear_cache()

--- a/tests/qdash/common/infrastructure/test_logging.py
+++ b/tests/qdash/common/infrastructure/test_logging.py
@@ -4,54 +4,32 @@ from qdash.workflow.start_worker import _prefect_logging_yaml_path
 
 def test_resolve_config_dir_prefers_app_logging(monkeypatch, tmp_path):
     app_dir = tmp_path / "app" / "logging"
-    legacy_dir = tmp_path / "logging"
     app_dir.mkdir(parents=True)
-    legacy_dir.mkdir()
 
     monkeypatch.setattr(logging_config, "_CONFIG_DIR", app_dir)
-    monkeypatch.setattr(logging_config, "_LEGACY_CONFIG_DIR", legacy_dir)
 
     assert logging_config._resolve_config_dir(app_dir) == app_dir
 
 
-def test_resolve_config_dir_falls_back_to_legacy_container_path(monkeypatch, tmp_path):
+def test_resolve_config_dir_falls_back_to_repo_app_logging(monkeypatch, tmp_path):
     app_dir = tmp_path / "missing" / "app" / "logging"
-    legacy_dir = tmp_path / "logging"
-    legacy_dir.mkdir()
+    repo_app_dir = tmp_path / "repo" / "config" / "app" / "logging"
+    repo_app_dir.mkdir(parents=True)
 
     monkeypatch.setattr(logging_config, "_CONFIG_DIR", app_dir)
-    monkeypatch.setattr(logging_config, "_LEGACY_CONFIG_DIR", legacy_dir)
+    monkeypatch.setattr(logging_config, "_LOCAL_CONFIG_DIR", repo_app_dir)
 
-    assert logging_config._resolve_config_dir(app_dir) == legacy_dir
+    assert logging_config._resolve_config_dir(app_dir) == repo_app_dir
 
 
 def test_prefect_logging_yaml_path_prefers_app_logging(monkeypatch, tmp_path):
     app_path = tmp_path / "app" / "logging" / "prefect.yaml"
-    legacy_path = tmp_path / "logging" / "prefect.yaml"
     app_path.parent.mkdir(parents=True)
-    legacy_path.parent.mkdir()
     app_path.write_text("version: 1\n")
-    legacy_path.write_text("version: 1\n")
 
     paths = {
         "/app/config/app/logging/prefect.yaml": app_path,
-        "/app/config/logging/prefect.yaml": legacy_path,
     }
     monkeypatch.setattr("qdash.workflow.start_worker.Path", lambda value: paths[str(value)])
 
     assert _prefect_logging_yaml_path() == app_path
-
-
-def test_prefect_logging_yaml_path_falls_back_to_legacy(monkeypatch, tmp_path):
-    app_path = tmp_path / "missing" / "app" / "logging" / "prefect.yaml"
-    legacy_path = tmp_path / "logging" / "prefect.yaml"
-    legacy_path.parent.mkdir()
-    legacy_path.write_text("version: 1\n")
-
-    paths = {
-        "/app/config/app/logging/prefect.yaml": app_path,
-        "/app/config/logging/prefect.yaml": legacy_path,
-    }
-    monkeypatch.setattr("qdash.workflow.start_worker.Path", lambda value: paths[str(value)])
-
-    assert _prefect_logging_yaml_path() == legacy_path


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Remove migration-time config fallback paths now that YAML files live in grouped config directories.
- Keep configuration loading explicit by requiring app, domain, and copilot files from their current locations.

## Changes
- Removed ConfigLoader root YAML fallback, local YAML overlay handling, copilot.yaml fallback, and workflow-in-settings fallback.
- Simplified logging configuration path resolution to app logging paths only.
- Updated Prefect worker logging path resolution to use config/app/logging/prefect.yaml directly.
- Removed fallback-specific tests and updated docs/gitignore references.