### PR TITLE
style(ui): update download button text visibility in MetricsPdfDownlo…

### DIFF
--- a/ui/src/components/features/metrics/MetricsPdfDownloadButton.tsx
+++ b/ui/src/components/features/metrics/MetricsPdfDownloadButton.tsx
@@ -81,12 +81,12 @@ export function MetricsPdfDownloadButton({
         {isDownloading ? (
           <>
             <Loader2 className="h-4 w-4 animate-spin" />
-            <span className="hidden sm:inline">Generating...</span>
+            <span>Generating...</span>
           </>
         ) : (
           <>
             <Download className="h-4 w-4" />
-            <span className="hidden sm:inline">PDF</span>
+            <span>PDF</span>
           </>
         )}
       </button>

--- a/ui/src/components/features/metrics/MetricsYamlDownloadButton.tsx
+++ b/ui/src/components/features/metrics/MetricsYamlDownloadButton.tsx
@@ -139,7 +139,7 @@ export function MetricsYamlDownloadButton({
       title="Download selected metric data as YAML"
     >
       <Download className="h-4 w-4" />
-      <span className="hidden sm:inline">YAML</span>
+      <span>YAML</span>
     </button>
   );
 }


### PR DESCRIPTION
## Ticket
close #737

## Summary
Always show the text labels on the metrics download buttons so the "PDF", "YAML", and "Generating..." labels are visible on small screens instead of being hidden below the `sm` breakpoint.

## Changes
- Remove `hidden sm:inline` from the label span in `MetricsPdfDownloadButton`, so the "PDF" and "Generating..." text is always visible
- Remove `hidden sm:inline` from the label span in `MetricsYamlDownloadButton`, so the "YAML" text is always visible
