### PR TITLE
Add qdash-client constructor helpers

### DIFF
--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -82,10 +82,9 @@ from qdash.client import QDashClient, QDashConfig
 ### 2.1 From Environment Variables
 
 ```python
-from qdash.client import QDashConfig, QDashClient
+from qdash.client import QDashClient
 
-config = QDashConfig.from_env()
-client = QDashClient(config)
+client = QDashClient.from_env()
 ```
 
 Main environment variables:
@@ -112,10 +111,9 @@ For legacy username/password authentication, set:
 ### 2.2 From a Configuration File
 
 ```python
-from qdash.client import QDashConfig, QDashClient
+from qdash.client import QDashClient
 
-config = QDashConfig.from_file(profile="default")
-client = QDashClient(config)
+client = QDashClient.from_profile("default")
 ```
 
 If `path` is omitted:

--- a/src/qdash/client/services/client.py
+++ b/src/qdash/client/services/client.py
@@ -5,7 +5,6 @@ import random
 import time
 from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import httpx
@@ -17,6 +16,7 @@ from qdash.client.rest.exceptions import ApiException as RestApiException
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
 
     from qdash.client.rest.api_response import ApiResponse as RestApiResponse
 from qdash.client.services.config import QDashConfig

--- a/src/qdash/client/services/client.py
+++ b/src/qdash/client/services/client.py
@@ -5,6 +5,7 @@ import random
 import time
 from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import httpx
@@ -73,6 +74,23 @@ class QDashClient:
         self._token: str | None = self.config.api_token
         if not self.config.user_agent or self.config.user_agent == "qdash-client/dev":
             self.config.user_agent = _resolve_user_agent()
+
+    @classmethod
+    def from_env(cls) -> QDashClient:
+        """Create a client from QDash environment variables."""
+
+        return cls(QDashConfig.from_env())
+
+    @classmethod
+    def from_profile(cls, profile: str = "default", path: str | Path | None = None) -> QDashClient:
+        """Create a client from a named config file profile."""
+
+        config = (
+            QDashConfig.from_file(profile=profile)
+            if path is None
+            else QDashConfig.from_file(profile=profile, path=path)
+        )
+        return cls(config)
 
     def close(self) -> None:
         self._rest_client.close()

--- a/tests/qdash/client/test_qdash_client.py
+++ b/tests/qdash/client/test_qdash_client.py
@@ -75,6 +75,18 @@ def test_config_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.retry.max_attempts == 5
 
 
+def test_client_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("QDASH_BASE_URL", "http://env.local")
+    monkeypatch.setenv("QDASH_API_TOKEN", "env-token")
+
+    client = QDashClient.from_env()
+    try:
+        assert client.config.base_url == "http://env.local"
+        assert client.config.api_token == "env-token"  # noqa: S105
+    finally:
+        client.close()
+
+
 def test_config_from_file_default_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config_dir = tmp_path / "xdg" / "qdash"
     config_dir.mkdir(parents=True)
@@ -121,6 +133,24 @@ api_token = file-token
 
     assert config.base_url == "http://home.local"
     assert config.api_token == "file-token"  # noqa: S105
+
+
+def test_client_from_profile(tmp_path: Path) -> None:
+    config_file = tmp_path / "config.ini"
+    config_file.write_text(
+        """
+[local]
+base_url = http://local.example/
+api_token = local-token
+""".strip()
+    )
+
+    client = QDashClient.from_profile("local", path=config_file)
+    try:
+        assert client.config.base_url == "http://local.example"
+        assert client.config.api_token == "local-token"  # noqa: S105
+    finally:
+        client.close()
 
 
 def test_config_save_writes_selected_section_and_preserves_others(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add QDashClient.from_env() as a shorthand for QDashClient(QDashConfig.from_env())
- add QDashClient.from_profile() as a shorthand for loading a named config profile
- update client README examples to use the explicit constructor helpers

## Tests
- uv run pytest tests/qdash/client/test_qdash_client.py