### PR TITLE
feat(api): implement time range note visibility based on window overl…

### DIFF
--- a/docs/reference/database-structure.md
+++ b/docs/reference/database-structure.md
@@ -489,6 +489,8 @@ class MetricNoteDocument(Document):
 
 When a cool-down ID is known, the note stores both `cooldown_id` and the cool-down time bounds. When no cool-down document exists, the dashboard can save a `time_range` note. If a cool-down document is added later, summary reads include matching time-range notes inside that cool-down until they are edited into the explicit cool-down scope.
 
+For `time_range` summary reads, notes are matched by **window overlap** rather than by an exact `scope_key`. The dashboard's default range is relative to "now", so its bounds drift by seconds/minutes between writing a note and reading it back; matching any `time_range` note whose `[scope_started_at, scope_ended_at]` window overlaps the requested window keeps those notes visible (issue #1109). When several overlapping notes exist for the same target metric, the one whose `scope_key` matches the request exactly wins, otherwise the most recently edited note is shown.
+
 ---
 
 ### ExecutionHistoryDocument

--- a/src/qdash/api/services/note_service.py
+++ b/src/qdash/api/services/note_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from datetime import datetime  # noqa: TC003
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from starlette.exceptions import HTTPException
@@ -39,6 +39,14 @@ def _make_note(content: str, username: str) -> NoteModel:
 
 def _is_set(note: NoteModel) -> bool:
     return bool(note.content) or note.updated_at is not None
+
+
+_RECENCY_FLOOR = datetime.min.replace(tzinfo=UTC)
+
+
+def _note_recency(note: NoteModel) -> datetime:
+    """Rank notes by last-edit time, treating an unset timestamp as oldest."""
+    return ensure_timezone(note.updated_at) or _RECENCY_FLOOR
 
 
 _AI_GENERATED_NOTE_RE = re.compile(
@@ -178,6 +186,26 @@ class NoteService:
         if scope_type == "time_range":
             return f"time_range:{format_iso(started_at) or ''}:{format_iso(ended_at) or ''}"
         return "global"
+
+    @staticmethod
+    def _prefer_metric_note(
+        candidate: MetricNoteDocument,
+        current: MetricNoteDocument,
+        *,
+        exact_scope_key: str,
+    ) -> bool:
+        """Return True when ``candidate`` should win over ``current``.
+
+        A note whose scope key matches the requested scope exactly always wins;
+        otherwise the most recently edited note is kept. This keeps the summary
+        deterministic when several overlapping time-range notes exist for the
+        same (target, metric).
+        """
+        candidate_exact = candidate.scope_key == exact_scope_key
+        current_exact = current.scope_key == exact_scope_key
+        if candidate_exact != current_exact:
+            return candidate_exact
+        return _note_recency(candidate.note) > _note_recency(current.note)
 
     @staticmethod
     def _cooldown_scope(cooldown: CooldownDocument, source: str) -> MetricNoteScope:
@@ -836,13 +864,39 @@ class NoteService:
             if scope.ended_at is not None:
                 range_query["scope_ended_at"] = {"$lte": scope.ended_at}
             metric_note_docs.extend(MetricNoteDocument.find(range_query).run())
-        metric_notes_by_target: dict[str, dict[str, NoteModel]] = {}
+        elif scope.scope_type == "time_range" and scope.started_at is not None:
+            # Match every time-range note whose window overlaps the requested
+            # window, not just the one whose key is byte-identical. The
+            # dashboard's default range is relative to "now", so its bounds
+            # drift by seconds/minutes between writing a note and reading it
+            # back; an exact scope_key match would make those notes vanish
+            # (issue #1109).
+            overlap_query: dict[str, object] = {
+                "project_id": project_id,
+                "chip_id": chip_id,
+                "scope_type": "time_range",
+                "$or": [
+                    {"scope_ended_at": {"$gte": scope.started_at}},
+                    {"scope_ended_at": None},
+                ],
+            }
+            if scope.ended_at is not None:
+                overlap_query["scope_started_at"] = {"$lte": scope.ended_at}
+            metric_note_docs.extend(MetricNoteDocument.find(overlap_query).run())
+
+        chosen_metric_notes: dict[str, dict[str, MetricNoteDocument]] = {}
         for metric_note in metric_note_docs:
             key = f"{metric_note.target_type}:{metric_note.target_id}"
-            notes = metric_notes_by_target.setdefault(key, {})
-            if metric_note.metric_key in notes and metric_note.scope_key != scope.scope_key:
-                continue
-            notes[metric_note.metric_key] = metric_note.note
+            target_notes = chosen_metric_notes.setdefault(key, {})
+            current = target_notes.get(metric_note.metric_key)
+            if current is None or self._prefer_metric_note(
+                metric_note, current, exact_scope_key=scope.scope_key
+            ):
+                target_notes[metric_note.metric_key] = metric_note
+        metric_notes_by_target: dict[str, dict[str, NoteModel]] = {
+            key: {metric_key: doc.note for metric_key, doc in target_notes.items()}
+            for key, target_notes in chosen_metric_notes.items()
+        }
 
         def metric_notes_for_target(
             *, target_type: str, target_id: str, legacy: dict[str, NoteModel]

--- a/tests/qdash/api/routers/test_note.py
+++ b/tests/qdash/api/routers/test_note.py
@@ -319,6 +319,48 @@ def test_notes_summary_excludes_time_range_notes_outside_window(test_client, ini
     assert summary.json()["qubits"] == []
 
 
+def test_notes_summary_prefers_exact_scope_when_time_ranges_overlap(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+    QubitDocument(
+        project_id="note_project",
+        username="note_user",
+        chip_id="chip-1",
+        qid="21",
+        data={},
+        system_info=SystemInfoModel(),
+    ).insert()
+
+    # Two overlapping time-range notes for the same (qubit, metric) but with
+    # slightly different bounds, so they land under distinct scope keys.
+    older = test_client.put(
+        "/chips/chip-1/qubits/21/metric-notes/t1",
+        headers=headers,
+        params={"start_at": "2026-02-01T00:00:00Z", "end_at": "2026-02-08T00:00:00Z"},
+        json={"content": "overlapping note"},
+    )
+    assert older.status_code == 200
+    exact = test_client.put(
+        "/chips/chip-1/qubits/21/metric-notes/t1",
+        headers=headers,
+        params={"start_at": "2026-02-01T00:01:00Z", "end_at": "2026-02-08T00:01:00Z"},
+        json={"content": "exact scope note"},
+    )
+    assert exact.status_code == 200
+    assert len(list(MetricNoteDocument.find(MetricNoteDocument.target_id == "21").run())) == 2
+
+    # The requested window matches the second note's scope key exactly while
+    # still overlapping the first. The exact-scope note must win regardless of
+    # edit order (issue #1109 follow-up).
+    summary = test_client.get(
+        "/chips/chip-1/notes-summary",
+        headers=headers,
+        params={"start_at": "2026-02-01T00:01:00Z", "end_at": "2026-02-08T00:01:00Z"},
+    )
+    assert summary.status_code == 200
+    assert summary.json()["qubits"][0]["metric_notes"]["t1"]["content"] == "exact scope note"
+
+
 def test_time_range_scope_infers_later_cooldown_document(test_client, init_db):
     headers = _create_project_user()
     _create_chip(cooldown_id=None)

--- a/tests/qdash/api/routers/test_note.py
+++ b/tests/qdash/api/routers/test_note.py
@@ -257,6 +257,68 @@ def test_metric_notes_can_use_explicit_time_range_scope(test_client, init_db):
     assert summary.json()["qubits"][0]["metric_notes"]["t1"]["content"] == "range note"
 
 
+def test_notes_summary_returns_time_range_notes_when_range_drifts(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+    QubitDocument(
+        project_id="note_project",
+        username="note_user",
+        chip_id="chip-1",
+        qid="21",
+        data={},
+        system_info=SystemInfoModel(),
+    ).insert()
+
+    response = test_client.put(
+        "/chips/chip-1/qubits/21/metric-notes/t1",
+        headers=headers,
+        params={"start_at": "2026-02-01T00:00:00Z", "end_at": "2026-02-08T00:00:00Z"},
+        json={"content": "range note"},
+    )
+    assert response.status_code == 200
+
+    # The dashboard's relative range drifts forward between writing the note and
+    # reading it back, so both bounds shift by a minute. The note must still be
+    # returned (issue #1109).
+    summary = test_client.get(
+        "/chips/chip-1/notes-summary",
+        headers=headers,
+        params={"start_at": "2026-02-01T00:01:00Z", "end_at": "2026-02-08T00:01:00Z"},
+    )
+    assert summary.status_code == 200
+    assert summary.json()["qubits"][0]["metric_notes"]["t1"]["content"] == "range note"
+
+
+def test_notes_summary_excludes_time_range_notes_outside_window(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+    QubitDocument(
+        project_id="note_project",
+        username="note_user",
+        chip_id="chip-1",
+        qid="21",
+        data={},
+        system_info=SystemInfoModel(),
+    ).insert()
+
+    response = test_client.put(
+        "/chips/chip-1/qubits/21/metric-notes/t1",
+        headers=headers,
+        params={"start_at": "2026-01-01T00:00:00Z", "end_at": "2026-01-08T00:00:00Z"},
+        json={"content": "old range note"},
+    )
+    assert response.status_code == 200
+
+    # A window that does not overlap the note's scope should not surface it.
+    summary = test_client.get(
+        "/chips/chip-1/notes-summary",
+        headers=headers,
+        params={"start_at": "2026-02-01T00:00:00Z", "end_at": "2026-02-08T00:00:00Z"},
+    )
+    assert summary.status_code == 200
+    assert summary.json()["qubits"] == []
+
+
 def test_time_range_scope_infers_later_cooldown_document(test_client, init_db):
     headers = _create_project_user()
     _create_chip(cooldown_id=None)


### PR DESCRIPTION
## Ticket

close #1109

## Summary

Time-range metric notes disappeared from the dashboard notes summary because the read matched notes by an exact `scope_key`, while the dashboard's default range is relative to "now" and its bounds drift by seconds/minutes between writing a note and reading it back. This matches `time_range` notes by window overlap instead, so a note stays visible as long as the requested window overlaps the note's scope.

## Changes

- Match `time_range` summary reads by **window overlap** (`scope_started_at`/`scope_ended_at` intersecting the requested window) rather than a byte-identical `scope_key`, in `NoteService` (`note_service.py`).
- Add `_prefer_metric_note` to keep selection deterministic when several overlapping notes exist for the same `(target, metric)`: a note whose `scope_key` matches the request exactly wins, otherwise the most recently edited note is kept.
- Add `_note_recency` helper to rank notes by last-edit time, treating an unset `updated_at` as oldest.
- Add tests covering a drifting window that still returns the note and a non-overlapping window that excludes it.
- Document the window-overlap matching and tie-breaking rules for `time_range` notes in `docs/reference/database-structure.md`.
