### PR TITLE
feat(ui): support notes on empty dashboard targets

### DIFF
--- a/src/qdash/api/services/chip/initializer.py
+++ b/src/qdash/api/services/chip/initializer.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from qdash.common.config.topology import load_topology
+from qdash.common.config.topology import TopologyDefinition, load_topology
 from qdash.dbmodel.chip import ChipDocument
 from qdash.dbmodel.coupling import CouplingDocument
 from qdash.dbmodel.qubit import QubitDocument
@@ -39,6 +39,16 @@ class ChipInitializer:
             result.append((edge[0], edge[1]))
             result.append((edge[1], edge[0]))
         return result
+
+    @staticmethod
+    def _load_topology(topology_id: str | None, size: int) -> tuple[str, TopologyDefinition]:
+        if topology_id is None:
+            topology_id = f"square-lattice-mux-{size}"
+        try:
+            return topology_id, load_topology(topology_id)
+        except FileNotFoundError as e:
+            msg = f"Topology '{topology_id}' not found"
+            raise ValueError(msg) from e
 
     @staticmethod
     def _generate_qubit_documents(
@@ -148,16 +158,8 @@ class ChipInitializer:
             FileNotFoundError: If topology file doesn't exist
 
         """
-        # Set default topology_id if not provided
-        if topology_id is None:
-            topology_id = f"square-lattice-mux-{size}"
-
         # Load topology definition
-        try:
-            topology = load_topology(topology_id)
-        except FileNotFoundError as e:
-            msg = f"Topology '{topology_id}' not found"
-            raise ValueError(msg) from e
+        topology_id, topology = cls._load_topology(topology_id, size)
 
         # Validate size matches topology
         if size != topology.num_qubits:
@@ -213,3 +215,149 @@ class ChipInitializer:
         except Exception as e:
             logger.error(f"Error creating chip {chip_id}: {e}")
             raise
+
+    @classmethod
+    def ensure_topology_documents(
+        cls,
+        *,
+        project_id: str,
+        chip_id: str,
+        topology_id: str | None,
+        size: int,
+    ) -> tuple[int, int]:
+        """Create missing qubit/coupling skeleton rows for a chip topology.
+
+        Existing rows are left untouched so calibration data and notes are preserved.
+        """
+        chip = ChipDocument.find_one(
+            ChipDocument.project_id == project_id,
+            ChipDocument.chip_id == chip_id,
+        ).run()
+        if chip is None:
+            raise ValueError(f"Chip {chip_id} not found")
+
+        topology_id, topology = cls._load_topology(topology_id, size)
+        if size != topology.num_qubits:
+            msg = f"Size {size} does not match topology num_qubits {topology.num_qubits}"
+            raise ValueError(msg)
+
+        existing_qubits = {
+            doc.qid
+            for doc in QubitDocument.find(
+                QubitDocument.project_id == project_id,
+                QubitDocument.chip_id == chip_id,
+            ).run()
+        }
+        missing_qubits = [
+            doc
+            for doc in cls._generate_qubit_documents(
+                topology.qubits,
+                chip.username,
+                chip_id,
+                project_id,
+            )
+            if doc.qid not in existing_qubits
+        ]
+        for doc in missing_qubits:
+            doc.insert()
+
+        existing_couplings = {
+            doc.qid
+            for doc in CouplingDocument.find(
+                CouplingDocument.project_id == project_id,
+                CouplingDocument.chip_id == chip_id,
+            ).run()
+        }
+        missing_couplings = [
+            doc
+            for doc in cls._generate_coupling_documents(
+                cls._bi_direction(topology.couplings),
+                chip.username,
+                chip_id,
+                project_id,
+            )
+            if doc.qid not in existing_couplings
+        ]
+        for doc in missing_couplings:
+            doc.insert()
+
+        if missing_qubits or missing_couplings:
+            logger.info(
+                "Created missing topology documents for chip %s: %d qubits, %d couplings",
+                chip_id,
+                len(missing_qubits),
+                len(missing_couplings),
+            )
+        return len(missing_qubits), len(missing_couplings)
+
+    @classmethod
+    def ensure_qubit_document(cls, *, project_id: str, chip_id: str, qid: str) -> QubitDocument:
+        """Return a qubit row, creating a topology-valid empty row when missing."""
+        doc = QubitDocument.find_one(
+            QubitDocument.project_id == project_id,
+            QubitDocument.chip_id == chip_id,
+            QubitDocument.qid == qid,
+        ).run()
+        if doc is not None:
+            return doc
+
+        chip = ChipDocument.find_one(
+            ChipDocument.project_id == project_id,
+            ChipDocument.chip_id == chip_id,
+        ).run()
+        if chip is None:
+            raise ValueError(f"Chip {chip_id} not found")
+        _, topology = cls._load_topology(chip.topology_id, chip.size)
+        try:
+            topology_qid = int(qid)
+        except ValueError as e:
+            raise ValueError(f"Qubit {qid} is not part of topology {chip.topology_id}") from e
+        if topology_qid not in topology.qubits:
+            raise ValueError(f"Qubit {qid} is not part of topology {chip.topology_id}")
+
+        new_doc = cls._generate_qubit_documents(
+            {topology_qid: topology.qubits[topology_qid]},
+            chip.username,
+            chip_id,
+            project_id,
+        )[0]
+        new_doc.insert()
+        return new_doc
+
+    @classmethod
+    def ensure_coupling_document(
+        cls, *, project_id: str, chip_id: str, coupling_id: str
+    ) -> CouplingDocument:
+        """Return a coupling row, creating a topology-valid empty row when missing."""
+        doc = CouplingDocument.find_one(
+            CouplingDocument.project_id == project_id,
+            CouplingDocument.chip_id == chip_id,
+            CouplingDocument.qid == coupling_id,
+        ).run()
+        if doc is not None:
+            return doc
+
+        chip = ChipDocument.find_one(
+            ChipDocument.project_id == project_id,
+            ChipDocument.chip_id == chip_id,
+        ).run()
+        if chip is None:
+            raise ValueError(f"Chip {chip_id} not found")
+        _, topology = cls._load_topology(chip.topology_id, chip.size)
+        try:
+            a, b = (int(part) for part in coupling_id.split("-", 1))
+        except ValueError as e:
+            raise ValueError(
+                f"Coupling {coupling_id} is not part of topology {chip.topology_id}"
+            ) from e
+        if (a, b) not in cls._bi_direction(topology.couplings):
+            raise ValueError(f"Coupling {coupling_id} is not part of topology {chip.topology_id}")
+
+        new_doc = cls._generate_coupling_documents(
+            [(a, b)],
+            chip.username,
+            chip_id,
+            project_id,
+        )[0]
+        new_doc.insert()
+        return new_doc

--- a/src/qdash/api/services/chip/service.py
+++ b/src/qdash/api/services/chip/service.py
@@ -22,6 +22,7 @@ from qdash.api.schemas.chip import (
     UpdateChipRequest,
 )
 from qdash.api.schemas.success import SuccessResponse
+from qdash.api.services.chip.initializer import ChipInitializer
 from qdash.common.config.metrics import load_metrics_config
 from qdash.common.utils.datetime import now
 from qdash.datamodel.note import NoteModel
@@ -389,6 +390,15 @@ class ChipService:
         if doc is None:
             raise HTTPException(status_code=404, detail="Chip not found")
         if body.topology_id is not None:
+            try:
+                ChipInitializer.ensure_topology_documents(
+                    project_id=project_id,
+                    chip_id=chip_id,
+                    topology_id=body.topology_id,
+                    size=doc.size,
+                )
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
             doc.topology_id = body.topology_id
         if body.activity_status is not None:
             doc.activity_status = body.activity_status

--- a/src/qdash/api/services/note_service.py
+++ b/src/qdash/api/services/note_service.py
@@ -17,6 +17,7 @@ from qdash.api.schemas.note import (
     TaskNoteEntry,
 )
 from qdash.api.schemas.success import SuccessResponse
+from qdash.api.services.chip.initializer import ChipInitializer
 from qdash.common.utils.datetime import ensure_timezone, format_iso, now
 from qdash.datamodel.note import NoteModel
 from qdash.dbmodel.chip import ChipDocument
@@ -326,13 +327,14 @@ class NoteService:
         content: str,
         username: str,
     ) -> NoteModel:
-        doc = QubitDocument.find_one(
-            QubitDocument.project_id == project_id,
-            QubitDocument.chip_id == chip_id,
-            QubitDocument.qid == qid,
-        ).run()
-        if doc is None:
-            raise HTTPException(status_code=404, detail="Qubit not found")
+        try:
+            doc = ChipInitializer.ensure_qubit_document(
+                project_id=project_id,
+                chip_id=chip_id,
+                qid=qid,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
         doc.note = _make_note(content, username)
         doc.system_info.update_time()
         doc.save()
@@ -521,13 +523,14 @@ class NoteService:
         content: str,
         username: str,
     ) -> NoteModel:
-        doc = CouplingDocument.find_one(
-            CouplingDocument.project_id == project_id,
-            CouplingDocument.chip_id == chip_id,
-            CouplingDocument.qid == coupling_id,
-        ).run()
-        if doc is None:
-            raise HTTPException(status_code=404, detail="Coupling not found")
+        try:
+            doc = ChipInitializer.ensure_coupling_document(
+                project_id=project_id,
+                chip_id=chip_id,
+                coupling_id=coupling_id,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
         doc.note = _make_note(content, username)
         doc.system_info.update_time()
         doc.save()

--- a/tests/qdash/api/routers/test_chip.py
+++ b/tests/qdash/api/routers/test_chip.py
@@ -6,6 +6,7 @@ from qdash.datamodel.project import ProjectRole
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.datamodel.user import SystemRole
 from qdash.dbmodel.chip import ChipDocument
+from qdash.dbmodel.coupling import CouplingDocument
 from qdash.dbmodel.project import ProjectDocument
 from qdash.dbmodel.project_membership import ProjectMembershipDocument
 from qdash.dbmodel.qubit import QubitDocument
@@ -204,6 +205,39 @@ class TestChipRouter:
         data = response.json()
         assert data["chip_id"] == "test_chip_status"
         assert data["activity_status"] == "inactive"
+
+    def test_update_chip_topology_creates_missing_target_skeletons(
+        self, test_client, test_project, auth_headers
+    ):
+        """Test topology update backfills empty qubit/coupling target rows."""
+        chip = ChipDocument(
+            chip_id="test_chip_topology",
+            username="test_user",
+            project_id="test_project",
+            size=64,
+            system_info=SystemInfoModel(),
+        )
+        chip.insert()
+
+        response = test_client.patch(
+            "/chips/test_chip_topology",
+            headers=auth_headers,
+            json={"topology_id": "square-lattice-mux-64"},
+        )
+
+        assert response.status_code == 200
+        assert (
+            QubitDocument.find(
+                {"project_id": "test_project", "chip_id": "test_chip_topology"}
+            ).count()
+            == 64
+        )
+        assert (
+            CouplingDocument.find(
+                {"project_id": "test_project", "chip_id": "test_chip_topology"}
+            ).count()
+            > 0
+        )
 
     def test_create_chip_success(self, test_client, test_project, auth_headers):
         """Test creating a new chip."""

--- a/tests/qdash/api/routers/test_note.py
+++ b/tests/qdash/api/routers/test_note.py
@@ -354,3 +354,51 @@ def test_notes_summary_includes_task_results_with_only_ai_review_note(test_clien
     assert task_note["task_id"] == "task-ai-review-note"
     assert task_note["note"]["content"] == ""
     assert task_note["ai_review_note"]["content"].startswith("## AI review")
+
+
+def test_qubit_note_creates_missing_topology_target(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+
+    response = test_client.put(
+        "/chips/chip-1/qubits/21/note",
+        headers=headers,
+        json={"content": "No data yet; check wiring before next run."},
+    )
+
+    assert response.status_code == 200
+    doc = QubitDocument.find_one(QubitDocument.qid == "21").run()
+    assert doc is not None
+    assert doc.data == {}
+    assert doc.note.content == "No data yet; check wiring before next run."
+
+
+def test_qubit_note_rejects_target_outside_topology(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+
+    response = test_client.put(
+        "/chips/chip-1/qubits/999/note",
+        headers=headers,
+        json={"content": "invalid target"},
+    )
+
+    assert response.status_code == 404
+    assert QubitDocument.find_one(QubitDocument.qid == "999").run() is None
+
+
+def test_coupling_note_creates_missing_topology_target(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+
+    response = test_client.put(
+        "/chips/chip-1/couplings/0-1/note",
+        headers=headers,
+        json={"content": "No coupling data yet."},
+    )
+
+    assert response.status_code == 200
+    doc = CouplingDocument.find_one(CouplingDocument.qid == "0-1").run()
+    assert doc is not None
+    assert doc.data == {}
+    assert doc.note.content == "No coupling data yet."

--- a/ui/src/components/features/dashboard/DashboardCouplingGrid.tsx
+++ b/ui/src/components/features/dashboard/DashboardCouplingGrid.tsx
@@ -23,6 +23,7 @@ interface DashboardCouplingGridProps {
   /** Maximum cell side length in px. Cells shrink to fit narrower containers. */
   maxCellSize?: number;
   notedTargets?: Set<string>;
+  targetNotedTargets?: Set<string>;
   crossMetricNotedTargets?: Set<string>;
   notesByTarget?: Record<string, NoteEntryWithMetric[]>;
   metricKey?: string;
@@ -71,6 +72,7 @@ export function DashboardCouplingGrid({
   colors,
   maxCellSize = 60,
   notedTargets,
+  targetNotedTargets,
   crossMetricNotedTargets,
   notesByTarget,
   metricKey,
@@ -213,16 +215,27 @@ export function DashboardCouplingGrid({
           const dy = pos2.row - pos1.row;
           const arrowAngle = (Math.atan2(dy, dx) * 180) / Math.PI;
           const hasNote = notedTargets?.has(couplingId) ?? false;
+          const hasTargetNote = targetNotedTargets?.has(couplingId) ?? false;
           const hasCrossMetricNote =
-            !hasNote && (crossMetricNotedTargets?.has(couplingId) ?? false);
+            !hasNote && !hasTargetNote && (crossMetricNotedTargets?.has(couplingId) ?? false);
           const Tag = onCouplingClick ? "button" : "div";
           const handleClick = () => onCouplingClick?.(couplingId);
           const titleText =
             (value !== null
               ? `Q${qid1}→Q${qid2}: ${value.toFixed(4)} ${unit}`
               : `Q${qid1}→Q${qid2}: No data`) +
-            (hasNote ? " · has note" : hasCrossMetricNote ? " · note on other metric" : "") +
-            (onCouplingClick ? " (click to edit note)" : "");
+            (hasNote
+              ? " · has metric note"
+              : hasTargetNote
+                ? " · has target note"
+                : hasCrossMetricNote
+                  ? " · note on other metric"
+                  : "") +
+            (onCouplingClick
+              ? value !== null
+                ? " (click to edit metric note)"
+                : " (click to edit target note)"
+              : "");
           return (
             <Tag
               key={couplingId}
@@ -280,10 +293,10 @@ export function DashboardCouplingGrid({
                   strokeLinejoin="round"
                 />
               </svg>
-              {hasNote && (
+              {(hasNote || hasTargetNote) && (
                 <span
                   className="absolute -top-1 -right-1 rounded-full bg-warning text-warning-content p-0.5 shadow"
-                  title="Has note"
+                  title={hasNote ? "Has metric note" : "Has target note"}
                 >
                   <StickyNote className="h-2.5 w-2.5" />
                 </span>

--- a/ui/src/components/features/dashboard/DashboardNotesSummary.tsx
+++ b/ui/src/components/features/dashboard/DashboardNotesSummary.tsx
@@ -17,13 +17,24 @@ interface TaskNoteEntry {
   updatedAt: string;
 }
 
+interface TargetNoteEntry {
+  targetId: string;
+  content: string;
+  username: string;
+  updatedAt: string;
+}
+
 interface DashboardNotesSummaryProps {
   /** Per-(target, metric) chip notes indexed by target_id. */
   notesByTarget: Record<string, NoteEntryWithMetric[]>;
+  /** Target-level qubit/coupling notes, indexed by target_id. */
+  targetNotesByTarget: Record<string, TargetNoteEntry>;
   /** Per-task_result notes for this chip. */
   taskNotes: TaskNoteEntry[];
-  /** Triggered when a chip-note row is clicked — opens the metric modal. */
+  /** Triggered when a metric-note row is clicked — opens the metric modal. */
   onEdit: (entry: NoteEntryWithMetric) => void;
+  /** Triggered when a target-note row is clicked — opens the target note modal. */
+  onEditTarget: (targetId: string) => void;
 }
 
 function formatTarget(targetId: string): string {
@@ -58,8 +69,10 @@ function isAiGeneratedNote(content: string, username: string): boolean {
 
 export function DashboardNotesSummary({
   notesByTarget,
+  targetNotesByTarget,
   taskNotes,
   onEdit,
+  onEditTarget,
 }: DashboardNotesSummaryProps) {
   const visibleNotesByTarget = useMemo(() => {
     const entries = Object.entries(notesByTarget)
@@ -80,6 +93,14 @@ export function DashboardNotesSummary({
     [visibleNotesByTarget],
   );
 
+  const sortedTargetNotes = useMemo(
+    () =>
+      Object.values(targetNotesByTarget)
+        .filter((note) => !isAiGeneratedNote(note.content, note.username))
+        .sort((a, b) => compareTargets(a.targetId, b.targetId)),
+    [targetNotesByTarget],
+  );
+
   const totalChipNotes = useMemo(
     () => sortedTargets.reduce((sum, t) => sum + (visibleNotesByTarget[t]?.length ?? 0), 0),
     [sortedTargets, visibleNotesByTarget],
@@ -93,7 +114,11 @@ export function DashboardNotesSummary({
     [taskNotes],
   );
 
-  if (sortedTargets.length === 0 && sortedTaskNotes.length === 0) {
+  if (
+    sortedTargets.length === 0 &&
+    sortedTargetNotes.length === 0 &&
+    sortedTaskNotes.length === 0
+  ) {
     return (
       <div className="text-sm text-base-content/60 italic flex items-center gap-2">
         <StickyNote className="h-4 w-4" />
@@ -104,6 +129,40 @@ export function DashboardNotesSummary({
 
   return (
     <div className="space-y-5">
+      {/* Target-level notes */}
+      {sortedTargetNotes.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-baseline gap-2">
+            <h4 className="text-sm font-semibold">Target notes</h4>
+            <span className="text-xs text-base-content/60">
+              {sortedTargetNotes.length} target-level note
+              {sortedTargetNotes.length > 1 ? "s" : ""} — click to edit the target.
+            </span>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+            {sortedTargetNotes.map((note) => (
+              <button
+                key={note.targetId}
+                onClick={() => onEditTarget(note.targetId)}
+                className="rounded-lg border border-base-300 bg-base-200/40 p-3 text-left hover:bg-base-300/40 transition-colors"
+                title={`Open target note for ${formatTarget(note.targetId)}`}
+                type="button"
+              >
+                <div className="flex items-center justify-between gap-2 text-xs">
+                  <span className="font-semibold">{formatTarget(note.targetId)}</span>
+                  <span className="text-base-content/50 truncate">
+                    {note.username} · {formatDate(note.updatedAt)}
+                  </span>
+                </div>
+                <p className="text-xs text-base-content/80 line-clamp-2 break-words mt-1">
+                  {note.content}
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Per-(target, metric) chip notes */}
       {sortedTargets.length > 0 && (
         <div className="space-y-2">

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -9,7 +9,10 @@ import { useListCooldowns } from "@/client/cooldown/cooldown";
 import { useGetChipMetrics } from "@/client/metrics/metrics";
 import { useGetChipNotesSummary } from "@/client/note/note";
 import { useListProjectMembers } from "@/client/projects/projects";
-import type { GetChipNotesSummaryParams, TargetNoteEntry } from "@/schemas";
+import type {
+  GetChipNotesSummaryParams,
+  TargetNoteEntry as SummaryTargetNoteEntry,
+} from "@/schemas";
 import { ChipSelector } from "@/components/selectors/ChipSelector";
 import { CooldownSelector } from "@/components/selectors/CooldownSelector";
 import { Card } from "@/components/ui/Card";
@@ -34,6 +37,10 @@ import { DashboardCouplingGrid } from "./DashboardCouplingGrid";
 import { DashboardNotesSummary } from "./DashboardNotesSummary";
 import { DashboardQubitGrid } from "./DashboardQubitGrid";
 import { DashboardSummaryTable } from "./DashboardSummaryTable";
+import {
+  DashboardTargetNoteModal,
+  type TargetNoteEntry as DashboardTargetNoteEntry,
+} from "./DashboardTargetNoteModal";
 import { DashboardChipNoteModal } from "./DashboardChipNoteModal";
 import { DashboardMetricModal } from "./DashboardMetricModal";
 import { type NoteEntry, type NoteEntryWithMetric } from "./MetricNotePanel";
@@ -250,7 +257,7 @@ export function DashboardPageContent() {
 
   const notesByMetric = useMemo(() => {
     const map: Record<string, Record<string, NoteEntry>> = {};
-    const collect = (entries: TargetNoteEntry[] | undefined) => {
+    const collect = (entries: SummaryTargetNoteEntry[] | undefined) => {
       (entries ?? []).forEach((entry) => {
         Object.entries(entry.metric_notes ?? {}).forEach(([metricKey, note]) => {
           const content = stripAiGeneratedNoteSections(note?.content ?? "");
@@ -277,7 +284,7 @@ export function DashboardPageContent() {
     couplingMetrics.forEach((m) => titleByKey.set(m.key, m.title));
 
     const map: Record<string, NoteEntryWithMetric[]> = {};
-    const collect = (entries: TargetNoteEntry[] | undefined) => {
+    const collect = (entries: SummaryTargetNoteEntry[] | undefined) => {
       (entries ?? []).forEach((entry) => {
         Object.entries(entry.metric_notes ?? {}).forEach(([metricKey, note]) => {
           const content = stripAiGeneratedNoteSections(note?.content ?? "");
@@ -299,12 +306,42 @@ export function DashboardPageContent() {
     return map;
   }, [summary, qubitMetrics, couplingMetrics]);
 
+  const targetNotesByTarget = useMemo(() => {
+    const map: Record<string, DashboardTargetNoteEntry> = {};
+    const collect = (entries: SummaryTargetNoteEntry[] | undefined) => {
+      (entries ?? []).forEach((entry) => {
+        const content = stripAiGeneratedNoteSections(entry.note?.content ?? "");
+        if (!content) return;
+        map[entry.target_id] = {
+          targetId: entry.target_id,
+          content,
+          username: entry.note?.updated_by ?? "",
+          updatedAt: entry.note?.updated_at ?? "",
+        };
+      });
+    };
+    collect(summary?.qubits);
+    collect(summary?.couplings);
+    return map;
+  }, [summary]);
+
+  const targetNotedQids = useMemo(
+    () => new Set(Object.keys(targetNotesByTarget).filter((targetId) => !targetId.includes("-"))),
+    [targetNotesByTarget],
+  );
+
+  const targetNotedCouplings = useMemo(
+    () => new Set(Object.keys(targetNotesByTarget).filter((targetId) => targetId.includes("-"))),
+    [targetNotesByTarget],
+  );
+
   const [editingNote, setEditingNote] = useState<{
     targetId: string;
     metricKey: string;
     metricTitle: string;
     metricUnit: string;
   } | null>(null);
+  const [editingTargetNote, setEditingTargetNote] = useState<string | null>(null);
   const [showChipNote, setShowChipNote] = useState(false);
 
   const editingExisting =
@@ -472,7 +509,9 @@ export function DashboardPageContent() {
             >
               <DashboardNotesSummary
                 notesByTarget={notesByTarget}
+                targetNotesByTarget={targetNotesByTarget}
                 taskNotes={taskNotes}
+                onEditTarget={setEditingTargetNote}
                 onEdit={(entry) => {
                   const cfg =
                     qubitMetrics.find((m) => m.key === entry.metricKey) ??
@@ -550,17 +589,23 @@ export function DashboardPageContent() {
                               topologyId={topologyId}
                               colors={colors}
                               notedQids={noted}
+                              targetNotedQids={targetNotedQids}
                               crossMetricNotedQids={crossMetricNoted}
                               notesByTarget={notesByTarget}
                               metricKey={m.key}
-                              onQubitClick={(qid) =>
+                              onQubitClick={(qid) => {
+                                const value = qubitMetricData[m.key]?.[qid]?.value ?? null;
+                                if (value === null) {
+                                  setEditingTargetNote(qid);
+                                  return;
+                                }
                                 setEditingNote({
                                   targetId: qid,
                                   metricKey: m.key,
                                   metricTitle: m.title,
                                   metricUnit: m.unit,
-                                })
-                              }
+                                });
+                              }}
                             />
                           </div>
                           <div className="xl:col-span-1 min-w-0">
@@ -627,17 +672,24 @@ export function DashboardPageContent() {
                               topologyId={topologyId}
                               colors={colors}
                               notedTargets={noted}
+                              targetNotedTargets={targetNotedCouplings}
                               crossMetricNotedTargets={crossMetricNoted}
                               notesByTarget={notesByTarget}
                               metricKey={m.key}
-                              onCouplingClick={(couplingId) =>
+                              onCouplingClick={(couplingId) => {
+                                const value =
+                                  couplingMetricData[m.key]?.[couplingId]?.value ?? null;
+                                if (value === null) {
+                                  setEditingTargetNote(couplingId);
+                                  return;
+                                }
                                 setEditingNote({
                                   targetId: couplingId,
                                   metricKey: m.key,
                                   metricTitle: m.title,
                                   metricUnit: m.unit,
-                                })
-                              }
+                                });
+                              }}
                             />
                           </div>
                           <div className="xl:col-span-1 min-w-0">
@@ -675,6 +727,17 @@ export function DashboardPageContent() {
           otherNotes={editingOtherNotes}
           mentionCandidates={mentionCandidates}
           onClose={() => setEditingNote(null)}
+        />
+      )}
+
+      {editingTargetNote && selectedChip && (
+        <DashboardTargetNoteModal
+          chipId={selectedChip}
+          targetId={editingTargetNote}
+          noteScopeParams={noteScopeParams}
+          existing={targetNotesByTarget[editingTargetNote]}
+          mentionCandidates={mentionCandidates}
+          onClose={() => setEditingTargetNote(null)}
         />
       )}
 

--- a/ui/src/components/features/dashboard/DashboardQubitGrid.tsx
+++ b/ui/src/components/features/dashboard/DashboardQubitGrid.tsx
@@ -24,6 +24,8 @@ interface DashboardQubitGridProps {
   maxCellSize?: number;
   /** Set of qubit IDs that have a note for the metric this grid represents. */
   notedQids?: Set<string>;
+  /** Set of qubit IDs that have a target-level note. */
+  targetNotedQids?: Set<string>;
   /**
    * Set of qubit IDs that have notes on OTHER metrics (not this one). Used to
    * render a subtle indicator so users know to click to read the cross-metric
@@ -77,6 +79,7 @@ export function DashboardQubitGrid({
   colors,
   maxCellSize = 60,
   notedQids,
+  targetNotedQids,
   crossMetricNotedQids,
   notesByTarget,
   metricKey,
@@ -170,12 +173,24 @@ export function DashboardQubitGrid({
         const value = metric?.value ?? null;
         const bg = value !== null ? pickColor(value, autoMin, autoMax, colors) : null;
         const hasNote = notedQids?.has(qid) ?? false;
-        const hasCrossMetricNote = !hasNote && (crossMetricNotedQids?.has(qid) ?? false);
+        const hasTargetNote = targetNotedQids?.has(qid) ?? false;
+        const hasCrossMetricNote =
+          !hasNote && !hasTargetNote && (crossMetricNotedQids?.has(qid) ?? false);
         const handleClick = () => onQubitClick?.(qid);
         const titleText =
           (value !== null ? `${qid}: ${value.toFixed(4)} ${unit}` : `${qid}: No data`) +
-          (hasNote ? " · has note" : hasCrossMetricNote ? " · note on other metric" : "") +
-          (onQubitClick ? " (click to edit note)" : "");
+          (hasNote
+            ? " · has metric note"
+            : hasTargetNote
+              ? " · has target note"
+              : hasCrossMetricNote
+                ? " · note on other metric"
+                : "") +
+          (onQubitClick
+            ? value !== null
+              ? " (click to edit metric note)"
+              : " (click to edit target note)"
+            : "");
         const Tag = onQubitClick ? "button" : "div";
         return (
           <Tag
@@ -203,10 +218,10 @@ export function DashboardQubitGrid({
             >
               {qid}
             </span>
-            {hasNote && (
+            {(hasNote || hasTargetNote) && (
               <span
                 className="absolute top-1 right-1 rounded-full bg-warning/90 text-warning-content p-0.5 shadow"
-                title="Has note"
+                title={hasNote ? "Has metric note" : "Has target note"}
               >
                 <StickyNote className="h-3 w-3" />
               </span>

--- a/ui/src/components/features/dashboard/DashboardTargetNoteModal.tsx
+++ b/ui/src/components/features/dashboard/DashboardTargetNoteModal.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Pencil, Save, StickyNote, Trash2, X } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  getGetChipNotesSummaryQueryKey,
+  useDeleteCouplingNote,
+  useDeleteQubitNote,
+  useUpsertCouplingNote,
+  useUpsertQubitNote,
+} from "@/client/note/note";
+import { MarkdownContent } from "@/components/ui/MarkdownContent";
+import { MarkdownEditor, type MentionCandidate } from "@/components/ui/MarkdownEditor";
+import { formatDateTime } from "@/lib/utils/datetime";
+import type { GetChipNotesSummaryParams } from "@/schemas";
+
+export interface TargetNoteEntry {
+  targetId: string;
+  content: string;
+  username: string;
+  updatedAt: string;
+}
+
+interface DashboardTargetNoteModalProps {
+  chipId: string;
+  targetId: string;
+  noteScopeParams?: GetChipNotesSummaryParams;
+  existing?: TargetNoteEntry;
+  mentionCandidates?: MentionCandidate[];
+  onClose: () => void;
+}
+
+function formatTarget(targetId: string): string {
+  if (targetId.includes("-")) {
+    const [a, b] = targetId.split("-");
+    return `Q${a} -> Q${b}`;
+  }
+  return `Q${targetId}`;
+}
+
+export function DashboardTargetNoteModal({
+  chipId,
+  targetId,
+  noteScopeParams,
+  existing,
+  mentionCandidates,
+  onClose,
+}: DashboardTargetNoteModalProps) {
+  const queryClient = useQueryClient();
+  const isCoupling = targetId.includes("-");
+  const upsertQubit = useUpsertQubitNote();
+  const deleteQubit = useDeleteQubitNote();
+  const upsertCoupling = useUpsertCouplingNote();
+  const deleteCoupling = useDeleteCouplingNote();
+  const upsertPending = isCoupling ? upsertCoupling.isPending : upsertQubit.isPending;
+  const deletePending = isCoupling ? deleteCoupling.isPending : deleteQubit.isPending;
+
+  const [mode, setMode] = useState<"view" | "edit">(existing ? "view" : "edit");
+  const [draft, setDraft] = useState(existing?.content ?? "");
+
+  useEffect(() => {
+    setDraft(existing?.content ?? "");
+    setMode(existing ? "view" : "edit");
+  }, [existing, targetId]);
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey: getGetChipNotesSummaryQueryKey(chipId, noteScopeParams),
+    });
+
+  const handleSave = async () => {
+    if (!draft.trim() || draft.length > 5000) return;
+    if (isCoupling) {
+      await upsertCoupling.mutateAsync({
+        chipId,
+        couplingId: targetId,
+        data: { content: draft },
+      });
+    } else {
+      await upsertQubit.mutateAsync({
+        chipId,
+        qid: targetId,
+        data: { content: draft },
+      });
+    }
+    await invalidate();
+    onClose();
+  };
+
+  const handleDelete = async () => {
+    if (!existing) {
+      setDraft("");
+      onClose();
+      return;
+    }
+    if (isCoupling) {
+      await deleteCoupling.mutateAsync({ chipId, couplingId: targetId });
+    } else {
+      await deleteQubit.mutateAsync({ chipId, qid: targetId });
+    }
+    await invalidate();
+    onClose();
+  };
+
+  const isTooLong = draft.length > 5000;
+
+  return (
+    <div
+      className="modal modal-open"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="modal-box w-full max-w-2xl p-0 overflow-hidden">
+        <div className="px-5 py-4 border-b border-base-300 flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 text-lg font-bold">
+              <StickyNote className="h-5 w-5 text-warning" />
+              <span className="truncate">Target note · {formatTarget(targetId)}</span>
+            </div>
+            <p className="text-sm text-base-content/60 mt-1">
+              Permanent target-level context, available even when this metric has no data.
+            </p>
+          </div>
+          <button
+            className="btn btn-ghost btn-sm btn-circle"
+            onClick={onClose}
+            type="button"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          {mode === "view" && existing ? (
+            <div className="space-y-3">
+              <div className="rounded-md bg-base-100 border border-base-300 p-3">
+                <MarkdownContent content={existing.content} />
+              </div>
+              <div className="text-[11px] text-base-content/60 flex flex-wrap gap-x-2">
+                <span>
+                  Last edited by{" "}
+                  <span className="font-medium text-base-content/80">
+                    {existing.username || "-"}
+                  </span>
+                </span>
+                {existing.updatedAt && <span>· {formatDateTime(existing.updatedAt)}</span>}
+              </div>
+              <div className="flex gap-2">
+                <button
+                  className="btn btn-sm btn-primary gap-1"
+                  onClick={() => setMode("edit")}
+                  type="button"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                  Edit
+                </button>
+                <button
+                  className="btn btn-sm btn-ghost text-error gap-1"
+                  onClick={handleDelete}
+                  disabled={deletePending}
+                  type="button"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  {deletePending ? "Deleting..." : "Delete"}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <MarkdownEditor
+                value={draft}
+                onChange={setDraft}
+                onSubmit={handleSave}
+                placeholder="Target-level caveats, missing-data reasons, wiring notes, or follow-up context..."
+                rows={8}
+                disabled={upsertPending}
+                mentionCandidates={mentionCandidates}
+              />
+              <div className="flex flex-wrap items-center justify-between gap-2 text-[11px] text-base-content/50">
+                <span className={isTooLong ? "text-error" : undefined}>{draft.length} / 5000</span>
+                {existing?.updatedAt && (
+                  <span>
+                    Last edited {formatDateTime(existing.updatedAt)} by {existing.username || "-"}
+                  </span>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+
+        {mode === "edit" && (
+          <div className="px-5 py-4 border-t border-base-300 flex flex-wrap justify-between gap-2">
+            <button
+              className="btn btn-sm btn-ghost text-error gap-1"
+              onClick={handleDelete}
+              disabled={!existing || deletePending}
+              type="button"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              {deletePending ? "Deleting..." : "Delete"}
+            </button>
+            <div className="flex gap-2">
+              <button className="btn btn-sm btn-ghost" onClick={onClose} type="button">
+                Cancel
+              </button>
+              <button
+                className="btn btn-sm btn-primary gap-1"
+                onClick={handleSave}
+                disabled={!draft.trim() || isTooLong || upsertPending}
+                type="button"
+              >
+                <Save className="h-4 w-4" />
+                {upsertPending ? "Saving..." : "Save note"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Allow dashboard users to leave target-level notes on qubit/coupling cells that do not yet have metric data.
- Existing chips are handled without a migration: topology-valid empty target rows are created lazily on note save, and topology updates backfill missing target skeletons.

## Changes
- Added API support for topology-valid qubit/coupling skeleton creation when saving general target notes.
- Backfilled missing topology target rows when chip topology metadata is updated.
- Added `DashboardTargetNoteModal` and updated `DashboardPageContent`, `DashboardQubitGrid`, `DashboardCouplingGrid`, and `DashboardNotesSummary` to route no-data cells to target notes while preserving metric notes for data cells.
- Added focused API tests for existing-chip lazy target creation, topology backfill, and invalid topology target rejection.
- No OpenAPI/client generation was needed because existing note endpoints and schemas are reused.

Verification:
- `uv run ruff check src/qdash/api/services/chip/initializer.py src/qdash/api/services/chip/service.py src/qdash/api/services/note_service.py tests/qdash/api/routers/test_note.py tests/qdash/api/routers/test_chip.py`
- `uv run pytest tests/qdash/api/routers/test_note.py tests/qdash/api/routers/test_chip.py`
- `bun run lint`
- `bunx tsc --noEmit`
