### PR TITLE
fix(repo): generate openapi locally

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -17,14 +17,15 @@ tasks:
     desc: Restart the API service
 
   generate:
-    dir: ui
     dotenv: [.env]
     cmds:
-      - docker compose -f ../compose.yaml restart api && sleep 2
-      - curl http://api:$API_PORT/openapi.json | jq > ../docs/oas/openapi.json
-      - bunx orval@7.14.0 --config ./orval.config.cjs
-      - bun run fmt
-      - bun run lint:fix
+      - |
+        OPENAPI_TMP="$(mktemp)"
+        ENV=test uv run python -c 'import json, os; from dotenv import load_dotenv; load_dotenv(".env"); os.environ["ENV"] = "test"; from qdash.api.main import app; print(json.dumps(app.openapi(), ensure_ascii=False, indent=2))' > "$OPENAPI_TMP"
+        mv "$OPENAPI_TMP" docs/oas/openapi.json
+      - cd ui && bunx orval@7.14.0 --config ./orval.config.cjs
+      - cd ui && bun run fmt
+      - cd ui && bun run lint:fix
     desc: Generate the TypeScript client
 
   knowledge:

--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -4483,7 +4483,7 @@
           "task-file"
         ],
         "summary": "Get task file settings",
-        "description": "Get task file settings from config/settings.yaml.\n\nReturns\n-------\n    Task file settings including default backend",
+        "description": "Get task file settings from config/app/settings.yaml.\n\nReturns\n-------\n    Task file settings including default backend",
         "operationId": "getTaskFileSettings",
         "responses": {
           "200": {
@@ -4688,7 +4688,7 @@
           "task-file"
         ],
         "summary": "Get backend configuration",
-        "description": "Get backend configuration from backend.yaml.\n\nReturns\n-------\n    Backend configuration",
+        "description": "Get backend configuration from config/app/backend.yaml.\n\nReturns\n-------\n    Backend configuration",
         "operationId": "getBackendConfig",
         "responses": {
           "200": {
@@ -15010,7 +15010,7 @@
           "task_notes"
         ],
         "title": "ChipNotesSummaryResponse",
-        "description": "All notes for a chip in one fetch \u2014 drives the dashboard summary view."
+        "description": "All notes for a chip in one fetch — drives the dashboard summary view."
       },
       "ChipResponse": {
         "properties": {

--- a/ui/src/client/task-file/task-file.ts
+++ b/ui/src/client/task-file/task-file.ts
@@ -47,7 +47,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 /**
- * Get task file settings from config/settings.yaml.
+ * Get task file settings from config/app/settings.yaml.
 
 Returns
 -------
@@ -513,7 +513,7 @@ export const useSaveTaskFileContent = <TError = HTTPValidationError,
       return useMutation(mutationOptions, queryClient);
     }
     /**
- * Get backend configuration from backend.yaml.
+ * Get backend configuration from config/app/backend.yaml.
 
 Returns
 -------


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Make `task generate` independent of Docker service DNS and API container lifecycle.
- Regenerate OpenAPI and the affected TypeScript client comments after the config path docstring updates.

## Changes
- Generate `docs/oas/openapi.json` directly from FastAPI `app.openapi()` with `ENV=test` to avoid DB initialization.
- Run Orval and UI format/lint commands from the repository root task without relying on Docker.
- Updated generated OpenAPI/client descriptions from legacy config paths to `config/app/*` paths.