### PR TITLE
chore(infra): prefer localhost forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,14 +7,15 @@ QDASH_INSTANCE=dev-fake-qdash
 # GATEWAY=""
 DEFAULT_BACKEND="fake"
 
-# QDASH_INSTANCE defaults to ${ENV}-qdash. Local and deploy tasks derive
-# ports, Compose project name, and reverse-proxy hostnames from these values.
+# QDASH_INSTANCE defaults to ${ENV}-qdash. Local and deploy tasks derive ports
+# and the Compose project name from these values.
 
 # Ports
-# task deploy publishes only the reverse proxy on 127.0.0.1:${PROXY_PORT}
-# for SSH forwarding. Use a different PROXY_PORT for each instance on the
-# same server, e.g. 18080 for dev and 18081 for staging.
+# task deploy publishes the reverse proxy and Prefect only on 127.0.0.1 for
+# SSH forwarding. Use different forward ports for each instance on the same
+# server, e.g. 18080/14200 for dev and 18081/14201 for staging.
 PROXY_PORT=18080
+PREFECT_FORWARD_PORT=14200
 MONGO_PORT=27017
 MONGO_EXPRESS_PORT=8081
 POSTGRES_PORT=5432
@@ -26,16 +27,14 @@ DEPLOYMENT_SERVICE_PORT=8001
 
 
 # URLs
-QDASH_LOCAL_DOMAIN=qdash.test
-CLIENT_URL=http://${ENV}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}
+CLIENT_URL=http://localhost:${PROXY_PORT}
 NEXT_PUBLIC_API_URL=/api
-NEXT_PUBLIC_PREFECT_URL=http://prefect.${ENV}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}
-# QDASH_LOCAL_HOST defaults to ${ENV}.${QDASH_LOCAL_DOMAIN}.
-# Configure local wildcard DNS so *.${QDASH_LOCAL_DOMAIN} resolves to 127.0.0.1.
+NEXT_PUBLIC_PREFECT_URL=http://localhost:${PREFECT_FORWARD_PORT}
+# QDASH_LOCAL_HOST defaults to localhost.
 # task deploy resolves templated CLIENT_URL and NEXT_PUBLIC_PREFECT_URL before
 # passing values to Docker Compose. For Cloudflare deploys, CLIENT_URL defaults
 # to https://${QDASH_HOST} when left templated or unset.
-# QDASH_LOCAL_HOST=dev-fake.qdash.test
+# QDASH_LOCAL_HOST=localhost
 QDASH_UI_UPSTREAM=ui:5714
 QDASH_API_UPSTREAM=api:5715
 # Comma-separated hostnames allowed to access the Next.js dev server, e.g. 192.168.0.4

--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,13 @@ QDASH_API_TOKEN=
 # CopilotKit AI Assistant (optional)
 # Enable the AI chat assistant in the UI
 NEXT_PUBLIC_COPILOT_ENABLED=true
+# Ollama endpoint used by config/copilot/chat.yaml and config/copilot/review.yaml.
+# Host-side dev usually uses http://localhost:11434. Docker deploys can use
+# http://host.docker.internal:11434 or a remote Ollama/OpenAI-compatible URL.
+OLLAMA_BASE_URL=
 OLLAMA_API_KEY=
 OPENAI_API_KEY=
+# Optional DeepSeek v4 OpenAI-compatible gateway used by config/copilot/chat.yaml.
+DS4_BASE_URL=
+DS4_API_KEY=
 KNOWLEDGE_REPO_URL=

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -100,7 +100,7 @@ tasks:
     desc: Start only the services needed by host-side API/UI development
     dotenv: [.env]
     cmds:
-      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-${ENV:-qdash}.${QDASH_LOCAL_DOMAIN:-qdash.test}}" QDASH_UI_UPSTREAM="host.docker.internal:${UI_PORT:-5714}" QDASH_API_UPSTREAM="host.docker.internal:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.local.yaml up -d mongo postgres prefect-server deployment-service user-flow-worker reverse-proxy
+      - QDASH_LOCAL_HOST="${QDASH_LOCAL_HOST:-localhost}" QDASH_UI_UPSTREAM="host.docker.internal:${UI_PORT:-5714}" QDASH_API_UPSTREAM="host.docker.internal:${API_PORT:-5715}" docker compose -f compose.yaml -f compose.local.yaml up -d mongo postgres prefect-server deployment-service user-flow-worker reverse-proxy
 
   dev-local-setup:
     desc: Install dependencies needed by host-side API/UI development
@@ -114,14 +114,14 @@ tasks:
     desc: Start the API on the host against Docker services
     dotenv: [.env]
     cmds:
-      - MONGO_HOST="${MONGO_HOST:-localhost}" CLIENT_URL="http://${QDASH_LOCAL_HOST:-${ENV:-dev-fake}.${QDASH_LOCAL_DOMAIN:-qdash.test}}:${PROXY_PORT:-18080}" PREFECT_API_URL="http://127.0.0.1:${PREFECT_PORT:-4200}/api" DEPLOYMENT_SERVICE_URL="http://127.0.0.1:${DEPLOYMENT_SERVICE_PORT:-4006}" uv run uvicorn src.qdash.api.main:app --reload --host 127.0.0.1 --port "${API_PORT:-5715}"
+      - MONGO_HOST="${MONGO_HOST:-localhost}" CLIENT_URL="http://${QDASH_LOCAL_HOST:-localhost}:${PROXY_PORT:-18080}" PREFECT_API_URL="http://127.0.0.1:${PREFECT_PORT:-4200}/api" DEPLOYMENT_SERVICE_URL="http://127.0.0.1:${DEPLOYMENT_SERVICE_PORT:-4006}" uv run uvicorn src.qdash.api.main:app --reload --host 127.0.0.1 --port "${API_PORT:-5715}"
 
   dev-ui-local:
     desc: Start the UI on the host against the local API
     dir: ui
     dotenv: [../.env]
     cmds:
-      - PORT="${UI_PORT:-5714}" INTERNAL_API_URL="http://127.0.0.1:${API_PORT:-5715}" NEXT_PUBLIC_PREFECT_URL="http://prefect.${QDASH_LOCAL_HOST:-${ENV:-dev-fake}.${QDASH_LOCAL_DOMAIN:-qdash.test}}:${PROXY_PORT:-18080}" bun run dev
+      - PORT="${UI_PORT:-5714}" INTERNAL_API_URL="http://127.0.0.1:${API_PORT:-5715}" NEXT_PUBLIC_PREFECT_URL="http://localhost:${PREFECT_PORT:-4200}" bun run dev
 
   dev-local:
     desc: Start lightweight local development services, API, and UI

--- a/compose.forward.yaml
+++ b/compose.forward.yaml
@@ -2,3 +2,7 @@ services:
   reverse-proxy:
     ports:
       - "127.0.0.1:${PROXY_PORT:-18080}:80"
+
+  prefect-server:
+    ports:
+      - "127.0.0.1:${PREFECT_FORWARD_PORT:-14200}:4200"

--- a/compose.yaml
+++ b/compose.yaml
@@ -97,6 +97,8 @@ services:
     depends_on:
       - prefect-server
       - deployment-service
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./src/qdash/workflow:/app/qdash/workflow
       - ./src/qdash/analysis:/app/qdash/analysis # Shared spectroscopy analysis
@@ -155,6 +157,8 @@ services:
       - mongo
       - prefect-server
       - deployment-service
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       - PYTHONPATH=/app:/app/qdash:/app/qdash/api:/app/qdash/dbmodel:/app/qdash/datamodel:/app/qdash
       - CALIB_DATA_PATH=/app/calib_data

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -110,7 +110,7 @@ task dev-local
 
 This starts MongoDB, PostgreSQL, Prefect, the deployment service, and the user flow worker with
 Docker Compose, then runs the API and UI on the host. The UI is available through the reverse proxy
-at `http://dev-fake.qdash.test:${PROXY_PORT}`.
+at `http://localhost:${PROXY_PORT}`.
 
 ### Install Dependencies
 
@@ -164,74 +164,50 @@ automatically:
 task deploy-local
 ```
 
-`ENV` is the short application environment label and is used for local hostnames.
-`QDASH_INSTANCE` defaults to `${ENV}-qdash` and is used for the Compose project name. The default
-`.env` uses `ENV="dev-fake"` and `QDASH_INSTANCE=dev-fake-qdash`, so Docker resources are scoped by
-the instance while local URLs stay short. The assignment task derives `COMPOSE_PROJECT_NAME`,
-reverse-proxy hostnames, service ports, and public URLs from these values. Existing assigned ports
-are kept on later deploys for the same instance.
+`ENV` is the short application environment label. `QDASH_INSTANCE` defaults to `${ENV}-qdash` and is
+used for the Compose project name. The default `.env` uses `ENV="dev-fake"` and
+`QDASH_INSTANCE=dev-fake-qdash`, so Docker resources are scoped by the instance while local access
+uses `localhost` ports. The assignment task derives `COMPOSE_PROJECT_NAME`, service ports, and local
+URLs from these values. Existing assigned ports are kept on later deploys for the same instance.
 
-The Compose stack includes a Caddy reverse proxy. For `ENV="dev-fake"`, the proxied
-URLs are `http://dev-fake.qdash.test:${PROXY_PORT}`,
-`http://api.dev-fake.qdash.test:${PROXY_PORT}`,
-`http://prefect.dev-fake.qdash.test:${PROXY_PORT}`, and
-`http://mongo.dev-fake.qdash.test:${PROXY_PORT}`. These URLs work for both `task dev-local` and
-`task deploy-local`; the direct service ports remain available in these local tasks for tools that
-connect to MongoDB, PostgreSQL, or the API directly. `task deploy` does not publish these service
-ports; Cloudflare Tunnel reaches the reverse proxy through Docker networking at
-`http://reverse-proxy:80`.
+The Compose stack includes a Caddy reverse proxy. QDash is served at
+`http://localhost:${PROXY_PORT}`, and the main UI hostname proxies `/api/*` to the API so frontend
+traffic can stay on one origin. Prefect is available directly at `http://localhost:${PREFECT_PORT}`
+for `task dev-local` and `task deploy-local`.
 
-The main UI hostname also proxies `/api/*` to the API, so frontend traffic can stay on one origin.
-
-For server environments that should also be reachable through SSH port forwarding, set
-`QDASH_LOCAL_DOMAIN` once for the local wildcard DNS zone. `QDASH_LOCAL_HOST` defaults to
-`${ENV}.${QDASH_LOCAL_DOMAIN}` and only needs to be set when the local alias should differ
-from that pattern. `task deploy` resolves templated URL values before starting Compose: `CLIENT_URL`
-defaults to `https://${QDASH_HOST}`, `NEXT_PUBLIC_API_URL` defaults to `/api`, and
-`NEXT_PUBLIC_PREFECT_URL` defaults to `http://prefect.${QDASH_LOCAL_HOST}:${PROXY_PORT}`.
-`task deploy` keeps the Cloudflare Tunnel setup and publishes only the reverse proxy on
-`127.0.0.1:${PROXY_PORT}`. Forward it from the workstation with a matching local port:
+For server environments that should also be reachable through SSH port forwarding, `task deploy`
+keeps the Cloudflare Tunnel setup and publishes only the reverse proxy and Prefect on `127.0.0.1`.
+`task deploy` resolves templated URL values before starting Compose: `CLIENT_URL` defaults to
+`https://${QDASH_HOST}`, `NEXT_PUBLIC_API_URL` defaults to `/api`, and `NEXT_PUBLIC_PREFECT_URL`
+defaults to `http://localhost:${PREFECT_FORWARD_PORT}`. Forward the ports from the workstation:
 
 ```shell
-ssh -L 18080:127.0.0.1:18080 anemone
+ssh -L 18080:127.0.0.1:18080 -L 14200:127.0.0.1:14200 anemone
 ```
 
-Then open `http://${ENV}.qdash.test:18080`.
-Configure local wildcard DNS once so `*.${QDASH_LOCAL_DOMAIN}` resolves to `127.0.0.1`; this avoids per-host
-`/etc/hosts` entries and does not depend on public DNS.
-
-On macOS with Homebrew:
-
-```shell
-brew install dnsmasq
-mkdir -p "$(brew --prefix)/etc/dnsmasq.d"
-echo 'address=/.qdash.test/127.0.0.1' | sudo tee "$(brew --prefix)/etc/dnsmasq.d/qdash.conf"
-sudo mkdir -p /etc/resolver
-echo 'nameserver 127.0.0.1' | sudo tee /etc/resolver/qdash.test
-sudo brew services start dnsmasq
-```
+Then open `http://localhost:18080` for QDash and `http://localhost:14200/dashboard` for Prefect.
 
 When running multiple QDash environments on one server, keep `ENV`, the Docker Compose project name,
-forwarded proxy port, local alias, public hostname, and data paths unique for each environment. The
-internal service ports such as `API_PORT=5715` and `UI_PORT=5714` may stay the same because they are
-not published directly by `task deploy`.
+forwarded ports, public hostname, and data paths unique for each environment. The internal service
+ports such as `API_PORT=5715` and `UI_PORT=5714` may stay the same because they are not published
+directly by `task deploy`.
 
 ```env
 # qdash-dev
 ENV=dev
 QDASH_INSTANCE=dev-qdash
-QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-dev.qiqb.dev
 PROXY_PORT=18080
+PREFECT_FORWARD_PORT=14200
 POSTGRES_DATA_PATH=./postgres_data_dev
 MONGO_DATA_PATH=./mongo_data_dev/data/db
 
 # qdash-stg
 ENV=stg
 QDASH_INSTANCE=stg-qdash
-QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-stg.qiqb.dev
 PROXY_PORT=18081
+PREFECT_FORWARD_PORT=14201
 POSTGRES_DATA_PATH=./postgres_data_stg
 MONGO_DATA_PATH=./mongo_data_stg/data/db
 ```
@@ -239,17 +215,22 @@ MONGO_DATA_PATH=./mongo_data_stg/data/db
 Forward both environments from the workstation when needed:
 
 ```shell
-ssh -L 18080:127.0.0.1:18080 -L 18081:127.0.0.1:18081 anemone
+ssh \
+  -L 18080:127.0.0.1:18080 \
+  -L 14200:127.0.0.1:14200 \
+  -L 18081:127.0.0.1:18081 \
+  -L 14201:127.0.0.1:14201 \
+  anemone
 ```
 
 ### Access Points
 
 | Service           | URL                                             |
 | ----------------- | ----------------------------------------------- |
-| QDash UI          | `http://${ENV}.qdash.test:${PROXY_PORT}`         |
-| API Documentation | `http://api.${ENV}.qdash.test:${PROXY_PORT}/docs` |
-| Prefect Dashboard | `http://prefect.${ENV}.qdash.test:${PROXY_PORT}` |
-| MongoDB Admin     | `http://mongo.${ENV}.qdash.test:${PROXY_PORT}`   |
+| QDash UI          | `http://localhost:${PROXY_PORT}`       |
+| API Documentation | `http://localhost:${PROXY_PORT}/docs`  |
+| Prefect Dashboard | `http://localhost:${PREFECT_FORWARD_PORT}` for `task deploy`, `http://localhost:${PREFECT_PORT}` for local tasks |
+| MongoDB Admin     | `http://localhost:${MONGO_EXPRESS_PORT}` for local tasks |
 
 ## Development Commands
 
@@ -378,6 +359,7 @@ Key environment variables are configured in `.env`. See `.env.example` for avail
 | Variable                  | Default | Description                 |
 | ------------------------- | ------- | --------------------------- |
 | `PROXY_PORT`              | 18080   | Reverse proxy port          |
+| `PREFECT_FORWARD_PORT`    | 14200   | Prefect SSH forwarding port used by `task deploy` |
 | `API_PORT`                | 5715    | Backend API port            |
 | `UI_PORT`                 | 5714    | Frontend UI port            |
 | `QDASH_INSTANCE`          | -       | Optional instance name; defaults to `${ENV}-qdash` |

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -373,3 +373,8 @@ Key environment variables are configured in `.env`. See `.env.example` for avail
 | `NEXT_PUBLIC_API_URL`     | -       | Public API URL for frontend |
 | `NEXT_PUBLIC_PREFECT_URL` | -       | Prefect dashboard URL       |
 | `NEXT_ALLOWED_DEV_ORIGINS` | -       | Additional hostnames allowed to access the Next.js dev server |
+| `OLLAMA_BASE_URL`         | -       | Ollama/OpenAI-compatible endpoint for Copilot models |
+| `OLLAMA_API_KEY`          | -       | Optional API key for Ollama-compatible endpoints |
+| `OPENAI_API_KEY`          | -       | OpenAI API key for Copilot models |
+| `DS4_BASE_URL`            | -       | Optional DeepSeek v4 OpenAI-compatible gateway URL |
+| `DS4_API_KEY`             | -       | Optional DeepSeek v4 gateway API key |

--- a/docs/operator-guide/setup.md
+++ b/docs/operator-guide/setup.md
@@ -62,26 +62,25 @@ task deploy
 
 This starts the Compose stack with the Cloudflare tunnel profile.
 Configure Cloudflare Tunnel public hostnames to forward to `http://reverse-proxy:80`. The main
-hostname serves the UI and `/api/*`; optional Prefect and Mongo Express hostnames can use the same
-service URL for operator-only access.
+hostname serves the UI and `/api/*`. Prefect is published only on localhost for SSH forwarding.
 `task deploy` validates the tunnel token and reverse-proxy hostname settings before starting the
 stack; it resolves templated URL values for Compose and does not rewrite `.env`. When left unset or
 templated, `CLIENT_URL` becomes `https://${QDASH_HOST}`, `NEXT_PUBLIC_API_URL` becomes `/api`, and
-`NEXT_PUBLIC_PREFECT_URL` becomes `http://prefect.${ENV}.${QDASH_LOCAL_DOMAIN}:${PROXY_PORT}`.
+`NEXT_PUBLIC_PREFECT_URL` becomes `http://localhost:${PREFECT_FORWARD_PORT}`.
 
 For multiple QDash environments on the same server, give each environment a unique
 `ENV`, `QDASH_INSTANCE`, `QDASH_HOST`, `PROXY_PORT`, and database data path. Set
-`QDASH_LOCAL_DOMAIN` to the local wildcard DNS zone used on the workstation. `COMPOSE_PROJECT_NAME`
-defaults from `QDASH_INSTANCE`, and `QDASH_LOCAL_HOST` defaults from `ENV`. The
-application service ports can stay at their defaults because `task deploy` publishes only the
-reverse proxy on `127.0.0.1:${PROXY_PORT}` for SSH forwarding.
+`PREFECT_FORWARD_PORT` uniquely when Prefect should be reachable through SSH forwarding.
+`COMPOSE_PROJECT_NAME` defaults from `QDASH_INSTANCE`, and `QDASH_LOCAL_HOST` defaults to
+`localhost`. The application service ports can stay at their defaults because `task deploy`
+publishes only the reverse proxy and Prefect on `127.0.0.1`.
 
 ```env
 ENV=dev
 QDASH_INSTANCE=dev-qdash
-QDASH_LOCAL_DOMAIN=qdash.test
 QDASH_HOST=qdash-dev.qiqb.dev
 PROXY_PORT=18080
+PREFECT_FORWARD_PORT=14200
 POSTGRES_DATA_PATH=./postgres_data_dev
 MONGO_DATA_PATH=./mongo_data_dev/data/db
 ```

--- a/scripts/assign_local_ports.sh
+++ b/scripts/assign_local_ports.sh
@@ -10,6 +10,7 @@ PORT_KEYS=(
   MONGO_EXPRESS_PORT
   POSTGRES_PORT
   PREFECT_PORT
+  PREFECT_FORWARD_PORT
   API_PORT
   UI_PORT
   DEPLOYMENT_SERVICE_PORT
@@ -108,12 +109,7 @@ else
 fi
 
 proxy_name="$instance"
-local_name="$env_name"
-local_domain="${QDASH_LOCAL_DOMAIN:-$(env_value QDASH_LOCAL_DOMAIN)}"
-if [ -z "$local_domain" ]; then
-  local_domain="qdash.test"
-fi
-host="${local_name}.${local_domain}"
+host="localhost"
 force=0
 if [ "${1:-}" = "--force" ]; then
   force=1
@@ -138,8 +134,6 @@ declare -A updates
 updates[ENV]="$env_name"
 updates[COMPOSE_PROJECT_NAME]="$proxy_name"
 updates[QDASH_INSTANCE]="$instance"
-updates[QDASH_LOCAL_DOMAIN]="$local_domain"
-updates[QDASH_HOST]="$host"
 updates[QDASH_LOCAL_HOST]="$host"
 updates[QDASH_API_HOST]="api.${host}"
 updates[QDASH_PREFECT_HOST]="prefect.${host}"
@@ -158,7 +152,7 @@ done
 
 updates[CLIENT_URL]="http://${updates[QDASH_LOCAL_HOST]}:${updates[PROXY_PORT]}"
 updates[NEXT_PUBLIC_API_URL]="/api"
-updates[NEXT_PUBLIC_PREFECT_URL]="http://prefect.${updates[QDASH_LOCAL_HOST]}:${updates[PROXY_PORT]}"
+updates[NEXT_PUBLIC_PREFECT_URL]="http://localhost:${updates[PREFECT_PORT]}"
 updates[QDASH_UI_UPSTREAM]="ui:${updates[UI_PORT]}"
 updates[QDASH_API_UPSTREAM]="api:${updates[API_PORT]}"
 updates[PREFECT_API_URL]='http://localhost:${PREFECT_PORT}/api'
@@ -220,7 +214,5 @@ else
   echo "Updated .env for $instance"
 fi
 echo "Compose project: $proxy_name"
-echo "Proxy: http://${host}:${updates[PROXY_PORT]}"
-echo "Local alias: http://${updates[QDASH_LOCAL_HOST]}:${updates[PROXY_PORT]}"
-echo "API: http://api.${host}:${updates[PROXY_PORT]}"
-echo "Prefect: http://prefect.${host}:${updates[PROXY_PORT]}"
+echo "Proxy: http://localhost:${updates[PROXY_PORT]}"
+echo "Prefect: http://localhost:${updates[PREFECT_PORT]}"

--- a/scripts/check_deploy_env.sh
+++ b/scripts/check_deploy_env.sh
@@ -33,7 +33,7 @@ for key in TUNNEL_TOKEN QDASH_HOST; do
   fi
 done
 
-for key in ENV COMPOSE_PROJECT_NAME QDASH_HOST QDASH_LOCAL_DOMAIN QDASH_LOCAL_HOST CLIENT_URL NEXT_PUBLIC_PREFECT_URL PROXY_PORT; do
+for key in ENV COMPOSE_PROJECT_NAME QDASH_HOST QDASH_LOCAL_HOST CLIENT_URL NEXT_PUBLIC_PREFECT_URL PROXY_PORT PREFECT_FORWARD_PORT; do
   count="$(
     awk -v key="$key" '
       $0 ~ "^[[:space:]]*(export[[:space:]]+)?" key "[[:space:]]*=" { count++ }
@@ -54,7 +54,7 @@ for key in QDASH_UI_UPSTREAM QDASH_API_UPSTREAM; do
   esac
 done
 
-for key in MONGO_PORT MONGO_EXPRESS_PORT POSTGRES_PORT PREFECT_PORT API_PORT UI_PORT; do
+for key in MONGO_PORT MONGO_EXPRESS_PORT POSTGRES_PORT PREFECT_PORT PREFECT_FORWARD_PORT API_PORT UI_PORT; do
   value="$(env_value "$key")"
   if [ -n "$value" ]; then
     case "$value" in

--- a/scripts/resolve_deploy_env.sh
+++ b/scripts/resolve_deploy_env.sh
@@ -44,14 +44,14 @@ qdash_instance="${qdash_instance:-${env_name}-qdash}"
 compose_project_name="${COMPOSE_PROJECT_NAME:-$(env_value COMPOSE_PROJECT_NAME)}"
 compose_project_name="${compose_project_name:-$qdash_instance}"
 
-local_domain="${QDASH_LOCAL_DOMAIN:-$(env_value QDASH_LOCAL_DOMAIN)}"
-local_domain="${local_domain:-qdash.test}"
-
 local_host="${QDASH_LOCAL_HOST:-$(env_value QDASH_LOCAL_HOST)}"
-local_host="${local_host:-${env_name}.${local_domain}}"
+local_host="${local_host:-localhost}"
 
 proxy_port="${PROXY_PORT:-$(env_value PROXY_PORT)}"
 proxy_port="${proxy_port:-18080}"
+
+prefect_forward_port="${PREFECT_FORWARD_PORT:-$(env_value PREFECT_FORWARD_PORT)}"
+prefect_forward_port="${prefect_forward_port:-14200}"
 
 ui_port="${UI_PORT:-$(env_value UI_PORT)}"
 ui_port="${ui_port:-5714}"
@@ -73,19 +73,19 @@ next_public_api_url="${next_public_api_url:-/api}"
 prefect_url="${NEXT_PUBLIC_PREFECT_URL:-$(env_value NEXT_PUBLIC_PREFECT_URL)}"
 case "$prefect_url" in
   ""|*'$'*)
-    prefect_url="http://prefect.${local_host}:${proxy_port}"
+    prefect_url="http://localhost:${prefect_forward_port}"
     ;;
 esac
 
 emit_export ENV "$env_name"
 emit_export QDASH_INSTANCE "$qdash_instance"
 emit_export COMPOSE_PROJECT_NAME "$compose_project_name"
-emit_export QDASH_LOCAL_DOMAIN "$local_domain"
 emit_export QDASH_LOCAL_HOST "$local_host"
 emit_export QDASH_API_HOST "api.${local_host}"
 emit_export QDASH_PREFECT_HOST "prefect.${local_host}"
 emit_export QDASH_MONGO_HOST "mongo.${local_host}"
 emit_export PROXY_PORT "$proxy_port"
+emit_export PREFECT_FORWARD_PORT "$prefect_forward_port"
 emit_export CLIENT_URL "$client_url"
 emit_export NEXT_PUBLIC_API_URL "$next_public_api_url"
 emit_export NEXT_PUBLIC_PREFECT_URL "$prefect_url"


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Removes the local wildcard DNS workflow from the default deploy guidance and uses `localhost` port forwarding instead.
- Keeps Cloudflare UI/API deployment intact while exposing Prefect through a separate localhost-only forward port for operator access.

## Changes
- Added `PREFECT_FORWARD_PORT` and published Prefect on `127.0.0.1:${PREFECT_FORWARD_PORT}` for `task deploy`.
- Updated deploy environment resolution so local access defaults to `localhost:${PROXY_PORT}` and Prefect defaults to `localhost:${PREFECT_FORWARD_PORT}`.
- Simplified local port assignment and docs by removing the default `*.qdash.test` route from setup instructions.
- Updated validation to cover `PREFECT_FORWARD_PORT`.