### PR TITLE
feat(api): package qdash client for PyPI

### DIFF
--- a/.github/workflows/publish-qdash-client.yml
+++ b/.github/workflows/publish-qdash-client.yml
@@ -1,0 +1,73 @@
+name: Publish qdash-client
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - "src/qdash/client/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/publish-qdash-client.yml"
+  push:
+    tags:
+      - "qdash-client-v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build qdash-client
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Check tag version
+        if: startsWith(github.ref, 'refs/tags/qdash-client-v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#qdash-client-v}"
+          PACKAGE_VERSION="$(python -c 'import pathlib, tomllib; pyproject = pathlib.Path("src/qdash/client/pyproject.toml"); print(tomllib.loads(pyproject.read_text())["project"]["version"])')"
+          if [ "${TAG_VERSION}" != "${PACKAGE_VERSION}" ]; then
+            echo "Tag version ${TAG_VERSION} does not match qdash-client version ${PACKAGE_VERSION}." >&2
+            exit 1
+          fi
+
+      - name: Build package
+        run: uv build --package qdash-client --out-dir dist
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: qdash-client-dist
+          path: dist/qdash_client-*
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/qdash-client-v')
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download package artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: qdash-client-dist
+          path: dist
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/docs/user-guide/qdash-client.md
+++ b/docs/user-guide/qdash-client.md
@@ -2,6 +2,26 @@
 
 `qdash.client` is a Python client for reading QDash data from scripts, notebooks, and external automation.
 
+## Installation
+
+Install the lightweight client package when only programmatic API access is needed.
+
+```bash
+pip install qdash-client
+```
+
+For development against this repository, install it from the workspace path.
+
+```bash
+pip install ./src/qdash/client
+```
+
+The distribution name is `qdash-client`, but the Python import path is `qdash.client`.
+
+```python
+from qdash.client import QDashClient
+```
+
 ## Configuration
 
 Use an API token for programmatic access. The client reads configuration from environment variables or from `config.ini`.
@@ -152,4 +172,3 @@ except QDashApiError as exc:
 finally:
     client.close()
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ dev = [
 [tool.uv.workspace]
 members = [
     "src/qdash/api",
+    "src/qdash/client",
     "src/qdash/workflow",
 ]
 

--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -8,6 +8,36 @@
 This package follows the same approach as `oqtopus-client`, separating the transport layer from the service layer.
 For user-facing examples, see `docs/user-guide/qdash-client.md`.
 
+## Installation
+
+Install the lightweight client package when only programmatic API access is needed.
+
+```bash
+pip install qdash-client
+```
+
+For development against this repository:
+
+```bash
+pip install ./src/qdash/client
+```
+
+The distribution name is `qdash-client`, but the Python import path is `qdash.client`.
+
+## Publishing
+
+`qdash-client` is published from this repository with PyPI Trusted Publishing. Configure the
+`qdash-client` project on PyPI to trust this GitHub repository and the
+`.github/workflows/publish-qdash-client.yml` workflow.
+
+Release tags use the `qdash-client-v<version>` format and must match the version in
+`pyproject.toml`.
+
+```bash
+git tag qdash-client-v0.1.0
+git push origin qdash-client-v0.1.0
+```
+
 ## Minimal Quick Start
 
 This is a minimal example using `/chips`, `/metrics/config`, and `/task-results/timeseries`.

--- a/src/qdash/client/pyproject.toml
+++ b/src/qdash/client/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "qdash-client"
+version = "0.1.0"
+description = "Python client for the QDash API"
+authors = [
+    {name = "OQTOPUS Team", email = "oqtopus-team@googlegroups.com"}
+]
+readme = "README.md"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "httpx>=0.27.0",
+    "pydantic>=2.8.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+]
+
+[tool.hatch.build.targets.wheel.force-include]
+"__init__.py" = "qdash/client/__init__.py"
+"py.typed" = "qdash/client/py.typed"
+"rest" = "qdash/client/rest"
+"services" = "qdash/client/services"

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,7 @@ exclude-newer-span = "P3D"
 members = [
     "qdash",
     "qdash-api",
+    "qdash-client",
     "qdash-workflow",
 ]
 
@@ -3143,6 +3144,21 @@ requires-dist = [
     { name = "ruff", specifier = "==0.15.14" },
     { name = "scipy" },
     { name = "uvicorn", extras = ["standard"] },
+]
+
+[[package]]
+name = "qdash-client"
+version = "0.1.0"
+source = { editable = "src/qdash/client" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "pydantic", specifier = ">=2.8.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add a lightweight qdash-client Python distribution so users can install only the API client with pip install qdash-client.
- Prepare PyPI release automation using GitHub Actions and Trusted Publishing; root API/workflow behavior is unchanged.

## Changes
- Add src/qdash/client/pyproject.toml for the qdash-client package with minimal httpx and pydantic dependencies.
- Add qdash-client to the uv workspace and update uv.lock.
- Add a publish workflow that builds on PRs and publishes on qdash-client-v* tags after checking the tag version matches the package version.
- Document install and publishing steps in the QDash Client guide and package README.
- OpenAPI/schema and generated clients were not changed; generation was not run.