### PR TITLE
feat(ui): edit forum metadata from preview panel

### DIFF
--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState, type MutableRefObject, type ReactNode } from "react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
@@ -244,6 +244,7 @@ function PostBody({
 
 export function ForumDetailPage({ postId }: { postId: string }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const { isOwner, projectId } = useProject();
@@ -295,12 +296,28 @@ export function ForumDetailPage({ postId }: { postId: string }) {
     [membersResponse?.data.members],
   );
   const { data: chipsResponse } = useListChips({ query: { staleTime: 60_000 } });
-  const chips = chipsResponse?.data.chips ?? [];
+  const chips = useMemo(
+    () =>
+      [...(chipsResponse?.data.chips ?? [])].sort((a, b) => {
+        const aTime = a.installed_at ? new Date(a.installed_at).getTime() : 0;
+        const bTime = b.installed_at ? new Date(b.installed_at).getTime() : 0;
+        return bTime - aTime || b.chip_id.localeCompare(a.chip_id);
+      }),
+    [chipsResponse?.data.chips],
+  );
   const { data: cooldownsResponse } = useListCooldowns(
     { chip_id: targetDraftChipId || undefined },
     { query: { enabled: !!targetDraftChipId || !!post?.cooldown_id, staleTime: 60_000 } },
   );
-  const cooldowns = cooldownsResponse?.data.cooldowns ?? [];
+  const cooldowns = useMemo(
+    () =>
+      [...(cooldownsResponse?.data.cooldowns ?? [])].sort((a, b) => {
+        const aTime = a.started_at ? new Date(a.started_at).getTime() : 0;
+        const bTime = b.started_at ? new Date(b.started_at).getTime() : 0;
+        return bTime - aTime || b.cooldown_id.localeCompare(a.cooldown_id);
+      }),
+    [cooldownsResponse?.data.cooldowns],
+  );
   const selectedCooldown = cooldowns.find((cooldown) => cooldown.cooldown_id === cooldownDraftId);
   const currentPostCooldown = cooldowns.find(
     (cooldown) => cooldown.cooldown_id === post?.cooldown_id,
@@ -317,6 +334,8 @@ export function ForumDetailPage({ postId }: { postId: string }) {
     error: aiError,
     triggerAiReply,
   } = useForumAiReply();
+  const fromQuery = searchParams.get("from");
+  const forumReturnHref = fromQuery ? `/forum?${fromQuery.replace(/^\?/, "")}` : "/forum";
 
   useEffect(() => {
     if (!post) return;
@@ -543,7 +562,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   const handleDelete = async (targetPostId: string, isRoot: boolean) => {
     await deleteMutation.mutateAsync({ postId: targetPostId });
     if (isRoot) {
-      router.push("/forum");
+      router.push(forumReturnHref);
       return;
     }
     invalidateThread();
@@ -561,7 +580,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
     return (
       <div className="flex flex-col items-center justify-center gap-4 py-16">
         <p className="text-base-content/60">Forum thread not found</p>
-        <Link href="/forum" className="btn btn-sm btn-ghost">
+        <Link href={forumReturnHref} className="btn btn-sm btn-ghost">
           <ArrowLeft className="h-4 w-4" />
           Back to Forum
         </Link>
@@ -579,7 +598,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
       <div className="mb-6 flex min-w-0 items-start gap-3">
         <button
           className="btn btn-square btn-ghost btn-sm shrink-0"
-          onClick={() => router.push("/forum")}
+          onClick={() => router.push(forumReturnHref)}
         >
           <ArrowLeft className="h-4 w-4" />
         </button>

--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   CalendarDays,
@@ -11,15 +11,21 @@ import {
   ExternalLink,
   Lock,
   MessageSquare,
+  Pencil,
   Plus,
   Settings,
+  Tag,
   Trash2,
   Unlock,
   UserRound,
   X,
 } from "lucide-react";
 
+import { useListChips } from "@/client/chip/chip";
+import { useListCooldowns } from "@/client/cooldown/cooldown";
+import { useListProjectMembers } from "@/client/projects/projects";
 import {
+  getGetForumPostQueryKey,
   getListForumCategoriesQueryKey,
   getListForumPostsQueryKey,
   useCloseForumPost,
@@ -31,6 +37,7 @@ import {
   useListForumCategories,
   useListForumPosts,
   useReopenForumPost,
+  useUpdateForumPost,
 } from "@/client/forum/forum";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";
@@ -41,7 +48,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
 import { useForumAiReply } from "@/hooks/useForumAiReply";
 import { useImageUpload } from "@/hooks/useImageUpload";
-import { formatRelativeTime } from "@/lib/utils/datetime";
+import { formatDateTimeCompact, formatRelativeTime } from "@/lib/utils/datetime";
 import type { ForumPostResponse, ListForumPostsParams } from "@/schemas";
 
 import {
@@ -53,7 +60,7 @@ import {
   toForumCategoryDefinition,
   type ForumCategoryDefinition,
 } from "./categories";
-import { ForumLabelSelector } from "./ForumLabelSelector";
+import { ForumLabelPicker, ForumLabelSelector } from "./ForumLabelSelector";
 import { ForumBlockViewer } from "./ForumBlockEditor";
 
 const ForumBlockEditor = dynamic(
@@ -65,6 +72,15 @@ const PAGE_SIZE = 30;
 
 type CategoryFilter = "all" | NonNullable<ListForumPostsParams["category"]>;
 type StatusFilter = "open" | "closed" | "all";
+
+function parseForumPage(value: string | null): number {
+  const page = Number.parseInt(value ?? "1", 10);
+  return Number.isFinite(page) && page > 0 ? page : 1;
+}
+
+function parseForumStatus(value: string | null): StatusFilter {
+  return value === "closed" || value === "all" ? value : "open";
+}
 
 type ForumTargetContext = {
   chipId: string;
@@ -82,6 +98,15 @@ function formatTargetLabel(targetType: "qubit" | "coupling", targetId: string): 
     return b ? `Q${a} -> Q${b}` : targetId;
   }
   return `Q${targetId}`;
+}
+
+function formatCooldownPeriod(
+  cooldown: { started_at?: string | null; ended_at?: string | null } | undefined,
+): string {
+  if (!cooldown?.started_at) return "";
+  const start = formatDateTimeCompact(cooldown.started_at);
+  const end = cooldown.ended_at ? formatDateTimeCompact(cooldown.ended_at) : "ongoing";
+  return `${start} - ${end}`;
 }
 
 function parseTargetId(
@@ -255,12 +280,27 @@ function ForumThreadCard({
 function ForumThreadPreviewSidebar({
   postId,
   categories,
+  currentUsername,
+  isOwner,
+  projectId,
+  returnQuery,
   onClose,
 }: {
   postId: string | null;
   categories: ForumCategoryDefinition[];
+  currentUsername?: string;
+  isOwner: boolean;
+  projectId?: string | null;
+  returnQuery: string;
   onClose: () => void;
 }) {
+  const queryClient = useQueryClient();
+  const [editingMetadata, setEditingMetadata] = useState(false);
+  const [targetDraftChipId, setTargetDraftChipId] = useState("");
+  const [targetDraftType, setTargetDraftType] = useState<"qubit" | "coupling">("qubit");
+  const [targetDraftId, setTargetDraftId] = useState("");
+  const [cooldownDraftId, setCooldownDraftId] = useState("");
+
   const {
     data: postResponse,
     isLoading,
@@ -273,12 +313,149 @@ function ForumThreadPreviewSidebar({
     { skip: 0, limit: 5 },
     { query: { enabled: !!postId, staleTime: 30_000 } },
   );
+  const { data: membersResponse } = useListProjectMembers(projectId ?? "", {
+    query: { enabled: !!projectId && editingMetadata, staleTime: 60_000 },
+  });
+  const { data: chipsResponse } = useListChips({
+    query: { enabled: editingMetadata, staleTime: 60_000 },
+  });
+
   const post = postResponse?.data;
   const replies = repliesResponse?.data ?? [];
   const isOpen = !!postId;
   const category = post ? getForumCategory(post.category, categories) : null;
+  const CategoryIcon = category?.icon;
   const label = post?.labels?.[0] ? getForumLabel(post.labels[0]) : null;
   const targetContext = post ? postTargetContext(post) : null;
+  const canManage = !!post && (isOwner || currentUsername === post.username);
+  const updateMutation = useUpdateForumPost();
+  const members = useMemo(
+    () => (membersResponse?.data.members ?? []).filter((member) => member.status === "active"),
+    [membersResponse?.data.members],
+  );
+  const chips = useMemo(
+    () =>
+      [...(chipsResponse?.data.chips ?? [])].sort((a, b) => {
+        const aTime = a.installed_at ? new Date(a.installed_at).getTime() : 0;
+        const bTime = b.installed_at ? new Date(b.installed_at).getTime() : 0;
+        return bTime - aTime || b.chip_id.localeCompare(a.chip_id);
+      }),
+    [chipsResponse?.data.chips],
+  );
+  const { data: cooldownsResponse } = useListCooldowns(
+    { chip_id: targetDraftChipId || undefined },
+    {
+      query: {
+        enabled: editingMetadata && (!!targetDraftChipId || !!post?.cooldown_id),
+        staleTime: 60_000,
+      },
+    },
+  );
+  const cooldowns = useMemo(
+    () =>
+      [...(cooldownsResponse?.data.cooldowns ?? [])].sort((a, b) => {
+        const aTime = a.started_at ? new Date(a.started_at).getTime() : 0;
+        const bTime = b.started_at ? new Date(b.started_at).getTime() : 0;
+        return bTime - aTime || b.cooldown_id.localeCompare(a.cooldown_id);
+      }),
+    [cooldownsResponse?.data.cooldowns],
+  );
+  const selectedCooldown = cooldowns.find((cooldown) => cooldown.cooldown_id === cooldownDraftId);
+
+  useEffect(() => {
+    setEditingMetadata(false);
+  }, [postId]);
+
+  useEffect(() => {
+    if (!post || editingMetadata) return;
+    const context = postTargetContext(post);
+    setTargetDraftChipId(context?.chipId ?? "");
+    setTargetDraftType(context?.targetType ?? "qubit");
+    setTargetDraftId(context?.targetId ?? "");
+    setCooldownDraftId(post.cooldown_id ?? "");
+  }, [editingMetadata, post]);
+
+  const syncPostCache = (nextPost: ForumPostResponse) => {
+    queryClient.setQueryData(getGetForumPostQueryKey(nextPost.id), (current: unknown) =>
+      current && typeof current === "object" ? { ...current, data: nextPost } : current,
+    );
+    queryClient.invalidateQueries({ queryKey: getListForumPostsQueryKey() });
+  };
+
+  const updateMetadata = async ({
+    category: nextCategory,
+    labels: nextLabels,
+    chipId: nextChipId,
+    targetType: nextTargetType,
+    targetId: nextTargetId,
+    cooldownId: nextCooldownId,
+    assigneeUsername: nextAssigneeUsername,
+  }: {
+    category?: string;
+    labels?: string[];
+    chipId?: string | null;
+    targetType?: "qubit" | "coupling" | null;
+    targetId?: string | null;
+    cooldownId?: string | null;
+    assigneeUsername?: string | null;
+  }) => {
+    if (!post || !canManage) return;
+    const response = await updateMutation.mutateAsync({
+      postId: post.id,
+      data: {
+        category: nextCategory ?? post.category,
+        title: post.title ?? null,
+        content: post.content,
+        content_blocks: (post.content_blocks ?? []) as Record<string, unknown>[],
+        labels: nextLabels ?? post.labels ?? [],
+        ...(nextCooldownId !== undefined ? { cooldown_id: nextCooldownId } : {}),
+        ...(nextAssigneeUsername !== undefined ? { assignee_username: nextAssigneeUsername } : {}),
+        ...(nextChipId !== undefined || nextTargetType !== undefined || nextTargetId !== undefined
+          ? {
+              chip_id: nextChipId,
+              target_type: nextTargetType,
+              target_id: nextTargetId,
+            }
+          : {}),
+      },
+    });
+    syncPostCache(response.data);
+  };
+
+  const togglePostLabel = (labelId: string) => {
+    if (!post) return;
+    const currentLabels = post.labels ?? [];
+    const nextLabels = currentLabels.includes(labelId) ? [] : [labelId];
+    updateMetadata({ labels: nextLabels });
+  };
+
+  const saveTargetMetadata = (
+    nextChipId = targetDraftChipId,
+    nextTargetType = targetDraftType,
+    nextTargetId = targetDraftId,
+  ) => {
+    const chipId = nextChipId.trim();
+    const targetId = nextTargetId.trim();
+    if (!chipId || !targetId) return;
+    updateMetadata({ chipId, targetType: nextTargetType, targetId });
+  };
+
+  const clearTargetMetadata = () => {
+    setTargetDraftChipId("");
+    setTargetDraftType("qubit");
+    setTargetDraftId("");
+    setCooldownDraftId("");
+    updateMetadata({ chipId: "", targetType: null, targetId: "", cooldownId: "" });
+  };
+
+  const saveCooldownMetadata = (nextCooldownId: string) => {
+    setCooldownDraftId(nextCooldownId);
+    updateMetadata({ cooldownId: nextCooldownId });
+  };
+
+  const saveAssigneeMetadata = (nextAssigneeUsername: string) => {
+    updateMetadata({ assigneeUsername: nextAssigneeUsername || null });
+  };
 
   return (
     <div
@@ -336,21 +513,38 @@ function ForumThreadPreviewSidebar({
                   </span>
                 </div>
                 <div className="mt-3 flex flex-wrap gap-2">
-                  <Link href={`/forum/${post.id}`} className="btn btn-primary btn-sm gap-1">
+                  <Link
+                    href={
+                      returnQuery
+                        ? `/forum/${post.id}?from=${encodeURIComponent(returnQuery)}`
+                        : `/forum/${post.id}`
+                    }
+                    className="btn btn-primary btn-sm gap-1"
+                  >
                     <ExternalLink className="h-3.5 w-3.5" />
                     Open full page
                   </Link>
+                  {canManage && (
+                    <button
+                      type="button"
+                      className={`btn btn-sm gap-1 ${editingMetadata ? "btn-neutral" : "btn-outline"}`}
+                      onClick={() => setEditingMetadata((open) => !open)}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                      Edit metadata
+                    </button>
+                  )}
                 </div>
               </header>
 
-              {(targetContext || post.cooldown_id) && (
+              {(targetContext || post.cooldown_id || post.assignee_username) && (
                 <div className="rounded-lg bg-base-200/60 p-3 text-xs">
                   <div className="grid gap-2 sm:grid-cols-2">
                     {targetContext && (
                       <div>
                         <div className="text-base-content/45">Target</div>
                         <div className="mt-1 font-medium">
-                          {formatTargetLabel(targetContext.targetType, targetContext.targetId)} ·{" "}
+                          {formatTargetLabel(targetContext.targetType, targetContext.targetId)} -{" "}
                           {targetContext.chipId}
                         </div>
                       </div>
@@ -361,8 +555,171 @@ function ForumThreadPreviewSidebar({
                         <div className="mt-1 font-medium">{post.cooldown_id}</div>
                       </div>
                     )}
+                    {post.assignee_username && (
+                      <div>
+                        <div className="text-base-content/45">Assignee</div>
+                        <div className="mt-1 font-medium">{post.assignee_username}</div>
+                      </div>
+                    )}
                   </div>
                 </div>
+              )}
+
+              {editingMetadata && canManage && (
+                <section className="rounded-lg border border-base-300 bg-base-200/40 p-3">
+                  <div className="mb-3 flex items-center justify-between gap-2">
+                    <h3 className="text-sm font-semibold">Metadata</h3>
+                    {updateMutation.isPending && (
+                      <span className="loading loading-spinner loading-xs" />
+                    )}
+                  </div>
+                  <div className="space-y-4">
+                    <label className="block space-y-1">
+                      <span className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+                        {CategoryIcon && <CategoryIcon className="h-3.5 w-3.5" />}
+                        Category
+                      </span>
+                      <select
+                        className="select select-bordered select-sm w-full"
+                        value={post.category}
+                        disabled={updateMutation.isPending}
+                        onChange={(event) => updateMetadata({ category: event.target.value })}
+                      >
+                        {categories.map((item) => (
+                          <option key={item.id} value={item.id}>
+                            {item.label}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+                        <Crosshair className="h-3.5 w-3.5" />
+                        Target
+                      </div>
+                      <select
+                        className="select select-bordered select-xs w-full"
+                        value={targetDraftChipId}
+                        disabled={updateMutation.isPending}
+                        onChange={(event) => {
+                          const nextChipId = event.target.value;
+                          setTargetDraftChipId(nextChipId);
+                          setCooldownDraftId("");
+                          saveTargetMetadata(nextChipId, targetDraftType, targetDraftId);
+                        }}
+                      >
+                        <option value="">Select chip</option>
+                        {chips.map((chip) => (
+                          <option key={chip.chip_id} value={chip.chip_id}>
+                            {chip.chip_id}
+                          </option>
+                        ))}
+                      </select>
+                      <div className="grid grid-cols-[96px_1fr] gap-2">
+                        <select
+                          className="select select-bordered select-xs w-full"
+                          value={targetDraftType}
+                          disabled={updateMutation.isPending}
+                          onChange={(event) => {
+                            const nextType =
+                              event.target.value === "coupling" ? "coupling" : "qubit";
+                            setTargetDraftType(nextType);
+                            saveTargetMetadata(targetDraftChipId, nextType, targetDraftId);
+                          }}
+                        >
+                          <option value="qubit">Qubit</option>
+                          <option value="coupling">Coupling</option>
+                        </select>
+                        <input
+                          className="input input-bordered input-xs w-full"
+                          value={targetDraftId}
+                          disabled={updateMutation.isPending}
+                          onChange={(event) => setTargetDraftId(event.target.value)}
+                          onBlur={() => saveTargetMetadata()}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") {
+                              event.currentTarget.blur();
+                            }
+                          }}
+                          placeholder={targetDraftType === "coupling" ? "0-1" : "0"}
+                        />
+                      </div>
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          className="btn btn-ghost btn-xs"
+                          onClick={clearTargetMetadata}
+                          disabled={updateMutation.isPending || !targetContext}
+                        >
+                          Clear
+                        </button>
+                      </div>
+                    </div>
+
+                    <label className="block space-y-1">
+                      <span className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+                        <CalendarDays className="h-3.5 w-3.5" />
+                        Cooldown
+                      </span>
+                      <select
+                        className="select select-bordered select-xs w-full"
+                        value={cooldownDraftId}
+                        onChange={(event) => saveCooldownMetadata(event.target.value)}
+                        disabled={!targetDraftChipId || updateMutation.isPending}
+                      >
+                        <option value="">No cooldown</option>
+                        {cooldowns.map((cooldown) => (
+                          <option key={cooldown.cooldown_id} value={cooldown.cooldown_id}>
+                            {cooldown.cooldown_id}
+                            {formatCooldownPeriod(cooldown)
+                              ? ` - ${formatCooldownPeriod(cooldown)}`
+                              : ""}
+                          </option>
+                        ))}
+                      </select>
+                      {selectedCooldown && (
+                        <span className="block text-xs text-base-content/55">
+                          {formatCooldownPeriod(selectedCooldown)}
+                        </span>
+                      )}
+                    </label>
+
+                    <label className="block space-y-1">
+                      <span className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+                        <UserRound className="h-3.5 w-3.5" />
+                        Assignee
+                      </span>
+                      <select
+                        className="select select-bordered select-xs w-full"
+                        value={post.assignee_username ?? ""}
+                        onChange={(event) => saveAssigneeMetadata(event.target.value)}
+                        disabled={updateMutation.isPending}
+                      >
+                        <option value="">Unassigned</option>
+                        {members.map((member) => (
+                          <option key={member.username} value={member.username}>
+                            {member.display_name
+                              ? `${member.display_name} (@${member.username})`
+                              : member.username}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+                        <Tag className="h-3.5 w-3.5" />
+                        Labels
+                      </div>
+                      <ForumLabelPicker
+                        selectedLabels={post.labels ?? []}
+                        onToggle={togglePostLabel}
+                        disabled={updateMutation.isPending}
+                      />
+                    </div>
+                  </div>
+                </section>
               )}
 
               <section>
@@ -430,13 +787,22 @@ function ForumThreadPreviewSidebar({
 
 export function ForumPageContent() {
   const queryClient = useQueryClient();
+  const router = useRouter();
   const searchParams = useSearchParams();
   const { user } = useAuth();
-  const { isOwner } = useProject();
-  const [category, setCategory] = useState<CategoryFilter>("all");
-  const [labelFilter, setLabelFilter] = useState<string>("all");
-  const [status, setStatus] = useState<StatusFilter>("open");
-  const [skip, setSkip] = useState(0);
+  const { isOwner, projectId } = useProject();
+  const [category, setCategory] = useState<CategoryFilter>(
+    () => (searchParams.get("forum_category") as CategoryFilter | null) ?? "all",
+  );
+  const [labelFilter, setLabelFilter] = useState<string>(
+    () => searchParams.get("forum_label") ?? "all",
+  );
+  const [status, setStatus] = useState<StatusFilter>(() =>
+    parseForumStatus(searchParams.get("forum_status")),
+  );
+  const [skip, setSkip] = useState(
+    () => (parseForumPage(searchParams.get("forum_page")) - 1) * PAGE_SIZE,
+  );
   const [showComposer, setShowComposer] = useState(false);
   const [showCategoryManager, setShowCategoryManager] = useState(false);
   const [selectedPostId, setSelectedPostId] = useState<string | null>(null);
@@ -533,6 +899,46 @@ export function ForumPageContent() {
     });
   };
 
+  const buildListQuery = (
+    nextState: {
+      category?: CategoryFilter;
+      labelFilter?: string;
+      status?: StatusFilter;
+      skip?: number;
+    } = {},
+  ) => {
+    const nextCategory = nextState.category ?? category;
+    const nextLabelFilter = nextState.labelFilter ?? labelFilter;
+    const nextStatus = nextState.status ?? status;
+    const nextSkip = nextState.skip ?? skip;
+    const next = new URLSearchParams();
+    const page = Math.floor(nextSkip / PAGE_SIZE) + 1;
+    if (page > 1) next.set("forum_page", String(page));
+    if (nextCategory !== "all") next.set("forum_category", nextCategory);
+    if (nextLabelFilter !== "all") next.set("forum_label", nextLabelFilter);
+    if (nextStatus !== "open") next.set("forum_status", nextStatus);
+    return next.toString();
+  };
+
+  const replaceListQuery = (nextState: {
+    category?: CategoryFilter;
+    labelFilter?: string;
+    status?: StatusFilter;
+    skip?: number;
+  }) => {
+    const next = new URLSearchParams(searchParams.toString());
+    next.delete("forum_page");
+    next.delete("forum_category");
+    next.delete("forum_label");
+    next.delete("forum_status");
+    const listQuery = buildListQuery(nextState);
+    new URLSearchParams(listQuery).forEach((value, key) => next.set(key, value));
+    const query = next.toString();
+    router.replace(query ? `/forum?${query}` : "/forum", { scroll: false });
+  };
+
+  const listReturnQuery = buildListQuery();
+
   const submitThread = async () => {
     const trimmedTitle = title.trim();
     const trimmedContent = content.trim();
@@ -568,11 +974,13 @@ export function ForumPageContent() {
   const setCategoryFilter = (nextCategory: CategoryFilter) => {
     setCategory(nextCategory);
     setSkip(0);
+    replaceListQuery({ category: nextCategory, skip: 0 });
   };
 
   const setStatusFilter = (nextStatus: StatusFilter) => {
     setStatus(nextStatus);
     setSkip(0);
+    replaceListQuery({ status: nextStatus, skip: 0 });
   };
 
   const toggleSelectedLabel = (label: string) => {
@@ -582,6 +990,13 @@ export function ForumPageContent() {
   const setLabelFilterValue = (nextLabel: string) => {
     setLabelFilter(nextLabel);
     setSkip(0);
+    replaceListQuery({ labelFilter: nextLabel, skip: 0 });
+  };
+
+  const setPageSkip = (nextSkip: number) => {
+    const boundedSkip = Math.max(0, nextSkip);
+    setSkip(boundedSkip);
+    replaceListQuery({ skip: boundedSkip });
   };
 
   const submitCategory = async () => {
@@ -948,7 +1363,7 @@ export function ForumPageContent() {
               <button
                 className="btn btn-sm btn-ghost"
                 disabled={currentPage === 0}
-                onClick={() => setSkip(Math.max(0, skip - PAGE_SIZE))}
+                onClick={() => setPageSkip(skip - PAGE_SIZE)}
               >
                 Previous
               </button>
@@ -958,7 +1373,7 @@ export function ForumPageContent() {
               <button
                 className="btn btn-sm btn-ghost"
                 disabled={currentPage >= totalPages - 1}
-                onClick={() => setSkip(skip + PAGE_SIZE)}
+                onClick={() => setPageSkip(skip + PAGE_SIZE)}
               >
                 Next
               </button>
@@ -969,6 +1384,10 @@ export function ForumPageContent() {
       <ForumThreadPreviewSidebar
         postId={selectedPostId}
         categories={categories}
+        currentUsername={user?.username}
+        isOwner={isOwner}
+        projectId={projectId}
+        returnQuery={listReturnQuery}
         onClose={() => setSelectedPostId(null)}
       />
     </PageContainer>


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add metadata editing to the Forum list preview panel so users can update thread metadata without opening the full detail page.
- UI-only change; no API, schema, or generated client changes.

## Changes
- Added an Edit metadata panel to ForumPageContent with category, target, cooldown, assignee, and label controls.
- Preserved forum list page/filter state when opening a thread detail page and returning to the list.
- Sorted chip and cooldown selectors newest-first in both the Forum list preview panel and ForumDetailPage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forum filters and pagination now stay in the URL, so you can bookmark or share the same forum view.
  * Thread sidebars now preserve your current forum list when opening a post or returning from a thread.
  * Metadata editing in thread previews now includes more fields and a clearer layout.

* **Bug Fixes**
  * “Back to forum” navigation now returns to the correct filtered list, even after deleting a thread or when a thread is unavailable.
  * Forum-related chips and cooldowns now appear in a consistent, sorted order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->