### PR TITLE
fix(ui): prevent unsaved changes flag from being set when editor is l…

### DIFF
--- a/ui/src/components/features/files/FilesPageContent.tsx
+++ b/ui/src/components/features/files/FilesPageContent.tsx
@@ -279,7 +279,9 @@ export function FilesPageContent() {
 
   const handleContentChange = (value: string | undefined) => {
     setFileContent(value || "");
-    setHasUnsavedChanges(true);
+    if (!isEditorLocked) {
+      setHasUnsavedChanges(true);
+    }
   };
 
   const getLanguage = (filename: string): string => {

--- a/ui/src/components/features/files/FilesPageContent.tsx
+++ b/ui/src/components/features/files/FilesPageContent.tsx
@@ -279,6 +279,9 @@ export function FilesPageContent() {
 
   const handleContentChange = (value: string | undefined) => {
     setFileContent(value || "");
+    // Only flag unsaved changes when the editor is unlocked (the user can actually type).
+    // @monaco-editor/react fires onChange for programmatic setValue() updates even while
+    // read-only, so loading/switching a file would otherwise mark it dirty by mistake.
     if (!isEditorLocked) {
       setHasUnsavedChanges(true);
     }


### PR DESCRIPTION
## Ticket

close #1035

## Summary

On the Files page, the "unsaved changes" discard dialog appeared when switching files even though the user never pressed Edit. While the editor is read-only, `@monaco-editor/react` still fires `onChange` for programmatic `value` updates (its read-only branch calls `editor.setValue()` without the prevent-trigger guard it uses for the editable `executeEdits` path), so simply loading a file flagged it as dirty.

## Changes

- Guard `handleContentChange` in `FilesPageContent.tsx` to set `hasUnsavedChanges` only when the editor is unlocked (edit mode); while locked the user cannot type, so any `onChange` is a programmatic file load rather than a real edit
- This stops freshly opened/switched files from being marked dirty, so the discard confirmation now appears only after genuine unsaved edits
