### PR TITLE
refactor(workflow): disable optimal readout amplitude in defaults

### DIFF
--- a/src/qdash/workflow/service/steps/one_qubit.py
+++ b/src/qdash/workflow/service/steps/one_qubit.py
@@ -165,7 +165,7 @@ class OneQubitCheck(CalibrationStep):
     """Basic 1-qubit characterization step.
 
     Executes CHECK_1Q_TASKS including Rabi/half-pi pulse checks,
-    optimal readout amplitude search, and T1/T2/Ramsey characterization.
+    and T1/T2/Ramsey characterization.
 
     Provides: one_qubit_check
     """

--- a/src/qdash/workflow/service/tasks.py
+++ b/src/qdash/workflow/service/tasks.py
@@ -57,7 +57,7 @@ CHECK_1Q_TASKS: list[str] = [
     "CreateHPIPulse",
     "CheckHPIPulse",
     # "CheckOptimalReadoutFrequency",
-    "CheckOptimalReadoutAmplitude",
+    # "CheckOptimalReadoutAmplitude",
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",

--- a/tests/qdash/workflow/service/test_tasks.py
+++ b/tests/qdash/workflow/service/test_tasks.py
@@ -1,0 +1,6 @@
+from qdash.workflow.service.tasks import CHECK_1Q_TASKS, FULL_1Q_TASKS_AFTER_CHECK
+
+
+def test_default_one_qubit_sequences_skip_optimal_readout_amplitude() -> None:
+    assert "CheckOptimalReadoutAmplitude" not in CHECK_1Q_TASKS
+    assert "CheckOptimalReadoutAmplitude" not in FULL_1Q_TASKS_AFTER_CHECK


### PR DESCRIPTION
## Ticket
N/A

## Summary
- Removes CheckOptimalReadoutAmplitude from the default 1Q workflow task sequence so fine-tune/check defaults no longer run the readout amplitude search automatically.
- Workflow-only change; the task remains available for explicit/manual use and no API or generated client changes are involved.

## Changes
- Comments out CheckOptimalReadoutAmplitude in CHECK_1Q_TASKS.
- Updates the OneQubitCheck description to match the new default sequence.
- Adds a focused test to guard that default 1Q sequences skip CheckOptimalReadoutAmplitude.