### PR TITLE
fix(workflow): adapt chevron result handling

### DIFF
--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_chevron.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_chevron.py
@@ -1,6 +1,6 @@
 import math
 from collections.abc import Mapping
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 import plotly.graph_objects as go
 from qubex.contrib.experiment import estimate_qubit_frequency_from_chevron_adaptive
@@ -45,7 +45,7 @@ class CheckChevron(QubexTask):
     output_parameters: ClassVar[dict[str, ParameterModel]] = {
         "qubit_frequency": ParameterModel(unit="GHz", description="Qubit bare frequency (coarse)"),
         "control_amplitude": ParameterModel(
-            unit="a.u.", description="Control pulse amplitude used for adaptive chevron"
+            unit="a.u.", description="Control pulse amplitude estimated by adaptive chevron"
         ),
     }
 
@@ -180,10 +180,37 @@ class CheckChevron(QubexTask):
             plot=False,
             save_image=False,
         )
-        result_data = cast("dict[str, Any]", dict(adaptive_result.data))
-        result_data["control_amplitude_used"] = result_data["amplitudes_used"][label]
+        result_data = self._adaptive_result_data(adaptive_result)
+        result_data["control_amplitude_used"] = self._control_amplitude_from_result(
+            result_data, label, control_amplitude
+        )
         result_data["figures"] = getattr(adaptive_result, "figures", {})
         return result_data
+
+    def _adaptive_result_data(self, adaptive_result: Any) -> dict[str, Any]:
+        data = getattr(adaptive_result, "data", adaptive_result)
+        if not isinstance(data, Mapping):
+            raise TypeError(
+                "estimate_qubit_frequency_from_chevron_adaptive returned "
+                f"unsupported data type: {type(data).__name__}"
+            )
+        return dict(data)
+
+    def _control_amplitude_from_result(
+        self, result: Mapping[str, Any], label: str, fallback: float
+    ) -> float:
+        for key in ("target_amplitudes", "amplitudes_used"):
+            values = result.get(key)
+            if isinstance(values, Mapping) and label in values:
+                return float(values[label])
+
+        results = result.get("results")
+        if isinstance(results, Mapping):
+            per_target = results.get(label)
+            if isinstance(per_target, Mapping) and "amplitude_used" in per_target:
+                return float(per_target["amplitude_used"])
+
+        return fallback
 
     def _build_figures(
         self, result: Mapping[str, Any], label: str, resonant_freq: float
@@ -193,6 +220,8 @@ class CheckChevron(QubexTask):
             preferred_keys = [
                 f"{label}_measurement",
                 f"{label}_transform",
+                f"{label}_search_measurement",
+                f"{label}_search_transform",
                 f"{label}_rough_measurement",
                 f"{label}_rough_transform",
             ]

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_chevron.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_chevron.py
@@ -50,11 +50,30 @@ def test_check_chevron_run_uses_adaptive_helper(monkeypatch) -> None:
         return SimpleNamespace(
             data={
                 "resonant_frequencies": {"Q00": 4.321},
-                "amplitudes_used": {"Q00": 0.082},
-                "omega_rabis": {"Q00": 0.011},
-                "peak_prominence_ratios": {"Q00": 1.5},
+                "target_amplitudes": {"Q00": 0.086},
+                "peak_background_rms_ratios": {"Q00": 8.5},
+                "results": {
+                    "Q00": {
+                        "omega_q": 4.321,
+                        "omega_rabi": 0.011,
+                        "peak_background_rms_ratio": 8.5,
+                        "frequency_used": 4.25,
+                        "amplitude_used": 0.082,
+                    }
+                },
+                "search_results": {
+                    "Q00": {
+                        "omega_q": 4.3,
+                        "omega_rabi": 0.0105,
+                        "peak_background_rms_ratio": 7.0,
+                        "frequency_used": 4.25,
+                        "amplitude_used": 0.07,
+                    }
+                },
             },
             figures={
+                "Q00_search_measurement": go.Figure(),
+                "Q00_search_transform": go.Figure(),
                 "Q00_measurement": go.Figure(),
                 "Q00_transform": go.Figure(),
             },
@@ -78,11 +97,11 @@ def test_check_chevron_run_uses_adaptive_helper(monkeypatch) -> None:
     assert captured["plot"] is False
     assert captured["save_image"] is False
     assert result.raw_result["resonant_frequencies"]["Q00"] == 4.321
-    assert result.raw_result["control_amplitude_used"] == 0.082
+    assert result.raw_result["control_amplitude_used"] == 0.086
     assert result.raw_result["readout_amplitude_used"] == 0.031
 
 
-def test_check_chevron_postprocess_handles_adaptive_figures(monkeypatch) -> None:
+def test_check_chevron_postprocess_handles_adaptive_search_figures(monkeypatch) -> None:
     task = CheckChevron()
     task.input_parameters["readout_amplitude"] = ParameterModel(value=0.031, unit="a.u.")
 
@@ -97,8 +116,8 @@ def test_check_chevron_postprocess_handles_adaptive_figures(monkeypatch) -> None
             "figures": {
                 "Q00_measurement": go.Figure(),
                 "Q00_transform": go.Figure(),
-                "Q00_rough_measurement": go.Figure(),
-                "Q00_rough_transform": go.Figure(),
+                "Q00_search_measurement": go.Figure(),
+                "Q00_search_transform": go.Figure(),
             },
         }
     )
@@ -114,6 +133,18 @@ def test_check_chevron_postprocess_handles_adaptive_figures(monkeypatch) -> None
     assert result.output_parameters["control_amplitude"].value == 0.082
     assert "readout_amplitude" not in result.output_parameters
     assert len(result.figures) == 5
+
+
+def test_check_chevron_extracts_legacy_adaptive_amplitude() -> None:
+    task = CheckChevron()
+
+    result = task._control_amplitude_from_result(
+        {"amplitudes_used": {"Q00": 0.082}},
+        "Q00",
+        fallback=0.07,
+    )
+
+    assert result == 0.082
 
 
 def test_check_chevron_run_requires_db_readout_amplitude(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3178,7 +3178,7 @@ requires-dist = [
 [[package]]
 name = "qubex"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?branch=develop#577721be3a3d25b199e068597d553742b04d85cc" }
+source = { git = "https://github.com/amachino/qubex.git?branch=develop#8b50ad632aac562db60b73e24d02aa8f5fdb268d" }
 dependencies = [
     { name = "anywidget" },
     { name = "cma" },
@@ -3267,7 +3267,7 @@ wheels = [
 [[package]]
 name = "qxcore"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxcore&branch=develop#577721be3a3d25b199e068597d553742b04d85cc" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxcore&branch=develop#8b50ad632aac562db60b73e24d02aa8f5fdb268d" }
 dependencies = [
     { name = "netcdf4" },
     { name = "numpy" },
@@ -3281,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "qxdriver-quel1"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxdriver-quel1&branch=develop#577721be3a3d25b199e068597d553742b04d85cc" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxdriver-quel1&branch=develop#8b50ad632aac562db60b73e24d02aa8f5fdb268d" }
 dependencies = [
     { name = "numpy" },
     { name = "plotly" },
@@ -3293,12 +3293,12 @@ dependencies = [
 [[package]]
 name = "qxfitting"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxfitting&branch=develop#577721be3a3d25b199e068597d553742b04d85cc" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxfitting&branch=develop#8b50ad632aac562db60b73e24d02aa8f5fdb268d" }
 
 [[package]]
 name = "qxpulse"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxpulse&branch=develop#577721be3a3d25b199e068597d553742b04d85cc" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxpulse&branch=develop#8b50ad632aac562db60b73e24d02aa8f5fdb268d" }
 dependencies = [
     { name = "numpy" },
     { name = "plotly" },
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "qxschema"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxschema&branch=develop#577721be3a3d25b199e068597d553742b04d85cc" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxschema&branch=develop#8b50ad632aac562db60b73e24d02aa8f5fdb268d" }
 dependencies = [
     { name = "numpy" },
     { name = "qxcore" },
@@ -3319,7 +3319,7 @@ dependencies = [
 [[package]]
 name = "qxsimulator"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxsimulator&branch=develop#577721be3a3d25b199e068597d553742b04d85cc" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxsimulator&branch=develop#8b50ad632aac562db60b73e24d02aa8f5fdb268d" }
 dependencies = [
     { name = "ipython" },
     { name = "jax" },
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "qxvisualizer"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxvisualizer&branch=develop#577721be3a3d25b199e068597d553742b04d85cc" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxvisualizer&branch=develop#8b50ad632aac562db60b73e24d02aa8f5fdb268d" }
 dependencies = [
     { name = "numpy" },
     { name = "plotly" },


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Update the qubex develop lockfile reference and adapt `CheckChevron` to the new adaptive chevron result payload.
- Workflow-only change; keeps backward compatibility with the previous `amplitudes_used` result format.

## Changes
- Update `qubex` and related `qx*` git sources in `uv.lock` to `8b50ad63`.
- Read adaptive chevron control amplitude from new `target_amplitudes`, with fallbacks for legacy result shapes.
- Include new search-stage figures (`*_search_measurement`, `*_search_transform`) in `CheckChevron` postprocessing.
- Update focused workflow tests for the new result shape and legacy compatibility.
