### PR TITLE
style(ui): enhance DashboardNotesSummary component with collapsible n…

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -17,7 +17,7 @@
   "overrides": {
     "brace-expansion": "^2.0.3",
     "defu": "^6.1.5",
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "esbuild": "^0.28.1",
     "glob": "^10.5.0",
     "mdast-util-to-hast": "^13.2.1",
@@ -460,7 +460,7 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "dompurify": ["dompurify@3.4.10", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w=="],
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
 
@@ -653,8 +653,6 @@
     "reka-ui/@vueuse/core": ["@vueuse/core@14.3.0", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "14.3.0", "@vueuse/shared": "14.3.0" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw=="],
 
     "reka-ui/@vueuse/shared": ["@vueuse/shared@14.3.0", "", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg=="],
-
-    "tinyglobby/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "vitepress-openapi/@vueuse/core": ["@vueuse/core@14.3.0", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "14.3.0", "@vueuse/shared": "14.3.0" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw=="],
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2736,9 +2736,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
   "overrides": {
     "brace-expansion": "^2.0.3",
     "defu": "^6.1.5",
-    "dompurify": "^3.4.9",
+    "dompurify": "^3.4.11",
     "esbuild": "^0.28.1",
     "glob": "^10.5.0",
     "mdast-util-to-hast": "^13.2.1",

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -63,7 +63,7 @@
     "@babel/runtime": "^7.26.10",
     "ajv": "^6.14.0",
     "brace-expansion": "^2.0.3",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.11",
     "esbuild": "^0.25.0",
     "fast-uri": "^3.1.2",
     "flatted": "^3.4.0",
@@ -858,7 +858,7 @@
 
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
-    "dompurify": ["dompurify@3.4.10", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w=="],
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -74,7 +74,7 @@
     "@babel/runtime": "^7.26.10",
     "ajv": "^6.14.0",
     "brace-expansion": "^2.0.3",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.11",
     "esbuild": "^0.25.0",
     "fast-uri": "^3.1.2",
     "flatted": "^3.4.0",

--- a/ui/src/components/features/dashboard/DashboardNotesSummary.tsx
+++ b/ui/src/components/features/dashboard/DashboardNotesSummary.tsx
@@ -163,16 +163,19 @@ export function DashboardNotesSummary({
         </div>
       )}
 
-      {/* Per-(target, metric) chip notes */}
+      {/* Per-(target, metric) chip notes — collapsed by default */}
       {sortedTargets.length > 0 && (
-        <div className="space-y-2">
-          <div className="flex items-baseline gap-2">
-            <h4 className="text-sm font-semibold">Per-metric notes</h4>
-            <span className="text-xs text-base-content/60">
-              {totalChipNotes} across {sortedTargets.length} target
-              {sortedTargets.length > 1 ? "s" : ""} — click to open the metric.
-            </span>
-          </div>
+        <details className="space-y-2">
+          <summary className="cursor-pointer list-none flex items-baseline justify-between gap-2">
+            <div className="flex items-baseline gap-2">
+              <h4 className="text-sm font-semibold">Per-metric notes</h4>
+              <span className="text-xs text-base-content/60">
+                {totalChipNotes} across {sortedTargets.length} target
+                {sortedTargets.length > 1 ? "s" : ""} — click to open the metric.
+              </span>
+            </div>
+            <span className="text-xs text-base-content/50 flex-shrink-0">click to expand</span>
+          </summary>
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
             {sortedTargets.map((targetId) => {
               const notes = [...(visibleNotesByTarget[targetId] ?? [])].sort((a, b) =>
@@ -214,7 +217,7 @@ export function DashboardNotesSummary({
               );
             })}
           </div>
-        </div>
+        </details>
       )}
 
       {/* Per-task_result notes */}


### PR DESCRIPTION
## Ticket
<!-- Link to the ticket / issue -->
close #1102

## Summary
<!-- What and why (1–2 sentences) -->
The "Per-metric notes" section on the dashboard notes summary could take up a lot of vertical space when many targets had notes. This change collapses that section by default so the dashboard stays compact, while keeping the notes one click away.

## Changes
<!-- Bullet list of key changes -->
- Wrap the "Per-metric notes" section in `DashboardNotesSummary` in a native `<details>`/`<summary>` element so it is collapsed by default.
- Move the section heading and note count into the `<summary>` and add a "click to expand" hint aligned to the right.
- No change to the notes data, sorting, or the existing click-to-open-metric behavior.
