### PR TITLE
ci(repo): add Claude Code PR review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   pull-requests: write
   issues: write
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,42 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    name: Review PR
+    runs-on: ubuntu-latest
+    if: >
+      !github.event.pull_request.draft &&
+      github.event.pull_request.base.ref == 'develop' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request for QDash.
+
+            Focus on actionable issues that could cause bugs, regressions, unsafe behavior,
+            missing tests, or maintainability problems. Prioritize repository conventions from
+            AGENTS.md and the docs under docs/development/.
+
+            Scope:
+            - Review only the changes in this pull request.
+            - Leave comments only when there is a concrete issue or a clearly useful fix.
+            - Do not block on style preferences unless they violate project conventions.
+            - If there are no significant issues, summarize that briefly.


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Adds an automatic Claude Code review workflow for pull requests targeting develop.
- The workflow is limited to non-draft same-repository PRs and requires the ANTHROPIC_API_KEY repository secret.

## Changes
- Add .github/workflows/claude-code-review.yml using anthropics/claude-code-action@v1.
- Trigger reviews on opened, reopened, synchronized, and ready-for-review PR events for develop.
- Configure review guidance to focus on actionable bugs, regressions, missing tests, and QDash repository conventions.

Verification:
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/claude-code-review.yml"); puts "ok"'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated pull request review workflow for changes targeting the `develop` branch.
  * Reviews now run only on eligible, non-draft pull requests, with constrained repository permissions.
  * The workflow checks out the latest changes and posts targeted feedback on the pull request, focusing on actionable issues and clear, convention-aligned guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->