### PR TITLE
refactor(ui): simplify dashboard summary note actions

### DIFF
--- a/ui/src/components/features/dashboard/DashboardTargetNoteModal.tsx
+++ b/ui/src/components/features/dashboard/DashboardTargetNoteModal.tsx
@@ -3,14 +3,12 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 
-import { ExternalLink, MessageSquarePlus, Pencil, Save, StickyNote, Trash2, X } from "lucide-react";
+import { ExternalLink, MessageSquarePlus, Pencil, Save, StickyNote, X } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useListForumPosts } from "@/client/forum/forum";
 import {
   getGetChipNotesSummaryQueryKey,
-  useDeleteCouplingNote,
-  useDeleteQubitNote,
   useUpsertCouplingNote,
   useUpsertQubitNote,
 } from "@/client/note/note";
@@ -119,11 +117,8 @@ export function DashboardTargetNoteModal({
   const queryClient = useQueryClient();
   const isCoupling = targetId.includes("-");
   const upsertQubit = useUpsertQubitNote();
-  const deleteQubit = useDeleteQubitNote();
   const upsertCoupling = useUpsertCouplingNote();
-  const deleteCoupling = useDeleteCouplingNote();
   const upsertPending = isCoupling ? upsertCoupling.isPending : upsertQubit.isPending;
-  const deletePending = isCoupling ? deleteCoupling.isPending : deleteQubit.isPending;
   const { data: forumPostsResponse } = useListForumPosts(
     {
       chip_id: chipId,
@@ -165,21 +160,6 @@ export function DashboardTargetNoteModal({
         qid: targetId,
         data: { content: draft },
       });
-    }
-    await invalidate();
-    onClose();
-  };
-
-  const handleDelete = async () => {
-    if (!existing) {
-      setDraft("");
-      onClose();
-      return;
-    }
-    if (isCoupling) {
-      await deleteCoupling.mutateAsync({ chipId, couplingId: targetId });
-    } else {
-      await deleteQubit.mutateAsync({ chipId, qid: targetId });
     }
     await invalidate();
     onClose();
@@ -299,15 +279,6 @@ export function DashboardTargetNoteModal({
                   <Pencil className="h-3.5 w-3.5" />
                   Edit
                 </button>
-                <button
-                  className="btn btn-sm btn-ghost text-error gap-1"
-                  onClick={handleDelete}
-                  disabled={deletePending}
-                  type="button"
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                  {deletePending ? "Deleting..." : "Delete"}
-                </button>
               </div>
             </div>
           ) : (
@@ -334,18 +305,7 @@ export function DashboardTargetNoteModal({
         </div>
 
         {mode === "edit" && (
-          <div className="px-5 py-4 border-t border-base-300 flex flex-wrap justify-between gap-2">
-            <div className="flex flex-wrap gap-2">
-              <button
-                className="btn btn-sm btn-ghost text-error gap-1"
-                onClick={handleDelete}
-                disabled={!existing || deletePending}
-                type="button"
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-                {deletePending ? "Deleting..." : "Delete"}
-              </button>
-            </div>
+          <div className="px-5 py-4 border-t border-base-300 flex flex-wrap justify-end gap-2">
             <div className="flex gap-2">
               <button className="btn btn-sm btn-ghost" onClick={onClose} type="button">
                 Cancel

--- a/ui/src/components/features/dashboard/MetricNotePanel.tsx
+++ b/ui/src/components/features/dashboard/MetricNotePanel.tsx
@@ -3,14 +3,12 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 
-import { ExternalLink, MessageSquarePlus, Pencil, Save, StickyNote, Trash2, X } from "lucide-react";
+import { ExternalLink, MessageSquarePlus, Pencil, Save, StickyNote, X } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useListForumPosts } from "@/client/forum/forum";
 import {
   getGetChipNotesSummaryQueryKey,
-  useDeleteCouplingNote,
-  useDeleteQubitNote,
   useUpsertCouplingNote,
   useUpsertQubitNote,
 } from "@/client/note/note";
@@ -152,11 +150,8 @@ export function MetricNotePanel({
   const [draft, setDraft] = useState(existing?.content ?? "");
 
   const upsertQubit = useUpsertQubitNote();
-  const deleteQubit = useDeleteQubitNote();
   const upsertCoupling = useUpsertCouplingNote();
-  const deleteCoupling = useDeleteCouplingNote();
   const upsertPending = isCoupling ? upsertCoupling.isPending : upsertQubit.isPending;
-  const deletePending = isCoupling ? deleteCoupling.isPending : deleteQubit.isPending;
   const { data: forumPostsResponse } = useListForumPosts(
     {
       chip_id: chipId,
@@ -203,28 +198,6 @@ export function MetricNotePanel({
     setMode("view");
   };
 
-  const handleDelete = async () => {
-    if (!existing) {
-      setDraft("");
-      setMode("view");
-      return;
-    }
-    if (isCoupling) {
-      await deleteCoupling.mutateAsync({
-        chipId,
-        couplingId: targetId,
-      });
-    } else {
-      await deleteQubit.mutateAsync({
-        chipId,
-        qid: targetId,
-      });
-    }
-    await invalidate();
-    setDraft("");
-    setMode("view");
-  };
-
   const handleCancel = () => {
     setDraft(existing?.content ?? "");
     setMode("view");
@@ -259,12 +232,7 @@ export function MetricNotePanel({
       {/* Body */}
       <div className="flex-1 overflow-auto p-4 space-y-3">
         {mode === "view" ? (
-          <ViewState
-            existing={existing}
-            onEdit={() => setMode("edit")}
-            onDelete={handleDelete}
-            deletePending={deletePending}
-          />
+          <ViewState existing={existing} onEdit={() => setMode("edit")} />
         ) : (
           <EditState
             existing={existing}
@@ -272,9 +240,7 @@ export function MetricNotePanel({
             onChange={setDraft}
             onSave={handleSave}
             onCancel={handleCancel}
-            onDelete={handleDelete}
             upsertPending={upsertPending}
-            deletePending={deletePending}
             mentionCandidates={mentionCandidates}
           />
         )}
@@ -383,17 +349,7 @@ export function MetricNotePanel({
   );
 }
 
-function ViewState({
-  existing,
-  onEdit,
-  onDelete,
-  deletePending,
-}: {
-  existing?: TargetNoteEntry;
-  onEdit: () => void;
-  onDelete: () => void;
-  deletePending: boolean;
-}) {
+function ViewState({ existing, onEdit }: { existing?: TargetNoteEntry; onEdit: () => void }) {
   if (!existing || !existing.content.trim()) {
     return (
       <div className="rounded-lg border border-dashed border-base-300 p-4 text-center space-y-3 bg-base-100">
@@ -426,15 +382,6 @@ function ViewState({
           <Pencil className="h-3.5 w-3.5" />
           Edit
         </button>
-        <button
-          className="btn btn-sm btn-ghost text-error gap-1"
-          onClick={onDelete}
-          disabled={deletePending}
-          type="button"
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-          {deletePending ? "Deleting…" : "Delete"}
-        </button>
       </div>
     </div>
   );
@@ -446,9 +393,7 @@ function EditState({
   onChange,
   onSave,
   onCancel,
-  onDelete,
   upsertPending,
-  deletePending,
   mentionCandidates,
 }: {
   existing?: TargetNoteEntry;
@@ -456,9 +401,7 @@ function EditState({
   onChange: (v: string) => void;
   onSave: () => void;
   onCancel: () => void;
-  onDelete: () => void;
   upsertPending: boolean;
-  deletePending: boolean;
   mentionCandidates?: MentionCandidate[];
 }) {
   const trimmed = draft.trim();
@@ -482,18 +425,8 @@ function EditState({
           </span>
         )}
       </div>
-      <div className="flex flex-wrap items-center justify-between gap-2 pt-1">
-        <button
-          className="btn btn-sm btn-ghost text-error gap-1"
-          onClick={onDelete}
-          disabled={!existing || deletePending}
-          type="button"
-          title={existing ? "Delete this note" : "No saved note to delete"}
-        >
-          <Trash2 className="h-3.5 w-3.5" />
-          Delete
-        </button>
-        <div className="flex gap-2 ml-auto">
+      <div className="flex flex-wrap items-center justify-end gap-2 pt-1">
+        <div className="flex gap-2">
           <button className="btn btn-sm btn-ghost gap-1" onClick={onCancel} type="button">
             <X className="h-3.5 w-3.5" />
             Cancel

--- a/ui/src/components/features/forum/categories.tsx
+++ b/ui/src/components/features/forum/categories.tsx
@@ -23,8 +23,8 @@ export const FORUM_LABELS: ForumLabelDefinition[] = [
   {
     id: "discussion",
     label: "Discussion",
-    badgeClass: "badge-warning",
-    buttonClass: "btn-warning",
+    badgeClass: "badge-secondary",
+    buttonClass: "btn-secondary",
   },
   { id: "info", label: "Info", badgeClass: "badge-info", buttonClass: "btn-info" },
   { id: "resolved", label: "Resolved", badgeClass: "badge-success", buttonClass: "btn-success" },
@@ -46,7 +46,7 @@ export function getForumLabel(label: string): ForumLabelDefinition {
 }
 
 export function forumMarkerClass(label: string | undefined): string {
-  if (label === "discussion") return "bg-warning text-warning-content";
+  if (label === "discussion") return "bg-secondary text-secondary-content";
   if (label === "resolved") return "bg-success text-success-content";
   return "bg-info text-info-content";
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Remove the visible delete action from dashboard pinned summaries so the primary workflow stays focused on editing the summary or moving discussion into forum threads.
- UI-only change; no API, schema, or generated client changes.

## Changes
- Removed pinned summary delete buttons from MetricNotePanel and DashboardTargetNoteModal.
- Removed unused delete note mutations and handlers from the dashboard summary UI.
- Changed the Forum Discussion label and dashboard marker from warning to secondary so it no longer matches pinned summary indicators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the option to delete existing dashboard target notes and pinned metric notes. Editing and saving still work, with cleaner action controls in the modal and panel.
* **Style**
  * Updated the forum “discussion” label appearance to use a new secondary color scheme for badges and markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->