### PR TITLE
refactor(ui): proxy auth through http only session cookie

### DIFF
--- a/ui/src/app/api/[...path]/route.ts
+++ b/ui/src/app/api/[...path]/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const INTERNAL_API_URL = process.env.INTERNAL_API_URL || "http://127.0.0.1:5715";
+const ACCESS_TOKEN_COOKIE = "access_token";
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+type RouteContext = {
+  params: Promise<{
+    path?: string[];
+  }>;
+};
+
+function backendUrl(path: string[], search: string): string {
+  const pathname = path.join("/");
+  return `${INTERNAL_API_URL}/${pathname}${search}`;
+}
+
+function buildForwardHeaders(request: NextRequest): Headers {
+  const headers = new Headers();
+  const contentType = request.headers.get("content-type");
+  const accept = request.headers.get("accept");
+  const projectId = request.headers.get("x-project-id");
+  const token = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+
+  if (contentType) {
+    headers.set("Content-Type", contentType);
+  }
+  if (accept) {
+    headers.set("Accept", accept);
+  }
+  if (projectId) {
+    headers.set("X-Project-Id", projectId);
+  }
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  return headers;
+}
+
+function copyResponseHeaders(upstream: Response): Headers {
+  const headers = new Headers();
+  const contentType = upstream.headers.get("content-type");
+  if (contentType) {
+    headers.set("Content-Type", contentType);
+  }
+  return headers;
+}
+
+function setSessionCookie(response: NextResponse, token: string): void {
+  response.cookies.set({
+    name: ACCESS_TOKEN_COOKIE,
+    value: token,
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+}
+
+function clearSessionCookie(response: NextResponse): void {
+  response.cookies.set({
+    name: ACCESS_TOKEN_COOKIE,
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+}
+
+async function proxyRequest(request: NextRequest, context: RouteContext): Promise<Response> {
+  const { path = [] } = await context.params;
+  const url = backendUrl(path, request.nextUrl.search);
+  const method = request.method.toUpperCase();
+  const hasBody = method !== "GET" && method !== "HEAD";
+
+  const upstream = await fetch(url, {
+    method,
+    headers: buildForwardHeaders(request),
+    body: hasBody ? await request.arrayBuffer() : undefined,
+    cache: "no-store",
+  });
+
+  if (path.join("/") === "auth/login") {
+    const payload = await upstream.json();
+    const responsePayload = { ...payload };
+    const token =
+      typeof responsePayload.access_token === "string" ? responsePayload.access_token : null;
+    delete responsePayload.access_token;
+
+    const response = NextResponse.json(responsePayload, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+    });
+    if (upstream.ok && token) {
+      setSessionCookie(response, token);
+    }
+    return response;
+  }
+
+  const response = new NextResponse(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: copyResponseHeaders(upstream),
+  });
+
+  if (path.join("/") === "auth/logout") {
+    clearSessionCookie(response);
+  }
+
+  return response;
+}
+
+export const GET = proxyRequest;
+export const POST = proxyRequest;
+export const PUT = proxyRequest;
+export const PATCH = proxyRequest;
+export const DELETE = proxyRequest;

--- a/ui/src/app/api/[...path]/route.ts
+++ b/ui/src/app/api/[...path]/route.ts
@@ -70,10 +70,22 @@ function clearSessionCookie(response: NextResponse): void {
     path: "/",
     maxAge: 0,
   });
+  response.headers.append(
+    "Set-Cookie",
+    `${ACCESS_TOKEN_COOKIE}=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+  );
 }
 
 async function proxyRequest(request: NextRequest, context: RouteContext): Promise<Response> {
   const { path = [] } = await context.params;
+  const backendPath = path.join("/");
+
+  if (backendPath === "auth/logout") {
+    const response = NextResponse.json({ message: "Successfully logged out" });
+    clearSessionCookie(response);
+    return response;
+  }
+
   const url = backendUrl(path, request.nextUrl.search);
   const method = request.method.toUpperCase();
   const hasBody = method !== "GET" && method !== "HEAD";
@@ -85,7 +97,7 @@ async function proxyRequest(request: NextRequest, context: RouteContext): Promis
     cache: "no-store",
   });
 
-  if (path.join("/") === "auth/login") {
+  if (backendPath === "auth/login") {
     const payload = await upstream.json();
     const responsePayload = { ...payload };
     const token =
@@ -107,10 +119,6 @@ async function proxyRequest(request: NextRequest, context: RouteContext): Promis
     statusText: upstream.statusText,
     headers: copyResponseHeaders(upstream),
   });
-
-  if (path.join("/") === "auth/logout") {
-    clearSessionCookie(response);
-  }
 
   return response;
 }

--- a/ui/src/app/api/[...path]/route.ts
+++ b/ui/src/app/api/[...path]/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+import { ACCESS_TOKEN_COOKIE, clearSessionCookie } from "@/lib/auth/cookies";
+
 const INTERNAL_API_URL = process.env.INTERNAL_API_URL || "http://127.0.0.1:5715";
-const ACCESS_TOKEN_COOKIE = "access_token";
 const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
 
 type RouteContext = {
@@ -58,22 +59,6 @@ function setSessionCookie(response: NextResponse, token: string): void {
     path: "/",
     maxAge: SESSION_MAX_AGE_SECONDS,
   });
-}
-
-function clearSessionCookie(response: NextResponse): void {
-  response.cookies.set({
-    name: ACCESS_TOKEN_COOKIE,
-    value: "",
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 0,
-  });
-  response.headers.append(
-    "Set-Cookie",
-    `${ACCESS_TOKEN_COOKIE}=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
-  );
 }
 
 async function proxyRequest(request: NextRequest, context: RouteContext): Promise<Response> {

--- a/ui/src/app/api/copilot/proxy-stream.ts
+++ b/ui/src/app/api/copilot/proxy-stream.ts
@@ -7,6 +7,24 @@
  */
 
 const INTERNAL_API_URL = process.env.INTERNAL_API_URL || "http://127.0.0.1:5715";
+const ACCESS_TOKEN_COOKIE = "access_token";
+
+function readCookie(request: Request, name: string): string | null {
+  const cookie = request.headers.get("cookie");
+  if (!cookie) return null;
+
+  const value = cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${name}=`))
+    ?.split("=")[1];
+  if (!value) return null;
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Forward relevant headers from the incoming request to the backend.
@@ -16,9 +34,9 @@ function forwardHeaders(request: Request): Record<string, string> {
     "Content-Type": "application/json",
   };
 
-  const auth = request.headers.get("authorization");
-  if (auth) {
-    headers["Authorization"] = auth;
+  const token = readCookie(request, ACCESS_TOKEN_COOKIE);
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
   }
 
   const username = request.headers.get("x-username");

--- a/ui/src/app/logout/route.ts
+++ b/ui/src/app/logout/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+import { clearSessionCookie } from "@/lib/auth/cookies";
+
+export function GET(request: NextRequest): NextResponse {
+  const response = NextResponse.redirect(new URL("/login", request.url));
+  clearSessionCookie(response);
+  return response;
+}

--- a/ui/src/components/features/settings/ApiAccessTokenPanel.tsx
+++ b/ui/src/components/features/settings/ApiAccessTokenPanel.tsx
@@ -1,27 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Check, Copy, Eye, EyeOff, Info } from "lucide-react";
-
-import { useAuth } from "@/contexts/AuthContext";
+import { Check, Copy, Info } from "lucide-react";
 
 export function ApiAccessTokenPanel() {
-  const { accessToken } = useAuth();
-  const [copied, setCopied] = useState(false);
   const [copiedCurl, setCopiedCurl] = useState(false);
-  const [showToken, setShowToken] = useState(false);
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:5715";
 
-  const handleCopyToken = async () => {
-    if (!accessToken) return;
-    await navigator.clipboard.writeText(accessToken);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
   const handleCopyCurl = async () => {
-    const token = accessToken || "<your-token>";
-    const curlCommand = `curl -H "Authorization: Bearer ${token}" ${apiUrl}/auth/me`;
+    const curlCommand = `curl -H "Authorization: Bearer <your-api-token>" ${apiUrl}/auth/me`;
     await navigator.clipboard.writeText(curlCommand);
     setCopiedCurl(true);
     setTimeout(() => setCopiedCurl(false), 2000);
@@ -34,36 +21,13 @@ export function ApiAccessTokenPanel() {
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-3">
             <p className="text-sm text-base-content/70">
-              Use this token to authenticate API requests. Include it in the Authorization header:
+              Browser sessions are stored in an HttpOnly cookie and are not exposed here. For
+              external API access, use a dedicated API token and include it in the Authorization
+              header:
             </p>
             <code className="rounded-lg bg-base-300 p-3 text-sm">
-              Authorization: Bearer {"<your-token>"}
+              Authorization: Bearer {"<your-api-token>"}
             </code>
-          </div>
-
-          <div className="flex flex-col gap-3">
-            <label className="text-sm font-medium">Your Access Token</label>
-            <div className="flex flex-col gap-2">
-              <input
-                type={showToken ? "text" : "password"}
-                value={accessToken || ""}
-                readOnly
-                className="input input-bordered w-full font-mono text-sm"
-              />
-              <div className="flex gap-2">
-                <button className="btn btn-sm flex-1" onClick={() => setShowToken(!showToken)}>
-                  {showToken ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  <span className="hidden sm:inline">{showToken ? "Hide" : "Show"}</span>
-                </button>
-                <button
-                  className={`btn btn-sm flex-1 ${copied ? "btn-success" : "btn-primary"}`}
-                  onClick={handleCopyToken}
-                >
-                  {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                  <span className="hidden sm:inline">{copied ? "Copied!" : "Copy"}</span>
-                </button>
-              </div>
-            </div>
           </div>
 
           <div className="flex flex-col gap-3">
@@ -71,10 +35,7 @@ export function ApiAccessTokenPanel() {
             <div className="relative">
               <div className="mockup-code overflow-x-auto text-xs sm:text-sm">
                 <pre className="whitespace-pre-wrap break-all sm:whitespace-pre sm:break-normal">
-                  <code>
-                    curl -H "Authorization: Bearer{" "}
-                    {showToken && accessToken ? accessToken : "<your-token>"}" \
-                  </code>
+                  <code>curl -H "Authorization: Bearer {"<your-api-token>"}" \</code>
                 </pre>
                 <pre>
                   <code> {apiUrl}/auth/me</code>
@@ -97,7 +58,8 @@ export function ApiAccessTokenPanel() {
             <div>
               <p className="font-medium">Keep your token secure</p>
               <p className="text-sm">
-                This token provides full access to your account. Do not share it publicly.
+                API tokens provide account access. Do not store them in browser localStorage or
+                commit them to source control.
               </p>
             </div>
           </div>

--- a/ui/src/components/layout/Sidebar/index.tsx
+++ b/ui/src/components/layout/Sidebar/index.tsx
@@ -160,20 +160,12 @@ export function Sidebar() {
   const modalRef = useRef<HTMLDialogElement>(null);
   const { isOpen, isMobileOpen, toggleSidebar, setMobileSidebarOpen } = useSidebar();
   const { canEdit } = useProject();
-  const { user, logout: authLogout } = useAuth();
+  const { user } = useAuth();
   const { theme, setTheme } = useTheme();
   const { data: unreadNotificationsResponse } = useUnreadNotificationCount();
   const unreadNotifications = unreadNotificationsResponse?.data.unread_count ?? 0;
   const isAdmin = user?.system_role === "admin";
   const isDarkTheme = DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
-
-  const handleLogout = useCallback(async () => {
-    try {
-      await authLogout();
-    } catch (error) {
-      console.error("Logout failed:", error);
-    }
-  }, [authLogout]);
 
   const openProfileModal = useCallback(() => {
     if (modalRef.current) {
@@ -192,11 +184,6 @@ export function Sidebar() {
     }
     router.push("/settings");
   }, [isMobileOpen, setMobileSidebarOpen, router]);
-
-  const handleModalLogout = useCallback(async () => {
-    modalRef.current?.close();
-    await handleLogout();
-  }, [handleLogout]);
 
   // Close mobile sidebar when clicking a link
   const handleLinkClick = () => {
@@ -473,13 +460,10 @@ export function Sidebar() {
           </button>
 
           {/* Logout */}
-          <button
-            onClick={handleModalLogout}
-            className="btn btn-ghost w-full justify-start gap-3 h-12 text-error"
-          >
+          <Link href="/logout" className="btn btn-ghost w-full justify-start gap-3 h-12 text-error">
             <LogOut size={18} />
             <span>Logout</span>
-          </button>
+          </Link>
         </div>
       </div>
       <form method="dialog" className="modal-backdrop">

--- a/ui/src/components/layout/Sidebar/index.tsx
+++ b/ui/src/components/layout/Sidebar/index.tsx
@@ -39,7 +39,6 @@ import {
 import type { LucideIcon } from "lucide-react";
 
 import { useTheme } from "@/contexts/ThemeContext";
-import { useLogout } from "@/client/auth/auth";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
@@ -168,16 +167,13 @@ export function Sidebar() {
   const isAdmin = user?.system_role === "admin";
   const isDarkTheme = DARK_THEMES.includes(theme as (typeof DARK_THEMES)[number]);
 
-  const logoutMutation = useLogout();
   const handleLogout = useCallback(async () => {
     try {
-      await logoutMutation.mutateAsync();
-      authLogout();
-      router.push("/login");
+      await authLogout();
     } catch (error) {
       console.error("Logout failed:", error);
     }
-  }, [logoutMutation, authLogout, router]);
+  }, [authLogout]);
 
   const openProfileModal = useCallback(() => {
     if (modalRef.current) {

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -80,6 +80,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Handle errors
   useEffect(() => {
+    if (isPublicAuthRoute) {
+      return;
+    }
     if (userError) {
       if (isAuthenticationError(userError)) {
         removeAuth();
@@ -90,7 +93,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       setLoading(false);
     }
-  }, [userError, clearServerSession, removeAuth]);
+  }, [isPublicAuthRoute, userError, clearServerSession, removeAuth]);
 
   // Initialization
   useEffect(() => {

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import { createContext, useCallback, useContext, useState, useEffect } from "react";
 import Axios from "axios";
 import { useQueryClient } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
 
 import type { User } from "@/schemas";
 
@@ -31,6 +32,9 @@ function isAuthenticationError(error: unknown): boolean {
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
+  const pathname = usePathname();
+  const isPublicAuthRoute =
+    pathname === "/login" || pathname === "/signup" || pathname === "/logout";
   const [user, setUser] = useState<User | null>(null);
   const [username, setUsername] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -55,12 +59,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const loginMutation = useLogin();
 
   // Get user info
-  const {
-    data: userData,
-    error: userError,
-    refetch: refetchCurrentUser,
-  } = useGetCurrentUser({
+  const { data: userData, error: userError } = useGetCurrentUser({
     query: {
+      enabled: !isPublicAuthRoute,
       retry: false,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
@@ -93,10 +94,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Initialization
   useEffect(() => {
+    if (isPublicAuthRoute) {
+      setLoading(false);
+      return;
+    }
     if (userData || userError) {
       setLoading(false);
     }
-  }, [userData, userError]);
+  }, [isPublicAuthRoute, userData, userError]);
 
   const login = useCallback(
     async (username: string, password: string) => {
@@ -111,7 +116,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         // The API route stores the session token in an HttpOnly cookie.
         saveAuth(response.data.username);
-        await refetchCurrentUser();
       } catch (error) {
         console.error("Login failed:", error);
         // Clear auth info
@@ -122,7 +126,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setLoading(false); // End loading
       }
     },
-    [loginMutation, refetchCurrentUser, saveAuth, removeAuth],
+    [loginMutation, saveAuth, removeAuth],
   );
 
   const logout = useCallback(async () => {

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -7,11 +7,11 @@ import Axios from "axios";
 import type { User } from "@/schemas";
 
 import { useGetCurrentUser, useLogin, useLogout } from "@/client/auth/auth";
-import { getAccessToken } from "@/lib/auth/session";
 
 interface AuthContextType {
   user: User | null;
   username: string | null;
+  isAuthenticated: boolean;
   accessToken: string | null;
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
@@ -31,22 +31,22 @@ function isAuthenticationError(error: unknown): boolean {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [username, setUsername] = useState<string | null>(null);
-  const [accessToken, setAccessToken] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   // Save authentication info
-  const saveAuth = useCallback((token: string, user: string) => {
-    const maxAge = 365 * 24 * 60 * 60; // 1 year (long-term token)
-    document.cookie = `access_token=${encodeURIComponent(token)}; path=/; max-age=${maxAge}; SameSite=Lax`;
-    setAccessToken(token);
+  const saveAuth = useCallback((user: string) => {
     setUsername(user);
   }, []);
 
   // Remove authentication info
   const removeAuth = useCallback(() => {
-    document.cookie = "access_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax";
-    setAccessToken(null);
     setUsername(null);
+  }, []);
+
+  const clearServerSession = useCallback(() => {
+    void fetch("/api/auth/logout", { method: "POST" }).catch((error: unknown) => {
+      console.warn("Failed to clear server session:", error);
+    });
   }, []);
 
   // Login mutation
@@ -56,9 +56,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logoutMutation = useLogout();
 
   // Get user info
-  const { data: userData, error: userError } = useGetCurrentUser({
+  const {
+    data: userData,
+    error: userError,
+    refetch: refetchCurrentUser,
+  } = useGetCurrentUser({
     query: {
-      enabled: !!accessToken,
       retry: false,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
@@ -71,29 +74,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (userData?.data) {
       setUser(userData.data);
       setUsername(userData.data.username);
+      setLoading(false);
     }
   }, [userData]);
 
   // Handle errors
   useEffect(() => {
     if (userError) {
-      console.error("Failed to fetch user info:", userError);
       if (isAuthenticationError(userError)) {
         removeAuth();
+        clearServerSession();
         setUser(null);
+      } else {
+        console.error("Failed to fetch user info:", userError);
       }
+      setLoading(false);
     }
-  }, [userError, removeAuth]);
+  }, [userError, clearServerSession, removeAuth]);
 
   // Initialization
   useEffect(() => {
-    const token = getAccessToken();
-
-    if (token) {
-      setAccessToken(token);
+    if (userData || userError) {
+      setLoading(false);
     }
-    setLoading(false);
-  }, [removeAuth]);
+  }, [userData, userError]);
 
   const login = useCallback(
     async (username: string, password: string) => {
@@ -106,8 +110,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           },
         });
 
-        // Save auth info (access_token and username)
-        saveAuth(response.data.access_token, response.data.username);
+        // The API route stores the session token in an HttpOnly cookie.
+        saveAuth(response.data.username);
+        await refetchCurrentUser();
       } catch (error) {
         console.error("Login failed:", error);
         // Clear auth info
@@ -118,7 +123,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setLoading(false); // End loading
       }
     },
-    [loginMutation, saveAuth, removeAuth],
+    [loginMutation, refetchCurrentUser, saveAuth, removeAuth],
   );
 
   const logout = useCallback(async () => {
@@ -143,7 +148,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [logoutMutation, removeAuth, loginMutation]);
 
   return (
-    <AuthContext.Provider value={{ user, username, accessToken, login, logout, loading }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        username,
+        isAuthenticated: !!user,
+        accessToken: null,
+        login,
+        logout,
+        loading,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -3,10 +3,11 @@
 import type { ReactNode } from "react";
 import { createContext, useCallback, useContext, useState, useEffect } from "react";
 import Axios from "axios";
+import { useQueryClient } from "@tanstack/react-query";
 
 import type { User } from "@/schemas";
 
-import { useGetCurrentUser, useLogin, useLogout } from "@/client/auth/auth";
+import { useGetCurrentUser, useLogin } from "@/client/auth/auth";
 
 interface AuthContextType {
   user: User | null;
@@ -29,6 +30,7 @@ function isAuthenticationError(error: unknown): boolean {
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
   const [user, setUser] = useState<User | null>(null);
   const [username, setUsername] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -51,9 +53,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Login mutation
   const loginMutation = useLogin();
-
-  // Logout mutation
-  const logoutMutation = useLogout();
 
   // Get user info
   const {
@@ -128,10 +127,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(async () => {
     try {
-      // Call logout API first
-      await logoutMutation.mutateAsync();
-      // Clear cache
-      await Promise.all([loginMutation.reset(), logoutMutation.reset()]);
+      await fetch("/api/auth/logout", {
+        method: "POST",
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+      await queryClient.clear();
+      loginMutation.reset();
       // Clear state
       setUser(null);
       // Remove auth info (middleware will handle redirect automatically)
@@ -145,7 +147,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       removeAuth();
       window.location.href = "/login";
     }
-  }, [logoutMutation, removeAuth, loginMutation]);
+  }, [loginMutation, queryClient, removeAuth]);
 
   return (
     <AuthContext.Provider

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -139,13 +139,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // Remove auth info (middleware will handle redirect automatically)
       removeAuth();
       // Explicitly navigate to login page
-      window.location.href = "/login";
+      window.location.href = "/logout";
     } catch (error) {
       console.error("Logout failed:", error);
       // Same handling on error
       setUser(null);
       removeAuth();
-      window.location.href = "/login";
+      window.location.href = "/logout";
     }
   }, [loginMutation, queryClient, removeAuth]);
 

--- a/ui/src/contexts/AuthContext.tsx
+++ b/ui/src/contexts/AuthContext.tsx
@@ -14,7 +14,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   accessToken: string | null;
   login: (username: string, password: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   loading: boolean;
 }
 

--- a/ui/src/contexts/ProjectContext.tsx
+++ b/ui/src/contexts/ProjectContext.tsx
@@ -40,7 +40,7 @@ const ProjectContext = createContext<ProjectContextType | undefined>(undefined);
 const PROJECT_STORAGE_KEY = "qdash_current_project_id";
 
 export function ProjectProvider({ children }: { children: ReactNode }) {
-  const { user, accessToken } = useAuth();
+  const { user, isAuthenticated } = useAuth();
   const queryClient = useQueryClient();
   const pathname = usePathname();
   const [urlProjectId, setUrlProjectId] = useState<string | null>(null);
@@ -55,14 +55,14 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
     refetch,
   } = useListProjects({
     query: {
-      enabled: !!accessToken,
+      enabled: isAuthenticated,
       retry: false,
     },
   });
 
   const { data: membersData } = useListProjectMembers(projectId ?? "", {
     query: {
-      enabled: !!projectId && !!accessToken,
+      enabled: !!projectId && isAuthenticated,
       retry: false,
     },
   });
@@ -174,7 +174,7 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
   ]);
 
   useEffect(() => {
-    if (!accessToken) {
+    if (!isAuthenticated) {
       setCurrentProject(null);
       setProjectId(null);
       setRole(null);
@@ -189,7 +189,7 @@ export function ProjectProvider({ children }: { children: ReactNode }) {
     setRole(null);
     localStorage.removeItem(PROJECT_STORAGE_KEY);
     clearProjectFromUrl();
-  }, [accessToken, clearProjectFromUrl, isLoading, projects.length, urlProjectInitialized]);
+  }, [isAuthenticated, clearProjectFromUrl, isLoading, projects.length, urlProjectInitialized]);
 
   const switchProject = useCallback(
     (newProjectId: string) => {

--- a/ui/src/lib/api/custom-instance.ts
+++ b/ui/src/lib/api/custom-instance.ts
@@ -2,7 +2,7 @@ import Axios, { AxiosHeaders } from "axios";
 
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 
-import { getAccessToken, getProjectId } from "@/lib/auth/session";
+import { getProjectId } from "@/lib/auth/session";
 
 export const AXIOS_INSTANCE = Axios.create({
   // Use /api proxy route (handled by Next.js rewrites)
@@ -12,18 +12,14 @@ export const AXIOS_INSTANCE = Axios.create({
 
 // Add request interceptor
 AXIOS_INSTANCE.interceptors.request.use((config) => {
-  const token = getAccessToken();
+  const projectId = getProjectId();
 
-  if (token) {
+  if (projectId) {
     if (!config.headers) {
       config.headers = new AxiosHeaders();
     }
     if (config.headers instanceof AxiosHeaders) {
-      config.headers.set("Authorization", `Bearer ${token}`);
-      const projectId = getProjectId();
-      if (projectId) {
-        config.headers.set("X-Project-Id", projectId);
-      }
+      config.headers.set("X-Project-Id", projectId);
     }
   }
 

--- a/ui/src/lib/api/custom-instance.ts
+++ b/ui/src/lib/api/custom-instance.ts
@@ -5,9 +5,9 @@ import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import { getProjectId } from "@/lib/auth/session";
 
 export const AXIOS_INSTANCE = Axios.create({
-  // Use /api proxy route (handled by Next.js rewrites)
-  // Falls back to direct API URL for backward compatibility
-  baseURL: process.env.NEXT_PUBLIC_API_URL || "/api",
+  // Browser API calls must go through the Next.js route handler so HttpOnly
+  // session cookies can be translated into backend Authorization headers.
+  baseURL: "/api",
 });
 
 // Add request interceptor

--- a/ui/src/lib/auth/__tests__/session.test.ts
+++ b/ui/src/lib/auth/__tests__/session.test.ts
@@ -13,10 +13,10 @@ describe("session helpers", () => {
     localStorage.clear();
   });
 
-  it("reads the access token cookie", () => {
+  it("does not expose the access token to client code", () => {
     document.cookie = "access_token=token-value; path=/";
 
-    expect(getAccessToken()).toBe("token-value");
+    expect(getAccessToken()).toBeNull();
   });
 
   it("returns null when the access token cookie is missing", () => {
@@ -29,13 +29,12 @@ describe("session helpers", () => {
     expect(getProjectId()).toBe("project-1");
   });
 
-  it("builds auth headers from token and project context", () => {
+  it("builds project context headers without bearer tokens", () => {
     document.cookie = "access_token=encoded%20token; path=/";
     localStorage.setItem("qdash_current_project_id", "project-1");
 
     expect(buildAuthHeaders()).toEqual({
       "Content-Type": "application/json",
-      Authorization: "Bearer encoded token",
       "X-Project-Id": "project-1",
     });
   });

--- a/ui/src/lib/auth/cookies.ts
+++ b/ui/src/lib/auth/cookies.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+export const ACCESS_TOKEN_COOKIE = "access_token";
+
+export function clearSessionCookie(response: NextResponse): void {
+  response.cookies.set({
+    name: ACCESS_TOKEN_COOKIE,
+    value: "",
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+  response.headers.append(
+    "Set-Cookie",
+    `${ACCESS_TOKEN_COOKIE}=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`,
+  );
+}

--- a/ui/src/lib/auth/session.ts
+++ b/ui/src/lib/auth/session.ts
@@ -1,29 +1,7 @@
-const ACCESS_TOKEN_COOKIE = "access_token";
 const PROJECT_STORAGE_KEY = "qdash_current_project_id";
 
-function readCookie(name: string): string | null {
-  if (typeof document === "undefined") {
-    return null;
-  }
-
-  const cookie = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith(`${name}=`))
-    ?.split("=")[1];
-
-  if (!cookie) {
-    return null;
-  }
-
-  try {
-    return decodeURIComponent(cookie);
-  } catch {
-    return null;
-  }
-}
-
 export function getAccessToken(): string | null {
-  return readCookie(ACCESS_TOKEN_COOKIE);
+  return null;
 }
 
 export function getProjectId(): string | null {
@@ -37,11 +15,6 @@ export function buildAuthHeaders(): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
-
-  const accessToken = getAccessToken();
-  if (accessToken) {
-    headers.Authorization = `Bearer ${accessToken}`;
-  }
 
   const projectId = getProjectId();
   if (projectId) {


### PR DESCRIPTION
## Ticket

N/A

## Summary

Move browser authentication token handling behind a Next.js server-side proxy so client JavaScript no longer reads or forwards bearer tokens directly.

## Changes

- Add a Next.js `/api/[...path]` route handler that forwards API requests to FastAPI and attaches `Authorization` from an HttpOnly session cookie server side
- Store login tokens in an HttpOnly, SameSite=Lax session cookie and remove the token from the browser-visible login response
- Clear the session cookie through the logout proxy and on invalid session detection
- Remove client-side access token reads and bearer header injection from UI API helpers
- Update Copilot SSE proxy and settings API token guidance for the HttpOnly session model

## Verification

- `bun run fmt:check`
- `bun run lint`
- `bunx tsc --noEmit`
- `bun run test:run src/lib/auth/__tests__/session.test.ts`
- `bun run build`
