### PR TITLE
ci(infra): run renovate from github actions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,32 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check Renovate token
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+        run: |
+          if [ -z "$RENOVATE_TOKEN" ]; then
+            echo "RENOVATE_TOKEN secret is required to run Renovate." >&2
+            exit 1
+          fi
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v46.1.14
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- add a scheduled and manually runnable Renovate GitHub Actions workflow
- run Renovate against the current repository with the existing renovate.json5 config
- fail early with a clear message when RENOVATE_TOKEN is not configured

## Required setup
- add repository secret RENOVATE_TOKEN
- use a PAT that can open PRs; include workflow scope because Renovate manages GitHub Actions dependencies

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/renovate.yml"); puts "ok"'
- git diff --check