### PR TITLE
fix(api): surface qdash client config and payload errors

### DIFF
--- a/src/qdash/client/services/client.py
+++ b/src/qdash/client/services/client.py
@@ -76,20 +76,24 @@ class QDashClient:
     def close(self) -> None:
         self._rest_client.close()
 
-    def _validate_model_or_default(
+    def _validate_model_payload(
         self,
         model_type: type[TModel],
         payload: Any,
-        *,
-        default: TModel,
     ) -> TModel:
         if isinstance(payload, dict):
             normalized_payload = self._normalize_datetime_fields(payload)
             try:
                 return model_type.model_validate(normalized_payload)
-            except ValidationError:
-                pass
-        return default
+            except ValidationError as exc:
+                raise QDashValidationError(
+                    f"Response payload did not match {model_type.__name__}",
+                    payload=payload,
+                ) from exc
+        raise QDashValidationError(
+            f"Response payload did not match {model_type.__name__}",
+            payload=payload,
+        )
 
     def _normalize_datetime_fields(self, payload: Any) -> Any:
         if isinstance(payload, dict):
@@ -150,10 +154,9 @@ class QDashClient:
 
     def list_chips(self) -> ListChipsResponse:
         response = self._request("GET", "/chips")
-        return self._validate_model_or_default(
+        return self._validate_model_payload(
             ListChipsResponse,
             response.data,
-            default=ListChipsResponse(chips=[], total=0),
         )
 
     def get_chip_metrics(self, chip_id: str) -> ChipMetricsResponse:
@@ -194,20 +197,18 @@ class QDashClient:
             params["qid"] = qid
 
         response = self._request("GET", "/task-results/timeseries", params=params)
-        return self._validate_model_or_default(
+        return self._validate_model_payload(
             TimeSeriesData,
             response.data,
-            default=TimeSeriesData(data={}),
         )
 
     async def list_chips_async(self) -> ListChipsResponse:
         """Async variant of list_chips using the same auth/header behavior."""
 
         response = await self._request_async("/chips")
-        return self._validate_model_or_default(
+        return self._validate_model_payload(
             ListChipsResponse,
             response.json(),
-            default=ListChipsResponse(chips=[], total=0),
         )
 
     async def get_task_results_timeseries_async(
@@ -234,10 +235,9 @@ class QDashClient:
             params["qid"] = qid
 
         response = await self._request_async("/task-results/timeseries", params=params)
-        return self._validate_model_or_default(
+        return self._validate_model_payload(
             TimeSeriesData,
             response.json(),
-            default=TimeSeriesData(data={}),
         )
 
     async def get_metrics_config_async(self) -> dict[str, Any]:

--- a/src/qdash/client/services/config.py
+++ b/src/qdash/client/services/config.py
@@ -82,7 +82,7 @@ class QDashConfig(BaseModel):
             config_path = (
                 Path(xdg_config_home, "qdash", "config.ini")
                 if xdg_config_home
-                else Path("~/.config/qdash/config.ini")
+                else Path("~/.config/qdash/config.ini").expanduser()
             )
         else:
             config_path = Path(str(path)).expanduser()

--- a/tests/qdash/client/test_qdash_client.py
+++ b/tests/qdash/client/test_qdash_client.py
@@ -98,6 +98,30 @@ retry_max_attempts = 4
     assert config.retry.max_attempts == 4
 
 
+def test_config_from_file_default_home_path_expands_user(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_dir = tmp_path / ".config" / "qdash"
+    config_dir.mkdir(parents=True)
+    config_file = config_dir / "config.ini"
+    config_file.write_text(
+        """
+[default]
+base_url = http://home.local/
+api_token = file-token
+""".strip()
+    )
+
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    config = QDashConfig.from_file()
+
+    assert config.base_url == "http://home.local"
+    assert config.api_token == "file-token"  # noqa: S105
+
+
 def test_config_from_env_missing_base_url_raises_config_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -232,6 +256,21 @@ def test_list_chips_accepts_naive_installed_at() -> None:
         chips = client.list_chips()
         assert chips.total == 1
         assert chips.chips[0].chip_id == "chip-a"
+    finally:
+        client.close()
+
+
+def test_list_chips_invalid_payload_raises_validation_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/chips":
+            return httpx.Response(200, json={"items": []})
+        return httpx.Response(404, json={"detail": "missing"})
+
+    client = _build_client(httpx.MockTransport(handler), api_token="api-token")
+    try:
+        with pytest.raises(QDashValidationError) as exc_info:
+            client.list_chips()
+        assert exc_info.value.payload == {"items": []}
     finally:
         client.close()
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Fix qdash-client config loading so the default home config path resolves correctly when XDG_CONFIG_HOME is not set.
- Surface invalid API response payloads as QDashValidationError instead of silently returning empty client models.

## Changes
- Expand the default ~/.config/qdash/config.ini path in QDashConfig.from_file().
- Replace empty response fallbacks for validated qdash-client models with QDashValidationError including the original payload.
- Add focused tests for home config path expansion and invalid list_chips payload handling.
- OpenAPI/schema and generated clients were not changed; generation was not run.