### PR TITLE
feat: add cancel confirmation dialog on execution list page

### DIFF
--- a/ui/src/components/features/execution/ExecutionPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionPageContent.tsx
@@ -2,7 +2,14 @@
 
 import { useState, useEffect, useMemo } from "react";
 
-import { ExternalLink, ArrowUpRight, StopCircle, UserRound } from "lucide-react";
+import {
+  ExternalLink,
+  ArrowUpRight,
+  StopCircle,
+  UserRound,
+  CheckCircle,
+  XCircle,
+} from "lucide-react";
 import Link from "next/link";
 
 import { formatDate, formatDateTime } from "@/lib/utils/datetime";
@@ -78,6 +85,7 @@ export function ExecutionPageContent() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [expandedTaskIndex, setExpandedTaskIndex] = useState<number | null>(null);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [showCancelConfirm, setShowCancelConfirm] = useState(false);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -187,6 +195,22 @@ export function ExecutionPageContent() {
     setIsSidebarOpen(false);
     setSelectedExecutionId(null);
     setExpandedTaskIndex(null);
+  };
+
+  const handleCancel = () => {
+    const flowRunId = executionDetailData?.data?.note?.flow_run_id as string | undefined;
+    if (!flowRunId) return;
+    cancelMutation.mutate(
+      { flowRunId },
+      {
+        onSuccess: () => {
+          setShowCancelConfirm(false);
+        },
+        onError: () => {
+          setShowCancelConfirm(false);
+        },
+      },
+    );
   };
 
   // Toggle task expansion on click
@@ -364,13 +388,7 @@ export function ExecutionPageContent() {
                   return (
                     isCancellable && (
                       <button
-                        onClick={() => {
-                          if (detailFlowRunId) {
-                            cancelMutation.mutate({
-                              flowRunId: detailFlowRunId,
-                            });
-                          }
-                        }}
+                        onClick={() => setShowCancelConfirm(true)}
                         disabled={cancelMutation.isPending}
                         className="btn btn-error btn-sm sm:btn-md"
                       >
@@ -493,6 +511,62 @@ export function ExecutionPageContent() {
           </>
         )}
       </div>
+      {/* Cancel Confirmation Modal */}
+      {showCancelConfirm && (
+        <div className="modal modal-open">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg">Cancel Execution</h3>
+            <p className="py-4">
+              Are you sure you want to cancel this execution? This action cannot be undone.
+            </p>
+            {cancelMutation.isError && (
+              <div className="alert alert-error mb-4">
+                <XCircle size={16} />
+                <span>
+                  {(
+                    cancelMutation.error as {
+                      response?: { data?: { detail?: string } };
+                    }
+                  )?.response?.data?.detail || "Failed to cancel execution"}
+                </span>
+              </div>
+            )}
+            <div className="modal-action">
+              <button
+                className="btn btn-ghost"
+                onClick={() => setShowCancelConfirm(false)}
+                disabled={cancelMutation.isPending}
+              >
+                Close
+              </button>
+              <button
+                className="btn btn-error"
+                onClick={handleCancel}
+                disabled={cancelMutation.isPending}
+              >
+                {cancelMutation.isPending ? (
+                  <span className="loading loading-spinner loading-sm" />
+                ) : (
+                  "Cancel Execution"
+                )}
+              </button>
+            </div>
+          </div>
+          <div
+            className="modal-backdrop"
+            onClick={() => !cancelMutation.isPending && setShowCancelConfirm(false)}
+          />
+        </div>
+      )}
+      {/* Cancel success alert */}
+      {cancelMutation.isSuccess && (
+        <div className="toast toast-end">
+          <div className="alert alert-success">
+            <CheckCircle size={16} />
+            <span>Cancellation requested successfully</span>
+          </div>
+        </div>
+      )}
     </PageContainer>
   );
 }

--- a/ui/src/components/features/execution/__tests__/ExecutionPageContent.test.tsx
+++ b/ui/src/components/features/execution/__tests__/ExecutionPageContent.test.tsx
@@ -1,0 +1,167 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ExecutionPageContent } from "@/components/features/execution/ExecutionPageContent";
+
+const mockCancelMutate = vi.fn();
+
+vi.mock("@/client/chip/chip", () => ({
+  useListChips: () => ({
+    data: {
+      data: {
+        chips: [{ chip_id: "chip-1", installed_at: "2026-06-01T00:00:00Z" }],
+      },
+    },
+  }),
+}));
+
+vi.mock("@/client/execution/execution", () => ({
+  useListExecutions: () => ({
+    data: {
+      data: {
+        executions: [
+          {
+            execution_id: "exec-1",
+            name: "Running Execution",
+            status: "running",
+            start_at: "2026-06-01T00:00:00Z",
+            elapsed_time: "1m",
+            username: "tester",
+          },
+        ],
+      },
+    },
+    isError: false,
+    isLoading: false,
+  }),
+  useGetExecution: () => ({
+    data: {
+      data: {
+        note: { flow_run_id: "flow-123" },
+        task: [],
+      },
+    },
+    isLoading: false,
+    isError: false,
+  }),
+  useCancelExecution: () => ({
+    mutate: mockCancelMutate,
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/hooks/useDateNavigation", () => ({
+  useDateNavigation: () => undefined,
+}));
+
+vi.mock("@/hooks/useUrlState", () => ({
+  useExecutionUrlState: () => ({
+    selectedChip: "chip-1",
+    setSelectedChip: vi.fn(),
+    isInitialized: true,
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/components/features/execution/ExecutionDurationBreakdown", () => ({
+  ExecutionDurationBreakdown: () => <div>DurationBreakdown</div>,
+}));
+
+vi.mock("@/components/charts/TaskFigure", () => ({
+  TaskFigure: () => <div>TaskFigure</div>,
+}));
+
+vi.mock("@/components/selectors/ChipSelector", () => ({
+  ChipSelector: () => <div>ChipSelector</div>,
+}));
+
+vi.mock("@/components/selectors/DateSelector", () => ({
+  DateSelector: () => <div>DateSelector</div>,
+}));
+
+vi.mock("@/components/ui/PageContainer", () => ({
+  PageContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/PageFiltersBar", () => ({
+  PageFiltersBar: Object.assign(
+    ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    {
+      Group: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+      Item: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    },
+  ),
+}));
+
+vi.mock("@/components/ui/PageHeader", () => ({
+  PageHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
+}));
+
+vi.mock("@/components/ui/Skeleton/PageSkeletons", () => ({
+  ExecutionPageSkeleton: () => <div>Skeleton</div>,
+}));
+
+function openSidebarAndClickCancel() {
+  // Open the sidebar for the running execution.
+  fireEvent.click(screen.getByText("Running Execution"));
+  // Click the list-page Cancel button inside the sidebar.
+  fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+}
+
+describe("ExecutionPageContent cancel confirmation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not cancel immediately but shows a confirmation dialog when Cancel is clicked", () => {
+    render(<ExecutionPageContent />);
+
+    openSidebarAndClickCancel();
+
+    // The project-specific confirmation dialog is shown.
+    expect(
+      screen.getByText(
+        "Are you sure you want to cancel this execution? This action cannot be undone.",
+      ),
+    ).toBeTruthy();
+    // The cancellation is NOT triggered until the user confirms.
+    expect(mockCancelMutate).not.toHaveBeenCalled();
+  });
+
+  it("cancels the execution with its flow_run_id after confirming in the dialog", () => {
+    render(<ExecutionPageContent />);
+
+    openSidebarAndClickCancel();
+    // Confirm inside the modal.
+    fireEvent.click(screen.getByRole("button", { name: "Cancel Execution" }));
+
+    expect(mockCancelMutate).toHaveBeenCalledTimes(1);
+    expect(mockCancelMutate.mock.calls[0][0]).toEqual({ flowRunId: "flow-123" });
+  });
+
+  it("closes the dialog without cancelling when Close is clicked", () => {
+    render(<ExecutionPageContent />);
+
+    openSidebarAndClickCancel();
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(
+      screen.queryByText(
+        "Are you sure you want to cancel this execution? This action cannot be undone.",
+      ),
+    ).toBeNull();
+    expect(mockCancelMutate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Ticket
- #782

## Summary
The Cancel button on the execution list page cancelled the running execution immediately, with no confirmation. This adds a confirmation dialog — mirroring the one already implemented on the execution **detail** page — so users must explicitly confirm before an execution is cancelled.

## Changes
- Add a `showCancelConfirm` state and a DaisyUI `modal modal-open` confirmation dialog to the execution list sidebar (same wording/styling as the detail page in `ExecutionClient.tsx`).
- The sidebar **Cancel** button now opens the dialog instead of cancelling immediately; the cancel request runs only after the user confirms.
- Add a success toast and in-dialog error alert, consistent with the detail page.
- Add a component test: no immediate cancel on click, cancel fires with `flow_run_id` only after confirming, and the dialog dismisses via **Close** without cancelling.

## Behavior

| Before | After |
| --- | --- |
| Clicking **Cancel** cancels immediately (no confirmation) | Clicking **Cancel** shows a confirmation dialog first |
| <img width="1303" height="690" alt="スクリーンショット 2026-07-02 20 09 01" src="https://github.com/user-attachments/assets/64a8c218-5672-42fa-89fa-733a7b5be6e6" /> | <img width="1482" height="844" alt="スクリーンショット 2026-07-02 20 10 09" src="https://github.com/user-attachments/assets/c322424e-6a97-4cde-bbc5-904a7181db29" /> |

## Verification
- Verified in the browser locally (before: cancel request fired immediately on click / after: confirmation dialog shown, no request until confirmed).
- `oxlint`, `oxfmt --check`, `tsc --noEmit`, and `vitest` all pass.
