### PR TITLE
fix(infra): derive qdash-client version from tags

### DIFF
--- a/.github/workflows/publish-qdash-client.yml
+++ b/.github/workflows/publish-qdash-client.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -31,16 +33,6 @@ jobs:
 
       - name: Set up Python
         run: uv python install 3.11
-
-      - name: Check tag version
-        if: startsWith(github.ref, 'refs/tags/qdash-client-v')
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#qdash-client-v}"
-          PACKAGE_VERSION="$(python -c 'import pathlib, tomllib; pyproject = pathlib.Path("src/qdash/client/pyproject.toml"); print(tomllib.loads(pyproject.read_text())["project"]["version"])')"
-          if [ "${TAG_VERSION}" != "${PACKAGE_VERSION}" ]; then
-            echo "Tag version ${TAG_VERSION} does not match qdash-client version ${PACKAGE_VERSION}." >&2
-            exit 1
-          fi
 
       - name: Build package
         run: uv build --package qdash-client --out-dir dist

--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -30,12 +30,12 @@ The distribution name is `qdash-client`, but the Python import path is `qdash.cl
 `qdash-client` project on PyPI to trust this GitHub repository and the
 `.github/workflows/publish-qdash-client.yml` workflow.
 
-Release tags use the `qdash-client-v<version>` format and must match the version in
-`pyproject.toml`.
+Release tags use the `qdash-client-v<version>` format. Do not edit a package version in
+`pyproject.toml`; the package version is derived from the matching Git tag at build time.
 
 ```bash
-git tag qdash-client-v0.1.0
-git push origin qdash-client-v0.1.0
+git tag qdash-client-v<version>
+git push origin qdash-client-v<version>
 ```
 
 ## Minimal Quick Start

--- a/src/qdash/client/pyproject.toml
+++ b/src/qdash/client/pyproject.toml
@@ -1,20 +1,33 @@
 [project]
 name = "qdash-client"
-version = "0.1.0"
 description = "Python client for the QDash API"
 authors = [
     {name = "OQTOPUS Team", email = "oqtopus-team@googlegroups.com"}
 ]
 readme = "README.md"
 requires-python = ">=3.11,<3.13"
+dynamic = ["version"]
 dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.8.0",
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^qdash-client-v(?P<version>\\d+\\.\\d+\\.\\d+)$"
+fallback-version = "0.0.0"
+
+[tool.hatch.version.raw-options]
+root = "../../.."
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
+
+[tool.hatch.version.raw-options.scm.git]
+describe_command = "git describe --dirty --tags --long --match qdash-client-v*"
 
 [tool.hatch.build]
 exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -3148,7 +3148,6 @@ requires-dist = [
 
 [[package]]
 name = "qdash-client"
-version = "0.1.0"
 source = { editable = "src/qdash/client" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Switch qdash-client packaging to derive versions from qdash-client-v<version> Git tags using hatch-vcs.
- Reduces release risk by removing manual pyproject version synchronization; affects qdash-client publishing only.

## Changes
- Removed static qdash-client version metadata and configured dynamic VCS versioning.
- Updated the publish workflow to fetch tags and build directly from tag-derived metadata.
- Updated qdash-client publishing docs and lock metadata.