### PR TITLE
style(ui): update ExpandableImage to support custom wrapper class

### DIFF
--- a/ui/src/components/charts/TaskFigure.tsx
+++ b/ui/src/components/charts/TaskFigure.tsx
@@ -22,11 +22,13 @@ function ExpandableImage({
   src,
   alt,
   className,
+  wrapperClassName = "",
   jsonFigurePath,
 }: {
   src: string;
   alt: string;
   className: string;
+  wrapperClassName?: string;
   jsonFigurePath?: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -34,14 +36,16 @@ function ExpandableImage({
 
   if (hasError) {
     return (
-      <div className="flex items-center justify-center h-full text-base-content/40 text-xs">
+      <div
+        className={`flex items-center justify-center h-full text-base-content/40 text-xs ${wrapperClassName}`}
+      >
         Failed to load image
       </div>
     );
   }
 
   return (
-    <div className="relative group inline-flex h-full min-w-0 min-h-0">
+    <div className={`relative group inline-flex h-full min-w-0 min-h-0 ${wrapperClassName}`}>
       {/* eslint-disable-next-line @next/next/no-img-element -- dynamic API image with native sizing */}
       <img src={src} alt={alt} className={className} onError={() => setHasError(true)} />
       <button
@@ -129,14 +133,18 @@ export function TaskFigure({ path, jsonFigurePath, taskId, qid, className = "" }
     );
   }
 
+  // Multiple figures: lay them out in a horizontally scrollable row so each
+  // image keeps its natural aspect ratio instead of shrinking as more are
+  // added. Each image keeps its own expand-to-lightbox control. (#1050)
   return (
-    <div className="flex flex-wrap gap-2 overflow-hidden w-full h-full">
+    <div className="flex h-full w-full items-center gap-2 overflow-x-auto">
       {normalizedPaths.map((p, i) => (
         <ExpandableImage
           key={p}
           src={figureUrl(p)}
           alt={`Result for QID ${qid}`}
-          className={`${className} max-w-full max-h-full`}
+          className={className}
+          wrapperClassName="shrink-0"
           jsonFigurePath={normalizedJsonPaths[i]}
         />
       ))}

--- a/ui/src/components/charts/TaskFigure.tsx
+++ b/ui/src/components/charts/TaskFigure.tsx
@@ -41,7 +41,6 @@ function ExpandableImage({
   }
 
   return (
-    // `shrink-0` keeps the image at its natural size inside horizontally
     <div className="relative group inline-flex h-full min-w-0 min-h-0 shrink-0">
       {/* eslint-disable-next-line @next/next/no-img-element -- dynamic API image with native sizing */}
       <img src={src} alt={alt} className={className} onError={() => setHasError(true)} />
@@ -130,9 +129,6 @@ export function TaskFigure({ path, jsonFigurePath, taskId, qid, className = "" }
     );
   }
 
-  // Multiple figures: lay them out in a horizontally scrollable row so each
-  // image keeps its natural aspect ratio instead of shrinking as more are
-  // added. Each image keeps its own expand-to-lightbox control. (#1050)
   return (
     <div className="flex h-full w-full items-center gap-2 overflow-x-auto">
       {normalizedPaths.map((p, i) => (

--- a/ui/src/components/charts/TaskFigure.tsx
+++ b/ui/src/components/charts/TaskFigure.tsx
@@ -22,13 +22,11 @@ function ExpandableImage({
   src,
   alt,
   className,
-  wrapperClassName = "",
   jsonFigurePath,
 }: {
   src: string;
   alt: string;
   className: string;
-  wrapperClassName?: string;
   jsonFigurePath?: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -36,16 +34,16 @@ function ExpandableImage({
 
   if (hasError) {
     return (
-      <div
-        className={`flex items-center justify-center h-full text-base-content/40 text-xs ${wrapperClassName}`}
-      >
+      <div className="flex items-center justify-center h-full text-base-content/40 text-xs">
         Failed to load image
       </div>
     );
   }
 
   return (
-    <div className={`relative group inline-flex h-full min-w-0 min-h-0 ${wrapperClassName}`}>
+    // `shrink-0` keeps the image at its natural size inside horizontally
+    // scrollable figure rows instead of shrinking as siblings are added (#1050).
+    <div className="relative group inline-flex h-full min-w-0 min-h-0 shrink-0">
       {/* eslint-disable-next-line @next/next/no-img-element -- dynamic API image with native sizing */}
       <img src={src} alt={alt} className={className} onError={() => setHasError(true)} />
       <button
@@ -144,7 +142,6 @@ export function TaskFigure({ path, jsonFigurePath, taskId, qid, className = "" }
           src={figureUrl(p)}
           alt={`Result for QID ${qid}`}
           className={className}
-          wrapperClassName="shrink-0"
           jsonFigurePath={normalizedJsonPaths[i]}
         />
       ))}

--- a/ui/src/components/charts/TaskFigure.tsx
+++ b/ui/src/components/charts/TaskFigure.tsx
@@ -42,7 +42,6 @@ function ExpandableImage({
 
   return (
     // `shrink-0` keeps the image at its natural size inside horizontally
-    // scrollable figure rows instead of shrinking as siblings are added (#1050).
     <div className="relative group inline-flex h-full min-w-0 min-h-0 shrink-0">
       {/* eslint-disable-next-line @next/next/no-img-element -- dynamic API image with native sizing */}
       <img src={src} alt={alt} className={className} onError={() => setHasError(true)} />


### PR DESCRIPTION
## Ticket

close #1050

## Summary

In the history figure panel, images shrank as more were added because the
multi-figure layout wrapped and clamped every image to the container. Lay the
figures out in a single horizontally scrollable row so each keeps its natural
size, while preserving the existing per-image magnifier/lightbox.

## Changes

- `TaskFigure` multi-figure branch: replaced `flex-wrap` + `overflow-hidden`
  (which shrank the images) with a single horizontally scrollable row
  (`overflow-x-auto`); each figure now renders at its natural aspect ratio at
  full panel height instead of being squeezed to fit.
- Added an optional `wrapperClassName` prop to the internal `ExpandableImage`
  and applied `shrink-0` to it, so the flex item itself opts out of shrinking.
  Previously the `shrink-0` on the `<img>` had no effect because the wrapping
  flex item still shrank.
- Kept the per-image expand-to-fullscreen control (magnifier → `FigureLightbox`)
  for every figure in the scrollable row.


<img width="1864" height="947" alt="image" src="https://github.com/user-attachments/assets/3177f1f2-0430-44c4-a07e-f8afc1fc8a7a" />
<img width="1839" height="929" alt="image" src="https://github.com/user-attachments/assets/ff203958-1b6c-4c5e-af2d-c89d84c2cfe2" />
