### PR TITLE
style(ui): enhance AnalysisSidebar layout and add close functionality…

### DIFF
--- a/ui/src/components/layout/AnalysisSidebar.tsx
+++ b/ui/src/components/layout/AnalysisSidebar.tsx
@@ -5,7 +5,7 @@ import { useAnalysisChatContext } from "@/contexts/AnalysisChatContext";
 import { AnalysisChatPanel } from "@/components/features/metrics/AnalysisChatPanel";
 
 export function AnalysisSidebar() {
-  const { isOpen, activeSession, openGeneralChat } = useAnalysisChatContext();
+  const { isOpen, activeSession, openGeneralChat, closeAnalysisChat } = useAnalysisChatContext();
 
   return (
     <>
@@ -26,14 +26,23 @@ export function AnalysisSidebar() {
         </button>
       )}
 
-      {/* Inline sidebar panel — participates in flex layout to push main content */}
+      {/* Mobile backdrop */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 lg:hidden"
+          onClick={closeAnalysisChat}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Full-screen overlay below lg; inline flex panel at lg+ */}
       <div
-        className={`h-screen flex-shrink-0 border-l border-base-300 bg-base-100 transition-[width] duration-300 ease-in-out overflow-hidden ${
-          isOpen ? "w-[28rem] xl:w-[32rem]" : "w-0"
+        className={`bg-base-100 overflow-hidden transition-[width] duration-300 ease-in-out max-lg:fixed max-lg:inset-y-0 max-lg:right-0 max-lg:z-50 lg:h-screen lg:flex-shrink-0 lg:border-l lg:border-base-300 ${
+          isOpen ? "max-lg:w-full lg:w-[28rem] xl:w-[32rem]" : "w-0"
         }`}
       >
         {isOpen && (
-          <div className="w-[28rem] xl:w-[32rem] h-full">
+          <div className="h-full w-screen max-w-full lg:w-[28rem] xl:w-[32rem]">
             <AnalysisChatPanel context={activeSession?.context ?? null} />
           </div>
         )}


### PR DESCRIPTION
## Ticket

close #1048

## Summary

Fix the broken layout of the Ask AI panel (opened from the floating follow button) on smartphones, where the fixed 448px panel overflowed the viewport and squeezed the navbar behind it.

## Changes

- Render the chat panel as a fixed full-screen overlay below `lg` so it never overflows the viewport and covers the navbar instead of competing with it for space
- Add a dismissible backdrop (tap to close) on mobile
- Keep the existing inline flex panel (`w-[28rem] xl:w-[32rem]`) that pushes main content aside at `lg` and up
