### PR TITLE
ci: guard pr creator assignment

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,6 +9,7 @@ on:
 #Permissions are required for PRs by dependabot.
 permissions:
   pull-requests: write
+  issues: write
   contents: write
 
 jobs:
@@ -75,6 +76,9 @@ jobs:
           labels: ${{ steps.set-labels.outputs.labels }}
 
       - name: Assign PR creator
+        if: >-
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Ticket
N/A

## Summary
- Updates the PR labeler workflow so PR creator assignment only runs for same-repository PRs and skips dependabot.
- CI-only change; no application behavior or generated files are affected.

## Changes
- Adds the same-repository and non-dependabot guard to the Assign PR creator step.
- Adds issues: write permission for the GitHub Issues API assignee update.
- Verified the workflow YAML parses successfully.