### PR TITLE
refactor(workflow): define template task lists locally

### DIFF
--- a/src/qdash/workflow/templates/bringup.py
+++ b/src/qdash/workflow/templates/bringup.py
@@ -20,6 +20,13 @@ from qdash.workflow.service.calib_service import on_flow_cancellation
 from qdash.workflow.service.steps import BringUp, ConfigureAll
 from qdash.workflow.service.targets import MuxTargets
 
+BRINGUP_TASKS: list[str] = [
+    "CheckResonatorSpectroscopy",
+    "CheckQubitSpectroscopy",
+    "CheckControlAmplitude",
+    "CheckChevron",
+]
+
 
 @flow(on_cancellation=[on_flow_cancellation])
 def bringup(
@@ -79,7 +86,7 @@ def bringup(
 
     steps = [
         ConfigureAll(),
-        BringUp(mode=mode),
+        BringUp(mode=mode, tasks=BRINGUP_TASKS),
     ]
 
     cal = CalibService(

--- a/src/qdash/workflow/templates/experimental_simultaneous_bringup.py
+++ b/src/qdash/workflow/templates/experimental_simultaneous_bringup.py
@@ -9,6 +9,13 @@ from qdash.workflow.service.calib_service import on_flow_cancellation
 from qdash.workflow.service.steps import ExperimentalSimultaneousBringUp
 from qdash.workflow.service.targets import MuxTargets
 
+EXPERIMENTAL_SIMULTANEOUS_BRINGUP_TASKS: list[str] = [
+    "CheckResonatorSpectroscopy",
+    "CheckSimultaneousQubitSpectroscopy",
+    "CheckControlAmplitude",
+    "CheckChevron",
+]
+
 
 @flow(on_cancellation=[on_flow_cancellation])
 def experimental_simultaneous_bringup(
@@ -56,7 +63,8 @@ def experimental_simultaneous_bringup(
         targets,
         steps=[
             ExperimentalSimultaneousBringUp(
-                simultaneous_spectroscopy_schedule_mode=simultaneous_spectroscopy_schedule_mode
+                tasks=EXPERIMENTAL_SIMULTANEOUS_BRINGUP_TASKS,
+                simultaneous_spectroscopy_schedule_mode=simultaneous_spectroscopy_schedule_mode,
             )
         ],
     )

--- a/src/qdash/workflow/templates/full_calibration.py
+++ b/src/qdash/workflow/templates/full_calibration.py
@@ -37,6 +37,48 @@ from qdash.workflow.service.steps import (
 )
 from qdash.workflow.service.targets import MuxTargets
 
+FULL_1Q_CHECK_TASKS: list[str] = [
+    "CheckRabi",
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    # "CheckOptimalReadoutFrequency",
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CheckT1",
+    "CheckT2Echo",
+    "CheckRamsey",
+]
+
+FULL_1Q_FINE_TUNE_TASKS: list[str] = [
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "ReadoutClassification",
+    "CheckT1Average",
+    "CheckT2EchoAverage",
+    "Check1QGateCoherenceLimit",
+    "RandomizedBenchmarking",
+    "X90InterleavedRandomizedBenchmarking",
+]
+
+FULL_2Q_TASKS: list[str] = [
+    "CheckCrossResonance",
+    "CreateZX90",
+    "CheckZX90",
+    "CheckBellState",
+    "CheckBellStateTomography",
+    "Check2QGateCoherenceLimit",
+    "ZX90InterleavedRandomizedBenchmarking",
+]
+
 
 @flow(on_cancellation=[on_flow_cancellation])
 def full_calibration(
@@ -96,16 +138,16 @@ def full_calibration(
         # Stage 0: Push current configuration to all selected MUXes
         ConfigureAll(),
         # Stage 1: Basic 1Q characterization
-        OneQubitCheck(mode="synchronized"),
+        OneQubitCheck(mode="synchronized", tasks=FULL_1Q_CHECK_TASKS),
         FilterByStatus(),  # Only proceed with successful qubits
         # Stage 2: Advanced 1Q calibration (DRAG, RB, IRB)
-        OneQubitFineTune(mode="synchronized"),
+        OneQubitFineTune(mode="synchronized", tasks=FULL_1Q_FINE_TUNE_TASKS),
         # Stage 3: Filter by X90 fidelity
         FilterByMetric(metric="x90_fidelity", threshold=fidelity_threshold),
         # Stage 4: Generate 2Q schedule with explicit direction
         GenerateCRSchedule(max_parallel_ops=max_parallel_ops, inverse=inverse),
         # Stage 5: 2Q calibration
-        TwoQubitCalibration(),
+        TwoQubitCalibration(tasks=FULL_2Q_TASKS),
     ]
 
     # =========================================================================

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -25,6 +25,38 @@ from qdash.workflow.service.steps import (
 )
 from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
 
+ONE_QUBIT_CHECK_TASKS: list[str] = [
+    "CheckRabi",
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    # "CheckOptimalReadoutFrequency",
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CheckT1",
+    "CheckT2Echo",
+    "CheckRamsey",
+]
+
+ONE_QUBIT_FINE_TUNE_TASKS: list[str] = [
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "ReadoutClassification",
+    "CheckT1Average",
+    "CheckT2EchoAverage",
+    "Check1QGateCoherenceLimit",
+    "RandomizedBenchmarking",
+    "X90InterleavedRandomizedBenchmarking",
+]
+
 
 @flow(on_cancellation=[on_flow_cancellation])
 def one_qubit(
@@ -68,14 +100,14 @@ def one_qubit(
     if check_only:
         # Basic check only
         steps = [
-            OneQubitCheck(mode="synchronized"),
+            OneQubitCheck(mode="synchronized", tasks=ONE_QUBIT_CHECK_TASKS),
         ]
     else:
         # Full 1Q calibration
         steps = [
-            OneQubitCheck(mode="synchronized"),
+            OneQubitCheck(mode="synchronized", tasks=ONE_QUBIT_CHECK_TASKS),
             FilterByStatus(),  # Only proceed with successful qubits
-            OneQubitFineTune(mode="synchronized"),
+            OneQubitFineTune(mode="synchronized", tasks=ONE_QUBIT_FINE_TUNE_TASKS),
         ]
 
     cal = CalibService(

--- a/src/qdash/workflow/templates/two_qubit.py
+++ b/src/qdash/workflow/templates/two_qubit.py
@@ -43,6 +43,16 @@ from qdash.workflow.service.steps import (
 )
 from qdash.workflow.service.targets import QubitTargets
 
+TWO_QUBIT_TASKS: list[str] = [
+    "CheckCrossResonance",
+    "CreateZX90",
+    "CheckZX90",
+    "CheckBellState",
+    "CheckBellStateTomography",
+    "Check2QGateCoherenceLimit",
+    "ZX90InterleavedRandomizedBenchmarking",
+]
+
 
 @flow(on_cancellation=[on_flow_cancellation])
 def two_qubit(
@@ -74,6 +84,7 @@ def two_qubit(
             - CheckZX90
             - CheckBellState
             - CheckBellStateTomography
+            - Check2QGateCoherenceLimit
             - ZX90InterleavedRandomizedBenchmarking
         inverse: CR direction control based on checkerboard pattern.
             False (default): Forward direction - control qubit is at even parity
@@ -158,7 +169,7 @@ def two_qubit(
         )
     else:
         # Full 2Q calibration
-        steps.append(TwoQubitCalibration())
+        steps.append(TwoQubitCalibration(tasks=TWO_QUBIT_TASKS))
 
     # =========================================================================
     # Execute Pipeline

--- a/src/qdash/workflow/templates/two_qubit_scheduled.py
+++ b/src/qdash/workflow/templates/two_qubit_scheduled.py
@@ -32,6 +32,16 @@ from qdash.workflow.service.steps import (
 )
 from qdash.workflow.service.targets import CouplingTargets
 
+TWO_QUBIT_SCHEDULED_TASKS: list[str] = [
+    "CheckCrossResonance",
+    "CreateZX90",
+    "CheckZX90",
+    "CheckBellState",
+    "CheckBellStateTomography",
+    "Check2QGateCoherenceLimit",
+    "ZX90InterleavedRandomizedBenchmarking",
+]
+
 
 @flow(on_cancellation=[on_flow_cancellation])
 def two_qubit_scheduled(
@@ -58,6 +68,7 @@ def two_qubit_scheduled(
             - CheckZX90
             - CheckBellState
             - CheckBellStateTomography
+            - Check2QGateCoherenceLimit
             - ZX90InterleavedRandomizedBenchmarking
         flow_name: Flow name (auto-injected)
         project_id: Project ID (auto-injected)
@@ -127,7 +138,7 @@ def two_qubit_scheduled(
         )
     else:
         # Full 2Q calibration
-        steps.append(TwoQubitCalibration())
+        steps.append(TwoQubitCalibration(tasks=TWO_QUBIT_SCHEDULED_TASKS))
 
     # =========================================================================
     # Execute Pipeline

--- a/tests/qdash/workflow/test_bringup_template.py
+++ b/tests/qdash/workflow/test_bringup_template.py
@@ -83,3 +83,25 @@ def test_experimental_simultaneous_bringup_defaults_to_all_mode(monkeypatch) -> 
 
     step = result["steps"][0]
     assert step.simultaneous_spectroscopy_schedule_mode == "all"
+
+
+def test_bringup_template_passes_template_task_list(monkeypatch) -> None:
+    monkeypatch.setattr(bringup_module, "CalibService", FakeCalibService)
+
+    result = bringup_module.bringup(username="alice", chip_id="16Q-test", mux_ids=[0])
+
+    assert result["steps"][1].tasks == bringup_module.BRINGUP_TASKS
+
+
+def test_experimental_simultaneous_bringup_passes_template_task_list(monkeypatch) -> None:
+    monkeypatch.setattr(experimental_bringup_module, "CalibService", FakeCalibService)
+
+    result = experimental_bringup_module.experimental_simultaneous_bringup(
+        username="alice",
+        chip_id="16Q-test",
+        mux_ids=[0],
+    )
+
+    assert result["steps"][0].tasks == (
+        experimental_bringup_module.EXPERIMENTAL_SIMULTANEOUS_BRINGUP_TASKS
+    )

--- a/tests/qdash/workflow/test_full_calibration_template.py
+++ b/tests/qdash/workflow/test_full_calibration_template.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+from qdash.workflow.service.steps import (
+    ConfigureAll,
+    FilterByMetric,
+    FilterByStatus,
+    GenerateCRSchedule,
+    OneQubitCheck,
+    OneQubitFineTune,
+    TwoQubitCalibration,
+)
+
+full_module = importlib.import_module("qdash.workflow.templates.full_calibration")
+
+
+class FakeCalibService:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self, targets: Any, *, steps: list[Any]) -> dict[str, Any]:
+        return {"targets": targets, "steps": steps, "service_kwargs": self.kwargs}
+
+
+def test_full_calibration_passes_template_task_lists(monkeypatch) -> None:
+    monkeypatch.setattr(full_module, "CalibService", FakeCalibService)
+
+    result = full_module.full_calibration(username="alice", chip_id="64Q", mux_ids=[0])
+
+    steps = result["steps"]
+    assert [type(step) for step in steps] == [
+        ConfigureAll,
+        OneQubitCheck,
+        FilterByStatus,
+        OneQubitFineTune,
+        FilterByMetric,
+        GenerateCRSchedule,
+        TwoQubitCalibration,
+    ]
+    assert steps[1].tasks == full_module.FULL_1Q_CHECK_TASKS
+    assert steps[3].tasks == full_module.FULL_1Q_FINE_TUNE_TASKS
+    assert steps[6].tasks == full_module.FULL_2Q_TASKS

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -51,3 +51,21 @@ def test_one_qubit_template_defaults_to_all_muxes(monkeypatch) -> None:
 
     assert isinstance(result["targets"], MuxTargets)
     assert result["targets"].mux_ids == list(range(16))
+
+
+def test_one_qubit_template_passes_template_task_lists(monkeypatch) -> None:
+    monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
+
+    result = one_qubit_module.one_qubit(username="alice", chip_id="64Q")
+
+    steps = result["steps"]
+    assert steps[0].tasks == one_qubit_module.ONE_QUBIT_CHECK_TASKS
+    assert steps[2].tasks == one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS
+
+
+def test_one_qubit_template_check_only_passes_template_task_list(monkeypatch) -> None:
+    monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
+
+    result = one_qubit_module.one_qubit(username="alice", chip_id="64Q", check_only=True)
+
+    assert result["steps"][0].tasks == one_qubit_module.ONE_QUBIT_CHECK_TASKS

--- a/tests/qdash/workflow/test_two_qubit_templates.py
+++ b/tests/qdash/workflow/test_two_qubit_templates.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+two_qubit_module = importlib.import_module("qdash.workflow.templates.two_qubit")
+two_qubit_scheduled_module = importlib.import_module("qdash.workflow.templates.two_qubit_scheduled")
+
+
+class FakeCalibService:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self, targets: Any, *, steps: list[Any]) -> dict[str, Any]:
+        return {"targets": targets, "steps": steps}
+
+
+def test_two_qubit_template_passes_template_task_list(monkeypatch) -> None:
+    monkeypatch.setattr(two_qubit_module, "CalibService", FakeCalibService)
+
+    result = two_qubit_module.two_qubit(
+        username="alice",
+        chip_id="64Q",
+        qids=["0", "1"],
+    )
+
+    assert result["steps"][1].tasks == two_qubit_module.TWO_QUBIT_TASKS
+
+
+def test_two_qubit_template_keeps_custom_tasks(monkeypatch) -> None:
+    monkeypatch.setattr(two_qubit_module, "CalibService", FakeCalibService)
+
+    result = two_qubit_module.two_qubit(
+        username="alice",
+        chip_id="64Q",
+        qids=["0", "1"],
+        tasks=["CheckCrossResonance"],
+    )
+
+    assert result["steps"][1].tasks == ["CheckCrossResonance"]
+
+
+def test_two_qubit_scheduled_template_passes_template_task_list(monkeypatch) -> None:
+    monkeypatch.setattr(two_qubit_scheduled_module, "CalibService", FakeCalibService)
+
+    result = two_qubit_scheduled_module.two_qubit_scheduled(
+        username="alice",
+        chip_id="64Q",
+        schedule=[[("0", "1")]],
+    )
+
+    assert result["steps"][1].tasks == two_qubit_scheduled_module.TWO_QUBIT_SCHEDULED_TASKS
+
+
+def test_two_qubit_scheduled_template_keeps_custom_tasks(monkeypatch) -> None:
+    monkeypatch.setattr(two_qubit_scheduled_module, "CalibService", FakeCalibService)
+
+    result = two_qubit_scheduled_module.two_qubit_scheduled(
+        username="alice",
+        chip_id="64Q",
+        schedule=[[("0", "1")]],
+        tasks=["CheckCrossResonance"],
+    )
+
+    assert result["steps"][1].tasks == ["CheckCrossResonance"]


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Move editable workflow task-list definitions into the official templates while keeping service task presets as fallback defaults.
- Make full, one-qubit, bring-up, experimental bring-up, and two-qubit templates show their executed task sequences directly.

## Changes
- Added template-local task list constants and passed them explicitly to workflow steps.
- Preserved custom task overrides for two-qubit templates.
- Added template tests covering explicit task-list wiring.

## Verification
- uv run ruff format src/qdash/workflow/templates/bringup.py src/qdash/workflow/templates/experimental_simultaneous_bringup.py src/qdash/workflow/templates/full_calibration.py src/qdash/workflow/templates/one_qubit.py src/qdash/workflow/templates/two_qubit.py src/qdash/workflow/templates/two_qubit_scheduled.py tests/qdash/workflow/test_bringup_template.py tests/qdash/workflow/test_one_qubit_template.py tests/qdash/workflow/test_full_calibration_template.py tests/qdash/workflow/test_two_qubit_templates.py
- uv run ruff check src/qdash/workflow/templates/bringup.py src/qdash/workflow/templates/experimental_simultaneous_bringup.py src/qdash/workflow/templates/full_calibration.py src/qdash/workflow/templates/one_qubit.py src/qdash/workflow/templates/two_qubit.py src/qdash/workflow/templates/two_qubit_scheduled.py tests/qdash/workflow/test_bringup_template.py tests/qdash/workflow/test_one_qubit_template.py tests/qdash/workflow/test_full_calibration_template.py tests/qdash/workflow/test_two_qubit_templates.py
- uv run pytest tests/qdash/workflow/test_bringup_template.py tests/qdash/workflow/test_one_qubit_template.py tests/qdash/workflow/test_full_calibration_template.py tests/qdash/workflow/test_two_qubit_templates.py tests/qdash/workflow/test_fast_full_calibration_template.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration and bring-up workflows now use explicit task lists for one-qubit, two-qubit, bring-up, and experimental simultaneous bring-up flows, making the executed steps more consistent and predictable.
  * Scheduled and full calibration flows now include an updated set of checks, including an additional two-qubit gate coherence limit check.

* **Tests**
  * Added coverage to verify each workflow passes the expected task lists and respects custom task overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->