### PR TITLE
fix(workflow): fail invalid calibration outputs after artifacts

### DIFF
--- a/src/qdash/workflow/calibtasks/qubex/measurement/readout_classification.py
+++ b/src/qdash/workflow/calibtasks/qubex/measurement/readout_classification.py
@@ -12,6 +12,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import finite_value_error, first_validation_error
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
@@ -137,7 +138,31 @@ class ReadoutClassification(QubexTask):
         output_parameters = self.attach_execution_id(execution_id)
 
         figures: list[go.Figure] = [self.plot_section_from_result(backend, result, qid)]
-        return PostProcessResult(output_parameters=output_parameters, figures=figures)
+        validation_error = first_validation_error(
+            finite_value_error(
+                self.output_parameters["average_readout_fidelity"].value,
+                f"ReadoutClassification average_readout_fidelity for {label}",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            finite_value_error(
+                self.output_parameters["readout_fidelity_0"].value,
+                f"ReadoutClassification readout_fidelity_0 for {label}",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            finite_value_error(
+                self.output_parameters["readout_fidelity_1"].value,
+                f"ReadoutClassification readout_fidelity_1 for {label}",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+        )
+        return PostProcessResult(
+            output_parameters=output_parameters,
+            figures=figures,
+            validation_error=validation_error,
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_qubit.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_qubit.py
@@ -8,6 +8,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import finite_value_error, first_validation_error
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
@@ -60,11 +61,22 @@ class CheckQubit(QubexTask):
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result.data[label].fit()["fig"]]
         raw_data = [result.data[label].data]
-        r2 = result.rabi_params[label].r2
-        if self.r2_is_lower_than_threshold(r2):
-            raise ValueError(f"R^2 value of Rabi oscillation is too low: {r2}")
+        validation_error = first_validation_error(
+            finite_value_error(
+                self.output_parameters["rabi_amplitude"].value,
+                f"CheckQubit rabi_amplitude for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["rabi_frequency"].value,
+                f"CheckQubit rabi_frequency for {label}",
+                minimum=0.0,
+            ),
+        )
         return PostProcessResult(
-            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+            output_parameters=output_parameters,
+            figures=figures,
+            raw_data=raw_data,
+            validation_error=validation_error,
         )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -90,7 +90,9 @@ def _rabi_validation_error(result: Any, label: str) -> str | None:
         return f"CheckRabi produced non-positive frequency for {label}: {frequency}"
 
     for field_name in ("amplitude", "phase", "offset", "angle", "noise", "distance"):
-        error = _finite_rabi_validation_error(getattr(rabi_param, field_name, None), field_name, label)
+        error = _finite_rabi_validation_error(
+            getattr(rabi_param, field_name, None), field_name, label
+        )
         if error is not None:
             return error
     return None

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -86,6 +86,7 @@ def _rabi_validation_error(result: Any, label: str) -> str | None:
     error = _finite_rabi_validation_error(frequency, "frequency", label)
     if error is not None:
         return error
+    assert frequency is not None
     if float(frequency) <= 0:
         return f"CheckRabi produced non-positive frequency for {label}: {frequency}"
 

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -1,5 +1,6 @@
+import logging
 import math
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import plotly.graph_objects as go
 from qubex.analysis import IQPlotter
@@ -19,6 +20,80 @@ DEFAULT_READOUT_AMPLITUDE = 0.2
 DEFAULT_CONTROL_AMPLITUDE = 0.0125
 CONTROL_AMPLITUDE_MIN = 1e-4
 CONTROL_AMPLITUDE_MAX = 1.0
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_rabi_r2_candidates(result: Any, label: str) -> dict[str, float | None]:
+    """Extract Rabi R² candidates from data/fit and rabi_params."""
+    candidates: dict[str, float | None] = {
+        "data_r2": None,
+        "fit_r2": None,
+        "rabi_params_r2": None,
+    }
+
+    data_by_label = getattr(result, "data", None) or {}
+    data = data_by_label.get(label) if hasattr(data_by_label, "get") else None
+    if data is not None:
+        data_r2 = getattr(data, "r2", None)
+        if data_r2 is not None:
+            candidates["data_r2"] = float(data_r2)
+        fit = getattr(data, "fit", None)
+        if callable(fit):
+            fit_result = fit()
+            if isinstance(fit_result, dict):
+                fit_r2 = fit_result.get("r2")
+                if fit_r2 is not None:
+                    candidates["fit_r2"] = float(fit_r2)
+
+    rabi_params = getattr(result, "rabi_params", None) or {}
+    rabi_param = rabi_params.get(label) if hasattr(rabi_params, "get") else None
+    rabi_params_r2 = getattr(rabi_param, "r2", None)
+    if rabi_params_r2 is not None:
+        candidates["rabi_params_r2"] = float(rabi_params_r2)
+
+    return candidates
+
+
+def _extract_rabi_r2(result: Any, label: str) -> float | None:
+    """Extract the Rabi fit R² used in the saved fit figure."""
+    candidates = _extract_rabi_r2_candidates(result, label)
+    return (
+        candidates["data_r2"]
+        if candidates["data_r2"] is not None
+        else candidates["fit_r2"]
+        if candidates["fit_r2"] is not None
+        else candidates["rabi_params_r2"]
+    )
+
+
+def _finite_rabi_validation_error(value: Any, field_name: str, label: str) -> str | None:
+    if value is None:
+        return f"CheckRabi produced no {field_name} for {label}"
+    numeric_value = float(value)
+    if not math.isfinite(numeric_value):
+        return f"CheckRabi produced non-finite {field_name} for {label}: {value}"
+    return None
+
+
+def _rabi_validation_error(result: Any, label: str) -> str | None:
+    rabi_params = getattr(result, "rabi_params", None) or {}
+    rabi_param = rabi_params.get(label) if hasattr(rabi_params, "get") else None
+    if rabi_param is None:
+        return f"CheckRabi produced no rabi_params for {label}"
+
+    frequency = getattr(rabi_param, "frequency", None)
+    error = _finite_rabi_validation_error(frequency, "frequency", label)
+    if error is not None:
+        return error
+    if float(frequency) <= 0:
+        return f"CheckRabi produced non-positive frequency for {label}: {frequency}"
+
+    for field_name in ("amplitude", "phase", "offset", "angle", "noise", "distance"):
+        error = _finite_rabi_validation_error(getattr(rabi_param, field_name, None), field_name, label)
+        if error is not None:
+            return error
+    return None
 
 
 class CheckRabi(QubexTask):
@@ -142,7 +217,10 @@ class CheckRabi(QubexTask):
         figures.append(go.Figure(iq_plotter._widget.to_dict()))
         raw_data = [result.data[label].data]
         return PostProcessResult(
-            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+            output_parameters=output_parameters,
+            figures=figures,
+            raw_data=raw_data,
+            validation_error=_rabi_validation_error(result, label),
         )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
@@ -178,5 +256,17 @@ class CheckRabi(QubexTask):
         )
 
         self.save_calibration(backend)
-        r2 = result.rabi_params[label].r2 if result.rabi_params else None
+        r2_candidates = _extract_rabi_r2_candidates(result, label)
+        r2 = _extract_rabi_r2(result, label)
+        logger.warning(
+            "CheckRabi R² candidates for qid=%s label=%s threshold=%.4f "
+            "selected=%s data_r2=%s fit_r2=%s rabi_params_r2=%s",
+            qid,
+            label,
+            self.r2_threshold,
+            r2,
+            r2_candidates["data_r2"],
+            r2_candidates["fit_r2"],
+            r2_candidates["rabi_params_r2"],
+        )
         return RunResult(raw_result=result, r2={qid: r2})

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
@@ -9,6 +9,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import finite_value_error
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
@@ -57,7 +58,17 @@ class CreateHPIPulse(QubexTask):
         self.output_parameters["hpi_amplitude"].value = result.data[label].calib_value
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result.data[label].fit()["fig"]]
-        return PostProcessResult(output_parameters=output_parameters, figures=figures)
+        validation_error = finite_value_error(
+            self.output_parameters["hpi_amplitude"].value,
+            f"CreateHPIPulse hpi_amplitude for {label}",
+            minimum=0.0,
+            maximum=1.0,
+        )
+        return PostProcessResult(
+            output_parameters=output_parameters,
+            figures=figures,
+            validation_error=validation_error,
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
@@ -9,6 +9,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import finite_value_error
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
@@ -57,7 +58,17 @@ class CreatePIPulse(QubexTask):
         self.output_parameters["pi_amplitude"].value = result.data[label].calib_value
         output_parameters = self.attach_execution_id(execution_id)
         figures = [result.data[label].fit()["fig"]]
-        return PostProcessResult(output_parameters=output_parameters, figures=figures)
+        validation_error = finite_value_error(
+            self.output_parameters["pi_amplitude"].value,
+            f"CreatePIPulse pi_amplitude for {label}",
+            minimum=0.0,
+            maximum=1.0,
+        )
+        return PostProcessResult(
+            output_parameters=output_parameters,
+            figures=figures,
+            validation_error=validation_error,
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
@@ -11,6 +11,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import finite_value_error, first_validation_error
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
@@ -66,7 +67,23 @@ class CreateDRAGHPIPulse(QubexTask):
         self.output_parameters["drag_hpi_amplitude"].value = result["amplitude"][label]["amplitude"]
         output_parameters = self.attach_execution_id(execution_id)
         figures: list[go.Figure] = [result["amplitude"][label]["fig"]]
-        return PostProcessResult(output_parameters=output_parameters, figures=figures)
+        validation_error = first_validation_error(
+            finite_value_error(
+                self.output_parameters["drag_hpi_beta"].value,
+                f"CreateDRAGHPIPulse drag_hpi_beta for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["drag_hpi_amplitude"].value,
+                f"CreateDRAGHPIPulse drag_hpi_amplitude for {label}",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+        )
+        return PostProcessResult(
+            output_parameters=output_parameters,
+            figures=figures,
+            validation_error=validation_error,
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
@@ -11,6 +11,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import finite_value_error, first_validation_error
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
@@ -66,7 +67,23 @@ class CreateDRAGPIPulse(QubexTask):
         self.output_parameters["drag_pi_amplitude"].value = result["amplitude"][label]["amplitude"]
         output_parameters = self.attach_execution_id(execution_id)
         figures: list[go.Figure] = [result["amplitude"][label]["fig"]]
-        return PostProcessResult(output_parameters=output_parameters, figures=figures)
+        validation_error = first_validation_error(
+            finite_value_error(
+                self.output_parameters["drag_pi_beta"].value,
+                f"CreateDRAGPIPulse drag_pi_beta for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["drag_pi_amplitude"].value,
+                f"CreateDRAGPIPulse drag_pi_amplitude for {label}",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+        )
+        return PostProcessResult(
+            output_parameters=output_parameters,
+            figures=figures,
+            validation_error=validation_error,
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
@@ -11,6 +11,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import finite_value_error, first_validation_error
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
@@ -141,8 +142,41 @@ class CheckCrossResonance(QubexTask):
             figures.append(figs["fig_c"])
             figures.append(figs["fig_t"])
         raw_data: list[Any] = []
+        validation_error = first_validation_error(
+            finite_value_error(
+                self.output_parameters["cr_amplitude"].value,
+                f"CheckCrossResonance cr_amplitude for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["cr_phase"].value,
+                f"CheckCrossResonance cr_phase for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["cancel_amplitude"].value,
+                f"CheckCrossResonance cancel_amplitude for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["cancel_phase"].value,
+                f"CheckCrossResonance cancel_phase for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["cancel_beta"].value,
+                f"CheckCrossResonance cancel_beta for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["rotary_amplitude"].value,
+                f"CheckCrossResonance rotary_amplitude for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["zx_rotation_rate"].value,
+                f"CheckCrossResonance zx_rotation_rate for {label}",
+            ),
+        )
         return PostProcessResult(
-            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+            output_parameters=output_parameters,
+            figures=figures,
+            raw_data=raw_data,
+            validation_error=validation_error,
         )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
@@ -9,6 +9,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import finite_value_error, first_validation_error
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
@@ -133,8 +134,42 @@ class CreateZX90(QubexTask):
         output_parameters = self.attach_execution_id(execution_id)
         figures: list[Any] = [result["n1"], result["n3"], result["fig"]]
         raw_data: list[Any] = []
+        validation_error = first_validation_error(
+            finite_value_error(
+                self.output_parameters["cr_amplitude"].value, f"CreateZX90 cr_amplitude for {qid}"
+            ),
+            finite_value_error(
+                self.output_parameters["cr_phase"].value, f"CreateZX90 cr_phase for {qid}"
+            ),
+            finite_value_error(
+                self.output_parameters["cancel_amplitude"].value,
+                f"CreateZX90 cancel_amplitude for {qid}",
+            ),
+            finite_value_error(
+                self.output_parameters["cancel_phase"].value, f"CreateZX90 cancel_phase for {qid}"
+            ),
+            finite_value_error(
+                self.output_parameters["cancel_beta"].value, f"CreateZX90 cancel_beta for {qid}"
+            ),
+            finite_value_error(
+                self.output_parameters["rotary_amplitude"].value,
+                f"CreateZX90 rotary_amplitude for {qid}",
+            ),
+            finite_value_error(
+                self.output_parameters["zx_rotation_rate"].value,
+                f"CreateZX90 zx_rotation_rate for {qid}",
+            ),
+            finite_value_error(
+                self.output_parameters["zx90_gate_time"].value,
+                f"CreateZX90 zx90_gate_time for {qid}",
+                minimum=0.0,
+            ),
+        )
         return PostProcessResult(
-            output_parameters=output_parameters, figures=figures, raw_data=raw_data
+            output_parameters=output_parameters,
+            figures=figures,
+            raw_data=raw_data,
+            validation_error=validation_error,
         )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:

--- a/src/qdash/workflow/calibtasks/qubex/validation.py
+++ b/src/qdash/workflow/calibtasks/qubex/validation.py
@@ -1,0 +1,28 @@
+"""Validation helpers for qubex calibration task outputs."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def finite_value_error(
+    value: Any, name: str, *, minimum: float | None = None, maximum: float | None = None
+) -> str | None:
+    if value is None:
+        return f"{name} is missing"
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return f"{name} is not numeric: {value}"
+    if not math.isfinite(numeric_value):
+        return f"{name} is non-finite: {value}"
+    if minimum is not None and numeric_value < minimum:
+        return f"{name} is below minimum {minimum}: {value}"
+    if maximum is not None and numeric_value > maximum:
+        return f"{name} is above maximum {maximum}: {value}"
+    return None
+
+
+def first_validation_error(*errors: str | None) -> str | None:
+    return next((error for error in errors if error is not None), None)

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -356,13 +356,33 @@ class TaskExecutor:
                 backend_success = True
                 r2_error_msg: str | None = None
                 if run_result.has_r2() and run_result.r2 is not None:
+                    logger.warning(
+                        "Validating R² for task=%s qid=%s threshold=%s r2=%s",
+                        task_name,
+                        qid,
+                        task.r2_threshold,
+                        run_result.r2,
+                    )
                     r2_value = run_result.r2.get(qid)
                     if r2_value is None:
+                        logger.warning(
+                            "R² validation skipped because value is missing: task=%s qid=%s r2=%s",
+                            task_name,
+                            qid,
+                            run_result.r2,
+                        )
                         backend_success = False
                     else:
                         try:
                             self.result_processor.validate_r2(run_result.r2, qid, task.r2_threshold)
                         except R2ValidationError:
+                            logger.warning(
+                                "R² validation failed for task=%s qid=%s value=%.4f threshold=%s",
+                                task_name,
+                                qid,
+                                r2_value,
+                                task.r2_threshold,
+                            )
                             if postprocess_result.output_parameters:
                                 self.state_manager.clear_output_parameters(
                                     task_name, task_type, qid
@@ -538,8 +558,21 @@ class TaskExecutor:
                     backend_success = True
                     r2_error_msg: str | None = None
                     if run_result.has_r2() and run_result.r2 is not None:
+                        logger.warning(
+                            "Validating R² for task=%s qid=%s threshold=%s r2=%s",
+                            task_name,
+                            qid,
+                            task.r2_threshold,
+                            run_result.r2,
+                        )
                         r2_value = run_result.r2.get(qid)
                         if r2_value is None:
+                            logger.warning(
+                                "R² validation skipped because value is missing: task=%s qid=%s r2=%s",
+                                task_name,
+                                qid,
+                                run_result.r2,
+                            )
                             backend_success = False
                         else:
                             try:
@@ -547,6 +580,13 @@ class TaskExecutor:
                                     run_result.r2, qid, task.r2_threshold
                                 )
                             except R2ValidationError:
+                                logger.warning(
+                                    "R² validation failed for task=%s qid=%s value=%.4f threshold=%s",
+                                    task_name,
+                                    qid,
+                                    r2_value,
+                                    task.r2_threshold,
+                                )
                                 if postprocess_result.output_parameters:
                                     self.state_manager.clear_output_parameters(
                                         task_name, task_type, qid

--- a/src/qdash/workflow/service/steps/one_qubit.py
+++ b/src/qdash/workflow/service/steps/one_qubit.py
@@ -23,6 +23,68 @@ if TYPE_CHECKING:
     from qdash.workflow.service.targets import Target
 
 
+def _execute_direct_one_qubit(
+    service: CalibService,
+    *,
+    qids: list[str],
+    tasks: list[str],
+    stage_name: str,
+) -> dict[str, Any]:
+    """Run explicit qubit targets under a visible parent Execution."""
+    from qdash.workflow.service._internal.scheduling_tasks import (
+        run_qubit_calibrations_parallel,
+    )
+    from qdash.workflow.service.calib_service import finish_calibration, init_calibration
+    from qdash.workflow.service.github import ConfigFileType, GitHubPushConfig
+
+    if not qids:
+        return {"direct": {}}
+
+    stage_flow_name = f"{service.flow_name}_{stage_name}" if service.flow_name else stage_name
+    session = init_calibration(
+        service.username,
+        service.chip_id,
+        qids,
+        flow_name=stage_flow_name,
+        backend_name=service.backend_name,
+        tags=service.tags or ([service.flow_name] if service.flow_name else None),
+        project_id=service.project_id,
+        use_lock=False,
+        enable_github_pull=True,
+        github_push_config=GitHubPushConfig(
+            enabled=True,
+            file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
+        ),
+        note={
+            "type": "1-qubit-direct",
+            "stage": stage_name,
+            "total_qubits": len(qids),
+        },
+    )
+
+    session_config = {
+        "username": service.username,
+        "chip_id": service.chip_id,
+        "backend_name": service.backend_name,
+        "execution_id": session.execution_id,
+        "project_id": service.project_id,
+        "default_run_parameters": service.default_run_parameters,
+        "tags": service.tags,
+        "flow_name": service.flow_name,
+        "note": service.note,
+    }
+
+    results = run_qubit_calibrations_parallel(
+        qids=qids,
+        tasks=tasks,
+        session_config=session_config,
+    )
+    wrapped_results = {"direct": results}
+    session.record_stage_result(stage_name, wrapped_results)
+    finish_calibration()
+    return wrapped_results
+
+
 @dataclass
 class CustomOneQubit(CalibrationStep):
     """Custom 1-qubit calibration step with user-defined tasks.
@@ -106,29 +168,12 @@ class CustomOneQubit(CalibrationStep):
         qids: list[str],
     ) -> dict[str, Any]:
         """Direct execution for QubitTargets using multiprocess parallelism."""
-        from qdash.workflow.service._internal.scheduling_tasks import (
-            run_qubit_calibrations_parallel,
-        )
-
-        # Build session config for multiprocess execution
-        session_config = {
-            "username": service.username,
-            "chip_id": service.chip_id,
-            "backend_name": service.backend_name,
-            "execution_id": service.execution_id,
-            "project_id": service.project_id,
-            "default_run_parameters": service.default_run_parameters,
-            "tags": service.tags,
-            "flow_name": service.flow_name,
-            "note": service.note,
-        }
-
-        results = run_qubit_calibrations_parallel(
+        return _execute_direct_one_qubit(
+            service,
             qids=qids,
             tasks=self.tasks,
-            session_config=session_config,
+            stage_name=self.step_name,
         )
-        return {"direct": results}
 
     def _build_result(self, raw_results: dict[str, Any]) -> OneQubitResult:
         """Build typed result from raw backend data."""
@@ -230,29 +275,12 @@ class OneQubitCheck(CalibrationStep):
         tasks: list[str],
     ) -> dict[str, Any]:
         """Direct execution for QubitTargets using multiprocess parallelism."""
-        from qdash.workflow.service._internal.scheduling_tasks import (
-            run_qubit_calibrations_parallel,
-        )
-
-        # Build session config for multiprocess execution
-        session_config = {
-            "username": service.username,
-            "chip_id": service.chip_id,
-            "backend_name": service.backend_name,
-            "execution_id": service.execution_id,
-            "project_id": service.project_id,
-            "default_run_parameters": service.default_run_parameters,
-            "tags": service.tags,
-            "flow_name": service.flow_name,
-            "note": service.note,
-        }
-
-        results = run_qubit_calibrations_parallel(
+        return _execute_direct_one_qubit(
+            service,
             qids=qids,
             tasks=tasks,
-            session_config=session_config,
+            stage_name=self.name,
         )
-        return {"direct": results}
 
     def _build_result(self, raw_results: dict[str, Any]) -> OneQubitResult:
         """Build typed result from raw backend data."""
@@ -386,29 +414,12 @@ class OneQubitFineTune(CalibrationStep):
         tasks: list[str],
     ) -> dict[str, Any]:
         """Direct execution for QubitTargets using multiprocess parallelism."""
-        from qdash.workflow.service._internal.scheduling_tasks import (
-            run_qubit_calibrations_parallel,
-        )
-
-        # Build session config for multiprocess execution
-        session_config = {
-            "username": service.username,
-            "chip_id": service.chip_id,
-            "backend_name": service.backend_name,
-            "execution_id": service.execution_id,
-            "project_id": service.project_id,
-            "default_run_parameters": service.default_run_parameters,
-            "tags": service.tags,
-            "flow_name": service.flow_name,
-            "note": service.note,
-        }
-
-        results = run_qubit_calibrations_parallel(
+        return _execute_direct_one_qubit(
+            service,
             qids=qids,
             tasks=tasks,
-            session_config=session_config,
+            stage_name=self.name,
         )
-        return {"direct": results}
 
     def _build_result(self, raw_results: dict[str, Any]) -> OneQubitResult:
         """Build typed result from raw backend data."""

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
@@ -1,5 +1,6 @@
 import math
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 import plotly.graph_objects as go
 import pytest
@@ -9,6 +10,9 @@ from qdash.datamodel.task import ParameterModel
 from qdash.workflow.calibtasks.base import RunResult
 from qdash.workflow.calibtasks.qubex.one_qubit_coarse.check_rabi import CheckRabi
 from qdash.workflow.engine.task.result_processor import R2ValidationError, TaskResultProcessor
+
+if TYPE_CHECKING:
+    from qdash.workflow.engine.backend.qubex import QubexBackend
 
 
 def test_check_rabi_uses_r2_threshold_0_6() -> None:
@@ -41,7 +45,7 @@ def test_check_rabi_run_uses_data_fit_r2_for_validation(monkeypatch: pytest.Monk
     )
     backend = SimpleNamespace(get_instance=lambda: exp)
 
-    run_result = task.run(backend, "1")
+    run_result = task.run(cast("QubexBackend", backend), "1")
 
     assert run_result.r2 == {"1": 0.127}
 
@@ -96,7 +100,7 @@ def test_check_rabi_postprocess_marks_non_finite_frequency_failed_after_artifact
     )
 
     result = task.postprocess(
-        SimpleNamespace(),
+        cast("QubexBackend", SimpleNamespace()),
         "exec-1",
         RunResult(raw_result=raw_result, r2={"1": 0.95}),
         "1",

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
@@ -1,5 +1,12 @@
+import math
+from types import SimpleNamespace
+
+import plotly.graph_objects as go
 import pytest
 
+import qdash.workflow.calibtasks.qubex.one_qubit_coarse.check_rabi as check_rabi_module
+from qdash.datamodel.task import ParameterModel
+from qdash.workflow.calibtasks.base import RunResult
 from qdash.workflow.calibtasks.qubex.one_qubit_coarse.check_rabi import CheckRabi
 from qdash.workflow.engine.task.result_processor import R2ValidationError, TaskResultProcessor
 
@@ -12,3 +19,89 @@ def test_check_rabi_uses_r2_threshold_0_6() -> None:
     assert processor.validate_r2({"0": 0.61}, "0", task.r2_threshold) is True
     with pytest.raises(R2ValidationError):
         processor.validate_r2({"0": 0.59}, "0", task.r2_threshold)
+
+
+def test_check_rabi_run_uses_data_fit_r2_for_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    task = CheckRabi()
+    task.input_parameters["qubit_frequency"] = ParameterModel(value=5.0, unit="GHz")
+    task.input_parameters["control_amplitude"] = ParameterModel(value=0.01, unit="a.u.")
+    monkeypatch.setattr(task, "save_calibration", lambda _backend: None)
+
+    class DummyData:
+        r2 = 0.127
+
+    result = SimpleNamespace(
+        data={"Q01": DummyData()},
+        rabi_params={"Q01": SimpleNamespace(r2=0.95)},
+    )
+    exp = SimpleNamespace(
+        params=SimpleNamespace(readout_amplitude={}),
+        get_qubit_label=lambda _qid: "Q01",
+        obtain_rabi_params=lambda **_kwargs: result,
+    )
+    backend = SimpleNamespace(get_instance=lambda: exp)
+
+    run_result = task.run(backend, "1")
+
+    assert run_result.r2 == {"1": 0.127}
+
+
+def test_check_rabi_postprocess_marks_non_finite_frequency_failed_after_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = CheckRabi()
+    task.input_parameters["control_amplitude"] = ParameterModel(value=0.0125, unit="a.u.")
+
+    class DummyIQPlotter:
+        def __init__(self, state_centers):
+            self._widget = go.Figure()
+
+        def update(self, data):
+            return None
+
+    class DummyData:
+        data = {"iq": [0.0, 1.0]}
+
+        def fit(self):
+            return {
+                "amplitude_err": 0.0,
+                "frequency_err": 0.0,
+                "phase_err": 0.0,
+                "offset_err": 0.0,
+                "fig": go.Figure(),
+            }
+
+    monkeypatch.setattr(check_rabi_module, "IQPlotter", DummyIQPlotter)
+    monkeypatch.setattr(task, "get_qubit_label", lambda _backend, _qid: "Q01")
+    monkeypatch.setattr(
+        task,
+        "get_experiment",
+        lambda _backend: SimpleNamespace(state_centers={}),
+    )
+
+    raw_result = SimpleNamespace(
+        data={"Q01": DummyData()},
+        rabi_params={
+            "Q01": SimpleNamespace(
+                amplitude=1.0,
+                frequency=math.nan,
+                phase=0.0,
+                offset=0.0,
+                angle=180.0,
+                noise=0.0,
+                distance=1.0,
+                reference_phase=0.0,
+            )
+        },
+    )
+
+    result = task.postprocess(
+        SimpleNamespace(),
+        "exec-1",
+        RunResult(raw_result=raw_result, r2={"1": 0.95}),
+        "1",
+    )
+
+    assert result.figures
+    assert result.raw_data
+    assert result.validation_error == "CheckRabi produced non-finite frequency for Q01: nan"

--- a/tests/qdash/workflow/service/test_one_qubit_steps.py
+++ b/tests/qdash/workflow/service/test_one_qubit_steps.py
@@ -1,6 +1,10 @@
 from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 
 from qdash.workflow.service.steps.one_qubit import CustomOneQubit
+
+if TYPE_CHECKING:
+    from qdash.workflow.service.calib_service import CalibService
 
 
 def test_custom_one_qubit_direct_targets_create_visible_execution(monkeypatch) -> None:
@@ -56,7 +60,7 @@ def test_custom_one_qubit_direct_targets_create_visible_execution(monkeypatch) -
     )
     step = CustomOneQubit(step_name="simple_tasks", tasks=["CheckRabi"])
 
-    result = step._execute_direct(service, ["1", "2"])
+    result = step._execute_direct(cast("CalibService", service), ["1", "2"])
 
     assert result == {"direct": {"1": {"status": "success"}, "2": {"status": "success"}}}
     assert init_calls

--- a/tests/qdash/workflow/service/test_one_qubit_steps.py
+++ b/tests/qdash/workflow/service/test_one_qubit_steps.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+from qdash.workflow.service.steps.one_qubit import CustomOneQubit
+
+
+def test_custom_one_qubit_direct_targets_create_visible_execution(monkeypatch) -> None:
+    init_calls = []
+    run_calls = []
+    finish_calls = []
+    recorded = []
+
+    session = SimpleNamespace(
+        execution_id="exec-visible",
+        record_stage_result=lambda stage_name, result: recorded.append((stage_name, result)),
+    )
+
+    def fake_init_calibration(*args, **kwargs):
+        init_calls.append((args, kwargs))
+        return session
+
+    def fake_run_qubit_calibrations_parallel(*, qids, tasks, session_config):
+        run_calls.append(
+            {
+                "qids": qids,
+                "tasks": tasks,
+                "session_config": session_config,
+            }
+        )
+        return {qid: {"status": "success"} for qid in qids}
+
+    def fake_finish_calibration():
+        finish_calls.append(True)
+
+    monkeypatch.setattr(
+        "qdash.workflow.service.calib_service.init_calibration",
+        fake_init_calibration,
+    )
+    monkeypatch.setattr(
+        "qdash.workflow.service.calib_service.finish_calibration",
+        fake_finish_calibration,
+    )
+    monkeypatch.setattr(
+        "qdash.workflow.service._internal.scheduling_tasks.run_qubit_calibrations_parallel",
+        fake_run_qubit_calibrations_parallel,
+    )
+
+    service = SimpleNamespace(
+        username="alice",
+        chip_id="64Qv3",
+        backend_name="qubex",
+        project_id="project-1",
+        default_run_parameters={"interval": {"value": 128, "value_type": "int"}},
+        tags=["simple"],
+        flow_name="simple_calibration",
+        note={"source": "test"},
+    )
+    step = CustomOneQubit(step_name="simple_tasks", tasks=["CheckRabi"])
+
+    result = step._execute_direct(service, ["1", "2"])
+
+    assert result == {"direct": {"1": {"status": "success"}, "2": {"status": "success"}}}
+    assert init_calls
+    assert init_calls[0][0][:3] == ("alice", "64Qv3", ["1", "2"])
+    assert init_calls[0][1]["flow_name"] == "simple_calibration_simple_tasks"
+    assert init_calls[0][1]["project_id"] == "project-1"
+    assert init_calls[0][1]["note"] == {
+        "type": "1-qubit-direct",
+        "stage": "simple_tasks",
+        "total_qubits": 2,
+    }
+    assert run_calls == [
+        {
+            "qids": ["1", "2"],
+            "tasks": ["CheckRabi"],
+            "session_config": {
+                "username": "alice",
+                "chip_id": "64Qv3",
+                "backend_name": "qubex",
+                "execution_id": "exec-visible",
+                "project_id": "project-1",
+                "default_run_parameters": {"interval": {"value": 128, "value_type": "int"}},
+                "tags": ["simple"],
+                "flow_name": "simple_calibration",
+                "note": {"source": "test"},
+            },
+        }
+    ]
+    assert recorded == [("simple_tasks", result)]
+    assert finish_calls == [True]


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Prevent calibration tasks from completing when they produce invalid numeric outputs such as NaN/inf or out-of-range amplitudes/fidelities.
- Keep workflow artifacts available for inspection by using postprocess validation errors after figures/raw data are prepared; also makes direct one-qubit template runs visible as parent Executions.

## Changes
- Add shared qubex output validation helpers for finite numeric checks.
- Mark invalid Rabi, pulse, DRAG pulse, CR/ZX90, and readout classification outputs as failed via PostProcessResult.validation_error after artifacts are created.
- Prefer fit/data R2 for CheckRabi validation and add diagnostic R2 logging in the task executor.
- Create visible parent Executions for direct one-qubit target runs from simple/custom templates.
- Add focused tests for Rabi artifact-preserving failure handling and direct one-qubit Execution creation.

Verification:
- uv run pytest tests/qdash/workflow/calibtasks/qubex
- uv run pytest tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py tests/qdash/workflow/engine/task/test_executor.py::TestTaskExecutorExecuteTask::test_execute_task_raises_on_r2_validation_failure
- uv run pytest tests/qdash/workflow/service/test_one_qubit_steps.py tests/qdash/workflow/test_one_qubit_template.py tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py tests/qdash/workflow/engine/task/test_result_processor.py tests/qdash/workflow/engine/task/test_executor.py::TestTaskExecutorExecuteTask::test_execute_task_raises_on_r2_validation_failure
- uv run ruff check changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calibration task outputs now report `validation_error` to make invalid or out-of-range results easier to diagnose.
  * Introduced shared direct execution flow for one-qubit calibration steps for more consistent stage handling.

* **Bug Fixes**
  * Improved postprocessing validation across qubit calibration tasks (including readout, HPI/PI/DRAG pulses, ZX90, and cross-resonance) with clearer range/finite checks.
  * Rabi checks now prioritize the best available R² source and add clearer warnings; non-finite frequency failures are surfaced via `validation_error`.
  * Enhanced executor logging to warn when R² validation runs, is skipped, or fails.

* **Tests**
  * Added/expanded coverage for Rabi R² selection and non-finite validation behavior, plus direct one-qubit step execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->