### PR TITLE
fix(ui): avoid nested chat session buttons

### DIFF
--- a/ui/src/components/features/chat/CopilotChatPage.tsx
+++ b/ui/src/components/features/chat/CopilotChatPage.tsx
@@ -276,34 +276,32 @@ function SessionListItem({
   onDelete: () => void;
 }) {
   return (
-    <button
-      onClick={onSelect}
-      className={`w-full text-left px-3 py-2.5 rounded-xl group ${
+    <div
+      className={`w-full rounded-xl group border ${
         isActive
           ? "chat-session-active shadow-sm"
-          : "hover:bg-base-200/80 border border-transparent"
+          : "hover:bg-base-200/80 border-transparent"
       }`}
     >
-      <div className="flex items-start justify-between gap-1">
-        <div className="min-w-0 flex-1">
+      <div className="flex items-start justify-between gap-1 px-3 py-2.5">
+        <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
           <div className="text-sm font-medium truncate">{session.title}</div>
           <div className="flex items-center gap-2 mt-1 text-xs text-base-content/50">
             <span>{session.messages.length} msgs</span>
             <span className="text-base-content/30">{formatTime(session.updatedAt)}</span>
           </div>
-        </div>
+        </button>
         <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete();
-          }}
-          className="btn btn-ghost btn-xs btn-square opacity-0 group-hover:opacity-100 shrink-0 text-base-content/40 hover:text-error"
+          type="button"
+          onClick={onDelete}
+          className="btn btn-ghost btn-xs btn-square opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0 text-base-content/40 hover:text-error"
           title="Delete session"
+          aria-label={`Delete ${session.title}`}
         >
           <Trash2 className="w-3 h-3" />
         </button>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/ui/src/components/features/metrics/AnalysisChatPanel.tsx
+++ b/ui/src/components/features/metrics/AnalysisChatPanel.tsx
@@ -311,16 +311,15 @@ function SessionItem({
   onDelete: () => void;
 }) {
   return (
-    <button
-      onClick={onSelect}
-      className={`w-full text-left px-3 py-2 rounded-lg transition-colors text-xs group ${
+    <div
+      className={`w-full rounded-lg transition-colors text-xs group border ${
         isActive
-          ? "bg-primary/10 border border-primary/30"
-          : "hover:bg-base-200 border border-transparent"
+          ? "bg-primary/10 border-primary/30"
+          : "hover:bg-base-200 border-transparent"
       }`}
     >
-      <div className="flex items-start justify-between gap-1">
-        <div className="min-w-0 flex-1">
+      <div className="flex items-start justify-between gap-1 px-3 py-2">
+        <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
           <div className="font-semibold truncate">{session.title || "Untitled"}</div>
           <div className="text-base-content/50 truncate">
             {session.context ? session.context.qid : "General"}
@@ -329,19 +328,18 @@ function SessionItem({
             <span>{session.messageCount} msgs</span>
             <span>{formatTimeAgo(session.updatedAt)}</span>
           </div>
-        </div>
+        </button>
         <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete();
-          }}
-          className="btn btn-ghost btn-xs btn-square opacity-0 group-hover:opacity-100 shrink-0"
+          type="button"
+          onClick={onDelete}
+          className="btn btn-ghost btn-xs btn-square opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0"
           title="Delete session"
+          aria-label={`Delete ${session.title || "Untitled"}`}
         >
           <Trash2 className="w-3 h-3" />
         </button>
       </div>
-    </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Fix invalid nested button markup in chat session rows that triggered a browser hydration warning.
- UI-only change affecting the Copilot chat page and metrics analysis chat panel; no API, workflow, schema, or generated client changes.

## Changes
- Update CopilotChatPage session rows to use a non-button container with separate select and delete buttons.
- Update AnalysisChatPanel session rows with the same valid DOM structure.
- Preserve existing hover and active row styling while adding focus-visible delete affordance and accessible labels.