### PR TITLE
feat(api): add qdash client config save

### DIFF
--- a/docs/user-guide/qdash-client.md
+++ b/docs/user-guide/qdash-client.md
@@ -54,7 +54,7 @@ retry_backoff_seconds = 0.2
 retry_max_backoff_seconds = 5.0
 ```
 
-Use sections as profiles for different environments, and save a profile from Python when needed.
+Use profiles for different environments. Profiles are stored as sections in `config.ini`.
 
 ```python
 from qdash.client import QDashConfig
@@ -65,7 +65,7 @@ config = QDashConfig(
     cf_access_client_id="your-client-id",
     cf_access_client_secret="your-client-secret",
 )
-config.save(section="prod")
+config.save(profile="prod")
 ```
 
 Saved config files use owner-only permissions (`0600`) because they can contain API tokens and

--- a/docs/user-guide/qdash-client.md
+++ b/docs/user-guide/qdash-client.md
@@ -54,6 +54,23 @@ retry_backoff_seconds = 0.2
 retry_max_backoff_seconds = 5.0
 ```
 
+Use sections as profiles for different environments, and save a profile from Python when needed.
+
+```python
+from qdash.client import QDashConfig
+
+config = QDashConfig(
+    base_url="https://your-qdash-instance/api",
+    api_token="your-api-token",
+    cf_access_client_id="your-client-id",
+    cf_access_client_secret="your-client-secret",
+)
+config.save(section="prod")
+```
+
+Saved config files use owner-only permissions (`0600`) because they can contain API tokens and
+Cloudflare Access secrets.
+
 ## Basic Usage
 
 Create a client, call the API, and close the HTTP session when the script exits.

--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -114,7 +114,7 @@ For legacy username/password authentication, set:
 ```python
 from qdash.client import QDashConfig, QDashClient
 
-config = QDashConfig.from_file(section="default")
+config = QDashConfig.from_file(profile="default")
 client = QDashClient(config)
 ```
 
@@ -152,7 +152,7 @@ config = QDashConfig(
     cf_access_client_id="your-cf-client-id",
     cf_access_client_secret="your-cf-client-secret",
 )
-config.save(section="prod")
+config.save(profile="prod")
 ```
 
 The saved file is created with owner-only permissions (`0600`) because it can contain API tokens

--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -141,6 +141,23 @@ retry_max_backoff_seconds = 5.0
 For legacy username/password authentication from a config file, use `username` and `password_env`
 instead of `api_token`.
 
+Save a profile to `config.ini`:
+
+```python
+from qdash.client import QDashConfig
+
+config = QDashConfig(
+    base_url="https://example.qdash/api",
+    api_token="your-token",
+    cf_access_client_id="your-cf-client-id",
+    cf_access_client_secret="your-cf-client-secret",
+)
+config.save(section="prod")
+```
+
+The saved file is created with owner-only permissions (`0600`) because it can contain API tokens
+and Cloudflare Access secrets.
+
 ### 2.3 Automatic Loading
 
 ```python

--- a/src/qdash/client/services/config.py
+++ b/src/qdash/client/services/config.py
@@ -80,11 +80,11 @@ class QDashConfig(BaseModel):
     @classmethod
     def from_file(
         cls,
-        section: str = DEFAULT_SECTION,
+        profile: str = DEFAULT_SECTION,
         path: str | Path | object = _DEFAULT_CONFIG_PATH,
     ) -> QDashConfig:
-        if section is None:
-            raise QDashConfigError("section should not be None.")
+        if profile is None:
+            raise QDashConfigError("profile should not be None.")
         if path is None:
             raise QDashConfigError("path should not be None.")
 
@@ -92,10 +92,10 @@ class QDashConfig(BaseModel):
         parser = configparser.ConfigParser()
         if not parser.read(config_path):
             raise QDashConfigError(f"Config file not found: {config_path}")
-        if section not in parser:
-            raise QDashConfigError(f"Config section not found: {section}")
+        if profile not in parser:
+            raise QDashConfigError(f"Config profile not found: {profile}")
 
-        sec = parser[section]
+        sec = parser[profile]
         raw: dict[str, Any] = {
             "base_url": sec.get("base_url"),
             "username": sec.get("username"),
@@ -122,7 +122,7 @@ class QDashConfig(BaseModel):
         try:
             return cls.model_validate(raw)
         except ValidationError as exc:
-            raise QDashConfigError(f"Invalid config values in section '{section}'.") from exc
+            raise QDashConfigError(f"Invalid config values in profile '{profile}'.") from exc
 
     @classmethod
     def from_env(cls) -> QDashConfig:
@@ -156,11 +156,11 @@ class QDashConfig(BaseModel):
 
     def save(
         self,
-        section: str = DEFAULT_SECTION,
+        profile: str = DEFAULT_SECTION,
         path: str | Path | object = _DEFAULT_CONFIG_PATH,
     ) -> Path:
-        if section is None:
-            raise QDashConfigError("section should not be None.")
+        if profile is None:
+            raise QDashConfigError("profile should not be None.")
         if path is None:
             raise QDashConfigError("path should not be None.")
 
@@ -169,7 +169,7 @@ class QDashConfig(BaseModel):
         if config_path.exists():
             parser.read(config_path)
 
-        parser[section] = self._to_file_section()
+        parser[profile] = self._to_file_section()
         config_path.parent.mkdir(parents=True, exist_ok=True)
         with config_path.open("w") as file:
             parser.write(file)

--- a/src/qdash/client/services/config.py
+++ b/src/qdash/client/services/config.py
@@ -25,6 +25,17 @@ DEFAULT_PROXY_ENV = "QDASH_PROXY"
 DEFAULT_USER_AGENT_ENV = "QDASH_USER_AGENT"
 
 
+def _resolve_config_path(path: str | Path | object = _DEFAULT_CONFIG_PATH) -> Path:
+    if path is _DEFAULT_CONFIG_PATH:
+        xdg_config_home = os.getenv("XDG_CONFIG_HOME")
+        return (
+            Path(xdg_config_home, "qdash", "config.ini")
+            if xdg_config_home
+            else Path("~/.config/qdash/config.ini").expanduser()
+        )
+    return Path(str(path)).expanduser()
+
+
 class QDashRetryConfig(BaseModel):
     """Retry tuning parameters for idempotent GET requests."""
 
@@ -77,16 +88,7 @@ class QDashConfig(BaseModel):
         if path is None:
             raise QDashConfigError("path should not be None.")
 
-        if path is _DEFAULT_CONFIG_PATH:
-            xdg_config_home = os.getenv("XDG_CONFIG_HOME")
-            config_path = (
-                Path(xdg_config_home, "qdash", "config.ini")
-                if xdg_config_home
-                else Path("~/.config/qdash/config.ini").expanduser()
-            )
-        else:
-            config_path = Path(str(path)).expanduser()
-
+        config_path = _resolve_config_path(path)
         parser = configparser.ConfigParser()
         if not parser.read(config_path):
             raise QDashConfigError(f"Config file not found: {config_path}")
@@ -151,3 +153,49 @@ class QDashConfig(BaseModel):
             return cls.model_validate(raw)
         except ValidationError as exc:
             raise QDashConfigError("Invalid config values loaded from environment.") from exc
+
+    def save(
+        self,
+        section: str = DEFAULT_SECTION,
+        path: str | Path | object = _DEFAULT_CONFIG_PATH,
+    ) -> Path:
+        if section is None:
+            raise QDashConfigError("section should not be None.")
+        if path is None:
+            raise QDashConfigError("path should not be None.")
+
+        config_path = _resolve_config_path(path)
+        parser = configparser.ConfigParser()
+        if config_path.exists():
+            parser.read(config_path)
+
+        parser[section] = self._to_file_section()
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        with config_path.open("w") as file:
+            parser.write(file)
+        config_path.chmod(0o600)
+        return config_path
+
+    def _to_file_section(self) -> dict[str, str]:
+        values: dict[str, str] = {
+            "base_url": self.base_url,
+            "timeout_seconds": str(self.timeout_sec),
+            "max_workers": str(self.max_workers),
+            "verify_tls": str(self.verify_tls).lower(),
+            "retry_max_attempts": str(self.retry.max_attempts),
+            "retry_backoff_seconds": str(self.retry.base_delay_sec),
+            "retry_max_backoff_seconds": str(self.retry.max_delay_sec),
+        }
+
+        optional_values = {
+            "username": self.username,
+            "password_env": self.password_env,
+            "api_token": self.api_token,
+            "project_id": self.project_id,
+            "cf_access_client_id": self.cf_access_client_id,
+            "cf_access_client_secret": self.cf_access_client_secret,
+            "proxy": self.proxy,
+            "user_agent": self.user_agent,
+        }
+        values.update({key: value for key, value in optional_values.items() if value})
+        return values

--- a/tests/qdash/client/test_qdash_client.py
+++ b/tests/qdash/client/test_qdash_client.py
@@ -140,9 +140,9 @@ api_token = local-token
         timeout_sec=12,
     )
 
-    saved_path = config.save(section="prod", path=config_file)
-    loaded = QDashConfig.from_file(section="prod", path=config_file)
-    local = QDashConfig.from_file(section="local", path=config_file)
+    saved_path = config.save(profile="prod", path=config_file)
+    loaded = QDashConfig.from_file(profile="prod", path=config_file)
+    local = QDashConfig.from_file(profile="local", path=config_file)
 
     assert saved_path == config_file
     assert loaded.base_url == "https://prod.example/api"

--- a/tests/qdash/client/test_qdash_client.py
+++ b/tests/qdash/client/test_qdash_client.py
@@ -122,6 +122,54 @@ api_token = file-token
     assert config.api_token == "file-token"  # noqa: S105
 
 
+def test_config_save_writes_selected_section_and_preserves_others(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.ini"
+    config_file.write_text(
+        """
+[local]
+base_url = http://local.example
+api_token = local-token
+""".strip()
+    )
+    config = QDashConfig(
+        base_url="https://prod.example/api",
+        api_token="prod-token",
+        project_id="project-1",
+        cf_access_client_id="cf-id",
+        cf_access_client_secret="cf-secret",
+        timeout_sec=12,
+    )
+
+    saved_path = config.save(section="prod", path=config_file)
+    loaded = QDashConfig.from_file(section="prod", path=config_file)
+    local = QDashConfig.from_file(section="local", path=config_file)
+
+    assert saved_path == config_file
+    assert loaded.base_url == "https://prod.example/api"
+    assert loaded.api_token == "prod-token"  # noqa: S105
+    assert loaded.project_id == "project-1"
+    assert loaded.cf_access_client_id == "cf-id"
+    assert loaded.cf_access_client_secret == "cf-secret"  # noqa: S105
+    assert loaded.timeout_sec == 12
+    assert local.base_url == "http://local.example"
+
+
+def test_config_save_uses_default_path_and_restricts_permissions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    config = QDashConfig(base_url="https://default.example/api", api_token="token")
+
+    saved_path = config.save()
+    loaded = QDashConfig.from_file()
+
+    assert saved_path == tmp_path / "xdg" / "qdash" / "config.ini"
+    assert loaded.base_url == "https://default.example/api"
+    assert loaded.api_token == "token"  # noqa: S105
+    assert saved_path.stat().st_mode & 0o777 == 0o600
+
+
 def test_config_from_env_missing_base_url_raises_config_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add `QDashConfig.save()` so qdash-client users can persist profile-based `config.ini` settings from Python.
- This affects qdash-client configuration only; saved files use owner-only permissions because they may contain API tokens and Cloudflare Access secrets.

## Changes
- Add shared config path resolution and `QDashConfig.save(section=..., path=...)`.
- Preserve existing config sections while writing the selected profile.
- Add tests for save/load roundtrip, section preservation, default path handling, and `0600` permissions.
- Document saving profile config in the qdash-client README and user guide.