### PR TITLE
feat(repo): add 16q square lattice topology

### DIFF
--- a/config/domain/topologies/square-lattice-mux-16.yaml
+++ b/config/domain/topologies/square-lattice-mux-16.yaml
@@ -1,0 +1,86 @@
+name: Square Lattice with MUX
+description: Square lattice topology with 2x2 MUX groups
+grid_size: 4
+num_qubits: 16
+direction_convention: checkerboard_cr
+mux:
+  enabled: true
+  size: 2
+qubits:
+  0:
+    row: 0
+    col: 0
+  1:
+    row: 0
+    col: 1
+  2:
+    row: 1
+    col: 0
+  3:
+    row: 1
+    col: 1
+  4:
+    row: 0
+    col: 2
+  5:
+    row: 0
+    col: 3
+  6:
+    row: 1
+    col: 2
+  7:
+    row: 1
+    col: 3
+  8:
+    row: 2
+    col: 0
+  9:
+    row: 2
+    col: 1
+  10:
+    row: 3
+    col: 0
+  11:
+    row: 3
+    col: 1
+  12:
+    row: 2
+    col: 2
+  13:
+    row: 2
+    col: 3
+  14:
+    row: 3
+    col: 2
+  15:
+    row: 3
+    col: 3
+couplings:
+- [0, 1]
+- [0, 2]
+- [4, 1]
+- [3, 1]
+- [3, 2]
+- [8, 2]
+- [3, 6]
+- [3, 9]
+- [4, 5]
+- [4, 6]
+- [7, 5]
+- [7, 6]
+- [12, 6]
+- [7, 13]
+- [8, 9]
+- [8, 10]
+- [12, 9]
+- [11, 9]
+- [11, 10]
+- [11, 14]
+- [12, 13]
+- [12, 14]
+- [15, 13]
+- [15, 14]
+visualization:
+  show_mux_boundaries: true
+  region_size: 4
+id: square-lattice-mux-16

--- a/docs/architecture/square-lattice-topology.md
+++ b/docs/architecture/square-lattice-topology.md
@@ -6,6 +6,7 @@ QDash supports superconducting quantum processors with square lattice topology, 
 
 ### Supported Chip Sizes
 
+- **16-qubit chip**: 4×4 grid
 - **64-qubit chip**: 8×8 grid (e.g., 64Qv3)
 - **144-qubit chip**: 12×12 grid (e.g., 144Qv2)
 
@@ -140,6 +141,12 @@ Edges can be classified as:
 
 ### Total Edge Counts
 
+**16-qubit chip (4×4 grid):**
+
+- Horizontal edges: 4 rows × 3 edges/row = 12 edges
+- Vertical edges: 3 rows × 4 edges/row = 12 edges
+- **Total: 24 nearest-neighbor edges**
+
 **64-qubit chip (8×8 grid):**
 
 - Horizontal edges: 8 rows × 7 edges/row = 56 edges
@@ -260,11 +267,11 @@ Edges are named as `"q1-q2"` where:
 ### Usage
 
 ```bash
-# Generate a 64-qubit square-lattice topology
+# Generate a 16-qubit square-lattice topology
 uv run python scripts/generate_topology.py \
   --template square-lattice-mux \
-  --size 64 \
-  --output config/domain/topologies/64q-square-lattice.yaml
+  --size 16 \
+  --output config/domain/topologies/square-lattice-mux-16.yaml
 ```
 
 ## References

--- a/tests/qdash/common/config/test_topology.py
+++ b/tests/qdash/common/config/test_topology.py
@@ -46,3 +46,19 @@ def test_list_topologies_reads_domain_topologies(monkeypatch, tmp_path):
     assert list_topologies(size=4) == [
         {"id": "test-topology", "name": "Test Topology", "num_qubits": 4}
     ]
+
+
+def test_builtin_16q_square_lattice_mux_topology(monkeypatch):
+    monkeypatch.setattr(ConfigLoader, "_CONFIG_DIR", ConfigLoader.LOCAL_CONFIG_DIR)
+    load_topology.cache_clear()
+
+    topology = load_topology("square-lattice-mux-16")
+
+    assert topology.grid_size == 4
+    assert topology.num_qubits == 16
+    assert len(topology.qubits) == 16
+    assert len(topology.couplings) == 24
+    assert topology.mux.enabled is True
+    assert topology.mux.size == 2
+
+    load_topology.cache_clear()


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add a built-in 16-qubit square-lattice MUX topology for smaller local and test configurations.
- Impact is limited to domain topology config, topology docs, and config loader coverage; no API or generated client changes.

## Changes
- Add square-lattice-mux-16.yaml with a 4x4 grid, 16 qubits, 24 nearest-neighbor couplings, and 2x2 MUX groups.
- Document 16-qubit square-lattice support and update the generation example.
- Add a topology config test covering the built-in 16Q MUX topology.

Verification:
- uv run pytest tests/qdash/common/config/test_topology.py
