### PR TITLE
refactor(ui): remove execution detail shortcut actions

### DIFF
--- a/ui/src/components/features/execution/ExecutionClient.tsx
+++ b/ui/src/components/features/execution/ExecutionClient.tsx
@@ -9,7 +9,6 @@ import {
   CheckCircle,
   Clock,
   Download,
-  ExternalLink,
   StopCircle,
   UserRound,
   XCircle,
@@ -235,20 +234,6 @@ export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailCl
                   {cancelMutation.isPending ? "Cancelling..." : "Cancel Execution"}
                 </button>
               )}
-              <a
-                href={`/execution/${executionId}/experiment`}
-                className="bg-neutral text-neutral-content px-4 py-2 rounded flex items-center justify-center hover:opacity-80 transition-colors text-sm sm:text-base"
-              >
-                <ExternalLink className="mr-2" size={16} />
-                Go to Experiment
-              </a>
-              <a
-                href={((execution.note as { [key: string]: unknown })?.ui_url as string) || "#"}
-                className="bg-accent text-accent-content px-4 py-2 rounded flex items-center justify-center hover:opacity-80 transition-colors text-sm sm:text-base"
-              >
-                <ExternalLink className="mr-2" size={16} />
-                Go to Flow
-              </a>
             </div>
           </div>
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Remove the Go to Experiment and Go to Flow shortcut buttons from the execution detail header.
- UI-only change; no API, schema, or generated client changes.

## Changes
- Removed the two shortcut action links from ExecutionClient.
- Removed the now-unused ExternalLink icon import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed two external navigation links from the execution view, simplifying the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->