### PR TITLE
Style/#1067 editor footer collapses

### DIFF
--- a/ui/src/components/features/files/FilesPageContent.tsx
+++ b/ui/src/components/features/files/FilesPageContent.tsx
@@ -369,7 +369,7 @@ export function FilesPageContent() {
 
   return (
     <>
-      <div className="h-screen flex flex-col bg-base-300">
+      <div className="h-full flex flex-col bg-base-300">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between px-2 sm:px-4 py-2 bg-base-200 border-b border-base-300 gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0">
             <button

--- a/ui/src/components/features/files/FilesPageContent.tsx
+++ b/ui/src/components/features/files/FilesPageContent.tsx
@@ -369,7 +369,7 @@ export function FilesPageContent() {
 
   return (
     <>
-      <div className="h-full flex flex-col bg-base-300">
+      <div className="h-[calc(100dvh-4rem)] flex flex-col bg-base-300">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between px-2 sm:px-4 py-2 bg-base-200 border-b border-base-300 gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0">
             <button

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -2039,22 +2039,24 @@ export function WorkflowEditorPageContent() {
               Ln {cursorPosition.line}, Col {cursorPosition.column}
             </button>
             {selection.chars > 0 && (
-              <span className="px-1.5 py-0.5 bg-primary-content/10 rounded">
+              <span className="hidden sm:inline-block px-1.5 py-0.5 bg-primary-content/10 rounded">
                 {selection.lines > 1 ? `${selection.lines} lines, ` : ""}
                 {selection.chars} selected
               </span>
             )}
-            <span className="px-1.5 py-0.5">Spaces: 4</span>
+            <span className="hidden sm:inline-block px-1.5 py-0.5">Spaces: 4</span>
             <span className="px-1.5 py-0.5">Python</span>
             <span className="px-1.5 py-0.5">UTF-8</span>
-            {isDirty && <span className="px-1.5 py-0.5 opacity-80">● Modified</span>}
+            {isDirty && (
+              <span className="hidden sm:inline-block px-1.5 py-0.5 opacity-80">● Modified</span>
+            )}
           </div>
           <div className="flex items-center gap-1">
             <span className="px-1.5 py-0.5">{code.split("\n").length} lines</span>
             <button
               type="button"
               onClick={() => setWordWrap((prev) => (prev === "on" ? "off" : "on"))}
-              className={`hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer flex items-center gap-1 ${wordWrap === "off" ? "opacity-50" : ""}`}
+              className={`hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer hidden sm:flex items-center gap-1 ${wordWrap === "off" ? "opacity-50" : ""}`}
               title="Toggle Word Wrap (⌥Z)"
             >
               <WrapText size={10} />
@@ -2062,7 +2064,7 @@ export function WorkflowEditorPageContent() {
             <button
               type="button"
               onClick={() => setIsBottomPanelOpen((prev) => !prev)}
-              className={`hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer flex items-center gap-1 ${isBottomPanelOpen ? "" : "opacity-60"}`}
+              className={`hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer hidden sm:flex items-center gap-1 ${isBottomPanelOpen ? "" : "opacity-60"}`}
               title="Toggle Panel (⌘`)"
             >
               <Terminal size={10} />
@@ -2071,7 +2073,7 @@ export function WorkflowEditorPageContent() {
               <button
                 type="button"
                 onClick={() => setFontSize(14)}
-                className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer"
+                className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer hidden sm:block"
                 title="Reset Zoom (⌘0)"
               >
                 {Math.round((fontSize / 14) * 100)}%
@@ -2081,7 +2083,7 @@ export function WorkflowEditorPageContent() {
               <button
                 type="button"
                 onClick={() => setIsEditorLocked(false)}
-                className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer flex items-center gap-1 opacity-80"
+                className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer hidden sm:flex items-center gap-1 opacity-80"
                 title="Click to enable editing"
               >
                 <Lock size={10} /> Read-only
@@ -2090,7 +2092,7 @@ export function WorkflowEditorPageContent() {
               <button
                 type="button"
                 onClick={() => setIsEditorLocked(true)}
-                className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer flex items-center gap-1"
+                className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer hidden sm:flex items-center gap-1"
                 title="Click to lock editor"
               >
                 <Pencil size={10} /> Editing
@@ -2102,7 +2104,7 @@ export function WorkflowEditorPageContent() {
                 setShowCommandPalette(true);
                 setCommandSearch("");
               }}
-              className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer flex items-center gap-1 opacity-70 hover:opacity-100"
+              className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer hidden sm:flex items-center gap-1 opacity-70 hover:opacity-100"
               title="Command Palette"
             >
               <Command size={10} />

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -1088,7 +1088,7 @@ export function WorkflowEditorPageContent() {
 
   return (
     <>
-      <div className="h-full flex flex-col bg-base-300">
+      <div className="h-[calc(100dvh-4rem)] flex flex-col bg-base-300">
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between px-2 sm:px-4 py-2 bg-base-200 border-b border-base-300 gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0">

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -1088,7 +1088,7 @@ export function WorkflowEditorPageContent() {
 
   return (
     <>
-      <div className="h-screen flex flex-col bg-base-300">
+      <div className="h-full flex flex-col bg-base-300">
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between px-2 sm:px-4 py-2 bg-base-200 border-b border-base-300 gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0">

--- a/ui/src/components/features/tasks/TasksPageContent.tsx
+++ b/ui/src/components/features/tasks/TasksPageContent.tsx
@@ -371,7 +371,7 @@ export function TasksPageContent() {
 
   return (
     <>
-      <div className="h-screen flex flex-col bg-base-300">
+      <div className="h-full flex flex-col bg-base-300">
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between px-2 sm:px-4 py-2 bg-base-200 border-b border-base-300 gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0">

--- a/ui/src/components/features/tasks/TasksPageContent.tsx
+++ b/ui/src/components/features/tasks/TasksPageContent.tsx
@@ -371,7 +371,7 @@ export function TasksPageContent() {
 
   return (
     <>
-      <div className="h-full flex flex-col bg-base-300">
+      <div className="h-[calc(100dvh-4rem)] flex flex-col bg-base-300">
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between px-2 sm:px-4 py-2 bg-base-200 border-b border-base-300 gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0">


### PR DESCRIPTION
## Ticket

close #1058
close #1067

## Summary

The editor footer (status bar) on the Files, Workflow (`workflow/[name]`), and Tasks pages broke its layout on mobile and was pushed out of the viewport, forcing scrolling. This fixes the footer so it always fits within the screen and stays usable on small screens.

## Changes

- Simplify the Workflow editor status bar on mobile: hide non-essential and interactive items (selection info, `Spaces: 4`, `Modified`, word-wrap / panel toggles, zoom, read-only toggle, command palette) below the `sm` breakpoint, keeping only `Ln/Col`, `Python`, `UTF-8`, and line count visible (matching the Files page footer). The hidden controls remain reachable on mobile via the FAB and the activity-bar command button.
- Fix the editor pages so the footer always fits within the viewport without scrolling: change the root container height from `h-screen` (100vh, which overflowed `<main>` by the navbar height) to `h-[calc(100dvh-4rem)]`, matching the `<main>` content area height (viewport − 4rem navbar).
- Apply the height fix consistently across the Files, Workflow, and Tasks pages.

### Notes

- `4rem` corresponds to the DaisyUI `.navbar` `min-height`; update these pages if the navbar height changes.
- `dvh` is used (instead of `vh`) so the footer stays visible on mobile even when the browser toolbar is shown, and so the page never exceeds `<main>` (no scrollbar).
