### PR TITLE
feat(api): add qdash client write helpers

### DIFF
--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -271,7 +271,45 @@ Available read-only helpers include:
   `get_provenance_impact()`, `get_provenance_history()`, `get_provenance_stats()`,
   `get_provenance_changes()`
 
-### 3.5 Metrics Configuration
+### 3.5 Explicit Write And Operational Queries
+
+Write helpers use the same profile, authentication, project headers, retries, and response
+validation as read-only helpers. Agents should ask for user confirmation before calling methods
+that mutate files, trigger executions, change issue status, push/pull git state, or alter task
+results.
+
+```python
+from qdash.client import QDashClient
+
+client = QDashClient.from_profile("local")
+try:
+    client.save_file_content(path="flows/demo.py", content="def demo(): pass")
+    client.validate_file_content(content="def demo(): pass", file_type="flow")
+    client.git_push_config(commit_message="Update demo flow")
+
+    flow = client.save_flow(name="demo", code="def demo(): pass", chip_id="chip-001")
+    execution = client.execute_flow(flow.name, parameters={"shots": 100})
+    client.upsert_task_note("task-001", content="Reviewed by operator")
+    client.set_task_result_excluded("task-001", excluded=True, reason="bad fit")
+
+    print(flow.file_path, execution.execution_id)
+finally:
+    client.close()
+```
+
+Available write and operational helpers include:
+
+- Files and git: `save_file_content()`, `validate_file_content()`, `git_pull_config()`,
+  `git_push_config()`
+- Flows and executions: `save_flow()`, `execute_flow()`, `schedule_flow()`,
+  `cancel_execution()`, `re_execute_execution()`
+- Task results: `upsert_task_note()`, `delete_task_note()`, `set_task_result_excluded()`,
+  `re_execute_task_result()`, `create_task_result_issue()`
+- Issues and knowledge: `update_issue()`, `close_issue()`, `reopen_issue()`,
+  `update_issue_knowledge()`, `approve_issue_knowledge()`, `reject_issue_knowledge()`,
+  `extract_issue_knowledge()`
+
+### 3.6 Metrics Configuration
 
 ```python
 from qdash.client import QDashClient

--- a/src/qdash/client/__init__.py
+++ b/src/qdash/client/__init__.py
@@ -16,8 +16,10 @@ from qdash.client.services.errors import (
 )
 from qdash.client.services.exporter_models import NormalizedMetricRecord
 from qdash.client.services.models import (
+    CancelExecutionResponse,
     ChipMetricsResponse,
     ChipResponse,
+    ExecuteFlowResponse,
     ExecutionResponseDetail,
     FileTreeNode,
     GetFlowResponse,
@@ -31,12 +33,17 @@ from qdash.client.services.models import (
     ListFlowsResponse,
     ListIssueKnowledgeResponse,
     ListIssuesResponse,
+    NoteModel,
     ParameterModel,
     ProjectResponse,
     ProvenanceStatsResponse,
     QdashApiSchemasProjectProjectListResponse,
     RecentChangesResponse,
+    SaveFlowResponse,
+    ScheduleFlowResponse,
+    SuccessResponse,
     TaskHistoryResponse,
+    TaskResultExcludeResponse,
     TaskResultListResponse,
     TimeSeriesData,
 )
@@ -44,8 +51,10 @@ from qdash.client.services.models import (
 from . import rest
 
 __all__ = [
+    "CancelExecutionResponse",
     "ChipMetricsResponse",
     "ChipResponse",
+    "ExecuteFlowResponse",
     "ExecutionResponseDetail",
     "FileTreeNode",
     "GetFlowResponse",
@@ -60,6 +69,7 @@ __all__ = [
     "ListIssueKnowledgeResponse",
     "ListIssuesResponse",
     "NormalizedMetricRecord",
+    "NoteModel",
     "ParameterModel",
     "ProjectResponse",
     "ProvenanceStatsResponse",
@@ -75,7 +85,11 @@ __all__ = [
     "QDashValidationError",
     "QdashApiSchemasProjectProjectListResponse",
     "RecentChangesResponse",
+    "SaveFlowResponse",
+    "ScheduleFlowResponse",
+    "SuccessResponse",
     "TaskHistoryResponse",
+    "TaskResultExcludeResponse",
     "TaskResultListResponse",
     "TimeSeriesData",
     "rest",

--- a/src/qdash/client/services/client.py
+++ b/src/qdash/client/services/client.py
@@ -29,8 +29,11 @@ from qdash.client.services.errors import (
 )
 from qdash.client.services.exporter_models import NormalizedMetricRecord
 from qdash.client.services.models import (
+    BodyReExecuteTaskResult,
+    CancelExecutionResponse,
     ChipMetricsResponse,
     ChipResponse,
+    ExecuteFlowResponse,
     ExecutionResponseDetail,
     FileTreeNode,
     GetFlowResponse,
@@ -44,13 +47,18 @@ from qdash.client.services.models import (
     ListFlowsResponse,
     ListIssueKnowledgeResponse,
     ListIssuesResponse,
+    NoteModel,
     ParameterHistoryResponse,
     ParameterVersionResponse,
     ProjectResponse,
     ProvenanceStatsResponse,
     QdashApiSchemasProjectProjectListResponse,
     RecentChangesResponse,
+    SaveFlowResponse,
+    ScheduleFlowResponse,
+    SuccessResponse,
     TaskHistoryResponse,
+    TaskResultExcludeResponse,
     TaskResultListResponse,
     TimeSeriesData,
 )
@@ -390,6 +398,42 @@ class QDashClient:
         data = response.data
         return data if isinstance(data, dict) else {}
 
+    def save_file_content(self, *, path: str, content: str) -> dict[str, Any]:
+        response = self._request(
+            "PUT",
+            "/files/content",
+            json={"path": path, "content": content},
+        )
+        data = response.data
+        return data if isinstance(data, dict) else {}
+
+    def validate_file_content(self, *, content: str, file_type: str) -> dict[str, Any]:
+        response = self._request(
+            "POST",
+            "/files/validate",
+            json={"content": content, "file_type": file_type},
+        )
+        data = response.data
+        return data if isinstance(data, dict) else {}
+
+    def git_pull_config(self) -> dict[str, Any]:
+        response = self._request("POST", "/files/git/pull", json={})
+        data = response.data
+        return data if isinstance(data, dict) else {}
+
+    def git_push_config(
+        self,
+        *,
+        commit_message: str = "Update config files from UI",
+    ) -> dict[str, Any]:
+        response = self._request(
+            "POST",
+            "/files/git/push",
+            json={"commit_message": commit_message},
+        )
+        data = response.data
+        return data if isinstance(data, dict) else {}
+
     def list_issues(
         self,
         *,
@@ -410,6 +454,43 @@ class QDashClient:
     def get_issue(self, issue_id: str) -> IssueResponse:
         response = self._request("GET", f"/issues/{issue_id}")
         return self._validate_model_payload(IssueResponse, response.data)
+
+    def create_task_result_issue(
+        self,
+        *,
+        task_id: str,
+        content: str,
+        title: str | None = None,
+        parent_id: str | None = None,
+    ) -> IssueResponse:
+        response = self._request(
+            "POST",
+            f"/task-results/{task_id}/issues",
+            json=self._query_params(title=title, content=content, parent_id=parent_id),
+        )
+        return self._validate_model_payload(IssueResponse, response.data)
+
+    def update_issue(
+        self,
+        issue_id: str,
+        *,
+        content: str,
+        title: str | None = None,
+    ) -> IssueResponse:
+        response = self._request(
+            "PATCH",
+            f"/issues/{issue_id}",
+            json=self._query_params(title=title, content=content),
+        )
+        return self._validate_model_payload(IssueResponse, response.data)
+
+    def close_issue(self, issue_id: str) -> SuccessResponse:
+        response = self._request("PATCH", f"/issues/{issue_id}/close", json={})
+        return self._validate_model_payload(SuccessResponse, response.data)
+
+    def reopen_issue(self, issue_id: str) -> SuccessResponse:
+        response = self._request("PATCH", f"/issues/{issue_id}/reopen", json={})
+        return self._validate_model_payload(SuccessResponse, response.data)
 
     def list_issue_knowledge(
         self,
@@ -432,6 +513,31 @@ class QDashClient:
         response = self._request("GET", f"/issue-knowledge/{knowledge_id}")
         return self._validate_model_payload(IssueKnowledgeResponse, response.data)
 
+    def update_issue_knowledge(
+        self,
+        knowledge_id: str,
+        *,
+        fields: dict[str, Any],
+    ) -> IssueKnowledgeResponse:
+        response = self._request(
+            "PATCH",
+            f"/issue-knowledge/{knowledge_id}",
+            json=fields,
+        )
+        return self._validate_model_payload(IssueKnowledgeResponse, response.data)
+
+    def approve_issue_knowledge(self, knowledge_id: str) -> IssueKnowledgeResponse:
+        response = self._request("PATCH", f"/issue-knowledge/{knowledge_id}/approve", json={})
+        return self._validate_model_payload(IssueKnowledgeResponse, response.data)
+
+    def reject_issue_knowledge(self, knowledge_id: str) -> IssueKnowledgeResponse:
+        response = self._request("PATCH", f"/issue-knowledge/{knowledge_id}/reject", json={})
+        return self._validate_model_payload(IssueKnowledgeResponse, response.data)
+
+    def extract_issue_knowledge(self, issue_id: str) -> IssueKnowledgeResponse:
+        response = self._request("POST", f"/issues/{issue_id}/extract-knowledge", json={})
+        return self._validate_model_payload(IssueKnowledgeResponse, response.data)
+
     def list_flows(self) -> ListFlowsResponse:
         response = self._request("GET", "/flows")
         return self._validate_model_payload(ListFlowsResponse, response.data)
@@ -439,6 +545,70 @@ class QDashClient:
     def get_flow(self, name: str) -> GetFlowResponse:
         response = self._request("GET", f"/flows/{name}")
         return self._validate_model_payload(GetFlowResponse, response.data)
+
+    def save_flow(
+        self,
+        *,
+        name: str,
+        code: str,
+        chip_id: str,
+        description: str = "",
+        flow_function_name: str | None = None,
+        default_parameters: dict[str, Any] | None = None,
+        default_run_parameters: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
+    ) -> SaveFlowResponse:
+        response = self._request(
+            "POST",
+            "/flows",
+            json=self._query_params(
+                name=name,
+                description=description,
+                code=code,
+                flow_function_name=flow_function_name,
+                chip_id=chip_id,
+                default_parameters=default_parameters,
+                default_run_parameters=default_run_parameters,
+                tags=tags,
+            ),
+        )
+        return self._validate_model_payload(SaveFlowResponse, response.data)
+
+    def execute_flow(
+        self,
+        name: str,
+        *,
+        parameters: dict[str, Any] | None = None,
+    ) -> ExecuteFlowResponse:
+        response = self._request(
+            "POST",
+            f"/flows/{name}/execute",
+            json={"parameters": parameters},
+        )
+        return self._validate_model_payload(ExecuteFlowResponse, response.data)
+
+    def schedule_flow(
+        self,
+        name: str,
+        *,
+        cron: str | None = None,
+        scheduled_time: str | None = None,
+        parameters: dict[str, Any] | None = None,
+        active: bool = True,
+        timezone: str = "Asia/Tokyo",
+    ) -> ScheduleFlowResponse:
+        response = self._request(
+            "POST",
+            f"/flows/{name}/schedule",
+            json=self._query_params(
+                cron=cron,
+                scheduled_time=scheduled_time,
+                parameters=parameters,
+                active=active,
+                timezone=timezone,
+            ),
+        )
+        return self._validate_model_payload(ScheduleFlowResponse, response.data)
 
     def list_executions(
         self,
@@ -457,6 +627,60 @@ class QDashClient:
     def get_execution(self, execution_id: str) -> ExecutionResponseDetail:
         response = self._request("GET", f"/executions/{execution_id}")
         return self._validate_model_payload(ExecutionResponseDetail, response.data)
+
+    def cancel_execution(self, flow_run_id: str) -> CancelExecutionResponse:
+        response = self._request("POST", f"/executions/{flow_run_id}/cancel", json={})
+        return self._validate_model_payload(CancelExecutionResponse, response.data)
+
+    def re_execute_execution(self, execution_id: str) -> ExecuteFlowResponse:
+        response = self._request("POST", f"/executions/{execution_id}/re-execute", json={})
+        return self._validate_model_payload(ExecuteFlowResponse, response.data)
+
+    def upsert_task_note(self, task_id: str, *, content: str) -> NoteModel:
+        response = self._request(
+            "PUT",
+            f"/task-results/{task_id}/note",
+            json={"content": content},
+        )
+        return self._validate_model_payload(NoteModel, response.data)
+
+    def delete_task_note(self, task_id: str) -> SuccessResponse:
+        response = self._request("DELETE", f"/task-results/{task_id}/note", json={})
+        return self._validate_model_payload(SuccessResponse, response.data)
+
+    def set_task_result_excluded(
+        self,
+        task_id: str,
+        *,
+        excluded: bool,
+        reason: str = "",
+    ) -> TaskResultExcludeResponse:
+        response = self._request(
+            "POST",
+            f"/task-results/{task_id}/exclude",
+            json={"excluded": excluded, "reason": reason},
+        )
+        return self._validate_model_payload(TaskResultExcludeResponse, response.data)
+
+    def re_execute_task_result(
+        self,
+        task_id: str,
+        *,
+        parameter_overrides: dict[str, dict[str, Any]] | None = None,
+        update_params: bool = True,
+        reconfigure: bool = False,
+    ) -> ExecuteFlowResponse:
+        body = BodyReExecuteTaskResult(
+            parameter_overrides=parameter_overrides,
+            update_params=update_params,
+            reconfigure=reconfigure,
+        )
+        response = self._request(
+            "POST",
+            f"/task-results/{task_id}/re-execute",
+            json=body.model_dump(mode="json"),
+        )
+        return self._validate_model_payload(ExecuteFlowResponse, response.data)
 
     def get_provenance_entity(self, entity_id: str) -> ParameterVersionResponse:
         response = self._request("GET", f"/provenance/entities/{entity_id}")
@@ -601,6 +825,7 @@ class QDashClient:
         path: str,
         *,
         params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> RestApiResponse[Any]:
         attempts = self.config.retry.max_attempts
 
@@ -611,6 +836,7 @@ class QDashClient:
                     method,
                     path,
                     params=params,
+                    json=json,
                     headers=headers,
                     raise_on_status=False,
                 )

--- a/tests/qdash/client/test_qdash_client.py
+++ b/tests/qdash/client/test_qdash_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, cast
 
 import httpx
 
@@ -9,7 +10,9 @@ if TYPE_CHECKING:
 import pytest
 
 from qdash.client import (
+    CancelExecutionResponse,
     ChipResponse,
+    ExecuteFlowResponse,
     FileTreeNode,
     LatestTaskResultResponse,
     ListChipsResponse,
@@ -22,6 +25,9 @@ from qdash.client import (
     QDashNotFoundError,
     QDashTransportError,
     QDashValidationError,
+    SaveFlowResponse,
+    ScheduleFlowResponse,
+    TaskResultExcludeResponse,
     TaskResultListResponse,
     TimeSeriesData,
 )
@@ -697,6 +703,244 @@ def test_agent_read_only_resource_methods_return_models_and_objects() -> None:
         )
         assert client.get_provenance_stats().total_entities == 0
         assert client.get_provenance_changes(parameter_names=["t1"]).total_count == 0
+    finally:
+        client.close()
+
+
+def test_file_and_git_write_helpers_send_json_bodies() -> None:
+    def request_json(request: httpx.Request) -> dict[str, object]:
+        return cast("dict[str, object]", json.loads(request.content.decode() or "{}"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        match (request.method, request.url.path):
+            case ("PUT", "/files/content"):
+                assert request_json(request) == {"path": "flows/demo.py", "content": "print('ok')"}
+                return httpx.Response(200, json={"message": "saved", "path": "flows/demo.py"})
+            case ("POST", "/files/validate"):
+                assert request_json(request) == {"content": "print('ok')", "file_type": "flow"}
+                return httpx.Response(200, json={"valid": True})
+            case ("POST", "/files/git/pull"):
+                assert request_json(request) == {}
+                return httpx.Response(200, json={"status": "pulled"})
+            case ("POST", "/files/git/push"):
+                assert request_json(request) == {"commit_message": "Update flow"}
+                return httpx.Response(200, json={"status": "pushed"})
+        return httpx.Response(404, json={"detail": "missing"})
+
+    client = _build_client(httpx.MockTransport(handler), api_token="api-token")
+    try:
+        assert client.save_file_content(path="flows/demo.py", content="print('ok')")["message"] == (
+            "saved"
+        )
+        assert (
+            client.validate_file_content(content="print('ok')", file_type="flow")["valid"] is True
+        )
+        assert client.git_pull_config()["status"] == "pulled"
+        assert client.git_push_config(commit_message="Update flow")["status"] == "pushed"
+    finally:
+        client.close()
+
+
+def test_flow_and_execution_write_helpers_return_models() -> None:
+    execute_payload = {
+        "execution_id": "exec-1",
+        "flow_run_url": "https://prefect.local/runs/exec-1",
+        "qdash_ui_url": "https://qdash.local/executions/exec-1",
+        "message": "started",
+    }
+
+    def request_json(request: httpx.Request) -> dict[str, object]:
+        return cast("dict[str, object]", json.loads(request.content.decode() or "{}"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        match (request.method, request.url.path):
+            case ("POST", "/flows"):
+                body = request_json(request)
+                assert body["name"] == "demo"
+                assert body["code"] == "def demo(): pass"
+                assert body["chip_id"] == "chip-a"
+                return httpx.Response(
+                    200,
+                    json={
+                        "name": "demo",
+                        "file_path": "flows/demo.py",
+                        "message": "saved",
+                    },
+                )
+            case ("POST", "/flows/demo/execute"):
+                assert request_json(request) == {"parameters": {"shots": 10}}
+                return httpx.Response(200, json=execute_payload)
+            case ("POST", "/flows/demo/schedule"):
+                assert request_json(request) == {
+                    "cron": "0 2 * * *",
+                    "parameters": {"shots": 10},
+                    "active": True,
+                    "timezone": "Asia/Tokyo",
+                }
+                return httpx.Response(
+                    200,
+                    json={
+                        "schedule_id": "schedule-1",
+                        "flow_name": "demo",
+                        "schedule_type": "cron",
+                        "cron": "0 2 * * *",
+                        "active": True,
+                        "message": "scheduled",
+                    },
+                )
+            case ("POST", "/executions/run-1/cancel"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "execution_id": "run-1",
+                        "status": "cancelled",
+                        "message": "cancelled",
+                    },
+                )
+            case ("POST", "/executions/exec-1/re-execute"):
+                return httpx.Response(200, json=execute_payload)
+        return httpx.Response(404, json={"detail": "missing"})
+
+    client = _build_client(httpx.MockTransport(handler), api_token="api-token")
+    try:
+        assert isinstance(
+            client.save_flow(name="demo", code="def demo(): pass", chip_id="chip-a"),
+            SaveFlowResponse,
+        )
+        assert isinstance(
+            client.execute_flow("demo", parameters={"shots": 10}),
+            ExecuteFlowResponse,
+        )
+        assert isinstance(
+            client.schedule_flow("demo", cron="0 2 * * *", parameters={"shots": 10}),
+            ScheduleFlowResponse,
+        )
+        assert isinstance(client.cancel_execution("run-1"), CancelExecutionResponse)
+        assert client.re_execute_execution("exec-1").execution_id == "exec-1"
+    finally:
+        client.close()
+
+
+def test_task_result_and_issue_write_helpers_return_models() -> None:
+    issue_payload = {
+        "id": "issue-1",
+        "task_id": "task-1",
+        "username": "operator",
+        "title": "Bad fit",
+        "content": "Needs review",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    }
+    knowledge_payload = {
+        "id": "knowledge-1",
+        "issue_id": "issue-1",
+        "task_id": "task-1",
+        "task_name": "t1",
+        "title": "Bad fit",
+        "status": "draft",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+    }
+    execute_payload = {
+        "execution_id": "exec-1",
+        "flow_run_url": "https://prefect.local/runs/exec-1",
+        "qdash_ui_url": "https://qdash.local/executions/exec-1",
+        "message": "started",
+    }
+
+    def request_json(request: httpx.Request) -> dict[str, object]:
+        return cast("dict[str, object]", json.loads(request.content.decode() or "{}"))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        match (request.method, request.url.path):
+            case ("PUT", "/task-results/task-1/note"):
+                assert request_json(request) == {"content": "reviewed"}
+                return httpx.Response(
+                    200,
+                    json={
+                        "content": "reviewed",
+                        "updated_by": "operator",
+                        "updated_at": "2026-01-01T00:00:00Z",
+                    },
+                )
+            case ("POST", "/task-results/task-1/exclude"):
+                assert request_json(request) == {"excluded": True, "reason": "bad fit"}
+                return httpx.Response(
+                    200,
+                    json={
+                        "task_id": "task-1",
+                        "excluded": True,
+                        "excluded_reason": "bad fit",
+                        "excluded_by_user_id": "user-1",
+                        "excluded_by": "operator",
+                        "excluded_at": "2026-01-01T00:00:00Z",
+                    },
+                )
+            case ("POST", "/task-results/task-1/re-execute"):
+                assert request_json(request) == {
+                    "parameter_overrides": {"run": {"shots": 10}},
+                    "update_params": False,
+                    "reconfigure": True,
+                }
+                return httpx.Response(200, json=execute_payload)
+            case ("POST", "/task-results/task-1/issues"):
+                assert request_json(request) == {"title": "Bad fit", "content": "Needs review"}
+                return httpx.Response(201, json=issue_payload)
+            case ("PATCH", "/issues/issue-1"):
+                assert request_json(request) == {"content": "Updated"}
+                return httpx.Response(200, json={**issue_payload, "content": "Updated"})
+            case ("PATCH", "/issues/issue-1/close"):
+                return httpx.Response(200, json={"message": "closed"})
+            case ("PATCH", "/issues/issue-1/reopen"):
+                return httpx.Response(200, json={"message": "reopened"})
+            case ("PATCH", "/issue-knowledge/knowledge-1"):
+                assert request_json(request) == {"title": "Updated case"}
+                return httpx.Response(200, json={**knowledge_payload, "title": "Updated case"})
+            case ("PATCH", "/issue-knowledge/knowledge-1/approve"):
+                return httpx.Response(200, json={**knowledge_payload, "status": "approved"})
+            case ("PATCH", "/issue-knowledge/knowledge-1/reject"):
+                return httpx.Response(200, json={**knowledge_payload, "status": "rejected"})
+            case ("POST", "/issues/issue-1/extract-knowledge"):
+                return httpx.Response(201, json=knowledge_payload)
+        return httpx.Response(404, json={"detail": "missing"})
+
+    client = _build_client(httpx.MockTransport(handler), api_token="api-token")
+    try:
+        assert client.upsert_task_note("task-1", content="reviewed").content == "reviewed"
+        assert isinstance(
+            client.set_task_result_excluded("task-1", excluded=True, reason="bad fit"),
+            TaskResultExcludeResponse,
+        )
+        assert (
+            client.re_execute_task_result(
+                "task-1",
+                parameter_overrides={"run": {"shots": 10}},
+                update_params=False,
+                reconfigure=True,
+            ).execution_id
+            == "exec-1"
+        )
+        assert (
+            client.create_task_result_issue(
+                task_id="task-1",
+                title="Bad fit",
+                content="Needs review",
+            ).id
+            == "issue-1"
+        )
+        assert client.update_issue("issue-1", content="Updated").content == "Updated"
+        assert client.close_issue("issue-1").message == "closed"
+        assert client.reopen_issue("issue-1").message == "reopened"
+        assert (
+            client.update_issue_knowledge(
+                "knowledge-1",
+                fields={"title": "Updated case"},
+            ).title
+            == "Updated case"
+        )
+        assert client.approve_issue_knowledge("knowledge-1").status == "approved"
+        assert client.reject_issue_knowledge("knowledge-1").status == "rejected"
+        assert client.extract_issue_knowledge("issue-1").id == "knowledge-1"
     finally:
         client.close()
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Adds explicit Python qdash client helpers for write and operational endpoints so agents and scripts can use authenticated client methods instead of private raw requests.
- Affected area is the qdash client package; methods cover file/git operations, flows/executions, task result notes/exclusion/re-execution, and issue knowledge workflows.

## Changes
- Added JSON-body support to QDashClient._request and typed helper methods for common POST, PUT, PATCH, and DELETE endpoints.
- Exported write-related response models from qdash.client.
- Documented write helper usage and confirmation expectations in the client README.
- Added focused MockTransport tests for request methods, paths, JSON bodies, and response model validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client helpers for file save/validate and git-based config sync (pull/push).
  * Added full issue and issue-knowledge workflows (create/update/close/reopen; approve/reject/extract).
  * Added flow management: save definitions, execute, schedule (cron/timezone/activation), cancel, and re-execute.
  * Added execution/task-result actions, including task notes and task result exclusion controls.
* **Documentation**
  * Updated client documentation with clearer guidance for explicit write/operational actions and confirmation warnings.
* **Tests**
  * Added request/JSON payload coverage for the new helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->