### PR TITLE
fix(workflow): preserve cron schedule and parameters on flow re-save …

### DIFF
--- a/src/qdash/workflow/deployment_service.py
+++ b/src/qdash/workflow/deployment_service.py
@@ -168,10 +168,15 @@ async def register_deployment(request: RegisterDeploymentRequest) -> RegisterDep
         # In Prefect 3, schedules and parameters live on the deployment object, so
         # deleting + recreating it would silently drop any cron schedule the user set
         # (see issue #793). We capture them here and re-apply them to the new deployment.
+        # Note: there is a small read->delete window where a concurrent change to the
+        # old deployment could be lost; deployment edits are not expected to race in
+        # practice, so this is accepted rather than locked.
         preserved_schedules: list[DeploymentScheduleCreate] = []
         preserved_parameters: dict[str, Any] | None = None
         if request.old_deployment_id:
-            old_deployment_id = cast("uuid_module.UUID", request.old_deployment_id)
+            # Parse to UUID up front so a malformed id fails fast and validated,
+            # rather than being passed downstream as an unchecked string.
+            old_deployment_id = uuid_module.UUID(request.old_deployment_id)
 
             try:
                 preserved_schedules, preserved_parameters = await _capture_deployment_state(

--- a/src/qdash/workflow/deployment_service.py
+++ b/src/qdash/workflow/deployment_service.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 
 from fastapi import FastAPI, HTTPException
 from prefect.client.orchestration import get_client
-from prefect.client.schemas.actions import WorkPoolCreate
+from prefect.client.schemas.actions import DeploymentScheduleCreate, WorkPoolCreate
 from pydantic import BaseModel
 
 from qdash.workflow.logging_config import setup_logging
@@ -85,6 +85,31 @@ async def _ensure_work_pool(client: Any) -> None:
             raise
 
 
+async def _capture_deployment_state(
+    deployment_id: uuid_module.UUID,
+) -> tuple[list[DeploymentScheduleCreate], dict[str, Any] | None]:
+    """Read an existing deployment's schedules and parameters for re-use.
+
+    In Prefect 3, schedules and parameters live on the deployment object, so a
+    deploy that deletes + recreates the deployment would otherwise drop them
+    (see issue #793). This captures them so the replacement deployment can carry
+    them over.
+
+    Returns
+    -------
+    A list of ``DeploymentScheduleCreate`` (cron/interval schedule + active flag)
+    and the deployment parameters (``None`` when empty).
+    """
+    async with get_client() as client:
+        deployment = await client.read_deployment(deployment_id)
+    parameters = deployment.parameters or None
+    schedules = [
+        DeploymentScheduleCreate(schedule=sched.schedule, active=sched.active)
+        for sched in (deployment.schedules or [])
+    ]
+    return schedules, parameters
+
+
 @app.post("/register-deployment", response_model=RegisterDeploymentResponse)
 async def register_deployment(request: RegisterDeploymentRequest) -> RegisterDeploymentResponse:
     """Register a user flow as a Prefect deployment.
@@ -139,11 +164,33 @@ async def register_deployment(request: RegisterDeploymentRequest) -> RegisterDep
 
         flow_obj = getattr(module, request.flow_function_name)
 
-        # Delete old deployment if it exists
+        # Preserve existing cron schedules and parameters before replacing the deployment.
+        # In Prefect 3, schedules and parameters live on the deployment object, so
+        # deleting + recreating it would silently drop any cron schedule the user set
+        # (see issue #793). We capture them here and re-apply them to the new deployment.
+        preserved_schedules: list[DeploymentScheduleCreate] = []
+        preserved_parameters: dict[str, Any] | None = None
         if request.old_deployment_id:
+            old_deployment_id = cast("uuid_module.UUID", request.old_deployment_id)
+
+            try:
+                preserved_schedules, preserved_parameters = await _capture_deployment_state(
+                    old_deployment_id
+                )
+                if preserved_schedules:
+                    logger.info(
+                        f"Preserving {len(preserved_schedules)} schedule(s) and parameters "
+                        f"from old deployment {request.old_deployment_id}"
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to read old deployment {request.old_deployment_id} for "
+                    f"schedule preservation: {type(e).__name__}: {e}"
+                )
+
+            # Delete old deployment now that its schedules/parameters are captured.
             try:
                 logger.info(f"Attempting to delete old deployment: {request.old_deployment_id}")
-                old_deployment_id = cast("uuid_module.UUID", request.old_deployment_id)
                 async with get_client() as client:
                     await client.delete_deployment(old_deployment_id)
                     logger.info(f"Deleted old deployment: {request.old_deployment_id}")
@@ -161,13 +208,16 @@ async def register_deployment(request: RegisterDeploymentRequest) -> RegisterDep
             flow_id = await client.create_flow(flow_obj)
             logger.info(f"Flow registered with ID: {flow_id}")
 
-            # Create deployment via client API
+            # Create deployment via client API, carrying over any preserved
+            # schedules and parameters from the previous deployment (issue #793).
             deployment_id = await client.create_deployment(
                 flow_id=flow_id,
                 name=deployment_name,
                 work_pool_name=WORK_POOL_NAME,
                 entrypoint=entrypoint,
                 path=str(working_dir),
+                schedules=preserved_schedules or None,
+                parameters=preserved_parameters,
             )
 
         logger.info(f"Deployment created successfully: {deployment_id}")

--- a/tests/qdash/workflow/test_deployment_service.py
+++ b/tests/qdash/workflow/test_deployment_service.py
@@ -1,4 +1,5 @@
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -148,3 +149,149 @@ async def test_capture_deployment_state_handles_no_schedules(
 
     assert schedules == []
     assert parameters is None
+
+
+class _FullFakeClient:
+    """Fake Prefect client recording the calls ``register_deployment`` makes."""
+
+    def __init__(self, deployment: object, new_deployment_id: uuid.UUID) -> None:
+        self._new_deployment_id = new_deployment_id
+        self.deleted: list[object] = []
+        self.create_deployment_kwargs: dict[str, object] | None = None
+        self.read_work_pool = AsyncMock(return_value=SimpleNamespace(id="pool-id"))
+        self.create_flow = AsyncMock(return_value="flow-id")
+        self.read_deployment = AsyncMock(return_value=deployment)
+
+    async def delete_deployment(self, deployment_id: object) -> None:
+        self.deleted.append(deployment_id)
+
+    async def create_deployment(self, **kwargs: object) -> uuid.UUID:
+        self.create_deployment_kwargs = kwargs
+        return self._new_deployment_id
+
+
+class _SharedClientCtx:
+    """Async-context-manager yielding the same client on every ``get_client()`` call."""
+
+    def __init__(self, client: object) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> object:
+        return self._client
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _make_flow_file(tmp_path: Path) -> Path:
+    flow_file = tmp_path / "myflow.py"
+    flow_file.write_text("def my_flow():\n    return None\n")
+    return flow_file
+
+
+def _patch_register_deps(
+    monkeypatch: pytest.MonkeyPatch, client: object, workflow_dir: Path
+) -> None:
+    monkeypatch.setattr(deployment_service, "get_client", lambda: _SharedClientCtx(client))
+    monkeypatch.setattr(
+        deployment_service,
+        "get_path_resolver",
+        lambda: SimpleNamespace(workflow_dir=workflow_dir),
+    )
+    monkeypatch.setattr(
+        deployment_service,
+        "DeploymentScheduleCreate",
+        lambda schedule, active: SimpleNamespace(schedule=schedule, active=active),
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_deployment_preserves_schedules_from_old_deployment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Re-saving a flow carries the old deployment's schedule + parameters over (#793)."""
+    cron = SimpleNamespace(cron="0 2 * * *", timezone="Asia/Tokyo")
+    old_deployment = SimpleNamespace(
+        parameters={"chip_id": "X", "username": "u"},
+        schedules=[SimpleNamespace(schedule=cron, active=True)],
+    )
+    new_deployment_id = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    client = _FullFakeClient(old_deployment, new_deployment_id)
+
+    flow_file = _make_flow_file(tmp_path)
+    _patch_register_deps(monkeypatch, client, tmp_path)
+
+    old_deployment_id = "00000000-0000-0000-0000-000000000000"
+    request = deployment_service.RegisterDeploymentRequest(
+        file_path=str(flow_file),
+        flow_function_name="my_flow",
+        old_deployment_id=old_deployment_id,
+    )
+
+    response = await deployment_service.register_deployment(request)
+
+    assert response.deployment_id == str(new_deployment_id)
+    assert response.deployment_name == "my_flow"
+    # Old deployment was deleted using the parsed UUID (not the raw string).
+    assert client.deleted == [uuid.UUID(old_deployment_id)]
+    # Preserved schedule + parameters were forwarded to the new deployment.
+    assert client.create_deployment_kwargs is not None
+    kwargs = client.create_deployment_kwargs
+    assert kwargs["parameters"] == {"chip_id": "X", "username": "u"}
+    assert len(kwargs["schedules"]) == 1  # type: ignore[arg-type]
+    assert kwargs["schedules"][0].schedule is cron  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_register_deployment_without_old_deployment_passes_no_schedules(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A fresh deployment (no old id) is created with no preserved schedule/parameters."""
+    new_deployment_id = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    client = _FullFakeClient(deployment=None, new_deployment_id=new_deployment_id)
+
+    flow_file = _make_flow_file(tmp_path)
+    _patch_register_deps(monkeypatch, client, tmp_path)
+
+    request = deployment_service.RegisterDeploymentRequest(
+        file_path=str(flow_file),
+        flow_function_name="my_flow",
+    )
+
+    response = await deployment_service.register_deployment(request)
+
+    assert response.deployment_id == str(new_deployment_id)
+    assert client.deleted == []
+    client.read_deployment.assert_not_awaited()
+    assert client.create_deployment_kwargs is not None
+    assert client.create_deployment_kwargs["schedules"] is None
+    assert client.create_deployment_kwargs["parameters"] is None
+
+
+@pytest.mark.asyncio
+async def test_register_deployment_continues_when_reading_old_deployment_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If capturing the old deployment fails, registration still proceeds without it."""
+    new_deployment_id = uuid.UUID("33333333-3333-3333-3333-333333333333")
+    client = _FullFakeClient(deployment=None, new_deployment_id=new_deployment_id)
+    client.read_deployment = AsyncMock(side_effect=lambda *_a, **_k: _raise(RuntimeError("boom")))
+
+    flow_file = _make_flow_file(tmp_path)
+    _patch_register_deps(monkeypatch, client, tmp_path)
+
+    old_deployment_id = "00000000-0000-0000-0000-000000000000"
+    request = deployment_service.RegisterDeploymentRequest(
+        file_path=str(flow_file),
+        flow_function_name="my_flow",
+        old_deployment_id=old_deployment_id,
+    )
+
+    response = await deployment_service.register_deployment(request)
+
+    # Read failure is swallowed: old deployment is still deleted and the new one is created.
+    assert response.deployment_id == str(new_deployment_id)
+    assert client.deleted == [uuid.UUID(old_deployment_id)]
+    assert client.create_deployment_kwargs is not None
+    assert client.create_deployment_kwargs["schedules"] is None
+    assert client.create_deployment_kwargs["parameters"] is None

--- a/tests/qdash/workflow/test_deployment_service.py
+++ b/tests/qdash/workflow/test_deployment_service.py
@@ -99,6 +99,7 @@ async def test_capture_deployment_state_preserves_cron_and_parameters(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Old deployment's cron schedule and parameters are captured for re-use (#793)."""
+
     # conftest mocks out prefect, so DeploymentScheduleCreate is not a real class here.
     # Stand in a recording factory to assert the schedule + active flag are carried over.
     def fake_schedule_create(schedule: object, active: bool) -> SimpleNamespace:

--- a/tests/qdash/workflow/test_deployment_service.py
+++ b/tests/qdash/workflow/test_deployment_service.py
@@ -1,10 +1,17 @@
+import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from prefect.client.schemas.actions import DeploymentScheduleCreate
+from prefect.client.schemas.schedules import CronSchedule
 
 from qdash.workflow import deployment_service
-from qdash.workflow.deployment_service import WORK_POOL_NAME, _ensure_work_pool
+from qdash.workflow.deployment_service import (
+    WORK_POOL_NAME,
+    _capture_deployment_state,
+    _ensure_work_pool,
+)
 
 
 class ObjectNotFound(Exception):
@@ -70,3 +77,65 @@ async def test_ensure_work_pool_ignores_race_when_pool_already_created() -> None
     await _ensure_work_pool(client)
 
     client.create_work_pool.assert_awaited_once()
+
+
+class _FakeClientCtx:
+    """Async-context-manager stand-in for ``get_client()`` yielding a fake client."""
+
+    def __init__(self, deployment: object) -> None:
+        self._client = SimpleNamespace(read_deployment=AsyncMock(return_value=deployment))
+
+    async def __aenter__(self) -> object:
+        return self._client
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+def _patch_get_client(monkeypatch: pytest.MonkeyPatch, deployment: object) -> None:
+    monkeypatch.setattr(deployment_service, "get_client", lambda: _FakeClientCtx(deployment))
+
+
+@pytest.mark.asyncio
+async def test_capture_deployment_state_preserves_cron_and_parameters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Old deployment's cron schedule and parameters are captured for re-use (#793)."""
+    deployment = SimpleNamespace(
+        parameters={"chip_id": "X", "username": "u"},
+        schedules=[
+            SimpleNamespace(
+                schedule=CronSchedule(cron="0 2 * * *", timezone="Asia/Tokyo"),
+                active=True,
+            )
+        ],
+    )
+    _patch_get_client(monkeypatch, deployment)
+
+    schedules, parameters = await _capture_deployment_state(
+        uuid.UUID("00000000-0000-0000-0000-000000000000")
+    )
+
+    assert parameters == {"chip_id": "X", "username": "u"}
+    assert len(schedules) == 1
+    assert isinstance(schedules[0], DeploymentScheduleCreate)
+    assert schedules[0].active is True
+    captured_schedule = schedules[0].schedule
+    assert isinstance(captured_schedule, CronSchedule)
+    assert captured_schedule.cron == "0 2 * * *"
+
+
+@pytest.mark.asyncio
+async def test_capture_deployment_state_handles_no_schedules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deployment with no schedules and empty parameters yields ([], None)."""
+    deployment = SimpleNamespace(parameters={}, schedules=[])
+    _patch_get_client(monkeypatch, deployment)
+
+    schedules, parameters = await _capture_deployment_state(
+        uuid.UUID("00000000-0000-0000-0000-000000000000")
+    )
+
+    assert schedules == []
+    assert parameters is None

--- a/tests/qdash/workflow/test_deployment_service.py
+++ b/tests/qdash/workflow/test_deployment_service.py
@@ -102,8 +102,15 @@ async def test_capture_deployment_state_preserves_cron_and_parameters(
 
     # conftest mocks out prefect, so DeploymentScheduleCreate is not a real class here.
     # Stand in a recording factory to assert the schedule + active flag are carried over.
+    # Assert on the recorded calls rather than the typed return value: the declared
+    # return type's `schedule` is a prefect schedule union with no `.cron` attribute,
+    # which mypy would reject (the SimpleNamespace records type as `Any`).
+    recorded: list[SimpleNamespace] = []
+
     def fake_schedule_create(schedule: object, active: bool) -> SimpleNamespace:
-        return SimpleNamespace(schedule=schedule, active=active)
+        created = SimpleNamespace(schedule=schedule, active=active)
+        recorded.append(created)
+        return created
 
     monkeypatch.setattr(deployment_service, "DeploymentScheduleCreate", fake_schedule_create)
 
@@ -120,10 +127,11 @@ async def test_capture_deployment_state_preserves_cron_and_parameters(
 
     assert parameters == {"chip_id": "X", "username": "u"}
     assert len(schedules) == 1
-    assert schedules[0].active is True
+    assert len(recorded) == 1
+    assert recorded[0].active is True
     # The original schedule object is passed through to DeploymentScheduleCreate unchanged.
-    assert schedules[0].schedule is cron
-    assert schedules[0].schedule.cron == "0 2 * * *"
+    assert recorded[0].schedule is cron
+    assert recorded[0].schedule.cron == "0 2 * * *"
 
 
 @pytest.mark.asyncio

--- a/tests/qdash/workflow/test_deployment_service.py
+++ b/tests/qdash/workflow/test_deployment_service.py
@@ -3,8 +3,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from prefect.client.schemas.actions import DeploymentScheduleCreate
-from prefect.client.schemas.schedules import CronSchedule
 
 from qdash.workflow import deployment_service
 from qdash.workflow.deployment_service import (
@@ -101,14 +99,17 @@ async def test_capture_deployment_state_preserves_cron_and_parameters(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Old deployment's cron schedule and parameters are captured for re-use (#793)."""
+    # conftest mocks out prefect, so DeploymentScheduleCreate is not a real class here.
+    # Stand in a recording factory to assert the schedule + active flag are carried over.
+    def fake_schedule_create(schedule: object, active: bool) -> SimpleNamespace:
+        return SimpleNamespace(schedule=schedule, active=active)
+
+    monkeypatch.setattr(deployment_service, "DeploymentScheduleCreate", fake_schedule_create)
+
+    cron = SimpleNamespace(cron="0 2 * * *", timezone="Asia/Tokyo")
     deployment = SimpleNamespace(
         parameters={"chip_id": "X", "username": "u"},
-        schedules=[
-            SimpleNamespace(
-                schedule=CronSchedule(cron="0 2 * * *", timezone="Asia/Tokyo"),
-                active=True,
-            )
-        ],
+        schedules=[SimpleNamespace(schedule=cron, active=True)],
     )
     _patch_get_client(monkeypatch, deployment)
 
@@ -118,11 +119,10 @@ async def test_capture_deployment_state_preserves_cron_and_parameters(
 
     assert parameters == {"chip_id": "X", "username": "u"}
     assert len(schedules) == 1
-    assert isinstance(schedules[0], DeploymentScheduleCreate)
     assert schedules[0].active is True
-    captured_schedule = schedules[0].schedule
-    assert isinstance(captured_schedule, CronSchedule)
-    assert captured_schedule.cron == "0 2 * * *"
+    # The original schedule object is passed through to DeploymentScheduleCreate unchanged.
+    assert schedules[0].schedule is cron
+    assert schedules[0].schedule.cron == "0 2 * * *"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Ticket

close #793

## Summary

Saving an edited flow re-registers its Prefect deployment by deleting and recreating it, which silently dropped the cron schedule and the parameters used by scheduled runs because, in Prefect 3, those live on the deployment object. This change captures the existing deployment's schedules and parameters before deletion and re-applies them to the replacement deployment so they survive a re-save.

## Changes

- Add `_capture_deployment_state` helper to read an existing deployment's schedules and parameters before it is deleted.
- In `register_deployment`, preserve the captured schedules/parameters and pass them to `create_deployment` when replacing an old deployment.
- Wrap the capture in a guarded `try/except` so a failed read logs a warning instead of blocking re-registration.
- Add unit tests covering both the cron-schedule-and-parameters case and the empty (no schedules / no parameters) case.
