### PR TITLE
feat(workflow): add check waveform template

### DIFF
--- a/config/app/backend.yaml
+++ b/config/app/backend.yaml
@@ -43,6 +43,7 @@ backends:
       - CheckQubitSpectroscopy
       - CheckSimultaneousQubitSpectroscopy
       - CheckQubitFrequencies
+      - CheckWaveform
       - CheckControlAmplitude
       - CheckReadoutAmplitude
       - CheckElectricalDelay
@@ -124,6 +125,7 @@ categories:
     - CheckQubitSpectroscopy
     - CheckSimultaneousQubitSpectroscopy
     - CheckQubitFrequencies
+    - CheckWaveform
     - CheckControlAmplitude
     - CheckReadoutAmplitude
     - CheckElectricalDelay

--- a/src/qdash/workflow/calibtasks/qubex/__init__.py
+++ b/src/qdash/workflow/calibtasks/qubex/__init__.py
@@ -37,6 +37,7 @@ from qdash.workflow.calibtasks.qubex.cw.check_resonator_spectroscopy import (
 from qdash.workflow.calibtasks.qubex.cw.check_simultaneous_qubit_spectroscopy import (
     CheckSimultaneousQubitSpectroscopy,
 )
+from qdash.workflow.calibtasks.qubex.cw.check_waveform import CheckWaveform
 from qdash.workflow.calibtasks.qubex.measurement.readout_classification import ReadoutClassification
 from qdash.workflow.calibtasks.qubex.one_qubit_coarse.check_chevron import CheckChevron
 from qdash.workflow.calibtasks.qubex.one_qubit_coarse.check_coarse_chevron import (
@@ -121,6 +122,7 @@ __all__ = [
     "CheckT1Average",
     "CheckT2Echo",
     "CheckT2EchoAverage",
+    "CheckWaveform",
     "CheckZX90",
     "ChevronPattern",  # legacy alias of CheckFineChevron — UI selector only
     "Configure",

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_waveform.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_waveform.py
@@ -1,0 +1,103 @@
+from typing import Any, ClassVar
+
+from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
+from qubex.measurement.measurement_defaults import DEFAULT_INTERVAL
+
+from qdash.datamodel.task import ParameterModel, RunParameterModel
+from qdash.workflow.calibtasks.base import (
+    PostProcessResult,
+    RunResult,
+)
+from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.engine.backend.qubex import QubexBackend
+
+
+class CheckWaveform(QubexTask):
+    """Task to check readout waveforms."""
+
+    name: str = "CheckWaveform"
+    task_type: str = "qubit"
+    input_parameters: ClassVar[dict[str, ParameterModel | None]] = {}
+    run_parameters: ClassVar[dict[str, RunParameterModel]] = {
+        "shots": RunParameterModel(
+            unit="a.u.",
+            value_type="int",
+            value=CALIBRATION_SHOTS,
+            description="Number of shots for waveform measurement",
+        ),
+        "interval": RunParameterModel(
+            unit="ns",
+            value_type="int",
+            value=DEFAULT_INTERVAL,
+            description="Shot interval for waveform measurement",
+        ),
+        "readout_amplitude": RunParameterModel(
+            unit="a.u.",
+            value_type="float",
+            value=None,
+            description="Readout pulse amplitude. Uses qubex default when unset.",
+        ),
+        "readout_duration": RunParameterModel(
+            unit="ns",
+            value_type="float",
+            value=None,
+            description="Readout pulse duration. Uses qubex default when unset.",
+        ),
+        "readout_pre_margin": RunParameterModel(
+            unit="ns",
+            value_type="float",
+            value=None,
+            description="Readout pre-margin. Uses qubex default when unset.",
+        ),
+        "readout_post_margin": RunParameterModel(
+            unit="ns",
+            value_type="float",
+            value=None,
+            description="Readout post-margin. Uses qubex default when unset.",
+        ),
+    }
+    output_parameters: ClassVar[dict[str, ParameterModel]] = {}
+
+    def _optional_run_parameter(self, name: str) -> Any:
+        parameter = self.run_parameters[name]
+        if parameter.value is None:
+            return None
+        return parameter.get_value()
+
+    def _check_waveform(self, backend: QubexBackend, targets: str | list[str]) -> Any:
+        exp = self.get_experiment(backend)
+        return exp.check_waveform(
+            targets=targets,
+            n_shots=self._optional_run_parameter("shots"),
+            shot_interval=self._optional_run_parameter("interval"),
+            readout_amplitude=self._optional_run_parameter("readout_amplitude"),
+            readout_duration=self._optional_run_parameter("readout_duration"),
+            readout_pre_margin=self._optional_run_parameter("readout_pre_margin"),
+            readout_post_margin=self._optional_run_parameter("readout_post_margin"),
+        )
+
+    def postprocess(
+        self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
+    ) -> PostProcessResult:
+        """Process the waveform check result."""
+        label = self.get_qubit_label(backend, qid)
+        data = getattr(run_result.raw_result, "data", {})
+        figure = None
+        if label in data and hasattr(data[label], "plot"):
+            figure = data[label].plot(return_figure=True)
+        figures = [figure] if figure is not None else []
+        return PostProcessResult(output_parameters={}, figures=figures)
+
+    def run(self, backend: QubexBackend, qid: str) -> RunResult:
+        """Run the task."""
+        label = self.get_qubit_label(backend, qid)
+        result = self._check_waveform(backend, label)
+        self.save_calibration(backend)
+        return RunResult(raw_result=result)
+
+    def batch_run(self, backend: QubexBackend, qids: list[str]) -> RunResult:
+        """Run the task for a batch of qubits."""
+        labels = [self.get_qubit_label(backend, qid) for qid in qids]
+        result = self._check_waveform(backend, labels)
+        self.save_calibration(backend)
+        return RunResult(raw_result=result)

--- a/src/qdash/workflow/templates/bringup.py
+++ b/src/qdash/workflow/templates/bringup.py
@@ -1,7 +1,7 @@
 """Bring-up calibration for MUX-level characterization.
 
-This template runs MUX-level bring-up tasks like resonator spectroscopy.
-These tasks are executed once per MUX, not per qubit.
+This template configures selected MUXes, then runs MUX-level bring-up tasks like
+resonator spectroscopy. Bring-up tasks are executed once per MUX, not per qubit.
 
 Example:
     bringup(
@@ -17,7 +17,7 @@ from prefect import flow
 
 from qdash.workflow.service import CalibService
 from qdash.workflow.service.calib_service import on_flow_cancellation
-from qdash.workflow.service.steps import BringUp
+from qdash.workflow.service.steps import BringUp, ConfigureAll
 from qdash.workflow.service.targets import MuxTargets
 
 
@@ -36,9 +36,10 @@ def bringup(
 ) -> Any:
     """Bring-up calibration for MUX-level characterization.
 
-    This flow runs MUX-level tasks (e.g., CheckResonatorSpectroscopy) that
-    characterize the entire MUX unit. Tasks are executed only for the
-    representative qubit (qid % 4 == 0) of each MUX.
+    This flow first pushes the current configuration to the selected MUXes, then
+    runs MUX-level tasks (e.g., CheckResonatorSpectroscopy) that characterize the
+    entire MUX unit. Tasks are executed only for the representative qubit
+    (qid % 4 == 0) of each MUX.
 
     Args:
         username: User name (from UI)
@@ -77,6 +78,7 @@ def bringup(
         }
 
     steps = [
+        ConfigureAll(),
         BringUp(mode=mode),
     ]
 

--- a/src/qdash/workflow/templates/check_waveform.py
+++ b/src/qdash/workflow/templates/check_waveform.py
@@ -1,0 +1,77 @@
+"""Readout waveform check flow template.
+
+This template runs qubex CheckWaveform for selected MUXes or qubits.
+
+Example:
+    check_waveform(
+        username="alice",
+        chip_id="64Qv3",
+        mux_ids=[0, 1],
+    )
+"""
+
+from typing import Any
+
+from prefect import flow
+
+from qdash.workflow.service import CalibService
+from qdash.workflow.service.calib_service import on_flow_cancellation
+from qdash.workflow.service.steps import CustomOneQubit
+from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
+
+
+@flow(on_cancellation=[on_flow_cancellation])
+def check_waveform(
+    username: str,
+    chip_id: str,
+    mux_ids: list[int] | None = None,
+    exclude_qids: list[str] | None = None,
+    qids: list[str] | None = None,
+    mode: str = "scheduled",
+    tags: list[str] | None = None,
+    flow_name: str | None = None,
+    project_id: str | None = None,
+) -> Any:
+    """Run readout waveform checks for selected targets.
+
+    Args:
+        username: User name (from UI)
+        chip_id: Chip ID (from UI)
+        mux_ids: MUX IDs to inspect (uses MUX-based scheduling)
+        exclude_qids: Qubit IDs to exclude (only with mux_ids)
+        qids: Qubit IDs to inspect (fallback if mux_ids not set)
+        mode: Execution mode for the one-qubit step
+        tags: Flow tags
+        flow_name: Flow name (auto-injected)
+        project_id: Project ID (auto-injected)
+
+    Returns:
+        Pipeline results
+    """
+    if exclude_qids is None:
+        exclude_qids = []
+
+    targets: Target
+    if mux_ids is not None:
+        targets = MuxTargets(mux_ids=mux_ids, exclude_qids=exclude_qids)
+    elif qids is not None:
+        targets = QubitTargets(qids=qids)
+    else:
+        targets = MuxTargets(mux_ids=list(range(16)), exclude_qids=exclude_qids)
+
+    steps = [
+        CustomOneQubit(step_name="check_waveform", tasks=["CheckWaveform"], mode=mode),
+    ]
+
+    cal = CalibService(
+        username,
+        chip_id,
+        flow_name=flow_name,
+        tags=tags,
+        project_id=project_id,
+        skip_execution=True,
+        default_run_parameters={
+            "interval": {"value": 150 * 1024, "value_type": "int"},
+        },
+    )
+    return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -2,7 +2,7 @@
   {
     "id": "bringup",
     "name": "Bring-up",
-    "description": "MUX-level bring-up calibration (resonator spectroscopy). Runs once per MUX for initial characterization.",
+    "description": "MUX-level bring-up calibration: ConfigureAll -> resonator spectroscopy. Runs once per MUX for initial characterization.",
     "category": "production",
     "filename": "bringup.py",
     "function_name": "bringup"
@@ -14,6 +14,14 @@
     "category": "advanced",
     "filename": "experimental_simultaneous_bringup.py",
     "function_name": "experimental_simultaneous_bringup"
+  },
+  {
+    "id": "check_waveform",
+    "name": "Check Waveform",
+    "description": "Readout waveform inspection using qubex CheckWaveform for selected MUXes or qubits.",
+    "category": "basic",
+    "filename": "check_waveform.py",
+    "function_name": "check_waveform"
   },
   {
     "id": "simple",

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_waveform.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_waveform.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+import plotly.graph_objects as go
+
+from qdash.workflow.calibtasks.base import RunResult
+from qdash.workflow.calibtasks.qubex.cw.check_waveform import CheckWaveform
+
+
+def _make_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.get_instance.return_value = backend.experiment
+    backend.experiment.get_qubit_label.side_effect = lambda qid: f"Q{qid:02d}"
+    return backend
+
+
+def test_run_calls_qubex_check_waveform_for_single_target() -> None:
+    task = CheckWaveform()
+    backend = _make_backend()
+    backend.experiment.check_waveform.return_value = {"ok": True}
+
+    result = task.run(backend, "0")
+
+    backend.experiment.check_waveform.assert_called_once_with(
+        targets="Q00",
+        n_shots=task.run_parameters["shots"].get_value(),
+        shot_interval=task.run_parameters["interval"].get_value(),
+        readout_amplitude=None,
+        readout_duration=None,
+        readout_pre_margin=None,
+        readout_post_margin=None,
+    )
+    assert result.raw_result == {"ok": True}
+
+
+def test_batch_run_calls_qubex_check_waveform_for_targets() -> None:
+    task = CheckWaveform()
+    backend = _make_backend()
+    backend.experiment.check_waveform.return_value = {"ok": True}
+
+    result = task.batch_run(backend, ["0", "1"])
+
+    backend.experiment.check_waveform.assert_called_once_with(
+        targets=["Q00", "Q01"],
+        n_shots=task.run_parameters["shots"].get_value(),
+        shot_interval=task.run_parameters["interval"].get_value(),
+        readout_amplitude=None,
+        readout_duration=None,
+        readout_pre_margin=None,
+        readout_post_margin=None,
+    )
+    assert result.raw_result == {"ok": True}
+
+
+def test_postprocess_returns_waveform_figure_when_result_has_plot() -> None:
+    task = CheckWaveform()
+    backend = _make_backend()
+    waveform = MagicMock()
+    figure = go.Figure()
+    waveform.plot.return_value = figure
+    raw_result = MagicMock()
+    raw_result.data = {"Q00": waveform}
+
+    result = task.postprocess(backend, "exec-1", RunResult(raw_result=raw_result), "0")
+
+    assert result.output_parameters == {}
+    assert result.figures == [figure]
+    waveform.plot.assert_called_once_with(return_figure=True)

--- a/tests/qdash/workflow/test_bringup_template.py
+++ b/tests/qdash/workflow/test_bringup_template.py
@@ -40,6 +40,18 @@ def test_bringup_injects_resonator_assignment_pattern(monkeypatch) -> None:
     }
 
 
+def test_bringup_starts_with_configure_all(monkeypatch) -> None:
+    monkeypatch.setattr(bringup_module, "CalibService", FakeCalibService)
+
+    result = bringup_module.bringup(
+        username="alice",
+        chip_id="16Q-test",
+        mux_ids=[0],
+    )
+
+    assert [step.name for step in result["steps"]] == ["configure_all", "bringup"]
+
+
 def test_bringup_step_accepts_resonator_assignment_pattern() -> None:
     from qdash.workflow.service.steps import BringUp
 

--- a/tests/qdash/workflow/test_check_waveform_template.py
+++ b/tests/qdash/workflow/test_check_waveform_template.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+check_waveform_module = importlib.import_module("qdash.workflow.templates.check_waveform")
+
+
+class FakeCalibService:
+    last_kwargs: dict[str, Any] | None = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        FakeCalibService.last_kwargs = kwargs
+
+    def run(self, targets: Any, *, steps: list[Any]) -> dict[str, Any]:
+        return {"targets": targets, "steps": steps}
+
+
+def test_check_waveform_template_runs_check_waveform_step(monkeypatch) -> None:
+    monkeypatch.setattr(check_waveform_module, "CalibService", FakeCalibService)
+
+    result = check_waveform_module.check_waveform(
+        username="alice",
+        chip_id="16Q-test",
+        mux_ids=[0],
+    )
+
+    step = result["steps"][0]
+    assert step.name == "check_waveform"
+    assert step.tasks == ["CheckWaveform"]
+    assert step.mode == "scheduled"
+
+
+def test_check_waveform_template_sets_default_interval(monkeypatch) -> None:
+    monkeypatch.setattr(check_waveform_module, "CalibService", FakeCalibService)
+
+    check_waveform_module.check_waveform(
+        username="alice",
+        chip_id="16Q-test",
+        qids=["0"],
+    )
+
+    assert FakeCalibService.last_kwargs is not None
+    assert FakeCalibService.last_kwargs["default_run_parameters"] == {
+        "interval": {"value": 150 * 1024, "value_type": "int"},
+    }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Adds a workflow template and qubex calibration task for readout waveform inspection.
- Affects workflow task registration, backend task availability config, and bring-up sequencing by running ConfigureAll before bring-up tasks.

## Changes
- Add CheckWaveform qubex task with optional readout waveform run parameters and figure postprocessing.
- Register the check_waveform template and expose CheckWaveform in backend task configuration.
- Update bringup to run ConfigureAll before BringUp and cover the step order with tests.
- Add focused workflow tests for the new task and template.

Verification:
- uv run pytest tests/qdash/workflow/calibtasks/qubex/test_check_waveform.py tests/qdash/workflow/test_check_waveform_template.py tests/qdash/workflow/test_bringup_template.py