### PR TITLE
style(ui): update RegionZoomToggle visibility logic in grid components

### DIFF
--- a/ui/src/components/features/chip/CouplingGrid.tsx
+++ b/ui/src/components/features/chip/CouplingGrid.tsx
@@ -931,15 +931,21 @@ export function CouplingGrid({
             </button>
           </div>
 
-          {viewMode === "region" &&
-            zoomMode === "full" &&
-            isSquareGrid &&
-            !downloadSelectionEnabled && (
-              <RegionZoomToggle
-                enabled={regionSelectionEnabled}
-                onToggle={setRegionSelectionEnabled}
-              />
-            )}
+          <div
+            className={
+              viewMode !== "region" ||
+              zoomMode !== "full" ||
+              !isSquareGrid ||
+              downloadSelectionEnabled
+                ? "invisible pointer-events-none"
+                : ""
+            }
+          >
+            <RegionZoomToggle
+              enabled={regionSelectionEnabled}
+              onToggle={setRegionSelectionEnabled}
+            />
+          </div>
         </div>
 
         {/* Download selection controls */}

--- a/ui/src/components/features/chip/QubitGrid.tsx
+++ b/ui/src/components/features/chip/QubitGrid.tsx
@@ -918,15 +918,21 @@ export function QubitGrid({
             </button>
           </div>
 
-          {viewMode === "region" &&
-            zoomMode === "full" &&
-            isSquareGrid &&
-            !downloadSelectionEnabled && (
-              <RegionZoomToggle
-                enabled={regionSelectionEnabled}
-                onToggle={setRegionSelectionEnabled}
-              />
-            )}
+          <div
+            className={
+              viewMode !== "region" ||
+              zoomMode !== "full" ||
+              !isSquareGrid ||
+              downloadSelectionEnabled
+                ? "invisible pointer-events-none"
+                : ""
+            }
+          >
+            <RegionZoomToggle
+              enabled={regionSelectionEnabled}
+              onToggle={setRegionSelectionEnabled}
+            />
+          </div>
         </div>
 
         {/* Download selection controls */}

--- a/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
@@ -629,12 +629,18 @@ export function CouplingMetricsGrid({
         </div>
 
         <div className="flex items-center gap-2">
-          {viewMode === "region" && zoomMode === "full" && isSquareGrid && (
+          <div
+            className={
+              viewMode !== "region" || zoomMode !== "full" || !isSquareGrid
+                ? "invisible pointer-events-none"
+                : ""
+            }
+          >
             <RegionZoomToggle
               enabled={regionSelectionEnabled}
               onToggle={setRegionSelectionEnabled}
             />
-          )}
+          </div>
           <button
             onClick={() => setIsDirectionReversed((prev) => !prev)}
             className={`btn btn-sm gap-1.5 ${isDirectionReversed ? "btn-secondary" : "btn-outline"}`}

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -693,9 +693,15 @@ export function QubitMetricsGrid({
           </button>
         </div>
 
-        {viewMode === "region" && zoomMode === "full" && isSquareGrid && (
+        <div
+          className={
+            viewMode !== "region" || zoomMode !== "full" || !isSquareGrid
+              ? "invisible pointer-events-none"
+              : ""
+          }
+        >
           <RegionZoomToggle enabled={regionSelectionEnabled} onToggle={setRegionSelectionEnabled} />
-        )}
+        </div>
       </div>
 
       {/* Back button */}


### PR DESCRIPTION
## Ticket

close #945

## Summary

Fix container height shift when swapping between Region and DOM view modes by preserving the RegionZoomToggle layout space instead of conditionally rendering it.

## Changes

- Replace conditional rendering of `RegionZoomToggle` with `invisible pointer-events-none` so the element always occupies space but is hidden and non-interactive when inactive
- Apply the fix to all four grid components: `CouplingGrid`, `QubitGrid`, `CouplingMetricsGrid`, and `QubitMetricsGrid`
