### PR TITLE
chore(infra): resolve deploy environment defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ QDASH_INSTANCE=dev-fake-qdash
 # GATEWAY=""
 DEFAULT_BACKEND="fake"
 
-# QDASH_INSTANCE defaults to ${ENV}-qdash. task assign-local-ports derives
+# QDASH_INSTANCE defaults to ${ENV}-qdash. Local and deploy tasks derive
 # ports, Compose project name, and reverse-proxy hostnames from these values.
 
 # Ports
@@ -27,14 +27,15 @@ DEPLOYMENT_SERVICE_PORT=8001
 
 # URLs
 QDASH_LOCAL_DOMAIN=qdash.test
-CLIENT_URL=http://${QDASH_INSTANCE}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}
+CLIENT_URL=http://${ENV}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}
 NEXT_PUBLIC_API_URL=/api
-NEXT_PUBLIC_PREFECT_URL=http://prefect.${QDASH_INSTANCE}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}
-# Defaults to ${QDASH_INSTANCE}.${QDASH_LOCAL_DOMAIN} in task deploy when unset.
+NEXT_PUBLIC_PREFECT_URL=http://prefect.${ENV}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}
+# QDASH_LOCAL_HOST defaults to ${ENV}.${QDASH_LOCAL_DOMAIN}.
 # Configure local wildcard DNS so *.${QDASH_LOCAL_DOMAIN} resolves to 127.0.0.1.
-# task assign-local-ports derives CLIENT_URL, NEXT_PUBLIC_PREFECT_URL, and
-# QDASH_LOCAL_HOST from QDASH_INSTANCE, QDASH_LOCAL_DOMAIN, and PROXY_PORT.
-# QDASH_LOCAL_HOST=dev-fake-qdash.qdash.test
+# task deploy resolves templated CLIENT_URL and NEXT_PUBLIC_PREFECT_URL before
+# passing values to Docker Compose. For Cloudflare deploys, CLIENT_URL defaults
+# to https://${QDASH_HOST} when left templated or unset.
+# QDASH_LOCAL_HOST=dev-fake.qdash.test
 QDASH_UI_UPSTREAM=ui:5714
 QDASH_API_UPSTREAM=api:5715
 # Comma-separated hostnames allowed to access the Next.js dev server, e.g. 192.168.0.4
@@ -75,10 +76,9 @@ GITHUB_TOKEN=
 GITHUB_USER=
 
 # Cloudflare Tunnel remote access. Configure public hostnames to route to
-# http://reverse-proxy:80. For production deploys, set QDASH_HOST and
-# CLIENT_URL to the public UI hostname, for example:
+# http://reverse-proxy:80. For production deploys, set QDASH_HOST to the public
+# UI hostname; task deploy derives CLIENT_URL when it is left templated.
 # QDASH_HOST=qdash.example.com
-# CLIENT_URL=https://qdash.example.com
 TUNNEL_TOKEN=
 QDASH_API_TOKEN=
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -100,7 +100,7 @@ tasks:
     desc: Start only the services needed by host-side API/UI development
     dotenv: [.env]
     cmds:
-      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-qdash}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}" QDASH_UI_UPSTREAM="host.docker.internal:${UI_PORT:-5714}" QDASH_API_UPSTREAM="host.docker.internal:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.local.yaml up -d mongo postgres prefect-server deployment-service user-flow-worker reverse-proxy
+      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${ENV:-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}" QDASH_UI_UPSTREAM="host.docker.internal:${UI_PORT:-5714}" QDASH_API_UPSTREAM="host.docker.internal:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.local.yaml up -d mongo postgres prefect-server deployment-service user-flow-worker reverse-proxy
 
   dev-local-setup:
     desc: Install dependencies needed by host-side API/UI development
@@ -114,14 +114,14 @@ tasks:
     desc: Start the API on the host against Docker services
     dotenv: [.env]
     cmds:
-      - MONGO_HOST="${MONGO_HOST:-localhost}" CLIENT_URL="http://${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-dev-fake}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}:${PROXY_PORT:-18080}" PREFECT_API_URL="http://127.0.0.1:${PREFECT_PORT:-4200}/api" DEPLOYMENT_SERVICE_URL="http://127.0.0.1:${DEPLOYMENT_SERVICE_PORT:-4006}" uv run uvicorn src.qdash.api.main:app --reload --host 127.0.0.1 --port "${API_PORT:-5715}"
+      - MONGO_HOST="${MONGO_HOST:-localhost}" CLIENT_URL="http://${QDASH_LOCAL_HOST:-${ENV:-dev-fake}.${QDASH_LOCAL_DOMAIN:-qdash.test}}:${PROXY_PORT:-18080}" PREFECT_API_URL="http://127.0.0.1:${PREFECT_PORT:-4200}/api" DEPLOYMENT_SERVICE_URL="http://127.0.0.1:${DEPLOYMENT_SERVICE_PORT:-4006}" uv run uvicorn src.qdash.api.main:app --reload --host 127.0.0.1 --port "${API_PORT:-5715}"
 
   dev-ui-local:
     desc: Start the UI on the host against the local API
     dir: ui
     dotenv: [../.env]
     cmds:
-      - PORT="${UI_PORT:-5714}" INTERNAL_API_URL="http://127.0.0.1:${API_PORT:-5715}" NEXT_PUBLIC_PREFECT_URL="http://prefect.${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-dev-fake}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}:${PROXY_PORT:-18080}" bun run dev
+      - PORT="${UI_PORT:-5714}" INTERNAL_API_URL="http://127.0.0.1:${API_PORT:-5715}" NEXT_PUBLIC_PREFECT_URL="http://prefect.${QDASH_LOCAL_HOST:-${ENV:-dev-fake}.${QDASH_LOCAL_DOMAIN:-qdash.test}}:${PROXY_PORT:-18080}" bun run dev
 
   dev-local:
     desc: Start lightweight local development services, API, and UI
@@ -385,7 +385,7 @@ tasks:
     cmds:
       - task: knowledge-pull
       - scripts/check_deploy_env.sh
-      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-qdash}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}" QDASH_UI_UPSTREAM="ui:${UI_PORT:-5714}" QDASH_API_UPSTREAM="api:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.forward.yaml --profile tunnel up -d --build
+      - eval "$(scripts/resolve_deploy_env.sh)" && docker compose -f compose.yaml -f compose.forward.yaml --profile tunnel up -d --build
       - sleep 3
-      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${QDASH_INSTANCE:-${ENV:-qdash}-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}" QDASH_UI_UPSTREAM="ui:${UI_PORT:-5714}" QDASH_API_UPSTREAM="api:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.forward.yaml restart api
+      - eval "$(scripts/resolve_deploy_env.sh)" && docker compose -f compose.yaml -f compose.forward.yaml restart api
     desc: Deploy with Cloudflare Tunnel and localhost-only reverse proxy for SSH forwarding

--- a/compose.yaml
+++ b/compose.yaml
@@ -158,6 +158,7 @@ services:
     environment:
       - PYTHONPATH=/app:/app/qdash:/app/qdash/api:/app/qdash/dbmodel:/app/qdash/datamodel:/app/qdash
       - CALIB_DATA_PATH=/app/calib_data
+      - CLIENT_URL=${CLIENT_URL}
       - PREFECT_API_URL=http://prefect-server:4200/api
       - DEPLOYMENT_SERVICE_URL=http://deployment-service:8001
     networks:
@@ -177,6 +178,8 @@ services:
       - .env
     environment:
       - PORT=${UI_PORT:-5714}
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+      - NEXT_PUBLIC_PREFECT_URL=${NEXT_PUBLIC_PREFECT_URL}
     depends_on:
       - api
     networks:
@@ -188,6 +191,9 @@ services:
       - .env
     environment:
       - QDASH_LOCAL_HOST=${QDASH_LOCAL_HOST}
+      - QDASH_API_HOST=${QDASH_API_HOST}
+      - QDASH_PREFECT_HOST=${QDASH_PREFECT_HOST}
+      - QDASH_MONGO_HOST=${QDASH_MONGO_HOST}
       - QDASH_UI_UPSTREAM=${QDASH_UI_UPSTREAM}
       - QDASH_API_UPSTREAM=${QDASH_API_UPSTREAM}
     volumes:

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -110,7 +110,7 @@ task dev-local
 
 This starts MongoDB, PostgreSQL, Prefect, the deployment service, and the user flow worker with
 Docker Compose, then runs the API and UI on the host. The UI is available through the reverse proxy
-at `http://dev-fake-qdash.qdash.test:${PROXY_PORT}`.
+at `http://dev-fake.qdash.test:${PROXY_PORT}`.
 
 ### Install Dependencies
 
@@ -164,18 +164,18 @@ automatically:
 task deploy-local
 ```
 
-`ENV` is the short application environment label. `QDASH_INSTANCE` defaults to `${ENV}-qdash` and is
-used for the Compose project name and local hostnames. The default `.env` uses `ENV="dev-fake"` and
-`QDASH_INSTANCE=dev-fake-qdash`, so Docker resources and local URLs share the same instance name.
-The assignment task derives `COMPOSE_PROJECT_NAME`, reverse-proxy hostnames, service ports, and
-public URLs from these values. Existing assigned ports are kept on later deploys for the same
-instance.
+`ENV` is the short application environment label and is used for local hostnames.
+`QDASH_INSTANCE` defaults to `${ENV}-qdash` and is used for the Compose project name. The default
+`.env` uses `ENV="dev-fake"` and `QDASH_INSTANCE=dev-fake-qdash`, so Docker resources are scoped by
+the instance while local URLs stay short. The assignment task derives `COMPOSE_PROJECT_NAME`,
+reverse-proxy hostnames, service ports, and public URLs from these values. Existing assigned ports
+are kept on later deploys for the same instance.
 
-The Compose stack includes a Caddy reverse proxy. For `QDASH_INSTANCE="dev-fake-qdash"`, the proxied
-URLs are `http://dev-fake-qdash.qdash.test:${PROXY_PORT}`,
-`http://api.dev-fake-qdash.qdash.test:${PROXY_PORT}`,
-`http://prefect.dev-fake-qdash.qdash.test:${PROXY_PORT}`, and
-`http://mongo.dev-fake-qdash.qdash.test:${PROXY_PORT}`. These URLs work for both `task dev-local` and
+The Compose stack includes a Caddy reverse proxy. For `ENV="dev-fake"`, the proxied
+URLs are `http://dev-fake.qdash.test:${PROXY_PORT}`,
+`http://api.dev-fake.qdash.test:${PROXY_PORT}`,
+`http://prefect.dev-fake.qdash.test:${PROXY_PORT}`, and
+`http://mongo.dev-fake.qdash.test:${PROXY_PORT}`. These URLs work for both `task dev-local` and
 `task deploy-local`; the direct service ports remain available in these local tasks for tools that
 connect to MongoDB, PostgreSQL, or the API directly. `task deploy` does not publish these service
 ports; Cloudflare Tunnel reaches the reverse proxy through Docker networking at
@@ -185,15 +185,18 @@ The main UI hostname also proxies `/api/*` to the API, so frontend traffic can s
 
 For server environments that should also be reachable through SSH port forwarding, set
 `QDASH_LOCAL_DOMAIN` once for the local wildcard DNS zone. `QDASH_LOCAL_HOST` defaults to
-`${QDASH_INSTANCE}.${QDASH_LOCAL_DOMAIN}` and only needs to be set when the local alias should differ
-from that pattern. `task deploy` keeps the Cloudflare Tunnel setup and publishes only the reverse proxy on
+`${ENV}.${QDASH_LOCAL_DOMAIN}` and only needs to be set when the local alias should differ
+from that pattern. `task deploy` resolves templated URL values before starting Compose: `CLIENT_URL`
+defaults to `https://${QDASH_HOST}`, `NEXT_PUBLIC_API_URL` defaults to `/api`, and
+`NEXT_PUBLIC_PREFECT_URL` defaults to `http://prefect.${QDASH_LOCAL_HOST}:${PROXY_PORT}`.
+`task deploy` keeps the Cloudflare Tunnel setup and publishes only the reverse proxy on
 `127.0.0.1:${PROXY_PORT}`. Forward it from the workstation with a matching local port:
 
 ```shell
 ssh -L 18080:127.0.0.1:18080 anemone
 ```
 
-Then open `http://${QDASH_INSTANCE}.qdash.test:18080`.
+Then open `http://${ENV}.qdash.test:18080`.
 Configure local wildcard DNS once so `*.${QDASH_LOCAL_DOMAIN}` resolves to `127.0.0.1`; this avoids per-host
 `/etc/hosts` entries and does not depend on public DNS.
 
@@ -208,7 +211,7 @@ echo 'nameserver 127.0.0.1' | sudo tee /etc/resolver/qdash.test
 sudo brew services start dnsmasq
 ```
 
-When running multiple QDash environments on one server, keep the Docker Compose project name,
+When running multiple QDash environments on one server, keep `ENV`, the Docker Compose project name,
 forwarded proxy port, local alias, public hostname, and data paths unique for each environment. The
 internal service ports such as `API_PORT=5715` and `UI_PORT=5714` may stay the same because they are
 not published directly by `task deploy`.
@@ -217,11 +220,8 @@ not published directly by `task deploy`.
 # qdash-dev
 ENV=dev
 QDASH_INSTANCE=dev-qdash
-COMPOSE_PROJECT_NAME=dev-qdash
 QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-dev.qiqb.dev
-QDASH_LOCAL_HOST=dev-qdash.qdash.test
-CLIENT_URL=https://qdash-dev.qiqb.dev
 PROXY_PORT=18080
 POSTGRES_DATA_PATH=./postgres_data_dev
 MONGO_DATA_PATH=./mongo_data_dev/data/db
@@ -229,11 +229,8 @@ MONGO_DATA_PATH=./mongo_data_dev/data/db
 # qdash-stg
 ENV=stg
 QDASH_INSTANCE=stg-qdash
-COMPOSE_PROJECT_NAME=stg-qdash
 QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-stg.qiqb.dev
-QDASH_LOCAL_HOST=stg-qdash.qdash.test
-CLIENT_URL=https://qdash-stg.qiqb.dev
 PROXY_PORT=18081
 POSTGRES_DATA_PATH=./postgres_data_stg
 MONGO_DATA_PATH=./mongo_data_stg/data/db
@@ -249,10 +246,10 @@ ssh -L 18080:127.0.0.1:18080 -L 18081:127.0.0.1:18081 anemone
 
 | Service           | URL                                             |
 | ----------------- | ----------------------------------------------- |
-| QDash UI          | `http://${QDASH_INSTANCE}.qdash.test:${PROXY_PORT}`         |
-| API Documentation | `http://api.${QDASH_INSTANCE}.qdash.test:${PROXY_PORT}/docs` |
-| Prefect Dashboard | `http://prefect.${QDASH_INSTANCE}.qdash.test:${PROXY_PORT}` |
-| MongoDB Admin     | `http://mongo.${QDASH_INSTANCE}.qdash.test:${PROXY_PORT}`   |
+| QDash UI          | `http://${ENV}.qdash.test:${PROXY_PORT}`         |
+| API Documentation | `http://api.${ENV}.qdash.test:${PROXY_PORT}/docs` |
+| Prefect Dashboard | `http://prefect.${ENV}.qdash.test:${PROXY_PORT}` |
+| MongoDB Admin     | `http://mongo.${ENV}.qdash.test:${PROXY_PORT}`   |
 
 ## Development Commands
 

--- a/docs/operator-guide/setup.md
+++ b/docs/operator-guide/setup.md
@@ -65,22 +65,22 @@ Configure Cloudflare Tunnel public hostnames to forward to `http://reverse-proxy
 hostname serves the UI and `/api/*`; optional Prefect and Mongo Express hostnames can use the same
 service URL for operator-only access.
 `task deploy` validates the tunnel token and reverse-proxy hostname settings before starting the
-stack; it does not rewrite `.env`.
+stack; it resolves templated URL values for Compose and does not rewrite `.env`. When left unset or
+templated, `CLIENT_URL` becomes `https://${QDASH_HOST}`, `NEXT_PUBLIC_API_URL` becomes `/api`, and
+`NEXT_PUBLIC_PREFECT_URL` becomes `http://prefect.${ENV}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}`.
 
 For multiple QDash environments on the same server, give each environment a unique
-`COMPOSE_PROJECT_NAME`, `QDASH_HOST`, `QDASH_LOCAL_HOST`, `PROXY_PORT`, and database data path. Set
-`QDASH_LOCAL_DOMAIN` to the local wildcard DNS zone used on the workstation. The
+`ENV`, `QDASH_INSTANCE`, `QDASH_HOST`, `PROXY_PORT`, and database data path. Set
+`QDASH_LOCAL_DOMAIN` to the local wildcard DNS zone used on the workstation. `COMPOSE_PROJECT_NAME`
+defaults from `QDASH_INSTANCE`, and `QDASH_LOCAL_HOST` defaults from `ENV`. The
 application service ports can stay at their defaults because `task deploy` publishes only the
 reverse proxy on `127.0.0.1:${PROXY_PORT}` for SSH forwarding.
 
 ```env
 ENV=dev
 QDASH_INSTANCE=dev-qdash
-COMPOSE_PROJECT_NAME=dev-qdash
 QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-dev.qiqb.dev
-QDASH_LOCAL_HOST=dev-qdash.qdash.test
-CLIENT_URL=https://qdash-dev.qiqb.dev
 PROXY_PORT=18080
 POSTGRES_DATA_PATH=./postgres_data_dev
 MONGO_DATA_PATH=./mongo_data_dev/data/db

--- a/scripts/assign_local_ports.sh
+++ b/scripts/assign_local_ports.sh
@@ -108,11 +108,12 @@ else
 fi
 
 proxy_name="$instance"
+local_name="$env_name"
 local_domain="${QDASH_LOCAL_DOMAIN:-$(env_value QDASH_LOCAL_DOMAIN)}"
 if [ -z "$local_domain" ]; then
   local_domain="qdash.test"
 fi
-host="${proxy_name}.${local_domain}"
+host="${local_name}.${local_domain}"
 force=0
 if [ "${1:-}" = "--force" ]; then
   force=1
@@ -139,7 +140,7 @@ updates[COMPOSE_PROJECT_NAME]="$proxy_name"
 updates[QDASH_INSTANCE]="$instance"
 updates[QDASH_LOCAL_DOMAIN]="$local_domain"
 updates[QDASH_HOST]="$host"
-updates[QDASH_LOCAL_HOST]="${proxy_name}.${local_domain}"
+updates[QDASH_LOCAL_HOST]="$host"
 updates[QDASH_API_HOST]="api.${host}"
 updates[QDASH_PREFECT_HOST]="prefect.${host}"
 updates[QDASH_MONGO_HOST]="mongo.${host}"

--- a/scripts/check_deploy_env.sh
+++ b/scripts/check_deploy_env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_FILE=".env"
+ENV_FILE="${ENV_FILE:-.env}"
 
 if [ ! -f "$ENV_FILE" ]; then
   echo "Missing .env. Create it with: cp .env.example .env" >&2
@@ -19,21 +19,21 @@ env_value() {
       gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
       gsub(/^"|"$/, "", line)
       gsub(/^'\''|'\''$/, "", line)
-      print line
-      exit
+      value = line
     }
+    END { print value }
   ' "$ENV_FILE"
 }
 
 missing=0
-for key in TUNNEL_TOKEN QDASH_HOST CLIENT_URL NEXT_PUBLIC_API_URL; do
+for key in TUNNEL_TOKEN QDASH_HOST; do
   if [ -z "$(env_value "$key")" ]; then
     echo "Missing required deploy setting: $key" >&2
     missing=1
   fi
 done
 
-for key in ENV COMPOSE_PROJECT_NAME QDASH_HOST QDASH_LOCAL_DOMAIN QDASH_LOCAL_HOST CLIENT_URL PROXY_PORT; do
+for key in ENV COMPOSE_PROJECT_NAME QDASH_HOST QDASH_LOCAL_DOMAIN QDASH_LOCAL_HOST CLIENT_URL NEXT_PUBLIC_PREFECT_URL PROXY_PORT; do
   count="$(
     awk -v key="$key" '
       $0 ~ "^[[:space:]]*(export[[:space:]]+)?" key "[[:space:]]*=" { count++ }
@@ -50,17 +50,6 @@ for key in QDASH_UI_UPSTREAM QDASH_API_UPSTREAM; do
   case "$value" in
     *'$'*|*:)
       echo "WARNING: $key=$value will be overridden by task deploy." >&2
-      ;;
-  esac
-done
-
-for key in CLIENT_URL NEXT_PUBLIC_PREFECT_URL; do
-  value="$(env_value "$key")"
-  case "$value" in
-    *'$'*)
-      echo "Invalid deploy setting: $key=$value" >&2
-      echo "$key must be an explicit URL before running task deploy." >&2
-      missing=1
       ;;
   esac
 done
@@ -88,7 +77,14 @@ if [ "$missing" -ne 0 ]; then
   exit 1
 fi
 
-case "$(env_value CLIENT_URL)" in
+client_url="$(env_value CLIENT_URL)"
+case "$client_url" in
+  ""|*'$'*)
+    client_url="https://$(env_value QDASH_HOST)"
+    ;;
+esac
+
+case "$client_url" in
   http://*.localhost:*|https://*.localhost:*)
     echo "WARNING: CLIENT_URL points to .localhost; this is usually not intended for Cloudflare deploy." >&2
     ;;

--- a/scripts/resolve_deploy_env.sh
+++ b/scripts/resolve_deploy_env.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE="${ENV_FILE:-.env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Missing .env. Create it with: cp .env.example .env" >&2
+  exit 1
+fi
+
+env_value() {
+  local key="$1"
+  awk -v key="$key" '
+    $0 ~ "^[[:space:]]*(export[[:space:]]+)?" key "[[:space:]]*=" {
+      line = $0
+      sub(/^[[:space:]]*export[[:space:]]+/, "", line)
+      sub("^[[:space:]]*" key "[[:space:]]*=", "", line)
+      sub(/[[:space:]]+#.*/, "", line)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      gsub(/^"|"$/, "", line)
+      gsub(/^'\''|'\''$/, "", line)
+      value = line
+    }
+    END { print value }
+  ' "$ENV_FILE"
+}
+
+shell_quote() {
+  printf "'%s'" "$(printf "%s" "$1" | sed "s/'/'\\\\''/g")"
+}
+
+emit_export() {
+  local key="$1"
+  local value="$2"
+  printf "export %s=%s\n" "$key" "$(shell_quote "$value")"
+}
+
+env_name="${ENV:-$(env_value ENV)}"
+env_name="${env_name:-qdash}"
+
+qdash_instance="${QDASH_INSTANCE:-$(env_value QDASH_INSTANCE)}"
+qdash_instance="${qdash_instance:-${env_name}-qdash}"
+
+compose_project_name="${COMPOSE_PROJECT_NAME:-$(env_value COMPOSE_PROJECT_NAME)}"
+compose_project_name="${compose_project_name:-$qdash_instance}"
+
+local_domain="${QDASH_LOCAL_DOMAIN:-$(env_value QDASH_LOCAL_DOMAIN)}"
+local_domain="${local_domain:-qdash.test}"
+
+local_host="${QDASH_LOCAL_HOST:-$(env_value QDASH_LOCAL_HOST)}"
+local_host="${local_host:-${env_name}.${local_domain}}"
+
+proxy_port="${PROXY_PORT:-$(env_value PROXY_PORT)}"
+proxy_port="${proxy_port:-18080}"
+
+ui_port="${UI_PORT:-$(env_value UI_PORT)}"
+ui_port="${ui_port:-5714}"
+
+api_port="${API_PORT:-$(env_value API_PORT)}"
+api_port="${api_port:-5715}"
+
+qdash_host="${QDASH_HOST:-$(env_value QDASH_HOST)}"
+client_url="${CLIENT_URL:-$(env_value CLIENT_URL)}"
+case "$client_url" in
+  ""|*'$'*)
+    client_url="https://${qdash_host}"
+    ;;
+esac
+
+next_public_api_url="${NEXT_PUBLIC_API_URL:-$(env_value NEXT_PUBLIC_API_URL)}"
+next_public_api_url="${next_public_api_url:-/api}"
+
+prefect_url="${NEXT_PUBLIC_PREFECT_URL:-$(env_value NEXT_PUBLIC_PREFECT_URL)}"
+case "$prefect_url" in
+  ""|*'$'*)
+    prefect_url="http://prefect.${local_host}:${proxy_port}"
+    ;;
+esac
+
+emit_export ENV "$env_name"
+emit_export QDASH_INSTANCE "$qdash_instance"
+emit_export COMPOSE_PROJECT_NAME "$compose_project_name"
+emit_export QDASH_LOCAL_DOMAIN "$local_domain"
+emit_export QDASH_LOCAL_HOST "$local_host"
+emit_export QDASH_API_HOST "api.${local_host}"
+emit_export QDASH_PREFECT_HOST "prefect.${local_host}"
+emit_export QDASH_MONGO_HOST "mongo.${local_host}"
+emit_export PROXY_PORT "$proxy_port"
+emit_export CLIENT_URL "$client_url"
+emit_export NEXT_PUBLIC_API_URL "$next_public_api_url"
+emit_export NEXT_PUBLIC_PREFECT_URL "$prefect_url"
+emit_export QDASH_UI_UPSTREAM "ui:${ui_port}"
+emit_export QDASH_API_UPSTREAM "api:${api_port}"


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Simplifies deploy/local URL configuration by deriving local hostnames from `ENV` and Docker/Compose identifiers from `QDASH_INSTANCE`.
- Lets `task deploy` resolve templated `.env` URL values before invoking Docker Compose, reducing required per-server settings while keeping Cloudflare Tunnel deployment explicit.

## Changes
- Added `scripts/resolve_deploy_env.sh` to emit deploy-ready environment values for Compose.
- Updated deploy tasks and Compose environment overrides so API, UI, and Caddy receive resolved URLs and hostnames.
- Changed local aliases to use `ENV.qdash.test` with `api.`, `prefect.`, and `mongo.` subdomains.
- Relaxed deploy env validation for templated URL values and updated `.env.example` plus setup docs.