### PR TITLE
fix(workflow): improve fake qubex coherence behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pendulum>=3.1.0",
     "pydantic>=2.8.0",
     "pymongo>=4.8.0",
+    "qdash-api",
 ]
 
 
@@ -183,4 +184,5 @@ members = [
 ]
 
 [tool.uv.sources]
+qdash-api = { workspace = true }
 qubex = { git = "https://github.com/amachino/qubex.git", branch = "develop" }

--- a/src/qdash/api/Dockerfile
+++ b/src/qdash/api/Dockerfile
@@ -26,7 +26,7 @@ COPY src/qdash/client/pyproject.toml src/qdash/client/pyproject.toml
 COPY src/qdash/client/README.md src/qdash/client/README.md
 COPY src/qdash/workflow/pyproject.toml src/qdash/workflow/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv --no-config sync --locked --package qdash-api --no-dev
+    uv sync --locked --package qdash-api --no-dev
 
 FROM python:3.11-slim-bookworm
 

--- a/src/qdash/api/lib/auth.py
+++ b/src/qdash/api/lib/auth.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 
 import bcrypt
 from fastapi import Depends, Header, HTTPException, status
@@ -67,7 +68,7 @@ def get_password_hash(password: str) -> str:
         logger.error(msg)
         raise ValueError(msg)
     salt = bcrypt.gensalt(rounds=BCRYPT_ROUNDS, prefix=b"2b")
-    return bcrypt.hashpw(_password_bytes(password), salt).decode("utf-8")
+    return cast("str", bcrypt.hashpw(_password_bytes(password), salt).decode("utf-8"))
 
 
 def get_user(username: str) -> UserInDB | None:

--- a/src/qdash/api/pyproject.toml
+++ b/src/qdash/api/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "QDash API service dependency project"
 requires-python = ">=3.11,<3.13"
 dependencies = [
+    "bcrypt>=5.0.0",
     "fastapi",
     "uvicorn[standard]",
     "gunicorn==26.0.0",

--- a/src/qdash/workflow/Dockerfile
+++ b/src/qdash/workflow/Dockerfile
@@ -36,7 +36,7 @@ COPY src/qdash/client/pyproject.toml src/qdash/client/pyproject.toml
 COPY src/qdash/client/README.md src/qdash/client/README.md
 COPY src/qdash/workflow/pyproject.toml src/qdash/workflow/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv --no-config sync --locked --package qdash-workflow --no-dev
+    uv sync --locked --package qdash-workflow --no-dev
 
 FROM python:3.11-slim-bookworm
 

--- a/src/qdash/workflow/Dockerfile.deployment
+++ b/src/qdash/workflow/Dockerfile.deployment
@@ -36,7 +36,7 @@ COPY src/qdash/client/pyproject.toml src/qdash/client/pyproject.toml
 COPY src/qdash/client/README.md src/qdash/client/README.md
 COPY src/qdash/workflow/pyproject.toml src/qdash/workflow/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv --no-config sync --locked --package qdash-workflow --no-dev
+    uv sync --locked --package qdash-workflow --no-dev
 
 FROM python:3.11-slim-bookworm
 

--- a/src/qdash/workflow/engine/backend/fake_qubex/simulation.py
+++ b/src/qdash/workflow/engine/backend/fake_qubex/simulation.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import random
 import re
 from collections.abc import Collection, Mapping
 from contextlib import contextmanager
@@ -4656,10 +4657,19 @@ class FakeExperiment:
                 )
 
             def _fit(*_: Any, **__: Any) -> dict[str, Any]:
-                return {
+                fit_result = {
                     "fig": _plot(return_figure=True),
                     "r2": float(fields.get("r2", 1.0)),
                 }
+                if title == "Ramsey":
+                    fit_result.update(
+                        {
+                            "f": float(fields.get("ramsey_freq", 0.0)),
+                            "f_err": float(fields.get("ramsey_freq_err", 0.0)),
+                            "tau_err": float(fields.get("t2_err", 0.0)),
+                        }
+                    )
+                return fit_result
 
             value.plot = _plot
             value.fit = _fit
@@ -4678,15 +4688,20 @@ class FakeExperiment:
                 t1_us, t2_us = self._qubit_lifetime(index)
                 t1_ns = float(t1_us) * 1000.0
                 t2_ns = float(t2_us) * 1000.0
+                target_time_values = (
+                    self._coherence_time_values(time_values, index)
+                    if experiment in {"t1", "t2"}
+                    else time_values
+                )
                 rabi_param = self._rabi_params.get(target) or self._synthetic_rabi_param(target)
 
                 if experiment == "t1":
-                    population = np.exp(-time_values / max(t1_ns, 1.0))
+                    population = np.exp(-target_time_values / max(t1_ns, 1.0))
                     signal = 0.5 + 0.5j * (1.0 - 2.0 * population)
                     data[target] = make_value(
                         target=target,
                         data=signal,
-                        sweep_range=time_values,
+                        sweep_range=target_time_values,
                         title="T1 decay",
                         xlabel="Time (us)",
                         ylabel="Measured value",
@@ -4698,12 +4713,12 @@ class FakeExperiment:
                         r2=1.0,
                     )
                 elif experiment == "t2":
-                    envelope = np.exp(-time_values / max(t2_ns, 1.0))
+                    envelope = np.exp(-target_time_values / max(t2_ns, 1.0))
                     signal = 0.5 + 0.5j * (2.0 * envelope - 1.0)
                     data[target] = make_value(
                         target=target,
                         data=signal,
-                        sweep_range=time_values,
+                        sweep_range=target_time_values,
                         title="T2 echo",
                         xlabel="Time (us)",
                         ylabel="Measured value",
@@ -4787,13 +4802,18 @@ class FakeExperiment:
                 )
                 for target, sweep_data in sweep_result.data.items():
                     ge_target = self._ge_label(target)
-                    t1_us, _ = self._qubit_lifetime(self.qubit_labels.index(ge_target))
+                    index = self.qubit_labels.index(ge_target)
+                    t1_us, _ = self._qubit_lifetime(index)
                     t1_ns = float(t1_us) * 1000.0
+                    sweep_range = self._coherence_time_values(
+                        np.asarray(sweep_data.sweep_range, dtype=float),
+                        index,
+                    )
                     rabi_param = self._rabi_params.get(target) or self._synthetic_rabi_param(target)
                     data[target] = make_value(
                         target=target,
                         data=np.asarray(sweep_data.data, dtype=complex),
-                        sweep_range=np.asarray(sweep_data.sweep_range, dtype=float),
+                        sweep_range=sweep_range,
                         title="T1 decay",
                         xlabel="Time (us)",
                         ylabel="Measured value",
@@ -4854,13 +4874,18 @@ class FakeExperiment:
                 )
                 for target, sweep_data in sweep_result.data.items():
                     ge_target = self._ge_label(target)
-                    _, t2_us = self._qubit_lifetime(self.qubit_labels.index(ge_target))
+                    index = self.qubit_labels.index(ge_target)
+                    _, t2_us = self._qubit_lifetime(index)
                     t2_ns = float(t2_us) * 1000.0
+                    sweep_range = self._coherence_time_values(
+                        np.asarray(sweep_data.sweep_range, dtype=float),
+                        index,
+                    )
                     rabi_param = self._rabi_params.get(target) or self._synthetic_rabi_param(target)
                     data[target] = make_value(
                         target=target,
                         data=np.asarray(sweep_data.data, dtype=complex),
-                        sweep_range=np.asarray(sweep_data.sweep_range, dtype=float),
+                        sweep_range=sweep_range,
                         title="T2 echo",
                         xlabel="Time (us)",
                         ylabel="Measured value",
@@ -5339,7 +5364,18 @@ class FakeExperiment:
     def _qubit_lifetime(self, index: int) -> tuple[float, float]:
         if self.qubit_lifetimes is not None:
             return self.qubit_lifetimes[index]
-        return self.qubit_lifetime
+        t1_base, t2_base = self.qubit_lifetime
+        qid_jitter = ((index % 5) - 2) * 0.03
+        t1 = float(t1_base) * (1.0 + qid_jitter + random.uniform(-0.04, 0.04))
+        t2 = float(t2_base) * (0.88 - qid_jitter * 0.5 + random.uniform(-0.04, 0.04))
+        return (t1, t2)
+
+    def _coherence_time_values(self, time_values: Any, index: int) -> Any:
+        import numpy as np
+
+        qid_jitter = ((index % 7) - 3) * 0.01
+        scale = 1.0 + qid_jitter + random.uniform(-0.025, 0.025)
+        return np.asarray(time_values, dtype=float) * max(scale, 0.1)
 
     def _qx_system(self, *, include_decoherence: bool = True) -> Any:
         return build_qxsimulator_system(

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -23,7 +23,7 @@ from qdash.workflow.service.steps import (
     OneQubitFineTune,
     Step,
 )
-from qdash.workflow.service.targets import MuxTargets
+from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
 
 
 @flow(on_cancellation=[on_flow_cancellation])
@@ -45,7 +45,7 @@ def one_qubit(
         chip_id: Chip ID (from UI)
         mux_ids: MUX IDs to calibrate (default: all 16)
         exclude_qids: Qubit IDs to exclude
-        qids: Not used (for UI compatibility)
+        qids: Qubit IDs to calibrate when mux_ids is not set
         flow_name: Flow name (auto-injected)
         project_id: Project ID (auto-injected)
         check_only: If True, only run basic check (no fine-tune)
@@ -53,12 +53,16 @@ def one_qubit(
     Returns:
         Pipeline results with typed step outputs
     """
-    if mux_ids is None:
-        mux_ids = list(range(16))
     if exclude_qids is None:
         exclude_qids = []
 
-    targets = MuxTargets(mux_ids=mux_ids, exclude_qids=exclude_qids)
+    targets: Target
+    if mux_ids is not None:
+        targets = MuxTargets(mux_ids=mux_ids, exclude_qids=exclude_qids)
+    elif qids is not None:
+        targets = QubitTargets(qids=qids)
+    else:
+        targets = MuxTargets(mux_ids=list(range(16)), exclude_qids=exclude_qids)
 
     steps: list[Step]
     if check_only:

--- a/tests/qdash/workflow/engine/backend/test_fake_qubex_simulation.py
+++ b/tests/qdash/workflow/engine/backend/test_fake_qubex_simulation.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import numpy as np
+
+from qdash.workflow.engine.backend.fake_qubex.simulation import FakeExperiment
+
+
+def test_fake_ramsey_fit_exposes_qubex_compatible_fields() -> None:
+    exp = FakeExperiment()
+
+    result = exp.ramsey_experiment(
+        targets=["Q00"],
+        time_range=np.arange(0.0, 1000.0, 100.0),
+        detuning=0.001,
+        plot=False,
+    )
+
+    fit = result.data["Q00"].fit()
+
+    assert fit["f"] == 0.001
+    assert fit["f_err"] == 0.0
+    assert fit["tau_err"] == 0.0
+
+
+def test_fake_default_t1_and_t2_echo_lifetimes_have_small_variation() -> None:
+    exp = FakeExperiment()
+
+    t1_result = exp.t1_experiment(
+        targets=["Q00", "Q01"],
+        time_range=np.geomspace(100.0, 10_000.0, 5),
+        plot=False,
+    )
+    t2_result = exp.t2_experiment(
+        targets=["Q00", "Q01"],
+        time_range=np.geomspace(300.0, 10_000.0, 5),
+        plot=False,
+    )
+
+    assert t1_result.data["Q00"].t1 != t2_result.data["Q00"].t2
+    assert t1_result.data["Q00"].t1 != t1_result.data["Q01"].t1
+    assert t2_result.data["Q00"].t2 != t2_result.data["Q01"].t2
+
+
+def test_fake_default_coherence_lifetimes_and_time_scale_vary_between_runs(
+    monkeypatch,
+) -> None:
+    values = iter(
+        [
+            0.0,
+            0.0,
+            -0.020,
+            0.030,
+            0.0,
+            0.020,
+            0.0,
+            0.0,
+            -0.015,
+            0.0,
+            0.025,
+            0.015,
+        ]
+    )
+    monkeypatch.setattr(
+        "qdash.workflow.engine.backend.fake_qubex.simulation.random.uniform",
+        lambda *_: next(values),
+    )
+    exp = FakeExperiment()
+
+    first_t1 = exp.t1_experiment(
+        targets=["Q00"],
+        time_range=np.geomspace(100.0, 10_000.0, 5),
+        plot=False,
+    )
+    second_t1 = exp.t1_experiment(
+        targets=["Q00"],
+        time_range=np.geomspace(100.0, 10_000.0, 5),
+        plot=False,
+    )
+    first_t2 = exp.t2_experiment(
+        targets=["Q00"],
+        time_range=np.geomspace(300.0, 10_000.0, 5),
+        plot=False,
+    )
+    second_t2 = exp.t2_experiment(
+        targets=["Q00"],
+        time_range=np.geomspace(300.0, 10_000.0, 5),
+        plot=False,
+    )
+
+    assert first_t1.data["Q00"].t1 != second_t1.data["Q00"].t1
+    assert not np.array_equal(first_t1.data["Q00"].sweep_range, second_t1.data["Q00"].sweep_range)
+    assert first_t2.data["Q00"].t2 != second_t2.data["Q00"].t2
+    assert not np.array_equal(first_t2.data["Q00"].sweep_range, second_t2.data["Q00"].sweep_range)
+
+
+def test_fake_explicit_lifetimes_are_preserved() -> None:
+    exp = FakeExperiment(qubit_lifetimes=((11.0, 12.0), (21.0, 22.0)))
+
+    assert exp._qubit_lifetime(0) == (11.0, 12.0)
+    assert exp._qubit_lifetime(1) == (21.0, 22.0)

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from qdash.workflow.service.targets import MuxTargets, QubitTargets
+
+one_qubit_module = importlib.import_module("qdash.workflow.templates.one_qubit")
+
+
+class FakeCalibService:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self, targets: Any, *, steps: list[Any]) -> dict[str, Any]:
+        return {"targets": targets, "steps": steps}
+
+
+def test_one_qubit_template_uses_explicit_qids(monkeypatch) -> None:
+    monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
+
+    result = one_qubit_module.one_qubit(
+        username="alice",
+        chip_id="64Q",
+        qids=["0", "1"],
+    )
+
+    assert isinstance(result["targets"], QubitTargets)
+    assert result["targets"].qids == ["0", "1"]
+
+
+def test_one_qubit_template_prefers_mux_ids(monkeypatch) -> None:
+    monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
+
+    result = one_qubit_module.one_qubit(
+        username="alice",
+        chip_id="64Q",
+        mux_ids=[0],
+        qids=["8"],
+    )
+
+    assert isinstance(result["targets"], MuxTargets)
+    assert result["targets"].mux_ids == [0]
+
+
+def test_one_qubit_template_defaults_to_all_muxes(monkeypatch) -> None:
+    monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
+
+    result = one_qubit_module.one_qubit(username="alice", chip_id="64Q")
+
+    assert isinstance(result["targets"], MuxTargets)
+    assert result["targets"].mux_ids == list(range(16))

--- a/uv.lock
+++ b/uv.lock
@@ -3028,6 +3028,7 @@ dependencies = [
     { name = "pendulum" },
     { name = "pydantic" },
     { name = "pymongo" },
+    { name = "qdash-api" },
 ]
 
 [package.dev-dependencies]
@@ -3057,6 +3058,7 @@ requires-dist = [
     { name = "pendulum", specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.8.0" },
     { name = "pymongo", specifier = ">=4.8.0" },
+    { name = "qdash-api", virtual = "src/qdash/api" },
 ]
 
 [package.metadata.requires-dev]
@@ -3083,6 +3085,7 @@ name = "qdash-api"
 version = "0.1.0"
 source = { virtual = "src/qdash/api" }
 dependencies = [
+    { name = "bcrypt" },
     { name = "bunnet" },
     { name = "croniter" },
     { name = "fastapi" },
@@ -3114,6 +3117,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "bunnet", specifier = "==1.3.0" },
     { name = "croniter", specifier = ">=6.0.0" },
     { name = "fastapi" },


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Improves fake Qubex coherence tasks so Ramsey postprocessing is compatible with Qubex-style fit fields and T1/T2 echo results vary more realistically across runs.
- Updates root check dependencies so API imports are available during repository-wide tests.

## Changes
- Add Ramsey fit compatibility fields in fake Qubex results.
- Add run-to-run jitter for fake T1/T2 echo lifetimes and sweep time scales while preserving explicit fixed lifetimes.
- Support explicit qid targets in the one-qubit workflow template when mux targets are not provided.
- Make root checks depend on the qdash-api workspace package and declare bcrypt explicitly for API auth.
- Add regression tests for fake Qubex coherence behavior and one-qubit target selection.

Verification:
- task check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration workflows now support selecting qubits directly, with clearer fallback behavior when no IDs are provided.
  * Simulated coherence experiments now produce more realistic, varied results across qubits.

* **Bug Fixes**
  * Improved consistency in build and runtime setup for workflow and API packages.
  * Added support for password hashing in the API.

* **Tests**
  * Added coverage for qubit selection behavior and simulated experiment outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->