### PR TITLE
Add default chip helpers to qdash-client

### DIFF
--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -184,8 +184,8 @@ finally:
 
 ### 3.2 Default Chip
 
-`get_default_chip()` returns the first active chip. If no chips are active, it falls back to the
-most recently installed chip returned by the API.
+`get_default_chip()` returns the most recently installed active chip. If no chips are active, it
+falls back to the most recently installed chip returned by the API.
 
 ```python
 from qdash.client import QDashClient

--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -182,15 +182,34 @@ finally:
     client.close()
 ```
 
-### 3.2 Time-Series Metrics
+### 3.2 Default Chip
+
+`get_default_chip()` returns the first active chip. If no chips are active, it falls back to the
+first chip returned by the API.
 
 ```python
 from qdash.client import QDashClient
 
 client = QDashClient()
 try:
+    chip = client.get_default_chip()
+    print(chip.chip_id)
+finally:
+    client.close()
+```
+
+Use `get_default_chip_id()` when an API call only needs the chip ID.
+
+### 3.3 Time-Series Metrics
+
+```python
+from qdash.client import QDashClient
+
+client = QDashClient()
+try:
+    chip_id = client.get_default_chip_id()
     series = client.get_task_results_timeseries(
-        chip_id="chip-001",
+        chip_id=chip_id,
         parameter="t1",
         tag="calibration",
         start_at="2026-06-01T00:00:00Z",
@@ -202,7 +221,7 @@ finally:
     client.close()
 ```
 
-### 3.3 Metrics Configuration
+### 3.4 Metrics Configuration
 
 ```python
 from qdash.client import QDashClient

--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -185,7 +185,7 @@ finally:
 ### 3.2 Default Chip
 
 `get_default_chip()` returns the first active chip. If no chips are active, it falls back to the
-first chip returned by the API.
+most recently installed chip returned by the API.
 
 ```python
 from qdash.client import QDashClient

--- a/src/qdash/client/services/client.py
+++ b/src/qdash/client/services/client.py
@@ -161,15 +161,14 @@ class QDashClient:
         )
 
     def get_default_chip(self) -> ChipResponse:
-        """Return the default chip, preferring an active chip when available."""
+        """Return the default chip, preferring the latest active chip when available."""
 
         chips = self.list_chips().chips
-        for chip in chips:
-            if str(chip.activity_status) == "active":
-                return chip
         if chips:
+            active_chips = [chip for chip in chips if str(chip.activity_status) == "active"]
+            candidates = active_chips or chips
             return max(
-                chips,
+                candidates,
                 key=lambda chip: (
                     chip.installed_at is not None,
                     chip.installed_at or datetime.min.replace(tzinfo=UTC),
@@ -178,7 +177,7 @@ class QDashClient:
         raise QDashNotFoundError("No chips found.")
 
     def get_default_chip_id(self) -> str:
-        """Return the default chip ID, preferring an active chip when available."""
+        """Return the default chip ID, preferring the latest active chip when available."""
 
         return self.get_default_chip().chip_id
 

--- a/src/qdash/client/services/client.py
+++ b/src/qdash/client/services/client.py
@@ -29,6 +29,7 @@ from qdash.client.services.errors import (
 from qdash.client.services.exporter_models import NormalizedMetricRecord
 from qdash.client.services.models import (
     ChipMetricsResponse,
+    ChipResponse,
     ListChipsResponse,
     TimeSeriesData,
 )
@@ -158,6 +159,22 @@ class QDashClient:
             ListChipsResponse,
             response.data,
         )
+
+    def get_default_chip(self) -> ChipResponse:
+        """Return the default chip, preferring an active chip when available."""
+
+        chips = self.list_chips().chips
+        for chip in chips:
+            if str(chip.activity_status) == "active":
+                return chip
+        if chips:
+            return chips[0]
+        raise QDashNotFoundError("No chips found.")
+
+    def get_default_chip_id(self) -> str:
+        """Return the default chip ID, preferring an active chip when available."""
+
+        return self.get_default_chip().chip_id
 
     def get_chip_metrics(self, chip_id: str) -> ChipMetricsResponse:
         response = self._request("GET", f"/metrics/chips/{chip_id}/metrics")

--- a/src/qdash/client/services/client.py
+++ b/src/qdash/client/services/client.py
@@ -168,7 +168,13 @@ class QDashClient:
             if str(chip.activity_status) == "active":
                 return chip
         if chips:
-            return chips[0]
+            return max(
+                chips,
+                key=lambda chip: (
+                    chip.installed_at is not None,
+                    chip.installed_at or datetime.min.replace(tzinfo=UTC),
+                ),
+            )
         raise QDashNotFoundError("No chips found.")
 
     def get_default_chip_id(self) -> str:

--- a/tests/qdash/client/test_qdash_client.py
+++ b/tests/qdash/client/test_qdash_client.py
@@ -309,7 +309,7 @@ def test_list_chips_accepts_naive_installed_at() -> None:
         client.close()
 
 
-def test_get_default_chip_prefers_first_active_chip() -> None:
+def test_get_default_chip_prefers_latest_active_chip() -> None:
     payload = {
         "chips": [
             {
@@ -340,8 +340,8 @@ def test_get_default_chip_prefers_first_active_chip() -> None:
     try:
         chip = client.get_default_chip()
         assert isinstance(chip, ChipResponse)
-        assert chip.chip_id == "chip-active-old"
-        assert client.get_default_chip_id() == "chip-active-old"
+        assert chip.chip_id == "chip-active-latest"
+        assert client.get_default_chip_id() == "chip-active-latest"
     finally:
         client.close()
 
@@ -375,7 +375,7 @@ def test_get_default_chip_falls_back_to_latest_chip() -> None:
         client.close()
 
 
-def test_get_default_chip_does_not_sort_active_chips_by_installed_at() -> None:
+def test_get_default_chip_uses_undated_chip_only_when_needed() -> None:
     payload = {
         "chips": [
             {"chip_id": "chip-undated", "activity_status": "active"},
@@ -395,7 +395,7 @@ def test_get_default_chip_does_not_sort_active_chips_by_installed_at() -> None:
 
     client = _build_client(httpx.MockTransport(handler), api_token="api-token")
     try:
-        assert client.get_default_chip().chip_id == "chip-undated"
+        assert client.get_default_chip().chip_id == "chip-dated"
     finally:
         client.close()
 

--- a/tests/qdash/client/test_qdash_client.py
+++ b/tests/qdash/client/test_qdash_client.py
@@ -309,13 +309,26 @@ def test_list_chips_accepts_naive_installed_at() -> None:
         client.close()
 
 
-def test_get_default_chip_prefers_active_chip() -> None:
+def test_get_default_chip_prefers_first_active_chip() -> None:
     payload = {
         "chips": [
-            {"chip_id": "chip-inactive", "activity_status": "inactive"},
-            {"chip_id": "chip-active", "activity_status": "active"},
+            {
+                "chip_id": "chip-inactive-latest",
+                "activity_status": "inactive",
+                "installed_at": "2026-01-03T00:00:00Z",
+            },
+            {
+                "chip_id": "chip-active-old",
+                "activity_status": "active",
+                "installed_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "chip_id": "chip-active-latest",
+                "activity_status": "active",
+                "installed_at": "2026-01-02T00:00:00Z",
+            },
         ],
-        "total": 2,
+        "total": 3,
     }
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -327,17 +340,25 @@ def test_get_default_chip_prefers_active_chip() -> None:
     try:
         chip = client.get_default_chip()
         assert isinstance(chip, ChipResponse)
-        assert chip.chip_id == "chip-active"
-        assert client.get_default_chip_id() == "chip-active"
+        assert chip.chip_id == "chip-active-old"
+        assert client.get_default_chip_id() == "chip-active-old"
     finally:
         client.close()
 
 
-def test_get_default_chip_falls_back_to_first_chip() -> None:
+def test_get_default_chip_falls_back_to_latest_chip() -> None:
     payload = {
         "chips": [
-            {"chip_id": "chip-a", "activity_status": "inactive"},
-            {"chip_id": "chip-b", "activity_status": "inactive"},
+            {
+                "chip_id": "chip-old",
+                "activity_status": "inactive",
+                "installed_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "chip_id": "chip-latest",
+                "activity_status": "inactive",
+                "installed_at": "2026-01-02T00:00:00Z",
+            },
         ],
         "total": 2,
     }
@@ -349,7 +370,32 @@ def test_get_default_chip_falls_back_to_first_chip() -> None:
 
     client = _build_client(httpx.MockTransport(handler), api_token="api-token")
     try:
-        assert client.get_default_chip().chip_id == "chip-a"
+        assert client.get_default_chip().chip_id == "chip-latest"
+    finally:
+        client.close()
+
+
+def test_get_default_chip_does_not_sort_active_chips_by_installed_at() -> None:
+    payload = {
+        "chips": [
+            {"chip_id": "chip-undated", "activity_status": "active"},
+            {
+                "chip_id": "chip-dated",
+                "activity_status": "active",
+                "installed_at": "2026-01-01T00:00:00Z",
+            },
+        ],
+        "total": 2,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/chips":
+            return httpx.Response(200, json=payload)
+        return httpx.Response(404, json={"detail": "missing"})
+
+    client = _build_client(httpx.MockTransport(handler), api_token="api-token")
+    try:
+        assert client.get_default_chip().chip_id == "chip-undated"
     finally:
         client.close()
 

--- a/tests/qdash/client/test_qdash_client.py
+++ b/tests/qdash/client/test_qdash_client.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 import pytest
 
 from qdash.client import (
+    ChipResponse,
     ListChipsResponse,
     QDashClient,
     QDashConfig,
@@ -304,6 +305,65 @@ def test_list_chips_accepts_naive_installed_at() -> None:
         chips = client.list_chips()
         assert chips.total == 1
         assert chips.chips[0].chip_id == "chip-a"
+    finally:
+        client.close()
+
+
+def test_get_default_chip_prefers_active_chip() -> None:
+    payload = {
+        "chips": [
+            {"chip_id": "chip-inactive", "activity_status": "inactive"},
+            {"chip_id": "chip-active", "activity_status": "active"},
+        ],
+        "total": 2,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/chips":
+            return httpx.Response(200, json=payload)
+        return httpx.Response(404, json={"detail": "missing"})
+
+    client = _build_client(httpx.MockTransport(handler), api_token="api-token")
+    try:
+        chip = client.get_default_chip()
+        assert isinstance(chip, ChipResponse)
+        assert chip.chip_id == "chip-active"
+        assert client.get_default_chip_id() == "chip-active"
+    finally:
+        client.close()
+
+
+def test_get_default_chip_falls_back_to_first_chip() -> None:
+    payload = {
+        "chips": [
+            {"chip_id": "chip-a", "activity_status": "inactive"},
+            {"chip_id": "chip-b", "activity_status": "inactive"},
+        ],
+        "total": 2,
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/chips":
+            return httpx.Response(200, json=payload)
+        return httpx.Response(404, json={"detail": "missing"})
+
+    client = _build_client(httpx.MockTransport(handler), api_token="api-token")
+    try:
+        assert client.get_default_chip().chip_id == "chip-a"
+    finally:
+        client.close()
+
+
+def test_get_default_chip_raises_not_found_for_empty_chip_list() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET" and request.url.path == "/chips":
+            return httpx.Response(200, json={"chips": [], "total": 0})
+        return httpx.Response(404, json={"detail": "missing"})
+
+    client = _build_client(httpx.MockTransport(handler), api_token="api-token")
+    try:
+        with pytest.raises(QDashNotFoundError):
+            client.get_default_chip()
     finally:
         client.close()
 


### PR DESCRIPTION
## Summary
- add QDashClient.get_default_chip() with active-chip preference and first-chip fallback
- add QDashClient.get_default_chip_id() convenience wrapper
- document the helpers in the client README

## Tests
- uv run pytest tests/qdash/client/test_qdash_client.py