### PR TITLE
docs: clarify qubex setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,11 +54,14 @@ GITHUB_TOKEN=
 GITHUB_USER=
 
 TUNNEL_TOKEN=
+# fill in your domain
+#CLIENT_URL=
 QDASH_API_TOKEN=
 
 # CopilotKit AI Assistant (optional)
 # Enable the AI chat assistant in the UI
 NEXT_PUBLIC_COPILOT_ENABLED=true
+OLLAMA_BASE_URL=
 OLLAMA_API_KEY=
 OPENAI_API_KEY=
 KNOWLEDGE_REPO_URL=

--- a/.env.example.qubex
+++ b/.env.example.qubex
@@ -18,6 +18,8 @@ DEPLOYMENT_SERVICE_PORT=4006
 CLIENT_URL=http://localhost:${UI_PORT}
 NEXT_PUBLIC_API_URL=/api
 NEXT_PUBLIC_PREFECT_URL=http://localhost:${PREFECT_PORT}
+# Comma-separated hostnames allowed to access the Next.js dev server, e.g. 192.168.0.4
+NEXT_ALLOWED_DEV_ORIGINS=
 PREFECT_API_URL=http://localhost:${PREFECT_PORT}/api
 INTERNAL_API_URL=http://api:${API_PORT}
 # MongoDB
@@ -35,6 +37,7 @@ POSTGRES_DATA_PATH="./postgres_data"
 MONGO_DATA_PATH="./mongo_data/data/db"
 CALIB_DATA_PATH="./calib_data"
 CALIB_TASKS_PATH="./src/qdash/workflow/calibtasks"
+# Qubex backend configuration repository/data. QDash app config lives under ./config.
 CONFIG_PATH="./config/qubex-config"
 
 QDASH_ADMIN_USERNAME="admin"
@@ -51,11 +54,14 @@ GITHUB_TOKEN=
 GITHUB_USER=
 
 TUNNEL_TOKEN=
+# fill in your domain
+#CLIENT_URL=
 QDASH_API_TOKEN=
 
 # CopilotKit AI Assistant (optional)
 # Enable the AI chat assistant in the UI
 NEXT_PUBLIC_COPILOT_ENABLED=true
+OLLAMA_BASE_URL=
 OLLAMA_API_KEY=
 OPENAI_API_KEY=
 KNOWLEDGE_REPO_URL=

--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -29,8 +29,20 @@ task dev-local
 
 ## Full Docker Stack
 
+Create and review `.env` before starting the stack:
+
 ```bash
-cp .env.example .env
+cp .env.example.qubex .env
+```
+
+Edit `.env` if you need custom ports, data paths, admin credentials, Qubex config repository
+settings, remote access settings, or Copilot provider credentials. For Qubex workflows, make sure
+`CONFIG_PATH` contains the chip configuration tree described in the
+[Operator Setup](../operator-guide/setup.md#qubex-configuration-files).
+
+Then start the full stack:
+
+```bash
 task deploy-local
 ```
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -28,16 +28,17 @@ git clone https://github.com/oqtopus-team/qdash.git
 cd qdash
 ```
 
-### Initial Setup
+### Qubex Setup
 
-Create the environment file from the example:
+Create the environment file from the Qubex example:
 
 ```shell
-cp .env.example .env
+cp .env.example.qubex .env
 ```
 
-Data directories are created by Docker Compose and `task dev-local-setup` as needed. Edit `.env`
-before starting services if you need custom ports, data paths, or admin credentials.
+Edit `.env` before starting services if you need custom ports, data paths, admin credentials,
+Qubex config repository settings, remote access settings, or Copilot provider credentials. Data
+directories are created by Docker Compose and `task dev-local-setup` as needed.
 
 ### Using DevContainer (Recommended)
 
@@ -286,7 +287,8 @@ lefthook install
 
 ## Environment Variables
 
-Key environment variables are configured in `.env`. See `.env.example` for available options:
+Key environment variables are configured in `.env`. See `.env.example.qubex` for the Qubex-backed
+defaults and `.env.example` for the fake backend defaults:
 
 | Variable                  | Default | Description                 |
 | ------------------------- | ------- | --------------------------- |
@@ -298,7 +300,11 @@ Key environment variables are configured in `.env`. See `.env.example` for avail
 | `DEPLOYMENT_SERVICE_PORT` | 4006    | Deployment service port     |
 | `CALIB_DATA_PATH`         | -       | Calibration data mount path |
 | `CALIB_TASKS_PATH`        | -       | Calibration tasks path      |
-| `CONFIG_PATH`             | -       | Qubex backend config repository/data path |
+| `CONFIG_PATH`             | -       | Qubex backend config root |
 | `NEXT_PUBLIC_API_URL`     | -       | Public API URL for frontend |
 | `NEXT_PUBLIC_PREFECT_URL` | -       | Prefect dashboard URL       |
 | `NEXT_ALLOWED_DEV_ORIGINS` | -       | Additional hostnames allowed to access the Next.js dev server |
+
+For Qubex-backed runs, `CONFIG_PATH` must contain chip-specific Qubex configuration directories.
+QDash reads `<CONFIG_PATH>/<chip_id>/config` and `<CONFIG_PATH>/<chip_id>/params`; see
+[Operator Setup](../operator-guide/setup.md#qubex-configuration-files) for the expected layout.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -11,17 +11,38 @@ git clone https://github.com/oqtopus-team/qdash.git
 cd qdash
 ```
 
-## Initial Setup
+## Qubex Setup
 
-Create the environment file from the example and install local dependencies.
+Create the Qubex-backed environment file:
 
 ```bash
-cp .env.example .env
+cp .env.example.qubex .env
+```
+
+Before starting services, edit `.env` if you need different ports, data directories, admin
+credentials, Qubex config repository settings, remote access settings, or Copilot provider
+credentials.
+
+Qubex-backed workflows also need configuration files under `CONFIG_PATH`. With the default
+`CONFIG_PATH="./config/qubex-config"`, put each chip's Qubex config tree at
+`./config/qubex-config/<chip_id>/`, including `config/`, `params/`, and optional `calibration/`
+directories. See the
+[Qubex system configuration guide](https://amachino.github.io/qubex/user-guide/getting-started/system-configuration/)
+for the required files.
+
+If your Qubex config is stored in a Git repository, set `CONFIG_REPO_URL`, `GITHUB_USER`, and
+`GITHUB_TOKEN` in `.env` so QDash can pull the latest config into `CONFIG_PATH` and push supported
+calibration updates back to the repository when workflow GitHub push is enabled.
+
+Complete this Qubex config setup before running `task deploy-local` or `task dev-local`.
+
+Install local dependencies after `.env` and Qubex config setup are ready:
+
+```bash
 task dev-local-setup
 ```
 
-The setup task installs Python and UI dependencies and creates the default Qubex config
-directory. Edit `.env` if you need different ports, data directories, or admin credentials.
+The setup task installs Python and UI dependencies and creates local data directories as needed.
 
 ## Start the Application
 

--- a/docs/operator-guide/setup.md
+++ b/docs/operator-guide/setup.md
@@ -4,27 +4,88 @@ QDash can run as a full Docker Compose stack or as a host-side API/UI connected 
 services. Operators normally use the Docker Compose stack; developers usually use the host-side
 stack.
 
-## Environment File
+## Qubex Setup
 
-Create `.env` from the example:
+Create `.env` from the Qubex example when you want QDash to run with the Qubex backend:
 
 ```bash
-cp .env.example .env
+cp .env.example.qubex .env
 ```
 
-Review these values before starting services:
+Review or fill in these values before starting services:
 
 | Variable | Purpose |
 | --- | --- |
+| `ENV` | Environment label; keep `dev-qubex` for local Qubex-backed setup unless you need another label |
+| `DEFAULT_BACKEND` | Backend selected by default; keep `qubex` for the Qubex-backed stack |
 | `QDASH_ADMIN_USERNAME` / `QDASH_ADMIN_PASSWORD` | Initial admin login |
 | `API_PORT` / `UI_PORT` / `PREFECT_PORT` | Host ports for API, UI, and Prefect |
 | `MONGO_DATA_PATH` / `POSTGRES_DATA_PATH` | Persistent database storage |
 | `CALIB_DATA_PATH` | Calibration figures and run artifacts |
+| `CALIB_TASKS_PATH` | Calibration task definitions used by the workflow worker |
 | `CONFIG_PATH` | Qubex backend configuration repository/data |
-| `DEFAULT_BACKEND` | Backend selected by default |
+| `CONFIG_REPO_URL` / `GITHUB_TOKEN` / `GITHUB_USER` | Optional Qubex config repository sync settings |
+| `CLIENT_URL` | Public UI URL when the app is served through a domain or tunnel |
+| `TUNNEL_TOKEN` | Optional Cloudflare Tunnel token for remote access |
+| `QDASH_API_TOKEN` | Optional API token for automation or service-to-service access |
+| `OPENAI_API_KEY` / `OLLAMA_BASE_URL` / `OLLAMA_API_KEY` | Optional Copilot AI provider settings |
+| `KNOWLEDGE_REPO_URL` | Optional external knowledge repository for Copilot context |
 
 QDash application settings are committed under `config/app`, `config/domain`, and
 `config/copilot`; `CONFIG_PATH` is only for the Qubex backend configuration tree.
+
+### Qubex Configuration Files
+
+The Qubex backend requires hardware and parameter configuration files before calibration tasks can
+run. Prepare a Qubex configuration tree following the
+[Qubex system configuration guide](https://amachino.github.io/qubex/user-guide/getting-started/system-configuration/)
+and place it under `CONFIG_PATH`.
+
+QDash resolves Qubex files by chip ID, so the expected local layout is:
+
+```text
+config/qubex-config/
+  <chip_id>/
+    config/
+      chip.yaml
+      box.yaml
+      system.yaml
+      wiring.yaml
+      skew.yaml
+    params/
+      measurement_defaults.yaml
+      ...
+    calibration/
+      calib_note.json
+```
+
+For the default `.env.example.qubex`, `CONFIG_PATH="./config/qubex-config"`. A task for
+`chip_id="64Qv3"` therefore reads shared Qubex files from
+`./config/qubex-config/64Qv3/config` and parameter files from
+`./config/qubex-config/64Qv3/params`. `skew.yaml` is only needed for Qubex setups that require
+inter-box timing adjustment.
+
+### Repository-Managed Qubex Config
+
+If the Qubex configuration tree is managed in a Git repository, set the repository settings in
+`.env`:
+
+```bash
+CONFIG_REPO_URL=https://github.com/<owner>/<qubex-config-repo>.git
+GITHUB_USER=<github-username>
+GITHUB_TOKEN=<github-token>
+```
+
+With these values set, QDash can keep `CONFIG_PATH` synchronized with the repository. Calibration
+sessions pull the latest config before running when GitHub pull is enabled, which is the default
+for Qubex workflows. Config changes can also be pulled or pushed from the file management UI.
+
+When workflow GitHub push is enabled, QDash can commit updated calibration files such as
+`calibration/calib_note.json` and parameter YAML files back to the config repository after a
+calibration run.
+
+Complete the Qubex config placement or repository setup before starting services with
+`task deploy-local` or `task dev-local`.
 
 ## Full Stack
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Clarifies the Qubex-backed setup flow so users create and review .env, prepare CONFIG_PATH, and only then run setup or service commands.
- Affects documentation and example environment files only; no API, workflow behavior, UI runtime, or generated client changes.

## Changes
- Update Quick Start, Operator Setup, Developer Setup, and Development Setup to use .env.example.qubex for Qubex-backed setup.
- Document the required Qubex config tree under CONFIG_PATH, including chip-specific config, params, and optional calibration directories.
- Add repository-managed qubex-config guidance for CONFIG_REPO_URL, GITHUB_USER, and GITHUB_TOKEN, including pull/push behavior.
- Split command blocks so environment editing and Qubex config preparation happen before task dev-local-setup, task deploy-local, or task dev-local.
- Add missing example environment entries/comments for client URL, NEXT_ALLOWED_DEV_ORIGINS, CONFIG_PATH, and OLLAMA_BASE_URL.