### PR TITLE
feat(infra): enhance reverse proxy and local port configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,14 @@
-ENV="dev-fake-qdash"
+ENV="dev-fake"
 # Set COMPOSE_PROJECT_NAME explicitly when running multiple QDash instances
 # from different directories on the same server.
 # COMPOSE_PROJECT_NAME=dev-fake-qdash
+QDASH_INSTANCE=dev-fake-qdash
 # SUBNET=""
 # GATEWAY=""
 DEFAULT_BACKEND="fake"
 
-# Local instance defaults to ENV. task assign-local-ports derives ports,
-# Compose project name, and reverse-proxy hostnames from it.
+# QDASH_INSTANCE defaults to ${ENV}-qdash. task assign-local-ports derives
+# ports, Compose project name, and reverse-proxy hostnames from these values.
 
 # Ports
 # task deploy publishes only the reverse proxy on 127.0.0.1:${PROXY_PORT}
@@ -25,11 +26,15 @@ DEPLOYMENT_SERVICE_PORT=8001
 
 
 # URLs
-CLIENT_URL=http://${ENV}.localhost:${PROXY_PORT}
+QDASH_LOCAL_DOMAIN=qdash.test
+CLIENT_URL=http://${QDASH_INSTANCE}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}
 NEXT_PUBLIC_API_URL=/api
-NEXT_PUBLIC_PREFECT_URL=http://prefect.${ENV}.localhost:${PROXY_PORT}
-# Defaults to ${ENV}.localhost in task deploy when unset.
-# QDASH_LOCAL_HOST=dev-fake-qdash.localhost
+NEXT_PUBLIC_PREFECT_URL=http://prefect.${QDASH_INSTANCE}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}
+# Defaults to ${QDASH_INSTANCE}.${QDASH_LOCAL_DOMAIN} in task deploy when unset.
+# Configure local wildcard DNS so *.${QDASH_LOCAL_DOMAIN} resolves to 127.0.0.1.
+# task assign-local-ports derives CLIENT_URL, NEXT_PUBLIC_PREFECT_URL, and
+# QDASH_LOCAL_HOST from QDASH_INSTANCE, QDASH_LOCAL_DOMAIN, and PROXY_PORT.
+# QDASH_LOCAL_HOST=dev-fake-qdash.qdash.test
 QDASH_UI_UPSTREAM=ui:5714
 QDASH_API_UPSTREAM=api:5715
 # Comma-separated hostnames allowed to access the Next.js dev server, e.g. 192.168.0.4

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -100,7 +100,7 @@ tasks:
     desc: Start only the services needed by host-side API/UI development
     dotenv: [.env]
     cmds:
-      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${ENV:-qdash}.localhost}" QDASH_UI_UPSTREAM="host.docker.internal:${UI_PORT:-5714}" QDASH_API_UPSTREAM="host.docker.internal:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.local.yaml up -d mongo postgres prefect-server deployment-service user-flow-worker reverse-proxy
+      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-qdash}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}" QDASH_UI_UPSTREAM="host.docker.internal:${UI_PORT:-5714}" QDASH_API_UPSTREAM="host.docker.internal:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.local.yaml up -d mongo postgres prefect-server deployment-service user-flow-worker reverse-proxy
 
   dev-local-setup:
     desc: Install dependencies needed by host-side API/UI development
@@ -114,14 +114,14 @@ tasks:
     desc: Start the API on the host against Docker services
     dotenv: [.env]
     cmds:
-      - MONGO_HOST="${MONGO_HOST:-localhost}" CLIENT_URL="http://${ENV:-dev-fake-qdash}.localhost:${PROXY_PORT:-18080}" PREFECT_API_URL="http://127.0.0.1:${PREFECT_PORT:-4200}/api" DEPLOYMENT_SERVICE_URL="http://127.0.0.1:${DEPLOYMENT_SERVICE_PORT:-4006}" uv run uvicorn src.qdash.api.main:app --reload --host 127.0.0.1 --port "${API_PORT:-5715}"
+      - MONGO_HOST="${MONGO_HOST:-localhost}" CLIENT_URL="http://${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-dev-fake}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}:${PROXY_PORT:-18080}" PREFECT_API_URL="http://127.0.0.1:${PREFECT_PORT:-4200}/api" DEPLOYMENT_SERVICE_URL="http://127.0.0.1:${DEPLOYMENT_SERVICE_PORT:-4006}" uv run uvicorn src.qdash.api.main:app --reload --host 127.0.0.1 --port "${API_PORT:-5715}"
 
   dev-ui-local:
     desc: Start the UI on the host against the local API
     dir: ui
     dotenv: [../.env]
     cmds:
-      - PORT="${UI_PORT:-5714}" INTERNAL_API_URL="http://127.0.0.1:${API_PORT:-5715}" NEXT_PUBLIC_PREFECT_URL="http://prefect.${ENV:-dev-fake-qdash}.localhost:${PROXY_PORT:-18080}" bun run dev
+      - PORT="${UI_PORT:-5714}" INTERNAL_API_URL="http://127.0.0.1:${API_PORT:-5715}" NEXT_PUBLIC_PREFECT_URL="http://prefect.${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-dev-fake}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}:${PROXY_PORT:-18080}" bun run dev
 
   dev-local:
     desc: Start lightweight local development services, API, and UI
@@ -385,7 +385,7 @@ tasks:
     cmds:
       - task: knowledge-pull
       - scripts/check_deploy_env.sh
-      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${ENV:-qdash}.localhost}" QDASH_UI_UPSTREAM="ui:${UI_PORT:-5714}" QDASH_API_UPSTREAM="api:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.forward.yaml --profile tunnel up -d --build
+      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-qdash}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}" QDASH_UI_UPSTREAM="ui:${UI_PORT:-5714}" QDASH_API_UPSTREAM="api:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.forward.yaml --profile tunnel up -d --build
       - sleep 3
-      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${ENV:-qdash}.localhost}" QDASH_UI_UPSTREAM="ui:${UI_PORT:-5714}" QDASH_API_UPSTREAM="api:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.forward.yaml restart api
+      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-qdash}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}" QDASH_UI_UPSTREAM="ui:${UI_PORT:-5714}" QDASH_API_UPSTREAM="api:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.forward.yaml restart api
     desc: Deploy with Cloudflare Tunnel and localhost-only reverse proxy for SSH forwarding

--- a/config/proxy/Caddyfile
+++ b/config/proxy/Caddyfile
@@ -2,7 +2,7 @@
 	auto_https off
 }
 
-http://{$QDASH_HOST:qdash.localhost}, http://{$QDASH_LOCAL_HOST:qdash.localhost} {
+http://{$QDASH_HOST:qdash.qdash.test}, http://{$QDASH_LOCAL_HOST:qdash.qdash.test} {
 	handle /api/* {
 		reverse_proxy {$QDASH_API_UPSTREAM:api:5715}
 	}
@@ -12,14 +12,14 @@ http://{$QDASH_HOST:qdash.localhost}, http://{$QDASH_LOCAL_HOST:qdash.localhost}
 	}
 }
 
-http://{$QDASH_API_HOST:api.qdash.localhost} {
+http://{$QDASH_API_HOST:api.qdash.qdash.test} {
 	reverse_proxy {$QDASH_API_UPSTREAM:api:5715}
 }
 
-http://{$QDASH_PREFECT_HOST:prefect.qdash.localhost} {
+http://{$QDASH_PREFECT_HOST:prefect.qdash.qdash.test} {
 	reverse_proxy prefect-server:4200
 }
 
-http://{$QDASH_MONGO_HOST:mongo.qdash.localhost} {
+http://{$QDASH_MONGO_HOST:mongo.qdash.qdash.test} {
 	reverse_proxy mongo-express:8081
 }

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -110,7 +110,7 @@ task dev-local
 
 This starts MongoDB, PostgreSQL, Prefect, the deployment service, and the user flow worker with
 Docker Compose, then runs the API and UI on the host. The UI is available through the reverse proxy
-at `http://dev-fake-qdash.localhost:${PROXY_PORT}`.
+at `http://dev-fake-qdash.qdash.test:${PROXY_PORT}`.
 
 ### Install Dependencies
 
@@ -164,17 +164,18 @@ automatically:
 task deploy-local
 ```
 
-`QDASH_INSTANCE` defaults to `ENV`, so the default `.env` uses the `dev-fake-qdash` namespace
-from `ENV="dev-fake-qdash"`. Set `QDASH_INSTANCE` only when the local instance name should differ from
-`ENV`. The assignment task derives `COMPOSE_PROJECT_NAME`, reverse-proxy hostnames, service ports,
-and public URLs from that instance name. Existing assigned ports are kept on later deploys for the
-same instance.
+`ENV` is the short application environment label. `QDASH_INSTANCE` defaults to `${ENV}-qdash` and is
+used for the Compose project name and local hostnames. The default `.env` uses `ENV="dev-fake"` and
+`QDASH_INSTANCE=dev-fake-qdash`, so Docker resources and local URLs share the same instance name.
+The assignment task derives `COMPOSE_PROJECT_NAME`, reverse-proxy hostnames, service ports, and
+public URLs from these values. Existing assigned ports are kept on later deploys for the same
+instance.
 
-The Compose stack includes a Caddy reverse proxy. For `ENV="dev-fake-qdash"`, the proxied URLs
-are `http://dev-fake-qdash.localhost:${PROXY_PORT}`,
-`http://api.dev-fake-qdash.localhost:${PROXY_PORT}`,
-`http://prefect.dev-fake-qdash.localhost:${PROXY_PORT}`, and
-`http://mongo.dev-fake-qdash.localhost:${PROXY_PORT}`. These URLs work for both `task dev-local` and
+The Compose stack includes a Caddy reverse proxy. For `QDASH_INSTANCE="dev-fake-qdash"`, the proxied
+URLs are `http://dev-fake-qdash.qdash.test:${PROXY_PORT}`,
+`http://api.dev-fake-qdash.qdash.test:${PROXY_PORT}`,
+`http://prefect.dev-fake-qdash.qdash.test:${PROXY_PORT}`, and
+`http://mongo.dev-fake-qdash.qdash.test:${PROXY_PORT}`. These URLs work for both `task dev-local` and
 `task deploy-local`; the direct service ports remain available in these local tasks for tools that
 connect to MongoDB, PostgreSQL, or the API directly. `task deploy` does not publish these service
 ports; Cloudflare Tunnel reaches the reverse proxy through Docker networking at
@@ -183,15 +184,29 @@ ports; Cloudflare Tunnel reaches the reverse proxy through Docker networking at
 The main UI hostname also proxies `/api/*` to the API, so frontend traffic can stay on one origin.
 
 For server environments that should also be reachable through SSH port forwarding, set
-`QDASH_LOCAL_HOST` only when the local alias should differ from `${ENV}.localhost`. `task deploy`
-keeps the Cloudflare Tunnel setup and publishes only the reverse proxy on
+`QDASH_LOCAL_DOMAIN` once for the local wildcard DNS zone. `QDASH_LOCAL_HOST` defaults to
+`${QDASH_INSTANCE}.${QDASH_LOCAL_DOMAIN}` and only needs to be set when the local alias should differ
+from that pattern. `task deploy` keeps the Cloudflare Tunnel setup and publishes only the reverse proxy on
 `127.0.0.1:${PROXY_PORT}`. Forward it from the workstation with a matching local port:
 
 ```shell
 ssh -L 18080:127.0.0.1:18080 anemone
 ```
 
-Then open `http://${ENV}.localhost:18080`.
+Then open `http://${QDASH_INSTANCE}.qdash.test:18080`.
+Configure local wildcard DNS once so `*.${QDASH_LOCAL_DOMAIN}` resolves to `127.0.0.1`; this avoids per-host
+`/etc/hosts` entries and does not depend on public DNS.
+
+On macOS with Homebrew:
+
+```shell
+brew install dnsmasq
+mkdir -p "$(brew --prefix)/etc/dnsmasq.d"
+echo 'address=/.qdash.test/127.0.0.1' | sudo tee "$(brew --prefix)/etc/dnsmasq.d/qdash.conf"
+sudo mkdir -p /etc/resolver
+echo 'nameserver 127.0.0.1' | sudo tee /etc/resolver/qdash.test
+sudo brew services start dnsmasq
+```
 
 When running multiple QDash environments on one server, keep the Docker Compose project name,
 forwarded proxy port, local alias, public hostname, and data paths unique for each environment. The
@@ -200,20 +215,24 @@ not published directly by `task deploy`.
 
 ```env
 # qdash-dev
-ENV=dev-qdash
+ENV=dev
+QDASH_INSTANCE=dev-qdash
 COMPOSE_PROJECT_NAME=dev-qdash
+QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-dev.qiqb.dev
-QDASH_LOCAL_HOST=dev-qdash.localhost
+QDASH_LOCAL_HOST=dev-qdash.qdash.test
 CLIENT_URL=https://qdash-dev.qiqb.dev
 PROXY_PORT=18080
 POSTGRES_DATA_PATH=./postgres_data_dev
 MONGO_DATA_PATH=./mongo_data_dev/data/db
 
 # qdash-stg
-ENV=stg-qdash
+ENV=stg
+QDASH_INSTANCE=stg-qdash
 COMPOSE_PROJECT_NAME=stg-qdash
+QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-stg.qiqb.dev
-QDASH_LOCAL_HOST=stg-qdash.localhost
+QDASH_LOCAL_HOST=stg-qdash.qdash.test
 CLIENT_URL=https://qdash-stg.qiqb.dev
 PROXY_PORT=18081
 POSTGRES_DATA_PATH=./postgres_data_stg
@@ -230,10 +249,10 @@ ssh -L 18080:127.0.0.1:18080 -L 18081:127.0.0.1:18081 anemone
 
 | Service           | URL                                             |
 | ----------------- | ----------------------------------------------- |
-| QDash UI          | `http://${ENV}.localhost:${PROXY_PORT}`         |
-| API Documentation | `http://api.${ENV}.localhost:${PROXY_PORT}/docs` |
-| Prefect Dashboard | `http://prefect.${ENV}.localhost:${PROXY_PORT}` |
-| MongoDB Admin     | `http://mongo.${ENV}.localhost:${PROXY_PORT}`   |
+| QDash UI          | `http://${QDASH_INSTANCE}.qdash.test:${PROXY_PORT}`         |
+| API Documentation | `http://api.${QDASH_INSTANCE}.qdash.test:${PROXY_PORT}/docs` |
+| Prefect Dashboard | `http://prefect.${QDASH_INSTANCE}.qdash.test:${PROXY_PORT}` |
+| MongoDB Admin     | `http://mongo.${QDASH_INSTANCE}.qdash.test:${PROXY_PORT}`   |
 
 ## Development Commands
 
@@ -364,7 +383,7 @@ Key environment variables are configured in `.env`. See `.env.example` for avail
 | `PROXY_PORT`              | 18080   | Reverse proxy port          |
 | `API_PORT`                | 5715    | Backend API port            |
 | `UI_PORT`                 | 5714    | Frontend UI port            |
-| `QDASH_INSTANCE`          | -       | Optional local instance name; defaults to `ENV` |
+| `QDASH_INSTANCE`          | -       | Optional instance name; defaults to `${ENV}-qdash` |
 | `MONGO_PORT`              | 27017   | MongoDB port                |
 | `POSTGRES_PORT`           | 5432    | PostgreSQL port             |
 | `PREFECT_PORT`            | 4200    | Prefect dashboard port      |

--- a/docs/operator-guide/setup.md
+++ b/docs/operator-guide/setup.md
@@ -68,15 +68,18 @@ service URL for operator-only access.
 stack; it does not rewrite `.env`.
 
 For multiple QDash environments on the same server, give each environment a unique
-`COMPOSE_PROJECT_NAME`, `QDASH_HOST`, `QDASH_LOCAL_HOST`, `PROXY_PORT`, and database data path. The
+`COMPOSE_PROJECT_NAME`, `QDASH_HOST`, `QDASH_LOCAL_HOST`, `PROXY_PORT`, and database data path. Set
+`QDASH_LOCAL_DOMAIN` to the local wildcard DNS zone used on the workstation. The
 application service ports can stay at their defaults because `task deploy` publishes only the
 reverse proxy on `127.0.0.1:${PROXY_PORT}` for SSH forwarding.
 
 ```env
-ENV=dev-qdash
+ENV=dev
+QDASH_INSTANCE=dev-qdash
 COMPOSE_PROJECT_NAME=dev-qdash
+QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-dev.qiqb.dev
-QDASH_LOCAL_HOST=dev-qdash.localhost
+QDASH_LOCAL_HOST=dev-qdash.qdash.test
 CLIENT_URL=https://qdash-dev.qiqb.dev
 PROXY_PORT=18080
 POSTGRES_DATA_PATH=./postgres_data_dev

--- a/scripts/assign_local_ports.sh
+++ b/scripts/assign_local_ports.sh
@@ -96,16 +96,23 @@ find_free_port() {
   exit 1
 }
 
-env_name="$(instance_name "${ENV:-$(env_value ENV)}")"
+env_name="$(sanitize "${ENV:-$(env_value ENV)}")"
+if [ -z "$env_name" ]; then
+  env_name="dev"
+fi
 raw_instance="${QDASH_INSTANCE:-$(env_value QDASH_INSTANCE)}"
 if [ -n "$raw_instance" ]; then
   instance="$(instance_name "$raw_instance")"
 else
-  instance="$env_name"
+  instance="$(instance_name "$env_name")"
 fi
 
 proxy_name="$instance"
-host="${proxy_name}.localhost"
+local_domain="${QDASH_LOCAL_DOMAIN:-$(env_value QDASH_LOCAL_DOMAIN)}"
+if [ -z "$local_domain" ]; then
+  local_domain="qdash.test"
+fi
+host="${proxy_name}.${local_domain}"
 force=0
 if [ "${1:-}" = "--force" ]; then
   force=1
@@ -130,8 +137,9 @@ declare -A updates
 updates[ENV]="$env_name"
 updates[COMPOSE_PROJECT_NAME]="$proxy_name"
 updates[QDASH_INSTANCE]="$instance"
+updates[QDASH_LOCAL_DOMAIN]="$local_domain"
 updates[QDASH_HOST]="$host"
-updates[QDASH_LOCAL_HOST]="${env_name}.localhost"
+updates[QDASH_LOCAL_HOST]="${proxy_name}.${local_domain}"
 updates[QDASH_API_HOST]="api.${host}"
 updates[QDASH_PREFECT_HOST]="prefect.${host}"
 updates[QDASH_MONGO_HOST]="mongo.${host}"
@@ -147,9 +155,9 @@ for index in "${!PORT_KEYS[@]}"; do
   fi
 done
 
-updates[CLIENT_URL]='http://${ENV}.localhost:${PROXY_PORT}'
+updates[CLIENT_URL]="http://${updates[QDASH_LOCAL_HOST]}:${updates[PROXY_PORT]}"
 updates[NEXT_PUBLIC_API_URL]="/api"
-updates[NEXT_PUBLIC_PREFECT_URL]='http://prefect.${ENV}.localhost:${PROXY_PORT}'
+updates[NEXT_PUBLIC_PREFECT_URL]="http://prefect.${updates[QDASH_LOCAL_HOST]}:${updates[PROXY_PORT]}"
 updates[QDASH_UI_UPSTREAM]="ui:${updates[UI_PORT]}"
 updates[QDASH_API_UPSTREAM]="api:${updates[API_PORT]}"
 updates[PREFECT_API_URL]='http://localhost:${PREFECT_PORT}/api'

--- a/scripts/check_deploy_env.sh
+++ b/scripts/check_deploy_env.sh
@@ -33,7 +33,7 @@ for key in TUNNEL_TOKEN QDASH_HOST CLIENT_URL NEXT_PUBLIC_API_URL; do
   fi
 done
 
-for key in ENV COMPOSE_PROJECT_NAME QDASH_HOST QDASH_LOCAL_HOST CLIENT_URL PROXY_PORT; do
+for key in ENV COMPOSE_PROJECT_NAME QDASH_HOST QDASH_LOCAL_DOMAIN QDASH_LOCAL_HOST CLIENT_URL PROXY_PORT; do
   count="$(
     awk -v key="$key" '
       $0 ~ "^[[:space:]]*(export[[:space:]]+)?" key "[[:space:]]*=" { count++ }
@@ -50,6 +50,17 @@ for key in QDASH_UI_UPSTREAM QDASH_API_UPSTREAM; do
   case "$value" in
     *'$'*|*:)
       echo "WARNING: $key=$value will be overridden by task deploy." >&2
+      ;;
+  esac
+done
+
+for key in CLIENT_URL NEXT_PUBLIC_PREFECT_URL; do
+  value="$(env_value "$key")"
+  case "$value" in
+    *'$'*)
+      echo "Invalid deploy setting: $key=$value" >&2
+      echo "$key must be an explicit URL before running task deploy." >&2
+      missing=1
       ;;
   esac
 done


### PR DESCRIPTION
<!-- Keep this template minimal for Copilot/auto-drafting; remove these comments when ready. -->
## Ticket
N/A

## Summary
- Introduced a reverse proxy configuration to streamline service access and local port assignments for Docker Compose services.
- Updated deployment settings to utilize environment variables, improving flexibility and reducing hardcoded values.

## Changes
- Added reverse proxy configuration for multiple services, including API and UI.
- Configured local port assignments in `.env.example` for better clarity and validation.
- Enhanced deployment task to validate environment settings before starting the stack.
- Updated documentation to reflect changes in proxy and port configurations.

