### PR TITLE
refactor(api): centralize dependency cache reset

### DIFF
--- a/src/qdash/api/dependencies.py
+++ b/src/qdash/api/dependencies.py
@@ -503,3 +503,62 @@ def get_flow_schedule_service() -> "FlowScheduleService":
     return FlowScheduleService(
         flow_repository=get_flow_repository(),
     )
+
+
+def clear_dependency_caches() -> None:
+    """Clear cached dependency providers.
+
+    Use this from tests or application reload hooks when provider instances
+    must be rebuilt after dependency overrides, configuration changes, or
+    database session resets.
+    """
+    get_chip_repository.cache_clear()
+    get_execution_counter_repository.cache_clear()
+    get_task_result_repository.cache_clear()
+    get_chip_service.cache_clear()
+    get_execution_history_repository.cache_clear()
+    get_execution_lock_repository.cache_clear()
+    get_execution_service.cache_clear()
+    get_calibration_note_repository.cache_clear()
+    get_calibration_service.cache_clear()
+    get_device_topology_service.cache_clear()
+    get_metrics_service.cache_clear()
+    get_task_result_service.cache_clear()
+    get_tag_repository.cache_clear()
+    get_backend_repository.cache_clear()
+    get_task_definition_repository.cache_clear()
+    get_qubit_calibration_repository.cache_clear()
+    get_coupling_calibration_repository.cache_clear()
+    get_parameter_version_repository.cache_clear()
+    get_provenance_relation_repository.cache_clear()
+    get_activity_repository.cache_clear()
+    get_seed_import_service.cache_clear()
+    get_manual_update_service.cache_clear()
+    get_provenance_service.cache_clear()
+    get_issue_service.cache_clear()
+    get_forum_service.cache_clear()
+    get_issue_knowledge_service.cache_clear()
+    get_copilot_runtime.cache_clear()
+    get_admin_service.cache_clear()
+    get_config_service.cache_clear()
+    get_task_service.cache_clear()
+    get_note_service.cache_clear()
+    get_notification_service.cache_clear()
+    get_copilot_chat_session_service.cache_clear()
+    get_cryostat_repository.cache_clear()
+    get_cryostat_service.cache_clear()
+    get_cooldown_repository.cache_clear()
+    get_cooldown_wiring_event_repository.cache_clear()
+    get_cooldown_service.cache_clear()
+    get_cooldown_wiring_event_service.cache_clear()
+    get_user_repository.cache_clear()
+    get_auth_service.cache_clear()
+    get_project_repository.cache_clear()
+    get_membership_repository.cache_clear()
+    get_project_service.cache_clear()
+    get_task_file_service.cache_clear()
+    get_file_service.cache_clear()
+    get_reanalysis_service.cache_clear()
+    get_flow_repository.cache_clear()
+    get_flow_service.cache_clear()
+    get_flow_schedule_service.cache_clear()

--- a/tests/qdash/api/test_dependencies.py
+++ b/tests/qdash/api/test_dependencies.py
@@ -4,15 +4,7 @@ from qdash.api import dependencies
 
 
 def _clear_dependency_caches() -> None:
-    dependencies.get_activity_repository.cache_clear()
-    dependencies.get_coupling_calibration_repository.cache_clear()
-    dependencies.get_manual_update_service.cache_clear()
-    dependencies.get_parameter_version_repository.cache_clear()
-    dependencies.get_provenance_relation_repository.cache_clear()
-    dependencies.get_provenance_service.cache_clear()
-    dependencies.get_qubit_calibration_repository.cache_clear()
-    dependencies.get_seed_import_service.cache_clear()
-    dependencies.get_user_repository.cache_clear()
+    dependencies.clear_dependency_caches()
 
 
 def test_provenance_services_use_shared_repository_providers() -> None:
@@ -49,3 +41,13 @@ def test_manual_update_service_uses_calibration_repository_providers() -> None:
 
     assert service._qubit_repo is qubit_repo
     assert service._coupling_repo is coupling_repo
+
+
+def test_clear_dependency_caches_rebuilds_cached_providers() -> None:
+    _clear_dependency_caches()
+    first_service = dependencies.get_config_service()
+
+    dependencies.clear_dependency_caches()
+    second_service = dependencies.get_config_service()
+
+    assert second_service is not first_service


### PR DESCRIPTION
## Ticket
N/A

## Summary
- Adds a single helper for clearing cached API dependency providers, making tests and future reload hooks easier to keep isolated.
- API-only refactor; runtime behavior is unchanged unless the helper is explicitly called.

## Changes
- Adds clear_dependency_caches() to qdash.api.dependencies.
- Updates dependency provider tests to use the shared cache reset helper.
- Adds coverage that cached providers are rebuilt after reset.

Verification:
- uv run ruff check src/qdash/api/dependencies.py tests/qdash/api/test_dependencies.py
- uv run mypy src/qdash/api/dependencies.py tests/qdash/api/test_dependencies.py
- uv run pytest tests/qdash/api/test_dependencies.py