### PR TITLE
fix(workflow): defer local repo sync for grouped pushes

### DIFF
--- a/src/qdash/workflow/service/github.py
+++ b/src/qdash/workflow/service/github.py
@@ -209,10 +209,12 @@ class GitHubIntegration:
             ```
         """
         results: dict[str, Any] = {}
+        pushed_any = False
+        had_error = False
 
         for file_type in push_config.file_types:
             try:
-                result: str | dict[str, str]
+                result: str | dict[str, Any]
                 if file_type == ConfigFileType.CALIB_NOTE:
                     result = self._push_calib_note(push_config)
                 elif file_type == ConfigFileType.PROPS:
@@ -225,11 +227,31 @@ class GitHubIntegration:
                     continue
 
                 results[file_type.value] = result
+                if self._push_result_has_commit(result):
+                    pushed_any = True
+                if isinstance(result, dict) and "error" in result:
+                    had_error = True
             except Exception as e:
                 self.logger.error(f"Failed to push {file_type.value}: {e}")
                 results[file_type.value] = f"Error: {e}"
+                had_error = True
+
+        if pushed_any and not had_error:
+            from qdash.workflow.worker.tasks.push_github import _sync_local_repo
+
+            _sync_local_repo(push_config.branch, self.logger)
 
         return results
+
+    @staticmethod
+    def _push_result_has_commit(result: str | dict[str, Any]) -> bool:
+        if isinstance(result, str):
+            return result not in {"No changes to commit", "No files to commit"}
+        commit = result.get("commit")
+        return isinstance(commit, str) and commit not in {
+            "No changes to commit",
+            "No files to commit",
+        }
 
     def _push_calib_note(self, config: GitHubPushConfig) -> str:
         """Push calib_note.json (fetch master note from MongoDB and write to config dir).
@@ -288,6 +310,7 @@ class GitHubIntegration:
             repo_subpath=repo_subpath,
             commit_message=commit_message,
             branch=config.branch,
+            sync_local=False,
         )
 
         self.logger.info(f"Pushed calib_note.json: {commit_sha}")
@@ -331,6 +354,7 @@ class GitHubIntegration:
             repo_subpath=repo_subpath,
             commit_message=commit_message,
             branch=config.branch,
+            sync_local=False,
         )
 
         self.logger.info(f"Pushed props.yaml: {commit_sha}")
@@ -366,6 +390,7 @@ class GitHubIntegration:
             repo_subpath=repo_subpath,
             commit_message=commit_message,
             branch=config.branch,
+            sync_local=False,
         )
 
         self.logger.info(f"Pushed params.yaml: {commit_sha}")
@@ -411,6 +436,7 @@ class GitHubIntegration:
                 files=files,
                 commit_message=commit_message,
                 branch=config.branch,
+                sync_local=False,
             )
             file_names = [Path(f[0]).name for f in files]
             self.logger.info(f"Pushed {len(files)} param files in single commit: {commit_sha}")

--- a/src/qdash/workflow/service/tasks.py
+++ b/src/qdash/workflow/service/tasks.py
@@ -57,7 +57,7 @@ CHECK_1Q_TASKS: list[str] = [
     "CreateHPIPulse",
     "CheckHPIPulse",
     # "CheckOptimalReadoutFrequency",
-    # "CheckOptimalReadoutAmplitude",
+    "CheckOptimalReadoutAmplitude",
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",

--- a/src/qdash/workflow/worker/tasks/push_github.py
+++ b/src/qdash/workflow/worker/tasks/push_github.py
@@ -58,6 +58,7 @@ def push_github(
     repo_subpath: str = "64Qv1/calibration/calib_note.json",
     commit_message: str = "Update calib_note.json",
     branch: str = "main",
+    sync_local: bool = True,
 ) -> str:
     """Push local calib_note.json to the GitHub repository.
 
@@ -67,6 +68,7 @@ def push_github(
         repo_subpath: Relative path inside the repo to replace
         commit_message: Commit message
         branch: Branch to push to
+        sync_local: Whether to sync the local qubex-config repo after a successful push
 
     Returns:
     -------
@@ -117,7 +119,8 @@ def push_github(
         repo.remotes.origin.push()
 
         commit_sha = str(repo.head.commit.hexsha[:8])
-        _sync_local_repo(branch, logger)
+        if sync_local:
+            _sync_local_repo(branch, logger)
         return commit_sha
 
     except GitCommandError as e:
@@ -136,6 +139,7 @@ def push_github_batch(
     files: list[tuple[str, str]],
     commit_message: str = "Update files",
     branch: str = "main",
+    sync_local: bool = True,
 ) -> str:
     """Push multiple files to GitHub repository in a single commit.
 
@@ -144,6 +148,7 @@ def push_github_batch(
         files: List of (source_path, repo_subpath) tuples
         commit_message: Commit message
         branch: Branch to push to
+        sync_local: Whether to sync the local qubex-config repo after a successful push
 
     Returns:
     -------
@@ -206,7 +211,8 @@ def push_github_batch(
 
         logger.info(f"Pushed {len(added_files)} files in single commit")
         commit_sha = str(repo.head.commit.hexsha[:8])
-        _sync_local_repo(branch, logger)
+        if sync_local:
+            _sync_local_repo(branch, logger)
         return commit_sha
 
     except GitCommandError as e:

--- a/tests/qdash/workflow/worker/tasks/test_push_github.py
+++ b/tests/qdash/workflow/worker/tasks/test_push_github.py
@@ -181,6 +181,74 @@ class TestGitHubPushConfigDefaults:
             GitHubPushConfig()
 
 
+class TestGitHubIntegrationPushFilesSync:
+    """Tests for deferred local repo sync during grouped GitHub pushes."""
+
+    def _make_integration(self):
+        from qdash.workflow.service.github import GitHubIntegration
+
+        integration = GitHubIntegration.__new__(GitHubIntegration)
+        integration.logger = MagicMock()
+        integration._push_calib_note = MagicMock(return_value="abc12345")
+        integration._push_all_params = MagicMock(
+            return_value={"commit": "def67890", "files": ["params.yaml"]}
+        )
+        integration._push_props = MagicMock()
+        integration._push_params_file = MagicMock()
+        return integration
+
+    def _make_config(self):
+        from qdash.workflow.service.github import ConfigFileType, GitHubPushConfig
+
+        with patch("qdash.workflow.service.github.ConfigLoader.load_workflow", return_value={}):
+            return GitHubPushConfig(
+                file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
+                branch="develop",
+            )
+
+    def test_syncs_local_repo_once_after_all_pushes_succeed(self):
+        """Grouped pushes should not reset local files between calib_note and params."""
+        integration = self._make_integration()
+        config = self._make_config()
+
+        with patch("qdash.workflow.worker.tasks.push_github._sync_local_repo") as sync_local:
+            result = integration.push_files(config)
+
+        assert result == {
+            "calib_note": "abc12345",
+            "all_params": {"commit": "def67890", "files": ["params.yaml"]},
+        }
+        sync_local.assert_called_once_with("develop", integration.logger)
+
+    def test_does_not_sync_local_repo_when_later_push_fails(self):
+        """Do not discard local params changes when a grouped push reports an error."""
+        integration = self._make_integration()
+        integration._push_all_params.return_value = {"error": "push failed"}
+        config = self._make_config()
+
+        with patch("qdash.workflow.worker.tasks.push_github._sync_local_repo") as sync_local:
+            result = integration.push_files(config)
+
+        assert result["calib_note"] == "abc12345"
+        assert result["all_params"] == {"error": "push failed"}
+        sync_local.assert_not_called()
+
+    def test_does_not_sync_local_repo_when_nothing_changed(self):
+        """No-op grouped pushes do not need to reset the local repository."""
+        integration = self._make_integration()
+        integration._push_calib_note.return_value = "No changes to commit"
+        integration._push_all_params.return_value = {
+            "commit": "No changes to commit",
+            "files": ["params.yaml"],
+        }
+        config = self._make_config()
+
+        with patch("qdash.workflow.worker.tasks.push_github._sync_local_repo") as sync_local:
+            integration.push_files(config)
+
+        sync_local.assert_not_called()
+
+
 class TestSelectParamYamlFiles:
     """Tests for selecting params YAML files for ALL_PARAMS batch pushes."""
 


### PR DESCRIPTION
## Ticket
N/A

## Summary
- Defers local qubex-config repo sync until grouped GitHub pushes complete successfully, preventing local generated files from being reset between files.
- Affects workflow GitHub push behavior only; no API, UI, or generated client changes.

## Changes
- Adds optional sync control to single and batch GitHub push tasks.
- Syncs the local repo once after successful grouped pushes and skips sync on errors or no-op pushes.
- Enables CheckOptimalReadoutAmplitude in the 1Q check task sequence.
- Adds regression tests for deferred sync behavior.