### PR TITLE
refactor(config): remove topology fallback

### DIFF
--- a/src/qdash/common/config/topology.py
+++ b/src/qdash/common/config/topology.py
@@ -56,7 +56,6 @@ class TopologyDefinition(BaseModel):
 
 
 TOPOLOGIES_DIR = "domain/topologies"
-LEGACY_TOPOLOGIES_DIR = "topologies"
 
 
 def _get_config_dir() -> Path:
@@ -65,11 +64,7 @@ def _get_config_dir() -> Path:
 
 
 def _topologies_dir() -> Path:
-    config_dir = _get_config_dir()
-    topologies_dir = config_dir / TOPOLOGIES_DIR
-    if topologies_dir.exists():
-        return topologies_dir
-    return config_dir / LEGACY_TOPOLOGIES_DIR
+    return _get_config_dir() / TOPOLOGIES_DIR
 
 
 @lru_cache(maxsize=32)

--- a/tests/qdash/common/config/test_topology.py
+++ b/tests/qdash/common/config/test_topology.py
@@ -37,12 +37,12 @@ def test_load_topology_reads_domain_topologies(monkeypatch, tmp_path):
     load_topology.cache_clear()
 
 
-def test_list_topologies_falls_back_to_legacy_root_topologies(monkeypatch, tmp_path):
-    topologies_dir = tmp_path / "topologies"
-    topologies_dir.mkdir()
-    _write_topology(topologies_dir / "legacy-topology.yaml", "legacy-topology", num_qubits=4)
+def test_list_topologies_reads_domain_topologies(monkeypatch, tmp_path):
+    topologies_dir = tmp_path / "domain" / "topologies"
+    topologies_dir.mkdir(parents=True)
+    _write_topology(topologies_dir / "test-topology.yaml", "test-topology", num_qubits=4)
     monkeypatch.setattr(ConfigLoader, "_CONFIG_DIR", tmp_path)
 
     assert list_topologies(size=4) == [
-        {"id": "legacy-topology", "name": "Test Topology", "num_qubits": 4}
+        {"id": "test-topology", "name": "Test Topology", "num_qubits": 4}
     ]


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Remove the remaining legacy topology config fallback now that topology YAML lives under `config/domain/topologies`.
- Keep topology loading aligned with the explicit grouped config layout.

## Changes
- Removed the `config/topologies` fallback from the topology loader.
- Updated topology tests to cover the `config/domain/topologies` path only.