### PR TITLE
fix(api): create topology targets for metric notes

### DIFF
--- a/src/qdash/api/services/note_service.py
+++ b/src/qdash/api/services/note_service.py
@@ -416,13 +416,14 @@ class NoteService:
         start_at: datetime | None = None,
         end_at: datetime | None = None,
     ) -> NoteModel:
-        doc = QubitDocument.find_one(
-            QubitDocument.project_id == project_id,
-            QubitDocument.chip_id == chip_id,
-            QubitDocument.qid == qid,
-        ).run()
-        if doc is None:
-            raise HTTPException(status_code=404, detail="Qubit not found")
+        try:
+            ChipInitializer.ensure_qubit_document(
+                project_id=project_id,
+                chip_id=chip_id,
+                qid=qid,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
         note = _make_note(content, username)
         scope = self._resolve_metric_note_scope(
             project_id=project_id,
@@ -612,13 +613,14 @@ class NoteService:
         start_at: datetime | None = None,
         end_at: datetime | None = None,
     ) -> NoteModel:
-        doc = CouplingDocument.find_one(
-            CouplingDocument.project_id == project_id,
-            CouplingDocument.chip_id == chip_id,
-            CouplingDocument.qid == coupling_id,
-        ).run()
-        if doc is None:
-            raise HTTPException(status_code=404, detail="Coupling not found")
+        try:
+            ChipInitializer.ensure_coupling_document(
+                project_id=project_id,
+                chip_id=chip_id,
+                coupling_id=coupling_id,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
         note = _make_note(content, username)
         scope = self._resolve_metric_note_scope(
             project_id=project_id,

--- a/tests/qdash/api/routers/test_note.py
+++ b/tests/qdash/api/routers/test_note.py
@@ -506,3 +506,55 @@ def test_coupling_note_creates_missing_topology_target(test_client, init_db):
     assert doc is not None
     assert doc.data == {}
     assert doc.note.content == "No coupling data yet."
+
+
+def test_qubit_metric_note_creates_missing_topology_target(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+
+    response = test_client.put(
+        "/chips/chip-1/qubits/21/metric-notes/t1",
+        headers=headers,
+        json={"content": "No metric data yet; check next cooldown."},
+    )
+
+    assert response.status_code == 200
+    doc = QubitDocument.find_one(QubitDocument.qid == "21").run()
+    assert doc is not None
+    assert doc.data == {}
+    metric_note = MetricNoteDocument.find_one(MetricNoteDocument.target_id == "21").run()
+    assert metric_note is not None
+    assert metric_note.scope_key == "global"
+    assert metric_note.note.content == "No metric data yet; check next cooldown."
+
+    summary = test_client.get("/chips/chip-1/notes-summary", headers=headers)
+    assert summary.status_code == 200
+    assert summary.json()["qubits"][0]["metric_notes"]["t1"]["content"] == (
+        "No metric data yet; check next cooldown."
+    )
+
+
+def test_coupling_metric_note_creates_missing_topology_target(test_client, init_db):
+    headers = _create_project_user()
+    _create_chip(cooldown_id=None)
+
+    response = test_client.put(
+        "/chips/chip-1/couplings/0-1/metric-notes/zx90_gate_fidelity",
+        headers=headers,
+        json={"content": "No coupling metric data yet."},
+    )
+
+    assert response.status_code == 200
+    doc = CouplingDocument.find_one(CouplingDocument.qid == "0-1").run()
+    assert doc is not None
+    assert doc.data == {}
+    metric_note = MetricNoteDocument.find_one(MetricNoteDocument.target_id == "0-1").run()
+    assert metric_note is not None
+    assert metric_note.scope_key == "global"
+    assert metric_note.note.content == "No coupling metric data yet."
+
+    summary = test_client.get("/chips/chip-1/notes-summary", headers=headers)
+    assert summary.status_code == 200
+    assert summary.json()["couplings"][0]["metric_notes"]["zx90_gate_fidelity"]["content"] == (
+        "No coupling metric data yet."
+    )


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Allows qubit and coupling metric notes to create missing topology target documents before storing the note.
- API-only change with focused router test coverage; no OpenAPI/schema or generated client changes involved.

## Changes
- Use the existing chip initializer when writing qubit and coupling metric notes so missing topology targets are created consistently.
- Add API router tests for qubit and coupling metric notes on targets without existing metric data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metric notes for qubits and couplings now work even when the target entry doesn’t already exist; the needed item is created automatically.
  * Newly added metric notes now appear in the chip notes summary in the expected location.

* **Bug Fixes**
  * Improved error handling so missing or invalid targets now return a clear not-found response instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->