### PR TITLE
style(ui): prevent mux view header text from wrapping (#792)

### DIFF
--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -528,23 +528,23 @@ export function ChipPageContent() {
                     }`}
                   >
                     <div
-                      className="p-4 cursor-pointer flex justify-between items-center hover:bg-base-200/50 transition-colors"
+                      className="p-4 cursor-pointer flex flex-wrap justify-between gap-2 items-center hover:bg-base-200/50 transition-colors"
                       onClick={() => toggleMuxExpansion(muxId)}
                     >
                       <div className="text-xl font-medium flex items-center gap-2">
-                        MUX {muxDetail.mux_id}
+                        <span className="whitespace-nowrap">MUX {muxDetail.mux_id}</span>
                         {updateInfo.isRecent && (
                           <div className="badge badge-primary gap-2 rounded-lg">
                             <div className="w-2 h-2 bg-primary-content rounded-full animate-ping" />
                             New
                           </div>
                         )}
-                        <div className="badge badge-ghost gap-2 rounded-lg">
+                        <div className="badge badge-ghost gap-2 rounded-lg whitespace-nowrap">
                           {Object.keys(taskGroups).length} Tasks
                         </div>
                       </div>
                       <div
-                        className={`text-sm ${
+                        className={`text-sm whitespace-nowrap ${
                           updateInfo.isRecent ? "text-primary font-medium" : "text-base-content/60"
                         }`}
                       >


### PR DESCRIPTION
## Ticket
Closes #792 

## Summary
Fixed the collapsed layout of the MUX View header on the chip page, where "MUX {id}", the task count badge, and "Last updated" wrapped mid-word at narrow widths. UI-only change with no behavior or API impact.

## Changes
- `ChipPageContent.tsx` (MUX View card header): wrap `MUX {mux_id}` in a `whitespace-nowrap` span and add `whitespace-nowrap` to the "Tasks" badge and the "Last updated" text so they no longer break mid-word.
- Add `flex-wrap` and `gap-2` to the header container so the title group and "Last updated" reflow as blocks on narrow screens instead of overflowing.


## Verification
Verified by narrowing the browser/devtools width on the chip page MUX View; the header text no longer wraps mid-word.
 
<img width="376" height="544" alt="image" src="https://github.com/user-attachments/assets/42c78981-5b82-4361-9a87-33b7e8bcfcbe" />
