### PR TITLE
fix(workflow): retry qubit spectroscopy trim twice

### DIFF
--- a/docs/oas/openapi.json
+++ b/docs/oas/openapi.json
@@ -21491,7 +21491,7 @@
               }
             ],
             "title": "Retry With Trim",
-            "description": "If true, retry after trimming the highest-power row when no f01 is found."
+            "description": "If true, retry after trimming the highest-power row when no f01 is found. If f01 is still not found, trim one additional row and retry once more."
           }
         },
         "type": "object",

--- a/src/qdash/analysis/spectroscopy/estimate_qubit_frequency.py
+++ b/src/qdash/analysis/spectroscopy/estimate_qubit_frequency.py
@@ -122,6 +122,9 @@ class QubitFrequencyResult:
         return self.f12.frequency - self.f01.frequency
 
 
+RETRY_TRIM_MAX_ROWS = 2
+
+
 class QubitResponse:
     """Analyzes qubit spectroscopy data to extract frequency information.
 
@@ -386,17 +389,23 @@ def _retry_trim(
     ys: Sequence[float],
     zs: Sequence[Sequence[float]],
     config: EstimateQubitFrequencyConfig,
+    trim_rows: int = 1,
 ) -> tuple[
     Sequence[float], Sequence[float], Sequence[Sequence[float]], EstimateQubitFrequencyConfig
 ]:
-    """Drop the highest-power row and lower top_power to that row's value.
+    """Drop the highest-power rows and lower top_power to the trim boundary.
 
-    Used to recover from cases where the topmost power row carries spurious
+    Used to recover from cases where the topmost power rows carry spurious
     noise that prevents f01 detection.
     """
-    new_top_power = float(ys[-1])
-    new_ys = list(ys[:-1])
-    new_zs = list(zs[:-1])
+    if trim_rows <= 0:
+        raise ValueError("trim_rows must be positive")
+    if len(ys) - trim_rows < 2:
+        raise ValueError("trim would leave fewer than two y points")
+
+    new_top_power = float(ys[-trim_rows])
+    new_ys = list(ys[:-trim_rows])
+    new_zs = list(zs[:-trim_rows])
     new_config = EstimateQubitFrequencyConfig(
         binarize_threshold_sigma_plus=config.binarize_threshold_sigma_plus,
         binarize_threshold_sigma_minus=config.binarize_threshold_sigma_minus,
@@ -426,7 +435,8 @@ def estimate_qubit_frequency(
         config: Configuration for the estimation algorithm.
         retry_with_trim: If True and no f01 is detected on the first pass,
             drop the topmost power row (lowering ``top_power`` to that row)
-            and try again. Mitigates spurious noise on the highest-power row.
+            and try again. If f01 is still not detected, trim one additional
+            highest-power row and retry once more.
 
     Returns:
         QubitFrequencyResult containing f01 and f12 frequency information.
@@ -436,8 +446,15 @@ def estimate_qubit_frequency(
 
     qubit_response = QubitResponse(xs, ys, zs, config)
 
-    if qubit_response.f01 is None and retry_with_trim and len(ys) >= 3:
+    trimmed_rows = 0
+    while (
+        qubit_response.f01 is None
+        and retry_with_trim
+        and trimmed_rows < RETRY_TRIM_MAX_ROWS
+        and len(ys) >= 3
+    ):
         xs, ys, zs, config = _retry_trim(xs, ys, zs, config)
+        trimmed_rows += 1
         qubit_response = QubitResponse(xs, ys, zs, config)
 
     return QubitFrequencyResult(

--- a/src/qdash/api/schemas/reanalysis.py
+++ b/src/qdash/api/schemas/reanalysis.py
@@ -74,7 +74,10 @@ class ReanalyzeQubitSpectroscopyParams(BaseModel):
     f12_height_min: float | None = Field(default=None)
     retry_with_trim: bool | None = Field(
         default=None,
-        description="If true, retry after trimming the highest-power row when no f01 is found.",
+        description=(
+            "If true, retry after trimming the highest-power row when no f01 is found. "
+            "If f01 is still not found, trim one additional row and retry once more."
+        ),
     )
 
 

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
@@ -109,7 +109,9 @@ class CheckQubitSpectroscopy(QubexTask):
             value="false",
             description=(
                 "If 'true', drop the highest-power row and retry when no f01 is "
-                "detected on the first pass. Useful when the top row is noisy."
+                "detected on the first pass. If f01 is still not detected, drop "
+                "one additional highest-power row and retry once more. Useful "
+                "when the top rows are noisy."
             ),
         ),
         "seed_amplitude_headroom_db": RunParameterModel(

--- a/tests/qdash/analysis/spectroscopy/test_estimate_qubit_frequency.py
+++ b/tests/qdash/analysis/spectroscopy/test_estimate_qubit_frequency.py
@@ -1,0 +1,49 @@
+import importlib
+from collections.abc import Sequence
+from types import SimpleNamespace
+
+from qdash.analysis.spectroscopy.estimate_qubit_frequency import (
+    EstimateQubitFrequencyConfig,
+    estimate_qubit_frequency,
+)
+
+qubit_frequency = importlib.import_module("qdash.analysis.spectroscopy.estimate_qubit_frequency")
+
+
+def test_retry_with_trim_retries_one_additional_top_row(monkeypatch) -> None:
+    calls: list[tuple[list[float], float]] = []
+
+    class FakeQubitResponse:
+        def __init__(
+            self,
+            _xs: Sequence[float],
+            ys: Sequence[float],
+            _zs: Sequence[Sequence[float]],
+            config: EstimateQubitFrequencyConfig,
+        ) -> None:
+            calls.append((list(ys), config.top_power))
+            self.f01 = SimpleNamespace(frequency=4.0) if len(ys) == 2 else None
+            self.f12 = None
+
+    monkeypatch.setattr(qubit_frequency, "QubitResponse", FakeQubitResponse)
+
+    config = EstimateQubitFrequencyConfig(top_power=0.0)
+    result = estimate_qubit_frequency(
+        xs=[4.0, 4.1],
+        ys=[-40.0, -30.0, -20.0, -10.0],
+        zs=[
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [0.0, 0.0],
+        ],
+        config=config,
+        retry_with_trim=True,
+    )
+
+    assert result.f01 is not None
+    assert calls == [
+        ([-40.0, -30.0, -20.0, -10.0], 0.0),
+        ([-40.0, -30.0, -20.0], -10.0),
+        ([-40.0, -30.0], -20.0),
+    ]

--- a/ui/src/schemas/reanalyzeQubitSpectroscopyParams.ts
+++ b/ui/src/schemas/reanalyzeQubitSpectroscopyParams.ts
@@ -25,6 +25,6 @@ export interface ReanalyzeQubitSpectroscopyParams {
   f12_distance_min?: ReanalyzeQubitSpectroscopyParamsF12DistanceMin;
   f12_distance_max?: ReanalyzeQubitSpectroscopyParamsF12DistanceMax;
   f12_height_min?: ReanalyzeQubitSpectroscopyParamsF12HeightMin;
-  /** If true, retry after trimming the highest-power row when no f01 is found. */
+  /** If true, retry after trimming the highest-power row when no f01 is found. If f01 is still not found, trim one additional row and retry once more. */
   retry_with_trim?: ReanalyzeQubitSpectroscopyParamsRetryWithTrim;
 }

--- a/ui/src/schemas/reanalyzeQubitSpectroscopyParamsRetryWithTrim.ts
+++ b/ui/src/schemas/reanalyzeQubitSpectroscopyParamsRetryWithTrim.ts
@@ -7,6 +7,6 @@
  */
 
 /**
- * If true, retry after trimming the highest-power row when no f01 is found.
+ * If true, retry after trimming the highest-power row when no f01 is found. If f01 is still not found, trim one additional row and retry once more.
  */
 export type ReanalyzeQubitSpectroscopyParamsRetryWithTrim = boolean | null;


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Extend qubit spectroscopy `retry_with_trim` so failed f01 detection retries after trimming the highest-power row, then retries once more after trimming one additional row.
- Affects workflow analysis and reanalysis documentation only; the existing boolean parameter remains backward-compatible.

## Changes
- Added a bounded two-step trim retry loop in qubit frequency estimation.
- Updated CheckQubitSpectroscopy and reanalysis schema descriptions to document the second retry.
- Regenerated OpenAPI and TypeScript schema outputs with `task generate`.
- Added a unit test covering the initial pass, first trim retry, and second trim retry.