### PR TITLE
chore(repo): add dev-local shutdown task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -85,6 +85,61 @@ tasks:
     cmds:
       - docker compose up -d mongo postgres prefect-server deployment-service user-flow-worker
 
+  dev-local-down:
+    desc: Stop host API/UI processes and Docker Compose services started for development
+    dotenv: [.env]
+    silent: true
+    cmds:
+      - |
+        stop_pidfile() {
+          pid_file="$1"
+          name="$2"
+          expected="$3"
+          if [ ! -f "$pid_file" ]; then
+            echo "${name} pid file not found"
+            return
+          fi
+
+          pid="$(cat "$pid_file")"
+          command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+          if [ -n "$command" ] && echo "$command" | grep -F "$expected" >/dev/null; then
+            echo "Stopping ${name}: ${pid}"
+            /bin/kill "$pid" 2>/dev/null || true
+          else
+            echo "${name} pid file is stale: ${pid}"
+          fi
+          rm -f "$pid_file"
+        }
+
+        stop_command() {
+          pattern="$1"
+          name="$2"
+          pids="$(ps ax -o pid= -o command= | awk -v pattern="$pattern" -v self="$$" 'index($0, pattern) > 0 && $1 != self {print $1}')"
+          if [ -n "$pids" ]; then
+            echo "Stopping ${name} processes: ${pids}"
+            /bin/kill $pids 2>/dev/null || true
+          fi
+        }
+
+        stop_port() {
+          port="$1"
+          name="$2"
+          pids="$(lsof -ti "tcp:${port}" -sTCP:LISTEN || true)"
+          if [ -n "$pids" ]; then
+            echo "Stopping ${name} on port ${port}: ${pids}"
+            /bin/kill $pids 2>/dev/null || true
+          else
+            echo "${name} is not listening on port ${port}"
+          fi
+        }
+        stop_pidfile ".tmp/dev-api-local.pid" "API" "uvicorn src.qdash.api.main:app"
+        stop_pidfile ".tmp/dev-ui-local.pid" "UI" "bun run dev"
+        stop_command "uvicorn src.qdash.api.main:app" "API"
+        stop_command "bun run dev" "UI"
+        stop_port "${API_PORT:-5715}" "API"
+        stop_port "${UI_PORT:-5714}" "UI"
+      - docker compose down
+
   dev-local-setup:
     desc: Install dependencies needed by host-side API/UI development
     cmds:
@@ -100,15 +155,27 @@ tasks:
   dev-api-local:
     desc: Start the API on the host against Docker services
     dotenv: [.env]
+    silent: true
     cmds:
-      - MONGO_HOST="${MONGO_HOST:-localhost}" PREFECT_API_URL="http://127.0.0.1:${PREFECT_PORT:-4200}/api" DEPLOYMENT_SERVICE_URL="http://127.0.0.1:${DEPLOYMENT_SERVICE_PORT:-4006}" uv run uvicorn src.qdash.api.main:app --reload --host 127.0.0.1 --port "${API_PORT:-5715}"
+      - |
+        /bin/sh -c '
+        mkdir -p .tmp
+        echo "$$" > .tmp/dev-api-local.pid
+        MONGO_HOST="${MONGO_HOST:-localhost}" PREFECT_API_URL="http://127.0.0.1:${PREFECT_PORT:-4200}/api" DEPLOYMENT_SERVICE_URL="http://127.0.0.1:${DEPLOYMENT_SERVICE_PORT:-4006}" exec uv run uvicorn src.qdash.api.main:app --reload --host 127.0.0.1 --port "${API_PORT:-5715}"
+        '
 
   dev-ui-local:
     desc: Start the UI on the host against the local API
     dir: ui
     dotenv: [../.env]
+    silent: true
     cmds:
-      - PORT="${UI_PORT:-5714}" INTERNAL_API_URL="http://127.0.0.1:${API_PORT:-5715}" bun run dev
+      - |
+        /bin/sh -c '
+        mkdir -p ../.tmp
+        echo "$$" > ../.tmp/dev-ui-local.pid
+        PORT="${UI_PORT:-5714}" INTERNAL_API_URL="http://127.0.0.1:${API_PORT:-5715}" exec bun run dev
+        '
 
   dev-local:
     desc: Start lightweight local development services, API, and UI

--- a/docs/developer-guide/commands.md
+++ b/docs/developer-guide/commands.md
@@ -8,6 +8,7 @@ Run commands from the repository root unless noted.
 task -l                  # list tasks
 task dev-local-setup     # install host-side Python/UI dependencies
 task dev-local           # Docker services + host API/UI
+task dev-local-down      # stop host API/UI and local Docker Compose services
 task deploy-local        # full Docker Compose stack
 ```
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -113,6 +113,12 @@ This starts MongoDB, PostgreSQL, Prefect, the deployment service, and the user f
 Docker Compose, then runs the API and UI on the host. The UI is available at
 <http://localhost:5714>.
 
+Stop the host API/UI processes and Docker Compose services:
+
+```shell
+task dev-local-down
+```
+
 ### Install Dependencies
 
 The DevContainer installs Python, frontend, and Lefthook dependencies automatically during
@@ -178,6 +184,9 @@ task deploy-local
 
 # Start supporting services with host API/UI
 task dev-local
+
+# Stop host API/UI and local Docker Compose services
+task dev-local-down
 
 # Deploy with Cloudflare Tunnel
 task deploy

--- a/docs/operator-guide/operations.md
+++ b/docs/operator-guide/operations.md
@@ -11,6 +11,9 @@ task deploy-local
 # Host-side API/UI with Docker-backed services
 task dev-local
 
+# Stop host API/UI and local Docker Compose services
+task dev-local-down
+
 # Supporting services only
 task dev-services
 

--- a/docs/operator-guide/setup.md
+++ b/docs/operator-guide/setup.md
@@ -113,6 +113,12 @@ task dev-local
 This starts MongoDB, PostgreSQL, Prefect, deployment-service, and user-flow-worker in Docker,
 then runs the API and UI on the host.
 
+Stop the host API/UI processes and Docker Compose services:
+
+```bash
+task dev-local-down
+```
+
 ## Remote Access
 
 Set `TUNNEL_TOKEN` in `.env`, then run:


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add a shutdown task for the lightweight local development stack so host API/UI processes and Docker Compose services can be stopped with one command.
- Affects local developer tooling and docs only; no API, workflow, or UI runtime contract changes.

## Changes
- Add `task dev-local-down` to stop host-side API/UI processes and run `docker compose down`.
- Record host-side API/UI process IDs when running `task dev-local`, with command and port fallbacks for older running processes.
- Document the shutdown command in developer and operator guides.