### PR TITLE
refactor(api): route provenance dependencies through providers

### DIFF
--- a/src/qdash/api/dependencies.py
+++ b/src/qdash/api/dependencies.py
@@ -51,6 +51,7 @@ from qdash.repository.backend import MongoBackendRepository
 from qdash.repository.calibration_note import MongoCalibrationNoteRepository
 from qdash.repository.cooldown import MongoCooldownRepository
 from qdash.repository.cooldown_wiring_event import MongoCooldownWiringEventRepository
+from qdash.repository.coupling import MongoCouplingCalibrationRepository
 from qdash.repository.cryostat import MongoCryostatRepository
 from qdash.repository.execution_history import MongoExecutionHistoryRepository
 from qdash.repository.execution_lock import MongoExecutionLockRepository
@@ -59,6 +60,7 @@ from qdash.repository.provenance import (
     MongoParameterVersionRepository,
     MongoProvenanceRelationRepository,
 )
+from qdash.repository.qubit import MongoQubitCalibrationRepository
 from qdash.repository.tag import MongoTagRepository
 from qdash.repository.task_definition import MongoTaskDefinitionRepository
 
@@ -256,24 +258,65 @@ def get_task_definition_repository() -> MongoTaskDefinitionRepository:
 
 
 @lru_cache(maxsize=1)
+def get_qubit_calibration_repository() -> MongoQubitCalibrationRepository:
+    """Get the qubit calibration repository instance."""
+    return MongoQubitCalibrationRepository()
+
+
+@lru_cache(maxsize=1)
+def get_coupling_calibration_repository() -> MongoCouplingCalibrationRepository:
+    """Get the coupling calibration repository instance."""
+    return MongoCouplingCalibrationRepository()
+
+
+@lru_cache(maxsize=1)
+def get_parameter_version_repository() -> MongoParameterVersionRepository:
+    """Get the parameter version repository instance."""
+    return MongoParameterVersionRepository()
+
+
+@lru_cache(maxsize=1)
+def get_provenance_relation_repository() -> MongoProvenanceRelationRepository:
+    """Get the provenance relation repository instance."""
+    return MongoProvenanceRelationRepository()
+
+
+@lru_cache(maxsize=1)
+def get_activity_repository() -> MongoActivityRepository:
+    """Get the provenance activity repository instance."""
+    return MongoActivityRepository()
+
+
+@lru_cache(maxsize=1)
 def get_seed_import_service() -> SeedImportService:
     """Get the seed import service instance."""
-    return SeedImportService()
+    return SeedImportService(
+        activity_repo=get_activity_repository(),
+        param_version_repo=get_parameter_version_repository(),
+        relation_repo=get_provenance_relation_repository(),
+        user_repository=get_user_repository(),
+    )
 
 
 @lru_cache(maxsize=1)
 def get_manual_update_service() -> ManualUpdateService:
     """Get the manual parameter update service instance."""
-    return ManualUpdateService()
+    return ManualUpdateService(
+        qubit_repo=get_qubit_calibration_repository(),
+        coupling_repo=get_coupling_calibration_repository(),
+        activity_repo=get_activity_repository(),
+        param_version_repo=get_parameter_version_repository(),
+        relation_repo=get_provenance_relation_repository(),
+    )
 
 
 @lru_cache(maxsize=1)
 def get_provenance_service() -> ProvenanceService:
     """Get the provenance service instance."""
     return ProvenanceService(
-        parameter_version_repo=MongoParameterVersionRepository(),
-        provenance_relation_repo=MongoProvenanceRelationRepository(),
-        activity_repo=MongoActivityRepository(),
+        parameter_version_repo=get_parameter_version_repository(),
+        provenance_relation_repo=get_provenance_relation_repository(),
+        activity_repo=get_activity_repository(),
     )
 
 

--- a/src/qdash/api/services/manual_update_service.py
+++ b/src/qdash/api/services/manual_update_service.py
@@ -36,12 +36,19 @@ logger = logging.getLogger(__name__)
 class ManualUpdateService:
     """Service for manually updating calibration parameters."""
 
-    def __init__(self) -> None:
-        self._qubit_repo = MongoQubitCalibrationRepository()
-        self._coupling_repo = MongoCouplingCalibrationRepository()
-        self._activity_repo = MongoActivityRepository()
-        self._param_version_repo = MongoParameterVersionRepository()
-        self._relation_repo = MongoProvenanceRelationRepository()
+    def __init__(
+        self,
+        qubit_repo: MongoQubitCalibrationRepository | None = None,
+        coupling_repo: MongoCouplingCalibrationRepository | None = None,
+        activity_repo: MongoActivityRepository | None = None,
+        param_version_repo: MongoParameterVersionRepository | None = None,
+        relation_repo: MongoProvenanceRelationRepository | None = None,
+    ) -> None:
+        self._qubit_repo = qubit_repo or MongoQubitCalibrationRepository()
+        self._coupling_repo = coupling_repo or MongoCouplingCalibrationRepository()
+        self._activity_repo = activity_repo or MongoActivityRepository()
+        self._param_version_repo = param_version_repo or MongoParameterVersionRepository()
+        self._relation_repo = relation_repo or MongoProvenanceRelationRepository()
 
     def update_parameters(
         self,

--- a/src/qdash/api/services/seed_import_service.py
+++ b/src/qdash/api/services/seed_import_service.py
@@ -26,12 +26,12 @@ from qdash.common.utils.datetime import now
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.provenance import ProvenanceRelationType
 from qdash.dbmodel.qubit import QubitDocument
-from qdash.dbmodel.user import UserDocument
 from qdash.repository.provenance import (
     MongoActivityRepository,
     MongoParameterVersionRepository,
     MongoProvenanceRelationRepository,
 )
+from qdash.repository.user import MongoUserRepository
 
 logger = logging.getLogger(__name__)
 
@@ -52,12 +52,19 @@ class SeedImportService:
     with full provenance tracking for data lineage.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        activity_repo: MongoActivityRepository | None = None,
+        param_version_repo: MongoParameterVersionRepository | None = None,
+        relation_repo: MongoProvenanceRelationRepository | None = None,
+        user_repository: MongoUserRepository | None = None,
+    ) -> None:
         """Initialize the seed import service."""
         self._config_base = QUBEX_CONFIG_BASE
-        self._activity_repo = MongoActivityRepository()
-        self._param_version_repo = MongoParameterVersionRepository()
-        self._relation_repo = MongoProvenanceRelationRepository()
+        self._activity_repo = activity_repo or MongoActivityRepository()
+        self._param_version_repo = param_version_repo or MongoParameterVersionRepository()
+        self._relation_repo = relation_repo or MongoProvenanceRelationRepository()
+        self._user_repository = user_repository or MongoUserRepository()
 
     def _params_dir(self, chip_id: str) -> pathlib.Path:
         """Get the params directory for a chip.
@@ -83,9 +90,8 @@ class SeedImportService:
             raise ValueError(f"Invalid chip_id: {chip_id}")
         return pathlib.Path(self._config_base) / chip_id / "params"
 
-    @staticmethod
-    def _user_id_for_username(username: str) -> str | None:
-        user = UserDocument.find_one({"username": username}).run()
+    def _user_id_for_username(self, username: str) -> str | None:
+        user = self._user_repository.find_by_username(username)
         return user.user_id if user else None
 
     def import_seeds(

--- a/tests/qdash/api/services/test_seed_import_service.py
+++ b/tests/qdash/api/services/test_seed_import_service.py
@@ -145,18 +145,21 @@ class TestSeedImportServiceImportFromManual:
             patch(
                 "qdash.api.services.seed_import_service.MongoProvenanceRelationRepository"
             ) as relation_repo,
+            patch("qdash.api.services.seed_import_service.MongoUserRepository") as user_repo,
             patch("qdash.api.services.seed_import_service.QubitDocument") as qubit_doc,
         ):
             mock_activity = MagicMock()
             mock_activity.activity_id = "test-activity-id"
             activity_repo.return_value.create_activity.return_value = mock_activity
 
+            user_repo.return_value.find_by_username.return_value = None
             qubit_doc.find_one.return_value.run.return_value = None
 
             yield {
                 "activity": activity_repo,
                 "param_version": param_repo,
                 "relation": relation_repo,
+                "user": user_repo,
                 "qubit_doc": qubit_doc,
             }
 
@@ -271,18 +274,21 @@ class TestSeedImportServiceImportFromQubex:
             patch(
                 "qdash.api.services.seed_import_service.MongoProvenanceRelationRepository"
             ) as relation_repo,
+            patch("qdash.api.services.seed_import_service.MongoUserRepository") as user_repo,
             patch("qdash.api.services.seed_import_service.QubitDocument") as qubit_doc,
         ):
             mock_activity = MagicMock()
             mock_activity.activity_id = "test-activity-id"
             activity_repo.return_value.create_activity.return_value = mock_activity
 
+            user_repo.return_value.find_by_username.return_value = None
             qubit_doc.find_one.return_value.run.return_value = None
 
             yield {
                 "activity": activity_repo,
                 "param_version": param_repo,
                 "relation": relation_repo,
+                "user": user_repo,
                 "qubit_doc": qubit_doc,
             }
 

--- a/tests/qdash/api/test_dependencies.py
+++ b/tests/qdash/api/test_dependencies.py
@@ -1,0 +1,51 @@
+"""Tests for API dependency providers."""
+
+from qdash.api import dependencies
+
+
+def _clear_dependency_caches() -> None:
+    dependencies.get_activity_repository.cache_clear()
+    dependencies.get_coupling_calibration_repository.cache_clear()
+    dependencies.get_manual_update_service.cache_clear()
+    dependencies.get_parameter_version_repository.cache_clear()
+    dependencies.get_provenance_relation_repository.cache_clear()
+    dependencies.get_provenance_service.cache_clear()
+    dependencies.get_qubit_calibration_repository.cache_clear()
+    dependencies.get_seed_import_service.cache_clear()
+    dependencies.get_user_repository.cache_clear()
+
+
+def test_provenance_services_use_shared_repository_providers() -> None:
+    _clear_dependency_caches()
+
+    parameter_version_repo = dependencies.get_parameter_version_repository()
+    provenance_relation_repo = dependencies.get_provenance_relation_repository()
+    activity_repo = dependencies.get_activity_repository()
+    user_repo = dependencies.get_user_repository()
+
+    provenance_service = dependencies.get_provenance_service()
+    seed_import_service = dependencies.get_seed_import_service()
+    manual_update_service = dependencies.get_manual_update_service()
+
+    assert provenance_service.parameter_version_repo is parameter_version_repo
+    assert provenance_service.provenance_relation_repo is provenance_relation_repo
+    assert provenance_service.activity_repo is activity_repo
+    assert seed_import_service._param_version_repo is parameter_version_repo
+    assert seed_import_service._relation_repo is provenance_relation_repo
+    assert seed_import_service._activity_repo is activity_repo
+    assert seed_import_service._user_repository is user_repo
+    assert manual_update_service._param_version_repo is parameter_version_repo
+    assert manual_update_service._relation_repo is provenance_relation_repo
+    assert manual_update_service._activity_repo is activity_repo
+
+
+def test_manual_update_service_uses_calibration_repository_providers() -> None:
+    _clear_dependency_caches()
+
+    qubit_repo = dependencies.get_qubit_calibration_repository()
+    coupling_repo = dependencies.get_coupling_calibration_repository()
+
+    service = dependencies.get_manual_update_service()
+
+    assert service._qubit_repo is qubit_repo
+    assert service._coupling_repo is coupling_repo


### PR DESCRIPTION
## Ticket
N/A

## Summary
- Improves API dependency injection by routing provenance-related repositories through provider functions instead of constructing them directly inside service providers.
- API-only refactor; no schema, OpenAPI, or UI generated client changes are involved.

## Changes
- Adds provider functions for provenance, qubit calibration, and coupling calibration repositories.
- Injects those repositories into ProvenanceService, SeedImportService, and ManualUpdateService.
- Moves SeedImportService user lookup behind MongoUserRepository for easier test substitution.
- Adds dependency provider tests and updates seed import tests for the injected user repository.

Verification:
- uv run ruff check src/qdash/api/dependencies.py src/qdash/api/services/manual_update_service.py src/qdash/api/services/seed_import_service.py tests/qdash/api/test_dependencies.py tests/qdash/api/services/test_seed_import_service.py
- uv run pytest tests/qdash/api/services/test_provenance_service.py tests/qdash/api/services/test_seed_import_service.py tests/qdash/api/test_dependencies.py