### PR TITLE
feat(ui): improve API access helper

### DIFF
--- a/ui/src/components/features/settings/ApiAccessTokenPanel.tsx
+++ b/ui/src/components/features/settings/ApiAccessTokenPanel.tsx
@@ -1,16 +1,115 @@
 "use client";
 
-import { useState } from "react";
-import { Check, Copy, Eye, EyeOff, Info } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Check, Copy, Eye, EyeOff, Info, Loader2, Play } from "lucide-react";
 
 import { useAuth } from "@/contexts/AuthContext";
+import { useProject } from "@/contexts/ProjectContext";
+
+type CurlMode = "standard" | "cloudflare";
+
+type TestResult = {
+  status: "success" | "error";
+  message: string;
+  responseBody: string;
+};
+
+const TEST_PATH = "/auth/me";
+
+function getConfiguredApiUrl() {
+  return process.env.NEXT_PUBLIC_API_URL || "/api";
+}
+
+function resolveApiUrl() {
+  const normalizedApiUrl = getConfiguredApiUrl().replace(/\/$/, "");
+
+  if (/^https?:\/\//.test(normalizedApiUrl)) {
+    return normalizedApiUrl;
+  }
+
+  if (typeof window !== "undefined") {
+    return `${window.location.origin}${normalizedApiUrl.startsWith("/") ? "" : "/"}${normalizedApiUrl}`;
+  }
+
+  return normalizedApiUrl || "http://127.0.0.1:5715";
+}
+
+function maskSecret(value: string) {
+  if (!value) return "<cloudflare-client-secret>";
+  if (value.length <= 8) return "********";
+  return `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function formatResponseBody(responseText: string, contentType: string) {
+  if (!responseText) {
+    return { parsedBody: null, responseBody: "<empty response>" };
+  }
+
+  if (!contentType.includes("application/json")) {
+    return { parsedBody: null, responseBody: responseText };
+  }
+
+  try {
+    const parsedBody = JSON.parse(responseText);
+    return { parsedBody, responseBody: JSON.stringify(parsedBody, null, 2) };
+  } catch {
+    return { parsedBody: null, responseBody: responseText };
+  }
+}
 
 export function ApiAccessTokenPanel() {
   const { accessToken } = useAuth();
+  const { projectId } = useProject();
   const [copied, setCopied] = useState(false);
   const [copiedCurl, setCopiedCurl] = useState(false);
+  const [copiedResponse, setCopiedResponse] = useState(false);
+  const [curlMode, setCurlMode] = useState<CurlMode>("standard");
   const [showToken, setShowToken] = useState(false);
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:5715";
+  const [showCfSecret, setShowCfSecret] = useState(false);
+  const [apiUrl, setApiUrl] = useState(() => getConfiguredApiUrl().replace(/\/$/, ""));
+  const [cfAccessClientId, setCfAccessClientId] = useState("");
+  const [cfAccessClientSecret, setCfAccessClientSecret] = useState("");
+  const [requestProjectId, setRequestProjectId] = useState("");
+  const [isTestingCurl, setIsTestingCurl] = useState(false);
+  const [testResult, setTestResult] = useState<TestResult | null>(null);
+
+  useEffect(() => {
+    setApiUrl(resolveApiUrl());
+  }, []);
+
+  useEffect(() => {
+    setRequestProjectId((currentProjectId) => currentProjectId || projectId || "");
+  }, [projectId]);
+
+  const tokenForDisplay = showToken && accessToken ? accessToken : "<your-token>";
+  const tokenForCopy = accessToken || "<your-token>";
+  const projectIdForCopy = requestProjectId || "<project-id>";
+  const cfClientIdForCopy = cfAccessClientId || "<cloudflare-client-id>";
+  const cfClientSecretForCopy = cfAccessClientSecret || "<cloudflare-client-secret>";
+  const cfClientIdForDisplay = cfAccessClientId || "<cloudflare-client-id>";
+  const cfClientSecretForDisplay = showCfSecret
+    ? cfClientSecretForCopy
+    : maskSecret(cfAccessClientSecret);
+  const curlHeaders =
+    curlMode === "cloudflare"
+      ? [
+          `-H "CF-Access-Client-Id: ${cfClientIdForCopy}"`,
+          `-H "CF-Access-Client-Secret: ${cfClientSecretForCopy}"`,
+          `-H "Authorization: Bearer ${tokenForCopy}"`,
+          `-H "X-Project-Id: ${projectIdForCopy}"`,
+        ]
+      : [`-H "Authorization: Bearer ${tokenForCopy}"`, `-H "X-Project-Id: ${projectIdForCopy}"`];
+  const curlDisplayHeaders =
+    curlMode === "cloudflare"
+      ? [
+          `-H "CF-Access-Client-Id: ${cfClientIdForDisplay}"`,
+          `-H "CF-Access-Client-Secret: ${cfClientSecretForDisplay}"`,
+          `-H "Authorization: Bearer ${tokenForDisplay}"`,
+          `-H "X-Project-Id: ${projectIdForCopy}"`,
+        ]
+      : [`-H "Authorization: Bearer ${tokenForDisplay}"`, `-H "X-Project-Id: ${projectIdForCopy}"`];
+  const curlLineBreak = " \\" + "\n  ";
+  const curlCommand = ["curl", ...curlHeaders, `${apiUrl}${TEST_PATH}`].join(curlLineBreak);
 
   const handleCopyToken = async () => {
     if (!accessToken) return;
@@ -20,11 +119,53 @@ export function ApiAccessTokenPanel() {
   };
 
   const handleCopyCurl = async () => {
-    const token = accessToken || "<your-token>";
-    const curlCommand = `curl -H "Authorization: Bearer ${token}" ${apiUrl}/auth/me`;
     await navigator.clipboard.writeText(curlCommand);
     setCopiedCurl(true);
     setTimeout(() => setCopiedCurl(false), 2000);
+  };
+
+  const handleCopyResponse = async () => {
+    if (!testResult) return;
+    await navigator.clipboard.writeText(testResult.responseBody);
+    setCopiedResponse(true);
+    setTimeout(() => setCopiedResponse(false), 2000);
+  };
+
+  const handleRunCurl = async () => {
+    setIsTestingCurl(true);
+    setCopiedResponse(false);
+    setTestResult(null);
+
+    try {
+      const headers = new Headers();
+      headers.set("Authorization", `Bearer ${tokenForCopy}`);
+      headers.set("X-Project-Id", projectIdForCopy);
+
+      if (curlMode === "cloudflare") {
+        headers.set("CF-Access-Client-Id", cfClientIdForCopy);
+        headers.set("CF-Access-Client-Secret", cfClientSecretForCopy);
+      }
+
+      const response = await fetch(`${apiUrl}${TEST_PATH}`, { headers });
+      const contentType = response.headers.get("content-type") || "";
+      const responseText = await response.text();
+      const { parsedBody, responseBody } = formatResponseBody(responseText, contentType);
+      const username = typeof parsedBody?.username === "string" ? ` (${parsedBody.username})` : "";
+
+      setTestResult({
+        status: response.ok ? "success" : "error",
+        message: `${response.status} ${response.statusText || "Response"}${username}`,
+        responseBody: responseBody || "<empty response>",
+      });
+    } catch (error) {
+      setTestResult({
+        status: "error",
+        message: error instanceof Error ? error.message : "Request failed",
+        responseBody: error instanceof Error ? error.stack || error.message : "Request failed",
+      });
+    } finally {
+      setIsTestingCurl(false);
+    }
   };
 
   return (
@@ -67,29 +208,150 @@ export function ApiAccessTokenPanel() {
           </div>
 
           <div className="flex flex-col gap-3">
-            <label className="text-sm font-medium">Example Usage (curl)</label>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <label className="text-sm font-medium">Example Usage (curl)</label>
+              <div className="tabs tabs-boxed w-fit">
+                <button
+                  className={`tab tab-sm ${curlMode === "standard" ? "tab-active" : ""}`}
+                  onClick={() => setCurlMode("standard")}
+                  type="button"
+                >
+                  Standard
+                </button>
+                <button
+                  className={`tab tab-sm ${curlMode === "cloudflare" ? "tab-active" : ""}`}
+                  onClick={() => setCurlMode("cloudflare")}
+                  type="button"
+                >
+                  Cloudflare
+                </button>
+              </div>
+            </div>
+
+            <label className="flex flex-col gap-1 text-sm font-medium">
+              Project ID
+              <input
+                className="input input-bordered font-mono text-sm"
+                onChange={(event) => setRequestProjectId(event.target.value)}
+                placeholder="project-id"
+                type="text"
+                value={requestProjectId}
+              />
+            </label>
+
+            {curlMode === "cloudflare" && (
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="flex flex-col gap-1 text-sm font-medium">
+                  Client ID
+                  <input
+                    autoComplete="off"
+                    className="input input-bordered font-mono text-sm"
+                    name="qdash-cloudflare-access-client-id"
+                    onChange={(event) => setCfAccessClientId(event.target.value)}
+                    placeholder="cloudflare-client-id"
+                    spellCheck={false}
+                    type="text"
+                    value={cfAccessClientId}
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-sm font-medium">
+                  Client Secret
+                  <div className="flex gap-2">
+                    <input
+                      autoComplete="new-password"
+                      className="input input-bordered w-full font-mono text-sm"
+                      name="qdash-cloudflare-access-client-secret"
+                      onChange={(event) => setCfAccessClientSecret(event.target.value)}
+                      placeholder="cloudflare-client-secret"
+                      spellCheck={false}
+                      type={showCfSecret ? "text" : "password"}
+                      value={cfAccessClientSecret}
+                    />
+                    <button
+                      className="btn btn-square btn-ghost"
+                      onClick={() => setShowCfSecret(!showCfSecret)}
+                      type="button"
+                    >
+                      {showCfSecret ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                    </button>
+                  </div>
+                </label>
+              </div>
+            )}
+
             <div className="relative">
-              <div className="mockup-code overflow-x-auto text-xs sm:text-sm">
+              <div className="mockup-code overflow-x-auto pr-28 text-xs sm:text-sm">
+                <pre className="whitespace-pre-wrap break-all sm:whitespace-pre sm:break-normal">
+                  <code>curl \</code>
+                </pre>
+                {curlDisplayHeaders.map((header) => (
+                  <pre
+                    className="whitespace-pre-wrap break-all sm:whitespace-pre sm:break-normal"
+                    key={header}
+                  >
+                    <code> {header} \</code>
+                  </pre>
+                ))}
                 <pre className="whitespace-pre-wrap break-all sm:whitespace-pre sm:break-normal">
                   <code>
-                    curl -H "Authorization: Bearer{" "}
-                    {showToken && accessToken ? accessToken : "<your-token>"}" \
+                    {" "}
+                    {apiUrl}
+                    {TEST_PATH}
                   </code>
                 </pre>
-                <pre>
-                  <code> {apiUrl}/auth/me</code>
-                </pre>
               </div>
-              <button
-                className={`btn btn-xs absolute right-2 top-2 sm:btn-sm ${
-                  copiedCurl ? "btn-success" : "btn-ghost"
-                }`}
-                onClick={handleCopyCurl}
-              >
-                {copiedCurl ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                <span className="hidden sm:inline">{copiedCurl ? "Copied!" : "Copy"}</span>
-              </button>
+              <div className="absolute right-2 top-2 flex gap-2">
+                <button
+                  className={`btn btn-xs sm:btn-sm ${testResult?.status === "success" ? "btn-success" : "btn-ghost"}`}
+                  disabled={isTestingCurl}
+                  onClick={handleRunCurl}
+                  type="button"
+                >
+                  {isTestingCurl ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Play className="h-4 w-4" />
+                  )}
+                  <span className="hidden sm:inline">Run</span>
+                </button>
+                <button
+                  className={`btn btn-xs sm:btn-sm ${copiedCurl ? "btn-success" : "btn-ghost"}`}
+                  onClick={handleCopyCurl}
+                  type="button"
+                >
+                  {copiedCurl ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                  <span className="hidden sm:inline">{copiedCurl ? "Copied!" : "Copy"}</span>
+                </button>
+              </div>
             </div>
+            {testResult && (
+              <div className="flex flex-col gap-2">
+                <div
+                  className={`alert py-2 text-sm ${
+                    testResult.status === "success" ? "alert-success" : "alert-error"
+                  }`}
+                >
+                  <span>{testResult.message}</span>
+                </div>
+                <div className="relative">
+                  <div className="mockup-code max-h-72 overflow-auto pr-24 text-xs sm:text-sm">
+                    <pre className="whitespace-pre-wrap break-all sm:break-normal">
+                      <code>{testResult.responseBody}</code>
+                    </pre>
+                  </div>
+                  <button
+                    className={`btn btn-xs absolute right-2 top-2 sm:btn-sm ${
+                      copiedResponse ? "btn-success" : "btn-ghost"
+                    }`}
+                    onClick={handleCopyResponse}
+                    type="button"
+                  >
+                    {copiedResponse ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    <span className="hidden sm:inline">{copiedResponse ? "Copied!" : "Copy"}</span>
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="alert alert-info">

--- a/ui/src/components/features/settings/SettingsPageContent.tsx
+++ b/ui/src/components/features/settings/SettingsPageContent.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Cpu } from "lucide-react";
+import { Check, Copy, Cpu } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { ApiAccessTokenPanel } from "@/components/features/settings/ApiAccessTokenPanel";
@@ -226,8 +226,9 @@ function ProfileSettingsPanel() {
 function ProjectMembersPanel() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { currentProject, projectId, isOwner } = useProject();
+  const { currentProject, projects, projectId, isOwner, switchProject } = useProject();
   const [inviteUsername, setInviteUsername] = useState("");
+  const [copiedProjectId, setCopiedProjectId] = useState<string | null>(null);
   const [inviteRole, setInviteRole] = useState<ProjectRole>("viewer");
   const [localError, setLocalError] = useState<string | null>(null);
 
@@ -254,6 +255,12 @@ function ProjectMembersPanel() {
     queryClient.invalidateQueries({
       queryKey: getListProjectMembersQueryKey(projectId),
     });
+  };
+
+  const handleCopyProjectId = async (id: string) => {
+    await navigator.clipboard.writeText(id);
+    setCopiedProjectId(id);
+    setTimeout(() => setCopiedProjectId(null), 2000);
   };
 
   const handleInvite = async () => {
@@ -319,6 +326,81 @@ function ProjectMembersPanel() {
             </div>
             <div className={`badge ${isOwner ? "badge-secondary" : "badge-ghost"} w-fit`}>
               {isOwner ? "Owner controls" : "Read only"}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(260px,360px)]">
+            <div className="rounded-lg bg-base-100 p-4">
+              <div className="text-xs font-semibold uppercase text-base-content/50">
+                Current project ID
+              </div>
+              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+                <code className="min-w-0 flex-1 rounded bg-base-300 px-3 py-2 text-sm break-all">
+                  {projectId ?? "No project selected"}
+                </code>
+                <button
+                  className={`btn btn-sm ${copiedProjectId === projectId ? "btn-success" : "btn-ghost"}`}
+                  disabled={!projectId}
+                  onClick={() => projectId && handleCopyProjectId(projectId)}
+                  type="button"
+                >
+                  {copiedProjectId === projectId ? (
+                    <Check className="h-4 w-4" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                  {copiedProjectId === projectId ? "Copied" : "Copy"}
+                </button>
+              </div>
+            </div>
+
+            <div className="rounded-lg bg-base-100 p-4">
+              <div className="text-xs font-semibold uppercase text-base-content/50">
+                Your projects
+              </div>
+              <div className="mt-2 flex max-h-48 flex-col gap-2 overflow-y-auto">
+                {projects.length === 0 ? (
+                  <span className="text-sm text-base-content/60">No projects available</span>
+                ) : (
+                  projects.map((project) => (
+                    <div
+                      className={`rounded border p-2 ${
+                        project.project_id === projectId
+                          ? "border-primary bg-primary/10"
+                          : "border-base-300"
+                      }`}
+                      key={project.project_id}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <button
+                          className="min-w-0 text-left"
+                          onClick={() => switchProject(project.project_id)}
+                          type="button"
+                        >
+                          <div className="truncate text-sm font-medium">{project.name}</div>
+                          <div className="font-mono text-xs text-base-content/60 break-all">
+                            {project.project_id}
+                          </div>
+                        </button>
+                        <button
+                          className={`btn btn-square btn-ghost btn-xs ${
+                            copiedProjectId === project.project_id ? "btn-success" : ""
+                          }`}
+                          onClick={() => handleCopyProjectId(project.project_id)}
+                          title="Copy project ID"
+                          type="button"
+                        >
+                          {copiedProjectId === project.project_id ? (
+                            <Check className="h-3 w-3" />
+                          ) : (
+                            <Copy className="h-3 w-3" />
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Adds a more complete API access helper in Settings so users can build, run, inspect, and copy authenticated curl requests.
- UI-only change; no API schema, generated client, or backend behavior changes.

## Changes
- Updates Settings > API Token to include Standard and Cloudflare Access curl modes, Project ID input, runnable request testing, response display, and copy controls.
- Adds Cloudflare Access Client ID/Secret inputs with autocomplete suppression to avoid QDash login credential autofill.
- Updates Settings > Project to show the current project ID and all available project IDs with copy controls.