### PR TITLE
refactor(ui): simplify TimeRangeSelector state management

### DIFF
--- a/ui/src/components/ui/TimeRangeSelector.tsx
+++ b/ui/src/components/ui/TimeRangeSelector.tsx
@@ -2,8 +2,6 @@
 
 import { useEffect, useState } from "react";
 
-import { toDateTimeLocal } from "@/lib/utils/datetime";
-
 interface TimeRangeSelectorProps {
   startDate: string;
   endDate: string;
@@ -19,15 +17,21 @@ export function TimeRangeSelector({
   onEndDateChange,
   onQuickRange,
 }: TimeRangeSelectorProps) {
-  const [localStart, setLocalStart] = useState(toDateTimeLocal(startDate));
-  const [localEnd, setLocalEnd] = useState(toDateTimeLocal(endDate));
+  // `startDate` / `endDate` are already datetime-local strings in the display
+  // timezone (e.g. "2026-06-21T15:30"), produced by useRangeModeUrlState /
+  // dateToDateTimeLocal. They must be shown verbatim in the
+  // <input type="datetime-local">. Do NOT pass them through toDateTimeLocal():
+  // that helper treats a timezone-less string as UTC and shifts it into the
+  // display timezone, double-applying the offset (+9h for JST). See issue #1107.
+  const [localStart, setLocalStart] = useState(startDate);
+  const [localEnd, setLocalEnd] = useState(endDate);
 
   useEffect(() => {
-    setLocalStart(toDateTimeLocal(startDate));
+    setLocalStart(startDate);
   }, [startDate]);
 
   useEffect(() => {
-    setLocalEnd(toDateTimeLocal(endDate));
+    setLocalEnd(endDate);
   }, [endDate]);
 
   return (


### PR DESCRIPTION
## Ticket

close #1107

## Summary

The calendar time-range input on the Dashboard (and the Metrics / CDF / Histogram / Correlation views that share it) displayed a time +9h ahead of the actual range, because an already-localized `datetime-local` value was re-converted as if it were UTC. This removes the redundant conversion so the input shows and emits the value exactly as selected.

## Changes

- **`TimeRangeSelector`**: stop passing the incoming `startDate` / `endDate` through `toDateTimeLocal()`. These props are already `datetime-local` (JST wall-clock, `"yyyy-MM-ddTHH:mm"`) strings produced by `useRangeModeUrlState` / `dateToDateTimeLocal`, so the helper was double-applying the timezone offset — showing +9h on initial render and drifting another +9h on every edit. The value is now displayed and emitted verbatim; the timezone offset is attached only at the API boundary via `toIsoSeconds`.
- Add comments documenting the `datetime-local` (display-timezone wall-clock) contract of these props to prevent the same regression.

## Notes

- No change to the data-fetch boundary: the API still receives JST with a `+09:00` offset and the backend converts it to UTC (inclusive `$gte` / `$lte` on UTC-stored `start_at`). Only the display layer was double-converting.
- `DateTimePicker` (TimeSeries / qubit views, fed by `useTimeRange`, which emits offset-aware ISO) was already correct and is left unchanged.
