### PR TITLE
style(ui): enable vertical resizing for textarea in MarkdownEditor co…

### DIFF
--- a/ui/src/components/ui/MarkdownEditor.tsx
+++ b/ui/src/components/ui/MarkdownEditor.tsx
@@ -434,7 +434,7 @@ export function MarkdownEditor({
           <div className="relative">
             <textarea
               ref={textareaRef}
-              className="textarea textarea-bordered w-full rounded-t-none border-t-0 text-sm resize-none focus:outline-none"
+              className="textarea textarea-bordered w-full rounded-t-none border-t-0 text-sm resize-y focus:outline-none"
               placeholder={placeholder}
               value={value}
               onChange={handleTextChange}


### PR DESCRIPTION
## Ticket

close #740

## Summary

The Markdown editor textarea used in the chip experiment history (the Issues
form inside the task history modal) had `resize-none`, so it could not be
resized and was hard to edit when entering longer text. Make it vertically
resizable so users can drag it taller.

## Changes

- `MarkdownEditor`: changed the textarea class from `resize-none` to `resize-y`,
  enabling vertical drag-resize while keeping horizontal size fixed to avoid
  breaking the `w-full` layout (matching the GitHub comment-box behavior).
- Since `MarkdownEditor` is a shared component, this also makes the textarea
  resizable everywhere it is used (issue forms, forum, dashboard notes, issue
  detail, etc.), not only the chip experiment history.
