### PR TITLE
docs(config): clarify qubex config path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ POSTGRES_DATA_PATH="./postgres_data"
 MONGO_DATA_PATH="./mongo_data/data/db"
 CALIB_DATA_PATH="./calib_data"
 CALIB_TASKS_PATH="./src/qdash/workflow/calibtasks"
+# Qubex backend configuration repository/data. QDash app config lives under ./config.
 CONFIG_PATH="./config/qubex-config"
 
 QDASH_ADMIN_USERNAME="admin"

--- a/compose.yaml
+++ b/compose.yaml
@@ -117,8 +117,8 @@ services:
       - ./src/qdash/repository:/app/qdash/repository
       - ./src/qdash/config.py:/app/qdash/config.py
       - ${CALIB_DATA_PATH:-./calib_data}:/app/calib_data
-      - ${CONFIG_PATH:-./config/qubex-config}:/app/config/qubex-config
-      - ./config:/app/config
+      - ${CONFIG_PATH:-./config/qubex-config}:/app/config/qubex-config # Qubex backend configuration repository/data
+      - ./config:/app/config # QDash app/domain/copilot config files
       - ./logs/worker:/app/logs
     working_dir: /app/qdash/workflow
     command: python start_worker.py
@@ -152,9 +152,9 @@ services:
       - ./src/qdash/workflow/templates:/app/qdash/workflow/templates # Flow templates
       - ./src/qdash/workflow/service:/app/qdash/workflow/service # Calibration service modules
       - ${CALIBTASKS_PATH:-./src/qdash/workflow/calibtasks}:/app/qdash/workflow/calibtasks # Calibration tasks
-      - ./config:/app/config # Metrics metadata and other config files
+      - ./config:/app/config # QDash app/domain/copilot config files
       - ${CALIB_DATA_PATH:-./calib_data}:/app/calib_data
-      - ${CONFIG_PATH:-./config/qubex-config}:/app/config/qubex-config
+      - ${CONFIG_PATH:-./config/qubex-config}:/app/config/qubex-config # Qubex backend configuration repository/data
       - ./logs/api:/app/logs
     working_dir: /app/qdash/api
     command: gunicorn main:app --workers 4 --worker-class uvicorn.workers.UvicornWorker --reload --bind :${API_PORT:-5715} --log-level debug

--- a/docs/developer-guide/codebase.md
+++ b/docs/developer-guide/codebase.md
@@ -32,5 +32,8 @@ inside individual services.
 Important mounted paths:
 
 - `CALIB_DATA_PATH` ↔ `/app/calib_data`
-- `CONFIG_PATH` ↔ `/app/config/qubex-config`
+- `CONFIG_PATH` ↔ `/app/config/qubex-config` for the Qubex backend configuration repository/data
 - `CALIB_TASKS_PATH` ↔ `/app/qdash/workflow/calibtasks`
+
+QDash application configuration is separate from `CONFIG_PATH` and lives under `config/app`,
+`config/domain`, and `config/copilot`.

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -298,7 +298,7 @@ Key environment variables are configured in `.env`. See `.env.example` for avail
 | `DEPLOYMENT_SERVICE_PORT` | 4006    | Deployment service port     |
 | `CALIB_DATA_PATH`         | -       | Calibration data mount path |
 | `CALIB_TASKS_PATH`        | -       | Calibration tasks path      |
-| `CONFIG_PATH`             | -       | Qubex config path           |
+| `CONFIG_PATH`             | -       | Qubex backend config repository/data path |
 | `NEXT_PUBLIC_API_URL`     | -       | Public API URL for frontend |
 | `NEXT_PUBLIC_PREFECT_URL` | -       | Prefect dashboard URL       |
 | `NEXT_ALLOWED_DEV_ORIGINS` | -       | Additional hostnames allowed to access the Next.js dev server |

--- a/docs/operator-guide/operations.md
+++ b/docs/operator-guide/operations.md
@@ -48,5 +48,6 @@ If workflow execution fails with a missing work pool, restart `deployment-servic
 If task figures do not render, confirm `CALIB_DATA_PATH` points at the directory mounted to
 `/app/calib_data` in Docker.
 
-If config or task file pages return missing-path errors, confirm `CONFIG_PATH` and
-`CALIB_TASKS_PATH` in `.env`.
+If Qubex config or task file pages return missing-path errors, confirm `CONFIG_PATH` points
+to the Qubex backend configuration tree and `CALIB_TASKS_PATH` points to the calibration
+task directory in `.env`.

--- a/docs/operator-guide/setup.md
+++ b/docs/operator-guide/setup.md
@@ -20,8 +20,11 @@ Review these values before starting services:
 | `API_PORT` / `UI_PORT` / `PREFECT_PORT` | Host ports for API, UI, and Prefect |
 | `MONGO_DATA_PATH` / `POSTGRES_DATA_PATH` | Persistent database storage |
 | `CALIB_DATA_PATH` | Calibration figures and run artifacts |
-| `CONFIG_PATH` | Qubex backend configuration |
+| `CONFIG_PATH` | Qubex backend configuration repository/data |
 | `DEFAULT_BACKEND` | Backend selected by default |
+
+QDash application settings are committed under `config/app`, `config/domain`, and
+`config/copilot`; `CONFIG_PATH` is only for the Qubex backend configuration tree.
 
 ## Full Stack
 

--- a/src/qdash/common/config/path_resolver.py
+++ b/src/qdash/common/config/path_resolver.py
@@ -51,7 +51,7 @@ def _resolve_runtime_base_path(
 
 
 def resolve_config_base_path() -> Path:
-    """Resolve the Qubex config directory for host and container execution."""
+    """Resolve the Qubex backend configuration tree for host and container execution."""
     return _resolve_runtime_base_path(
         env_name="CONFIG_PATH",
         container_path=QUBEX_CONFIG_BASE,


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Clarify that `CONFIG_PATH` points to the Qubex backend configuration repository/data, not QDash app configuration.
- Keep the current variable and mount paths unchanged ahead of a future release-level rename/move.

## Changes
- Updated `.env.example`, Compose comments, and operator/developer docs to distinguish QDash config from Qubex config.
- Refined the `resolve_config_base_path()` docstring to describe the Qubex backend configuration tree.