### PR TITLE
fix(workflow): skip optimal readout amplitude by default

### DIFF
--- a/src/qdash/workflow/service/tasks.py
+++ b/src/qdash/workflow/service/tasks.py
@@ -57,7 +57,6 @@ CHECK_1Q_TASKS: list[str] = [
     "CreateHPIPulse",
     "CheckHPIPulse",
     # "CheckOptimalReadoutFrequency",
-    "CheckOptimalReadoutAmplitude",
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Removes CheckOptimalReadoutAmplitude from the default one-qubit check sequence so the workflow task list matches the intended default behavior.
- Affects workflow defaults only; no generated files or API contracts changed.

## Changes
- Updated CHECK_1Q_TASKS to skip CheckOptimalReadoutAmplitude by default.
- Verified the full local check suite with nix develop -c task check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the 1Q check workflow so it no longer includes the optimal readout amplitude check.
  * The validation sequence now moves directly from the HPI checks to the next calibration steps, streamlining the run order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->