### PR TITLE
feat(workflow): add fast full calibration template

### DIFF
--- a/src/qdash/workflow/templates/fast_full_calibration.py
+++ b/src/qdash/workflow/templates/fast_full_calibration.py
@@ -1,0 +1,129 @@
+"""Fast full calibration using a shortened step-based pipeline.
+
+This template keeps the end-to-end 1Q-to-2Q flow from full_calibration, but
+skips long or duplicated 1Q coherence checks. It is intended for quicker daily
+passes when the chip is already close to a calibrated state.
+
+Execution flow:
+    1. ConfigureAll: Push the current full-chip configuration to the selected MUXes
+    2. OneQubitCheck: Fast pulse sanity check
+    3. FilterByStatus: Filter to only successful qubits
+    4. OneQubitFineTune: Pulse/readout/RB/X90 IRB tune without T1/T2 averages
+    5. FilterByMetric: Filter by X90 fidelity threshold
+    6. GenerateCRSchedule: Generate 2Q execution schedule
+    7. TwoQubitCalibration: 2Q coupling calibration
+
+Example:
+    fast_full_calibration(
+        username="alice",
+        chip_id="64Qv3",
+        mux_ids=[0, 1, 2, 3],
+    )
+"""
+
+from typing import Any
+
+from prefect import flow
+
+from qdash.workflow.service import CalibService
+from qdash.workflow.service.calib_service import on_flow_cancellation
+from qdash.workflow.service.steps import (
+    ConfigureAll,
+    FilterByMetric,
+    FilterByStatus,
+    GenerateCRSchedule,
+    OneQubitCheck,
+    OneQubitFineTune,
+    TwoQubitCalibration,
+)
+from qdash.workflow.service.targets import MuxTargets
+
+FAST_1Q_CHECK_TASKS: list[str] = [
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+]
+
+FAST_1Q_FINE_TUNE_TASKS: list[str] = [
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "ReadoutClassification",
+    "RandomizedBenchmarking",
+    "X90InterleavedRandomizedBenchmarking",
+]
+
+
+@flow(on_cancellation=[on_flow_cancellation])
+def fast_full_calibration(
+    username: str,
+    chip_id: str,
+    mux_ids: list[int] | None = None,
+    exclude_qids: list[str] | None = None,
+    qids: list[str] | None = None,
+    tags: list[str] | None = None,
+    flow_name: str | None = None,
+    project_id: str | None = None,
+    fidelity_threshold: float = 0.90,
+    max_parallel_ops: int = 10,
+    inverse: bool = False,
+) -> Any:
+    """Fast full calibration using a shortened step-based pipeline.
+
+    Args:
+        username: User name (from UI)
+        chip_id: Chip ID (from UI)
+        mux_ids: MUX IDs to calibrate (default: all 16)
+        exclude_qids: Qubit IDs to exclude
+        qids: Not used (for UI compatibility)
+        flow_name: Flow name (auto-injected)
+        project_id: Project ID (auto-injected)
+        fidelity_threshold: Minimum X90 fidelity for 2Q candidates (default: 0.90)
+        max_parallel_ops: Max parallel CR operations (default: 10)
+        inverse: CR direction control based on checkerboard pattern.
+            False (default): forward direction. True: reverse direction.
+
+    Returns:
+        Pipeline results with typed step outputs.
+    """
+    _ = qids
+
+    if mux_ids is None:
+        mux_ids = list(range(16))
+    if exclude_qids is None:
+        exclude_qids = []
+
+    targets = MuxTargets(mux_ids=mux_ids, exclude_qids=exclude_qids)
+
+    steps = [
+        ConfigureAll(),
+        OneQubitCheck(mode="synchronized", tasks=FAST_1Q_CHECK_TASKS),
+        FilterByStatus(),
+        OneQubitFineTune(mode="synchronized", tasks=FAST_1Q_FINE_TUNE_TASKS),
+        FilterByMetric(metric="x90_fidelity", threshold=fidelity_threshold),
+        GenerateCRSchedule(max_parallel_ops=max_parallel_ops, inverse=inverse),
+        TwoQubitCalibration(),
+    ]
+
+    cal = CalibService(
+        username,
+        chip_id,
+        flow_name=flow_name,
+        tags=tags,
+        project_id=project_id,
+        skip_execution=True,
+        default_run_parameters={
+            "hpi_duration": {"value": 32, "value_type": "int"},
+            "pi_duration": {"value": 32, "value_type": "int"},
+            "drag_hpi_duration": {"value": 16, "value_type": "int"},
+            "drag_pi_duration": {"value": 24, "value_type": "int"},
+            "interval": {"value": 150 * 1024, "value_type": "int"},
+        },
+    )
+    return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -48,6 +48,14 @@
     "function_name": "full_calibration"
   },
   {
+    "id": "fast_full_calibration",
+    "name": "Fast Full Calibration",
+    "description": "Shortened full calibration: ConfigureAll -> fast 1Q check -> 1Q fine-tune without T1/T2 averages -> Filter -> CR Schedule -> 2Q.",
+    "category": "production",
+    "filename": "fast_full_calibration.py",
+    "function_name": "fast_full_calibration"
+  },
+  {
     "id": "two_qubit",
     "name": "2Q Calibration",
     "description": "Two-qubit calibration from candidate qubits. Auto-generates optimal CR schedule with explicit checkerboard direction (forward/reverse). Default: forward.",

--- a/tests/qdash/api/routers/test_flow.py
+++ b/tests/qdash/api/routers/test_flow.py
@@ -367,3 +367,28 @@ class TestFlowTemplates:
         assert data["id"] == "full_calibration"
         assert "ConfigureAll -> 1Q Check" in data["description"]
         assert "ConfigureAll()," in data["code"]
+
+    def test_get_fast_full_calibration_template_includes_shortened_tasks(
+        self, test_client, test_project, auth_headers
+    ):
+        """Test that the fast full calibration template is registered and loadable."""
+        repo_root = Path(__file__).resolve().parents[4]
+        templates_dir = repo_root / "src/qdash/workflow/templates"
+
+        with (
+            patch("qdash.api.services.flow_service.TEMPLATES_DIR", templates_dir),
+            patch(
+                "qdash.api.services.flow_service.TEMPLATES_METADATA_FILE",
+                templates_dir / "templates.json",
+            ),
+        ):
+            response = test_client.get(
+                "/flows/templates/fast_full_calibration", headers=auth_headers
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == "fast_full_calibration"
+        assert "Shortened full calibration" in data["description"]
+        fine_tune_tasks_block = data["code"].split("FAST_1Q_FINE_TUNE_TASKS", 1)[1].split("]", 1)[0]
+        assert "CheckT1Average" not in fine_tune_tasks_block

--- a/tests/qdash/workflow/test_fast_full_calibration_template.py
+++ b/tests/qdash/workflow/test_fast_full_calibration_template.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from qdash.workflow.service.steps import (
+    ConfigureAll,
+    FilterByMetric,
+    FilterByStatus,
+    GenerateCRSchedule,
+    OneQubitCheck,
+    OneQubitFineTune,
+    TwoQubitCalibration,
+)
+from qdash.workflow.service.targets import MuxTargets
+
+fast_full_module = importlib.import_module("qdash.workflow.templates.fast_full_calibration")
+
+
+class FakeCalibService:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self, targets: Any, *, steps: list[Any]) -> dict[str, Any]:
+        return {"targets": targets, "steps": steps, "service_kwargs": self.kwargs}
+
+
+def test_fast_full_calibration_uses_shortened_one_qubit_steps(monkeypatch) -> None:
+    monkeypatch.setattr(fast_full_module, "CalibService", FakeCalibService)
+
+    result = fast_full_module.fast_full_calibration(
+        username="alice",
+        chip_id="64Q",
+        mux_ids=[0],
+    )
+
+    assert isinstance(result["targets"], MuxTargets)
+    assert result["targets"].mux_ids == [0]
+
+    steps = result["steps"]
+    assert [type(step) for step in steps] == [
+        ConfigureAll,
+        OneQubitCheck,
+        FilterByStatus,
+        OneQubitFineTune,
+        FilterByMetric,
+        GenerateCRSchedule,
+        TwoQubitCalibration,
+    ]
+
+    one_qubit_check = steps[1]
+    assert one_qubit_check.tasks == ["CheckRabi", "CreateHPIPulse", "CheckHPIPulse"]
+
+    one_qubit_fine_tune = steps[3]
+    assert "X90InterleavedRandomizedBenchmarking" in one_qubit_fine_tune.tasks
+    assert "CheckT1Average" not in one_qubit_fine_tune.tasks
+    assert "CheckT2EchoAverage" not in one_qubit_fine_tune.tasks
+    assert "Check1QGateCoherenceLimit" not in one_qubit_fine_tune.tasks


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Adds a fast full calibration workflow template for quicker daily calibration passes that keep the 1Q-to-2Q pipeline while skipping long 1Q coherence checks.
- Affects workflow template registration and flow template retrieval; no API schema or generated client changes are involved.

## Changes
- Added `fast_full_calibration` with shortened 1Q check and fine-tune task lists.
- Registered the template metadata so it is available from the flow templates API.
- Added workflow and API tests covering the shortened task set and template loading.

Verification:
- `uv run pytest tests/qdash/workflow/test_fast_full_calibration_template.py tests/qdash/api/routers/test_flow.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new fast full-calibration workflow template with a shortened 1Q-to-2Q calibration path.
  * Included the template in the available workflow list so it can be selected like other calibration options.

* **Bug Fixes**
  * Improved workflow filtering and step selection to keep the fast calibration path focused on the intended checks and tuning steps.
  * Added coverage to verify the new template returns the expected sequence and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->