### PR TITLE
fix(ui): preserve forum image resize

### DIFF
--- a/ui/src/components/features/forum/ForumBlockEditor.tsx
+++ b/ui/src/components/features/forum/ForumBlockEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import Image from "next/image";
+import { useEffect, useState, type MutableRefObject } from "react";
 
 import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
@@ -31,6 +32,20 @@ function useThemeScheme(): "light" | "dark" {
   return scheme;
 }
 
+function cloneBlocks(blocks: Record<string, unknown>[]): Record<string, unknown>[] {
+  if (typeof structuredClone === "function") {
+    return structuredClone(blocks);
+  }
+  return JSON.parse(JSON.stringify(blocks)) as Record<string, unknown>[];
+}
+
+export type ForumBlockSnapshot = {
+  blocks: Record<string, unknown>[];
+  markdown: string;
+};
+
+export type ForumBlockSnapshotGetter = () => Promise<ForumBlockSnapshot>;
+
 interface ForumBlockEditorProps {
   /** Current document, as opaque BlockNote JSON objects. */
   initialBlocks?: Record<string, unknown>[];
@@ -40,7 +55,118 @@ interface ForumBlockEditorProps {
   onImageUpload: (file: File) => Promise<string>;
   /** Called whenever the document changes, with both the block JSON and a lossy markdown export. */
   onChange: (blocks: Record<string, unknown>[], markdown: string) => void;
+  /** Imperative snapshot used by external Save buttons to avoid stale React state. */
+  snapshotRef?: MutableRefObject<ForumBlockSnapshotGetter | null>;
   editable?: boolean;
+}
+
+type ForumBlock = Record<string, unknown> & {
+  type?: string;
+  props?: Record<string, unknown>;
+  content?: unknown;
+  children?: ForumBlock[];
+};
+
+function textFromInlineContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (item && typeof item === "object" && "text" in item) {
+        const text = (item as { text?: unknown }).text;
+        return typeof text === "string" ? text : "";
+      }
+      return "";
+    })
+    .join("");
+}
+
+function renderViewerBlock(block: ForumBlock, index: number) {
+  const props = block.props ?? {};
+  const text = textFromInlineContent(block.content);
+  const children = Array.isArray(block.children) ? block.children : [];
+
+  if (block.type === "image") {
+    const url = typeof props.url === "string" ? props.url : "";
+    const caption = typeof props.caption === "string" ? props.caption : "";
+    const width = typeof props.previewWidth === "number" ? props.previewWidth : undefined;
+    if (!url) return null;
+    return (
+      <figure key={String(block.id ?? index)} className="my-3">
+        <Image
+          src={url}
+          alt={typeof props.name === "string" ? props.name : caption}
+          width={width ?? 800}
+          height={450}
+          unoptimized
+          style={
+            width
+              ? { width, maxWidth: "100%", height: "auto" }
+              : { maxWidth: "100%", height: "auto" }
+          }
+          className="rounded border border-base-300"
+        />
+        {caption && (
+          <figcaption className="mt-1 text-xs text-base-content/50">{caption}</figcaption>
+        )}
+      </figure>
+    );
+  }
+
+  const key = String(block.id ?? index);
+  if (block.type === "heading") {
+    const level = props.level === 1 || props.level === 2 || props.level === 3 ? props.level : 3;
+    const className = level === 1 ? "text-xl" : level === 2 ? "text-lg" : "text-base";
+    return (
+      <h3 key={key} className={`my-2 font-semibold ${className}`}>
+        {text}
+      </h3>
+    );
+  }
+  if (block.type === "bulletListItem") {
+    return (
+      <li key={key} className="ml-5 list-disc">
+        {text}
+      </li>
+    );
+  }
+  if (block.type === "numberedListItem") {
+    return (
+      <li key={key} className="ml-5 list-decimal">
+        {text}
+      </li>
+    );
+  }
+  if (block.type === "quote") {
+    return (
+      <blockquote key={key} className="my-2 border-l-2 border-base-300 pl-3 text-base-content/70">
+        {text}
+      </blockquote>
+    );
+  }
+  if (block.type === "codeBlock") {
+    return (
+      <pre key={key} className="my-2 overflow-x-auto rounded bg-base-200 p-3 text-xs">
+        <code>{text}</code>
+      </pre>
+    );
+  }
+
+  return (
+    <div key={key} className="my-1">
+      {text && <p>{text}</p>}
+      {children.length > 0 && <div className="ml-4">{children.map(renderViewerBlock)}</div>}
+    </div>
+  );
+}
+
+export function ForumBlockViewer({ blocks }: { blocks: Record<string, unknown>[] }) {
+  return (
+    <div className="text-sm leading-6 text-base-content/80">
+      {(blocks as ForumBlock[]).map(renderViewerBlock)}
+    </div>
+  );
 }
 
 /**
@@ -58,6 +184,7 @@ export function ForumBlockEditor({
   legacyMarkdown,
   onImageUpload,
   onChange,
+  snapshotRef,
   editable = true,
 }: ForumBlockEditorProps) {
   const colorScheme = useThemeScheme();
@@ -74,6 +201,17 @@ export function ForumBlockEditor({
     uploadFile: (file: File) =>
       file.type.startsWith("image/") ? onImageUpload(file) : uploadInlineFile(file),
   });
+
+  useEffect(() => {
+    if (!snapshotRef) return;
+    snapshotRef.current = async () => ({
+      blocks: cloneBlocks(editor.document as unknown as Record<string, unknown>[]),
+      markdown: await editor.blocksToMarkdownLossy(editor.document),
+    });
+    return () => {
+      snapshotRef.current = null;
+    };
+  }, [editor, snapshotRef]);
 
   // First-time migration: import legacy markdown when a post has no blocks yet.
   useEffect(() => {
@@ -100,7 +238,7 @@ export function ForumBlockEditor({
         editable={editable}
         theme={colorScheme}
         onChange={() => {
-          const blocks = editor.document as unknown as Record<string, unknown>[];
+          const blocks = cloneBlocks(editor.document as unknown as Record<string, unknown>[]);
           void Promise.resolve(editor.blocksToMarkdownLossy(editor.document)).then((md) =>
             onChange(blocks, md),
           );

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type MutableRefObject, type ReactNode } from "react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
@@ -49,6 +49,7 @@ import {
   toForumCategoryDefinition,
 } from "./categories";
 import { ForumLabelPicker } from "./ForumLabelSelector";
+import { ForumBlockViewer, type ForumBlockSnapshotGetter } from "./ForumBlockEditor";
 
 const ForumBlockEditor = dynamic(
   () => import("./ForumBlockEditor").then((m) => ({ default: m.ForumBlockEditor })),
@@ -140,6 +141,7 @@ function PostBody({
   onSave,
   saving,
   onImageUpload,
+  editorSnapshotRef,
 }: {
   post: ForumPostResponse;
   currentUsername?: string;
@@ -159,6 +161,7 @@ function PostBody({
   onSave: () => void;
   saving: boolean;
   onImageUpload: (file: File) => Promise<string>;
+  editorSnapshotRef?: MutableRefObject<ForumBlockSnapshotGetter | null>;
 }) {
   const canEdit = canEditOverride ?? currentUsername === post.username;
   const isAi = post.is_ai_reply || post.username === "qdash";
@@ -221,6 +224,7 @@ function PostBody({
             legacyMarkdown={editLegacyMarkdown}
             onChange={onEditChange}
             onImageUpload={onImageUpload}
+            snapshotRef={editorSnapshotRef}
           />
           <div className="flex justify-end gap-2">
             <button className="btn btn-ghost btn-sm" onClick={onCancel}>
@@ -236,7 +240,14 @@ function PostBody({
           </div>
         </div>
       ) : (
-        <MarkdownContent content={post.content} className="text-sm text-base-content/80" />
+        (() => {
+          const displayBlocks = (post.content_blocks ?? []) as Record<string, unknown>[];
+          return displayBlocks.length > 0 ? (
+            <ForumBlockViewer blocks={displayBlocks} />
+          ) : (
+            <MarkdownContent content={post.content} className="text-sm text-base-content/80" />
+          );
+        })()
       )}
     </div>
   );
@@ -257,6 +268,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   const [editRootTitle, setEditRootTitle] = useState("");
   const [editRootContent, setEditRootContent] = useState("");
   const [editRootBlocks, setEditRootBlocks] = useState<Record<string, unknown>[]>([]);
+  const editRootSnapshotRef = useRef<ForumBlockSnapshotGetter | null>(null);
   const [targetDraftChipId, setTargetDraftChipId] = useState("");
   const [targetDraftType, setTargetDraftType] = useState<"qubit" | "coupling">("qubit");
   const [targetDraftId, setTargetDraftId] = useState("");
@@ -264,6 +276,8 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   const [editingReplyId, setEditingReplyId] = useState<string | null>(null);
   const [editReplyContent, setEditReplyContent] = useState("");
   const [editReplyBlocks, setEditReplyBlocks] = useState<Record<string, unknown>[]>([]);
+  const editReplySnapshotRef = useRef<ForumBlockSnapshotGetter | null>(null);
+  const replyComposerSnapshotRef = useRef<ForumBlockSnapshotGetter | null>(null);
   const [replyLimit, setReplyLimit] = useState(REPLY_PAGE_SIZE);
 
   const { data: postResponse, isLoading: postLoading } = useGetForumPost(postId, {
@@ -326,6 +340,26 @@ export function ForumDetailPage({ postId }: { postId: string }) {
     queryClient.invalidateQueries({ queryKey: getListForumPostsQueryKey() });
   };
 
+  const syncRootPostCache = (nextPost: ForumPostResponse) => {
+    queryClient.setQueryData(getGetForumPostQueryKey(nextPost.id), (current: unknown) =>
+      current && typeof current === "object" ? { ...current, data: nextPost } : current,
+    );
+  };
+
+  const syncReplyCache = (nextReply: ForumPostResponse) => {
+    queryClient.setQueriesData(
+      { queryKey: getGetForumPostRepliesQueryKey(postId), exact: false },
+      (current: unknown) => {
+        if (!Array.isArray(current)) return current;
+        return current.map((reply) =>
+          reply && typeof reply === "object" && "id" in reply && reply.id === nextReply.id
+            ? nextReply
+            : reply,
+        );
+      },
+    );
+  };
+
   const handleStartEditRoot = () => {
     if (!post) return;
     setEditRootTitle(post.title ?? "");
@@ -335,30 +369,40 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   };
 
   const handleSaveRoot = async () => {
-    if (!post || !editRootContent.trim()) return;
-    await updateMutation.mutateAsync({
+    if (!post) return;
+    const snapshot = await editRootSnapshotRef.current?.();
+    const nextContent = (snapshot?.markdown ?? editRootContent).trim();
+    const nextBlocks = snapshot?.blocks ?? editRootBlocks;
+    if (!nextContent) return;
+    const response = await updateMutation.mutateAsync({
       postId: post.id,
       data: {
         category: post.category,
         title: editRootTitle.trim() || null,
-        content: editRootContent.trim(),
-        content_blocks: editRootBlocks,
+        content: nextContent,
+        content_blocks: nextBlocks,
         labels: post.labels ?? [],
       },
     });
+    syncRootPostCache(response.data);
+    setEditRootContent(nextContent);
+    setEditRootBlocks(nextBlocks);
     setEditingRoot(false);
     invalidateThread();
   };
 
   const handleAddReply = async () => {
-    if (!post || !replyText.trim()) return;
-    const trimmed = replyText.trim();
+    if (!post) return;
+    const snapshot = await replyComposerSnapshotRef.current?.();
+    const trimmed = (snapshot?.markdown ?? replyText).trim();
+    const nextBlocks = snapshot?.blocks ?? replyBlocks;
+    if (!trimmed) return;
     await createMutation.mutateAsync({
       data: {
         category: post.category,
         title: null,
         content: trimmed,
-        content_blocks: replyBlocks,
+        content_blocks: nextBlocks,
         parent_id: post.id,
       },
     });
@@ -378,15 +422,22 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   };
 
   const handleSaveReply = async () => {
-    if (!editingReplyId || !editReplyContent.trim()) return;
-    await updateMutation.mutateAsync({
+    if (!editingReplyId) return;
+    const snapshot = await editReplySnapshotRef.current?.();
+    const nextContent = (snapshot?.markdown ?? editReplyContent).trim();
+    const nextBlocks = snapshot?.blocks ?? editReplyBlocks;
+    if (!nextContent) return;
+    const response = await updateMutation.mutateAsync({
       postId: editingReplyId,
       data: {
         title: null,
-        content: editReplyContent.trim(),
-        content_blocks: editReplyBlocks,
+        content: nextContent,
+        content_blocks: nextBlocks,
       },
     });
+    syncReplyCache(response.data);
+    setEditReplyContent(nextContent);
+    setEditReplyBlocks(nextBlocks);
     setEditingReplyId(null);
     invalidateThread();
   };
@@ -535,6 +586,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
             onSave={handleSaveRoot}
             saving={updateMutation.isPending}
             onImageUpload={uploadImage}
+            editorSnapshotRef={editRootSnapshotRef}
           />
 
           <div className="divider text-xs text-base-content/40">
@@ -568,6 +620,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                     onSave={handleSaveReply}
                     saving={updateMutation.isPending}
                     onImageUpload={uploadImage}
+                    editorSnapshotRef={editReplySnapshotRef}
                   />
                 ))}
                 {replies.length >= replyLimit && (
@@ -611,6 +664,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                     setReplyText(markdown);
                   }}
                   onImageUpload={uploadImage}
+                  snapshotRef={replyComposerSnapshotRef}
                 />
                 <div className="mt-2 flex items-center justify-between gap-2">
                   <span className="text-xs text-base-content/50">

--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -53,6 +53,7 @@ import {
   type ForumCategoryDefinition,
 } from "./categories";
 import { ForumLabelSelector } from "./ForumLabelSelector";
+import { ForumBlockViewer } from "./ForumBlockEditor";
 
 const ForumBlockEditor = dynamic(
   () => import("./ForumBlockEditor").then((m) => ({ default: m.ForumBlockEditor })),
@@ -360,10 +361,16 @@ function ForumThreadPreviewSidebar({
               <section>
                 <h3 className="mb-2 text-sm font-semibold">Root thread</h3>
                 <div className="rounded-lg border border-base-300 bg-base-100 p-4">
-                  <MarkdownContent
-                    content={post.content}
-                    className="text-sm text-base-content/80"
-                  />
+                  {(post.content_blocks ?? []).length > 0 ? (
+                    <ForumBlockViewer
+                      blocks={(post.content_blocks ?? []) as Record<string, unknown>[]}
+                    />
+                  ) : (
+                    <MarkdownContent
+                      content={post.content}
+                      className="text-sm text-base-content/80"
+                    />
+                  )}
                 </div>
               </section>
 
@@ -386,11 +393,17 @@ function ForumThreadPreviewSidebar({
                           <span>{reply.username}</span>
                           <span>{formatRelativeTime(reply.created_at)}</span>
                         </div>
-                        <MarkdownContent
-                          content={reply.content}
-                          preview
-                          className="line-clamp-3 text-sm text-base-content/70"
-                        />
+                        {(reply.content_blocks ?? []).length > 0 ? (
+                          <ForumBlockViewer
+                            blocks={(reply.content_blocks ?? []) as Record<string, unknown>[]}
+                          />
+                        ) : (
+                          <MarkdownContent
+                            content={reply.content}
+                            preview
+                            className="line-clamp-3 text-sm text-base-content/70"
+                          />
+                        )}
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Fixes forum BlockNote image resize changes appearing to revert, save inconsistently, or briefly flicker after saving.
- UI-only change in forum rich-text editing/rendering; no API or generated client changes.

## Changes
- Keep normal forum thread display as a viewer; the BlockNote editor appears only after pressing the Edit button.
- Render saved forum `content_blocks` with a lightweight viewer that preserves image `previewWidth` values, with markdown fallback for legacy posts.
- Read the editor document snapshot directly when Save/Post/Reply is clicked so resize changes do not depend on possibly stale React state.
- Sync the saved post/reply response into TanStack Query cache before leaving edit mode to avoid briefly showing the stale pre-save content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forum updates so block content is saved from an immutable snapshot (avoiding live references) and exported consistently for external “Save” actions.
  * Improved root edit, reply edit, and reply creation so submitted `content`/`content_blocks` are derived from the latest snapshot and trimmed appropriately.
* **New Features**
  * Added a read-only block viewer for forum posts and replies when structured block content is available, with graceful fallback to legacy markdown.
  * Enabled structured block previews in the forum thread sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->