### PR TITLE
refactor(api): allow settings injection in app factory

### DIFF
--- a/src/qdash/api/app_factory.py
+++ b/src/qdash/api/app_factory.py
@@ -7,7 +7,7 @@ from fastapi.routing import APIRoute
 from qdash.api.db.session import lifespan
 from qdash.api.middleware.request_id import RequestIdMiddleware
 from qdash.api.router_registry import register_routers
-from qdash.config import get_settings, resolve_api_cors_origins
+from qdash.config import Settings, get_settings, resolve_api_cors_origins
 
 
 def custom_generate_unique_id(route: APIRoute) -> str:
@@ -15,7 +15,7 @@ def custom_generate_unique_id(route: APIRoute) -> str:
     return f"{route.tags[0]}-{route.name}"
 
 
-def create_app() -> FastAPI:
+def create_app(settings: Settings | None = None) -> FastAPI:
     """Create and configure the QDash API app."""
     app = FastAPI(
         title="QDash API",
@@ -51,7 +51,7 @@ def create_app() -> FastAPI:
         },
     )
 
-    app_settings = get_settings()
+    app_settings = settings or get_settings()
     app.add_middleware(
         CORSMiddleware,
         allow_origins=resolve_api_cors_origins(app_settings),

--- a/tests/qdash/api/test_app_factory.py
+++ b/tests/qdash/api/test_app_factory.py
@@ -1,0 +1,29 @@
+"""Tests for the FastAPI application factory."""
+
+from typing import Any, cast
+
+from fastapi.middleware.cors import CORSMiddleware
+
+from qdash.api.app_factory import create_app
+from qdash.config import Settings
+
+
+def test_create_app_accepts_settings_for_cors_origins() -> None:
+    settings = Settings.model_construct(
+        env="production",
+        client_url="",
+        api_cors_origins=("https://app.example.com",),
+        prefect_api_url="http://prefect.example.com",
+        postgres_data_path="/tmp/postgres",
+        mongo_data_path="/tmp/mongo",
+        calib_data_path="/tmp/calib",
+    )
+
+    app = create_app(settings=settings)
+
+    cors_middleware = next(
+        middleware
+        for middleware in app.user_middleware
+        if cast("Any", middleware.cls) is CORSMiddleware
+    )
+    assert cors_middleware.kwargs["allow_origins"] == ["https://app.example.com"]


### PR DESCRIPTION
## Ticket
N/A

## Summary
- Allows create_app to accept explicit Settings so app-level configuration can be tested without relying on global environment loading.
- API-only refactor; runtime behavior is unchanged when settings are not provided.

## Changes
- Adds an optional settings parameter to create_app.
- Keeps the existing get_settings fallback for normal application startup.
- Adds a focused app factory test for injected CORS origins.

Verification:
- uv run ruff check src/qdash/api/app_factory.py tests/qdash/api/test_app_factory.py
- uv run pytest tests/qdash/api/test_app_factory.py tests/qdash/test_config.py