### PR TITLE
fix(infra): align uv workspace metadata in Docker builds

### DIFF
--- a/src/qdash/agent/Dockerfile
+++ b/src/qdash/agent/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 COPY pyproject.toml uv.lock ./
 COPY src/qdash/api/pyproject.toml ./src/qdash/api/pyproject.toml
+COPY src/qdash/client/pyproject.toml ./src/qdash/client/pyproject.toml
 COPY src/qdash/workflow/pyproject.toml ./src/qdash/workflow/pyproject.toml
 
 ENV UV_COMPILE_BYTECODE=1 \

--- a/src/qdash/api/Dockerfile
+++ b/src/qdash/api/Dockerfile
@@ -21,6 +21,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 COPY pyproject.toml uv.lock ./
 COPY src/qdash/api/pyproject.toml src/qdash/api/pyproject.toml
+COPY src/qdash/client/pyproject.toml src/qdash/client/pyproject.toml
 COPY src/qdash/workflow/pyproject.toml src/qdash/workflow/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --package qdash-api --no-dev

--- a/src/qdash/workflow/Dockerfile
+++ b/src/qdash/workflow/Dockerfile
@@ -32,6 +32,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 COPY pyproject.toml uv.lock ./
 COPY src/qdash/api/pyproject.toml src/qdash/api/pyproject.toml
+COPY src/qdash/client/pyproject.toml src/qdash/client/pyproject.toml
 COPY src/qdash/workflow/pyproject.toml src/qdash/workflow/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --package qdash-workflow --no-dev

--- a/src/qdash/workflow/Dockerfile.deployment
+++ b/src/qdash/workflow/Dockerfile.deployment
@@ -32,6 +32,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 COPY pyproject.toml uv.lock ./
 COPY src/qdash/api/pyproject.toml src/qdash/api/pyproject.toml
+COPY src/qdash/client/pyproject.toml src/qdash/client/pyproject.toml
 COPY src/qdash/workflow/pyproject.toml src/qdash/workflow/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --package qdash-workflow --no-dev

--- a/uv.lock
+++ b/uv.lock
@@ -3213,7 +3213,7 @@ requires-dist = [
 [[package]]
 name = "qubex"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?branch=develop#4467162e3a81282f7a4e87d87e3911d8535acb1c" }
+source = { git = "https://github.com/amachino/qubex.git?branch=develop#a31f45142046ab1f5b127159072806d57f232c34" }
 dependencies = [
     { name = "anywidget" },
     { name = "cma" },
@@ -3302,7 +3302,7 @@ wheels = [
 [[package]]
 name = "qxcore"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxcore&branch=develop#4467162e3a81282f7a4e87d87e3911d8535acb1c" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxcore&branch=develop#a31f45142046ab1f5b127159072806d57f232c34" }
 dependencies = [
     { name = "netcdf4" },
     { name = "numpy" },
@@ -3316,7 +3316,7 @@ dependencies = [
 [[package]]
 name = "qxdriver-quel1"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxdriver-quel1&branch=develop#4467162e3a81282f7a4e87d87e3911d8535acb1c" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxdriver-quel1&branch=develop#a31f45142046ab1f5b127159072806d57f232c34" }
 dependencies = [
     { name = "numpy" },
     { name = "plotly" },
@@ -3328,12 +3328,12 @@ dependencies = [
 [[package]]
 name = "qxfitting"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxfitting&branch=develop#4467162e3a81282f7a4e87d87e3911d8535acb1c" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxfitting&branch=develop#a31f45142046ab1f5b127159072806d57f232c34" }
 
 [[package]]
 name = "qxpulse"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxpulse&branch=develop#4467162e3a81282f7a4e87d87e3911d8535acb1c" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxpulse&branch=develop#a31f45142046ab1f5b127159072806d57f232c34" }
 dependencies = [
     { name = "numpy" },
     { name = "plotly" },
@@ -3345,7 +3345,7 @@ dependencies = [
 [[package]]
 name = "qxschema"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxschema&branch=develop#4467162e3a81282f7a4e87d87e3911d8535acb1c" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxschema&branch=develop#a31f45142046ab1f5b127159072806d57f232c34" }
 dependencies = [
     { name = "numpy" },
     { name = "qxcore" },
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "qxsimulator"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxsimulator&branch=develop#4467162e3a81282f7a4e87d87e3911d8535acb1c" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxsimulator&branch=develop#a31f45142046ab1f5b127159072806d57f232c34" }
 dependencies = [
     { name = "ipython" },
     { name = "jax" },
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "qxvisualizer"
 version = "1.5.0b4"
-source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxvisualizer&branch=develop#4467162e3a81282f7a4e87d87e3911d8535acb1c" }
+source = { git = "https://github.com/amachino/qubex.git?subdirectory=packages%2Fqxvisualizer&branch=develop#a31f45142046ab1f5b127159072806d57f232c34" }
 dependencies = [
     { name = "numpy" },
     { name = "plotly" },


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Fix Docker image builds that run `uv sync --locked` against an incomplete uv workspace.
- Regenerate `uv.lock` from the current `qubex` `develop` branch head. This affects infrastructure and dependency resolution during container builds.

## Changes
- Add `src/qdash/client/pyproject.toml` to the copied workspace metadata in the workflow, deployment-service, API, and agent Dockerfiles.
- Keep Docker `uv sync --locked` resolution aligned with the full three-member uv workspace used to generate `uv.lock`.
- Refresh `uv.lock` so `qubex` and related subpackages point to the current `develop` commit `a31f45142046ab1f5b127159072806d57f232c34`.
- Preserve the existing `qubex` source configuration on `branch = "develop"`.
