### PR TITLE
feat(modals): add selectedDate prop to CouplingTaskHistoryModal and T…

### DIFF
--- a/ui/src/components/features/chip/CouplingGrid.tsx
+++ b/ui/src/components/features/chip/CouplingGrid.tsx
@@ -1162,6 +1162,7 @@ export function CouplingGrid({
         taskName={selectedTaskInfo?.taskName || ""}
         isOpen={!!selectedTaskInfo}
         onClose={() => setSelectedTaskInfo(null)}
+        selectedDate={selectedDate}
       />
     </div>
   );

--- a/ui/src/components/features/chip/QubitGrid.tsx
+++ b/ui/src/components/features/chip/QubitGrid.tsx
@@ -1155,6 +1155,7 @@ export function QubitGrid({
         taskName={selectedTaskInfo?.taskName || ""}
         isOpen={!!selectedTaskInfo}
         onClose={() => setSelectedTaskInfo(null)}
+        selectedDate={selectedDate}
       />
     </div>
   );

--- a/ui/src/components/features/chip/modals/CouplingTaskHistoryModal.tsx
+++ b/ui/src/components/features/chip/modals/CouplingTaskHistoryModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useState, useMemo, useCallback } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { useQueryClient } from "@tanstack/react-query";
 import { ChevronRight, History, FileText, GitBranch, Bot } from "lucide-react";
@@ -33,6 +33,7 @@ interface CouplingTaskHistoryModalProps {
   taskName: string;
   isOpen: boolean;
   onClose: () => void;
+  selectedDate?: string;
 }
 
 type MobileTab = "history" | "details";
@@ -43,6 +44,7 @@ export function CouplingTaskHistoryModal({
   taskName,
   isOpen,
   onClose,
+  selectedDate,
 }: CouplingTaskHistoryModalProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [viewMode, setViewMode] = useState<"static" | "interactive">("static");
@@ -113,13 +115,31 @@ export function CouplingTaskHistoryModal({
     },
   );
 
-  const historyArray = Object.entries(data?.data?.data || {})
-    .map(([key, task]) => ({ key, task: task as Task }))
-    .sort((a, b) => {
-      const dateA = a.task.end_at ? new Date(a.task.end_at).getTime() : 0;
-      const dateB = b.task.end_at ? new Date(b.task.end_at).getTime() : 0;
-      return dateB - dateA;
+  const historyArray = useMemo(
+    () =>
+      Object.entries(data?.data?.data || {})
+        .map(([key, task]) => ({ key, task: task as Task }))
+        .sort((a, b) => {
+          const dateA = a.task.end_at ? new Date(a.task.end_at).getTime() : 0;
+          const dateB = b.task.end_at ? new Date(b.task.end_at).getTime() : 0;
+          return dateB - dateA;
+        }),
+    [data],
+  );
+
+  React.useEffect(() => {
+    if (!isOpen || historyArray.length === 0) return;
+    if (!selectedDate || selectedDate === "latest") {
+      setSelectedIndex(0);
+      return;
+    }
+    const idx = historyArray.findIndex((item) => {
+      if (!item.task.end_at) return false;
+      const dateStr = formatDateTime(item.task.end_at, "yyyyMMdd");
+      return dateStr === selectedDate;
     });
+    setSelectedIndex(idx >= 0 ? idx : 0);
+  }, [isOpen, historyArray, selectedDate]);
 
   const selectedItem = historyArray[selectedIndex];
   const selectedTask = selectedItem?.task;

--- a/ui/src/components/features/chip/modals/TaskHistoryModal.tsx
+++ b/ui/src/components/features/chip/modals/TaskHistoryModal.tsx
@@ -28,6 +28,7 @@ interface TaskHistoryModalProps {
   taskName: string;
   isOpen: boolean;
   onClose: () => void;
+  selectedDate?: string;
 }
 
 type MobileTab = "history" | "details";
@@ -38,6 +39,7 @@ export function TaskHistoryModal({
   taskName,
   isOpen,
   onClose,
+  selectedDate,
 }: TaskHistoryModalProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [mobileTab, setMobileTab] = useState<MobileTab>("history");
@@ -122,13 +124,31 @@ export function TaskHistoryModal({
     },
   );
 
-  const historyArray = Object.entries(data?.data?.data || {})
-    .map(([key, task]) => ({ key, task: task as Task }))
-    .sort((a, b) => {
-      const dateA = a.task.end_at ? new Date(a.task.end_at).getTime() : 0;
-      const dateB = b.task.end_at ? new Date(b.task.end_at).getTime() : 0;
-      return dateB - dateA;
+  const historyArray = useMemo(
+    () =>
+      Object.entries(data?.data?.data || {})
+        .map(([key, task]) => ({ key, task: task as Task }))
+        .sort((a, b) => {
+          const dateA = a.task.end_at ? new Date(a.task.end_at).getTime() : 0;
+          const dateB = b.task.end_at ? new Date(b.task.end_at).getTime() : 0;
+          return dateB - dateA;
+        }),
+    [data],
+  );
+
+  React.useEffect(() => {
+    if (!isOpen || historyArray.length === 0) return;
+    if (!selectedDate || selectedDate === "latest") {
+      setSelectedIndex(0);
+      return;
+    }
+    const idx = historyArray.findIndex((item) => {
+      if (!item.task.end_at) return false;
+      const dateStr = formatDateTime(item.task.end_at, "yyyyMMdd");
+      return dateStr === selectedDate;
     });
+    setSelectedIndex(idx >= 0 ? idx : 0);
+  }, [isOpen, historyArray, selectedDate]);
 
   const selectedItem = historyArray[selectedIndex];
   const selectedTask = selectedItem?.task;


### PR DESCRIPTION
## Ticket

close #800

## Summary

When a specific date is selected on the Experiments page, the task history modals now automatically scroll to the matching date entry instead of always showing the latest result.

## Changes

- Add `selectedDate` prop to `TaskHistoryModal` and `CouplingTaskHistoryModal`
- Auto-select the history entry matching the chosen date via `useEffect`
- Wrap `historyArray` computation in `useMemo` for performance
- Pass `selectedDate` from `QubitGrid` and `CouplingGrid` to the modals
- Reuse `_save_qubex` for fake backend in `BackendSaver` to persist simulation results