### PR TITLE
fix(api): scope topology metrics by chip user

### DIFF
--- a/src/qdash/api/services/device_topology_service.py
+++ b/src/qdash/api/services/device_topology_service.py
@@ -138,8 +138,12 @@ class DeviceTopologyService:
         if chip_model is None:
             raise ValueError(f"No chip found for user {latest.username}")
 
-        qubit_models = self._chip_repo.get_all_qubit_models(project_id, chip_model.chip_id)
-        coupling_models = self._chip_repo.get_all_coupling_models(project_id, chip_model.chip_id)
+        qubit_models = self._chip_repo.get_all_qubit_models(
+            project_id, chip_model.chip_id, username=chip_model.username
+        )
+        coupling_models = self._chip_repo.get_all_coupling_models(
+            project_id, chip_model.chip_id, username=chip_model.username
+        )
 
         topology = load_topology(chip_model.topology_id)
         sorted_physical_ids = sorted(request.qubits, key=int)

--- a/src/qdash/repository/chip.py
+++ b/src/qdash/repository/chip.py
@@ -750,7 +750,9 @@ class MongoChipRepository:
 
     # Entity model methods for metrics extraction
 
-    def get_all_qubit_models(self, project_id: str, chip_id: str) -> dict[str, QubitDocument]:
+    def get_all_qubit_models(
+        self, project_id: str, chip_id: str, username: str | None = None
+    ) -> dict[str, QubitDocument]:
         """Get all qubit documents as a dict keyed by qubit ID.
 
         Returns documents that can be used directly with _extract_latest_metrics
@@ -769,10 +771,15 @@ class MongoChipRepository:
             Map of qubit ID to QubitDocument
 
         """
-        docs = list(QubitDocument.find({"project_id": project_id, "chip_id": chip_id}).run())
+        query = {"project_id": project_id, "chip_id": chip_id}
+        if username is not None:
+            query["username"] = username
+        docs = list(QubitDocument.find(query).run())
         return {doc.qid: doc for doc in docs}
 
-    def get_all_coupling_models(self, project_id: str, chip_id: str) -> dict[str, CouplingDocument]:
+    def get_all_coupling_models(
+        self, project_id: str, chip_id: str, username: str | None = None
+    ) -> dict[str, CouplingDocument]:
         """Get all coupling documents as a dict keyed by coupling ID.
 
         Returns documents that can be used directly with _extract_latest_metrics
@@ -791,7 +798,10 @@ class MongoChipRepository:
             Map of coupling ID to CouplingDocument
 
         """
-        docs = list(CouplingDocument.find({"project_id": project_id, "chip_id": chip_id}).run())
+        query = {"project_id": project_id, "chip_id": chip_id}
+        if username is not None:
+            query["username"] = username
+        docs = list(CouplingDocument.find(query).run())
         return {doc.qid: doc for doc in docs}
 
     def get_qubit_count(self, project_id: str, chip_id: str) -> int:

--- a/src/qdash/repository/protocols.py
+++ b/src/qdash/repository/protocols.py
@@ -427,11 +427,15 @@ class ChipRepository(Protocol):
         """Get multiple couplings by their IDs."""
         ...
 
-    def get_all_qubit_models(self, project_id: str, chip_id: str) -> dict[str, Any]:
+    def get_all_qubit_models(
+        self, project_id: str, chip_id: str, username: str | None = None
+    ) -> dict[str, Any]:
         """Get all qubit documents as a dict keyed by qubit ID."""
         ...
 
-    def get_all_coupling_models(self, project_id: str, chip_id: str) -> dict[str, Any]:
+    def get_all_coupling_models(
+        self, project_id: str, chip_id: str, username: str | None = None
+    ) -> dict[str, Any]:
         """Get all coupling documents as a dict keyed by coupling ID."""
         ...
 

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -26,6 +26,7 @@ class CheckRabi(QubexTask):
 
     name: str = "CheckRabi"
     task_type: str = "qubit"
+    r2_threshold: float = 0.6
     input_parameters: ClassVar[dict[str, ParameterModel | None]] = {
         "qubit_frequency": None,
         "control_amplitude": None,

--- a/tests/qdash/repository/test_chip_repository.py
+++ b/tests/qdash/repository/test_chip_repository.py
@@ -1,0 +1,58 @@
+"""Tests for chip repository entity model loaders."""
+
+from qdash.datamodel.system_info import SystemInfoModel
+from qdash.dbmodel.coupling import CouplingDocument
+from qdash.dbmodel.qubit import QubitDocument
+from qdash.repository.chip import MongoChipRepository
+
+
+def test_get_all_qubit_models_filters_by_username(init_db) -> None:
+    """Optional username filter prevents duplicate qids from other users overwriting data."""
+    QubitDocument(
+        project_id="project-1",
+        username="admin",
+        qid="20",
+        chip_id="64Qv3",
+        data={"readout_fidelity_0": {"value": 0.95}},
+        system_info=SystemInfoModel(),
+    ).insert()
+    QubitDocument(
+        project_id="project-1",
+        username="other",
+        qid="20",
+        chip_id="64Qv3",
+        data={"seed_only": {"value": 1.0}},
+        system_info=SystemInfoModel(),
+    ).insert()
+
+    result = MongoChipRepository().get_all_qubit_models("project-1", "64Qv3", username="admin")
+
+    assert set(result) == {"20"}
+    assert result["20"].username == "admin"
+    assert "readout_fidelity_0" in result["20"].data
+
+
+def test_get_all_coupling_models_filters_by_username(init_db) -> None:
+    """Optional username filter prevents duplicate coupling ids from other users overwriting data."""
+    CouplingDocument(
+        project_id="project-1",
+        username="admin",
+        qid="20-21",
+        chip_id="64Qv3",
+        data={"zx90_gate_fidelity": {"value": 0.91}},
+        system_info=SystemInfoModel(),
+    ).insert()
+    CouplingDocument(
+        project_id="project-1",
+        username="other",
+        qid="20-21",
+        chip_id="64Qv3",
+        data={"seed_only": {"value": 1.0}},
+        system_info=SystemInfoModel(),
+    ).insert()
+
+    result = MongoChipRepository().get_all_coupling_models("project-1", "64Qv3", username="admin")
+
+    assert set(result) == {"20-21"}
+    assert result["20-21"].username == "admin"
+    assert "zx90_gate_fidelity" in result["20-21"].data

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
@@ -1,0 +1,14 @@
+import pytest
+
+from qdash.workflow.calibtasks.qubex.one_qubit_coarse.check_rabi import CheckRabi
+from qdash.workflow.engine.task.result_processor import R2ValidationError, TaskResultProcessor
+
+
+def test_check_rabi_uses_r2_threshold_0_6() -> None:
+    task = CheckRabi()
+    processor = TaskResultProcessor()
+
+    assert task.r2_threshold == 0.6
+    assert processor.validate_r2({"0": 0.61}, "0", task.r2_threshold) is True
+    with pytest.raises(R2ValidationError):
+        processor.validate_r2({"0": 0.59}, "0", task.r2_threshold)


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Prevent device topology metric loading from mixing qubit and coupling documents that share the same project and chip ID across different users.
- Also sets the CheckRabi R2 validation threshold to 0.6 and covers both changes with focused tests. Affected areas: API topology service and workflow task validation.

## Changes
- Add optional username filtering to chip repository model loaders for qubits and couplings.
- Pass the current chip owner when building device topology metrics.
- Set CheckRabi-specific R2 threshold to 0.6.
- Add repository and workflow tests for the new behavior.
- No OpenAPI/schema or generated client changes involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved device topology loading to use the current user’s data when available, helping ensure the right qubit and coupling information is shown.
  * Added a default R2 threshold for Rabi checks to make validation more consistent.

* **Bug Fixes**
  * Fixed model lookups so records are filtered correctly by user as well as project and chip.
  * Added coverage to confirm the correct user-specific data is returned and R2 validation behaves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->