### PR TITLE
fix(workflow): include touched params in batch push

### DIFF
--- a/src/qdash/workflow/engine/params_updater.py
+++ b/src/qdash/workflow/engine/params_updater.py
@@ -82,6 +82,26 @@ class ParamsUpdater(Protocol):
     def update(self, qid: str, output_parameters: dict[str, Any]) -> set[str]: ...
 
 
+def resolve_param_yaml_file_names(output_parameters: dict[str, Any]) -> set[str]:
+    """Resolve params YAML files addressed by output parameter names.
+
+    This intentionally does not check whether the YAML value would change. Task
+    execution may have already updated local params files before finish-time
+    GitHub push, but the same files still need to be included in the batch push
+    candidate list.
+    """
+    param_file_map = _load_param_file_map()
+    extra_file_map = _load_extra_file_map()
+
+    file_names: set[str] = set()
+    for parameter_name in output_parameters:
+        file_name = param_file_map.get(parameter_name)
+        if file_name is not None:
+            file_names.add(file_name)
+        file_names.update(extra_file_map.get(parameter_name, []))
+    return file_names
+
+
 def get_params_updater(
     backend: BaseBackend | None, chip_id: str | None = None
 ) -> ParamsUpdater | None:

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -855,12 +855,15 @@ class CalibService:
         if updater_instance is None:
             return
 
-        updated_param_files: set[str] = set()
+        from qdash.workflow.engine.params_updater import resolve_param_yaml_file_names
+
+        push_candidate_files: set[str] = set()
         for qid, params in self.execution_service.calib_data.qubit.items():
             if "-" in qid or not params:
                 continue
+            push_candidate_files.update(resolve_param_yaml_file_names(params))
             try:
-                updated_param_files.update(updater_instance.update(qid, params))
+                push_candidate_files.update(updater_instance.update(qid, params))
             except Exception as exc:
                 logger.warning(f"Failed to sync params for qid={qid}: {exc}")
 
@@ -869,12 +872,12 @@ class CalibService:
             self.github_push_config.params_file_names = [
                 file_name
                 for file_name in configured_param_files
-                if file_name in updated_param_files
+                if file_name in push_candidate_files
             ]
-            skipped_files = sorted(set(configured_param_files) - updated_param_files)
+            skipped_files = sorted(set(configured_param_files) - push_candidate_files)
             if skipped_files:
                 logger.info(
-                    "Skipping unchanged params files from GitHub push: %s",
+                    "Skipping params files not touched by this calibration: %s",
                     ", ".join(skipped_files),
                 )
 

--- a/tests/qdash/workflow/engine/test_params_updater.py
+++ b/tests/qdash/workflow/engine/test_params_updater.py
@@ -14,6 +14,7 @@ from qdash.workflow.engine.params_updater import (
     _load_param_file_map,
     _QubexParamsUpdater,
     get_params_updater,
+    resolve_param_yaml_file_names,
 )
 
 
@@ -259,6 +260,36 @@ data:
             )
 
         assert updated_files == {"control_frequency.yaml", "t1.yaml"}
+
+    def test_resolve_param_yaml_file_names_includes_mapped_and_extra_files(self):
+        """Push candidates should be resolved even before checking file diffs."""
+        with patch(
+            "qdash.workflow.engine.params_updater.ConfigLoader.load_workflow",
+            return_value={
+                "params_updater": {
+                    "parameter_file_map": {
+                        "qubit_frequency": "qubit_frequency.yaml",
+                        "t1": "t1.yaml",
+                    },
+                    "extra_file_map": {
+                        "qubit_frequency": ["control_frequency.yaml"],
+                    },
+                }
+            },
+        ):
+            file_names = resolve_param_yaml_file_names(
+                {
+                    "qubit_frequency": {"value": 4.2},
+                    "t1": {"value": 12.0},
+                    "unmapped": {"value": 1.0},
+                }
+            )
+
+        assert file_names == {
+            "control_frequency.yaml",
+            "qubit_frequency.yaml",
+            "t1.yaml",
+        }
 
     def test_update_uses_params_mapping_from_qdash_settings(self, tmp_path):
         """Parameter-to-YAML mapping should be configurable through QDash settings."""

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -282,11 +282,11 @@ class TestCalibServiceParameterManagement:
         result = session.get_parameter("0", "nonexistent")
         assert result is None
 
-    def test_sync_backend_params_filters_configured_push_files_to_changed_files(
+    def test_sync_backend_params_filters_configured_push_files_to_touched_files(
         self,
         monkeypatch,
     ):
-        """Only configured params files changed by this calibration should be batch-pushed."""
+        """Only configured params files touched by this calibration should be batch-pushed."""
         from qdash.workflow.service.github import GitHubPushConfig
 
         class FakeUpdater:
@@ -312,6 +312,55 @@ class TestCalibServiceParameterManagement:
         monkeypatch.setattr(
             "qdash.workflow.service.calib_service.get_params_updater",
             lambda backend, chip_id: FakeUpdater(),
+        )
+        logger = MagicMock()
+
+        session._sync_backend_params_before_push(logger)
+
+        assert session.github_push_config.params_file_names == ["t1.yaml"]
+        logger.info.assert_called_once()
+
+    def test_sync_backend_params_keeps_touched_files_when_already_updated(
+        self,
+        monkeypatch,
+    ):
+        """Task-time params updates should still be batch-pushed on finish."""
+        from qdash.workflow.service.github import GitHubPushConfig
+
+        class FakeUpdater:
+            def update(self, qid, params):
+                assert qid == "0"
+                assert params == {"t1": {"value": 12.0}}
+                return set()
+
+        orchestrator = MagicMock()
+        orchestrator._execution_service = MockExecutionService()
+        orchestrator._execution_service.calib_data.qubit = {
+            "0": {"t1": {"value": 12.0}},
+        }
+        orchestrator._backend = MagicMock()
+
+        session = CalibService.__new__(CalibService)
+        session.chip_id = "chip_1"
+        session._orchestrator = orchestrator
+        session.github_push_config = GitHubPushConfig(
+            params_file_names=["t1.yaml", "t2_echo.yaml"],
+        )
+
+        monkeypatch.setattr(
+            "qdash.workflow.service.calib_service.get_params_updater",
+            lambda backend, chip_id: FakeUpdater(),
+        )
+        monkeypatch.setattr(
+            "qdash.workflow.engine.params_updater.ConfigLoader.load_workflow",
+            lambda: {
+                "params_updater": {
+                    "parameter_file_map": {
+                        "t1": "t1.yaml",
+                        "t2_echo": "t2_echo.yaml",
+                    },
+                },
+            },
         )
         logger = MagicMock()
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Fixes workflow GitHub batch push so params files touched by calibration outputs remain push candidates even when task-time YAML updates already wrote the same values.
- Affects workflow finish-time GitHub push filtering only; final commit creation still depends on Git diff in the batch push task.

## Changes
- Added params YAML candidate resolution from output parameter names and configured extra file mappings.
- Updated finish-time GitHub push filtering to keep touched params files instead of relying only on newly changed YAML writes.
- Added tests for touched-file filtering and candidate resolution.