### PR TITLE
style(ui): hide buttons in TaskFigure component for better layout

### DIFF
--- a/ui/src/components/charts/TaskFigure.tsx
+++ b/ui/src/components/charts/TaskFigure.tsx
@@ -12,6 +12,7 @@ interface TaskFigureProps {
   taskId?: string;
   qid: string;
   className?: string;
+  hideExpandButton?: boolean;
 }
 
 function figureUrl(path: string): string {
@@ -23,11 +24,13 @@ function ExpandableImage({
   alt,
   className,
   jsonFigurePath,
+  hideExpandButton,
 }: {
   src: string;
   alt: string;
   className: string;
   jsonFigurePath?: string;
+  hideExpandButton?: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [hasError, setHasError] = useState(false);
@@ -44,17 +47,19 @@ function ExpandableImage({
     <div className="relative group inline-flex h-full min-w-0 min-h-0">
       {/* eslint-disable-next-line @next/next/no-img-element -- dynamic API image with native sizing */}
       <img src={src} alt={alt} className={className} onError={() => setHasError(true)} />
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          setIsOpen(true);
-        }}
-        className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity btn btn-xs btn-circle bg-base-100/80 shadow hover:bg-base-200"
-        title="Expand"
-      >
-        <ZoomIn className="h-3 w-3" />
-      </button>
+      {!hideExpandButton && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsOpen(true);
+          }}
+          className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity btn btn-xs btn-circle bg-base-100/80 shadow hover:bg-base-200"
+          title="Expand"
+        >
+          <ZoomIn className="h-3 w-3" />
+        </button>
+      )}
       {isOpen && (
         <FigureLightbox
           src={src}
@@ -67,7 +72,14 @@ function ExpandableImage({
   );
 }
 
-export function TaskFigure({ path, jsonFigurePath, taskId, qid, className = "" }: TaskFigureProps) {
+export function TaskFigure({
+  path,
+  jsonFigurePath,
+  taskId,
+  qid,
+  className = "",
+  hideExpandButton,
+}: TaskFigureProps) {
   // Use generated API client hook when taskId is provided
   const {
     data: taskResultResponse,
@@ -125,6 +137,7 @@ export function TaskFigure({ path, jsonFigurePath, taskId, qid, className = "" }
         alt={`Result for QID ${qid}`}
         className={className}
         jsonFigurePath={normalizedJsonPaths[0]}
+        hideExpandButton={hideExpandButton}
       />
     );
   }
@@ -138,6 +151,7 @@ export function TaskFigure({ path, jsonFigurePath, taskId, qid, className = "" }
           alt={`Result for QID ${qid}`}
           className={`${className} max-w-full max-h-full`}
           jsonFigurePath={normalizedJsonPaths[i]}
+          hideExpandButton={hideExpandButton}
         />
       ))}
     </div>

--- a/ui/src/components/features/chip/CouplingGrid.tsx
+++ b/ui/src/components/features/chip/CouplingGrid.tsx
@@ -789,7 +789,7 @@ export function CouplingGrid({
               }`}
             >
               {figurePath && (
-                <div className="absolute inset-1">
+                <div className="absolute inset-1 [&_button]:hidden">
                   <TaskFigure
                     path={figurePath}
                     qid={String(task.couplingId)}

--- a/ui/src/components/features/chip/CouplingGrid.tsx
+++ b/ui/src/components/features/chip/CouplingGrid.tsx
@@ -789,11 +789,12 @@ export function CouplingGrid({
               }`}
             >
               {figurePath && (
-                <div className="absolute inset-1 [&_button]:hidden">
+                <div className="absolute inset-1">
                   <TaskFigure
                     path={figurePath}
                     qid={String(task.couplingId)}
                     className="w-full h-full object-contain"
+                    hideExpandButton
                   />
                 </div>
               )}

--- a/ui/src/components/features/chip/QubitGrid.tsx
+++ b/ui/src/components/features/chip/QubitGrid.tsx
@@ -218,8 +218,13 @@ const GridCell = memo(function GridCell({
       } ${isSelectionMode && !canBeSelected ? "opacity-40 cursor-not-allowed" : ""}`}
     >
       {task.figure_path && figurePath && (
-        <div className="absolute inset-1 [&_button]:hidden">
-          <TaskFigure path={figurePath} qid={qid} className="w-full h-full object-contain" />
+        <div className="absolute inset-1">
+          <TaskFigure
+            path={figurePath}
+            qid={qid}
+            className="w-full h-full object-contain"
+            hideExpandButton
+          />
         </div>
       )}
       {showLabels && (


### PR DESCRIPTION
## Ticket

close #1052

## Summary

On the chip page, each cell of the coupling grid rendered an unwanted "Expand"
(zoom-in) button on hover, inherited from the shared `TaskFigure` component. The
adjacent qubit grid already hides this button, so the coupling grid now follows
the same pattern for a consistent, uncluttered grid.

## Changes

- `CouplingGrid`: added the `[&_button]:hidden` utility to the figure wrapper
  `div` so the descendant expand button from `TaskFigure` is hidden, matching the
  existing approach used in `QubitGrid`.
- No changes to the shared `TaskFigure` component, so the expand/lightbox control
  remains intact everywhere else it is used (execution, qubit, metrics, etc.).
