### PR TITLE
feat(ui): add forum thread creation page

### DIFF
--- a/ui/src/app/(auth)/forum/new/page.tsx
+++ b/ui/src/app/(auth)/forum/new/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Suspense } from "react";
+
+import { ForumNewPage } from "@/components/features/forum/ForumNewPage";
+import { PageContainer } from "@/components/ui/PageContainer";
+
+function ForumNewSkeleton() {
+  return (
+    <div className="mx-auto max-w-6xl">
+      <div className="mb-6 flex items-center gap-3">
+        <div className="h-8 w-8 animate-pulse rounded bg-base-300" />
+        <div className="h-8 w-80 max-w-full animate-pulse rounded bg-base-300" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="h-80 animate-pulse rounded-lg bg-base-300" />
+        <div className="h-80 animate-pulse rounded-lg bg-base-300" />
+      </div>
+    </div>
+  );
+}
+
+export default function ForumNewPageRoute() {
+  return (
+    <Suspense fallback={<ForumNewSkeleton />}>
+      <PageContainer maxWidth>
+        <ForumNewPage />
+      </PageContainer>
+    </Suspense>
+  );
+}

--- a/ui/src/components/features/dashboard/DashboardTargetNoteModal.tsx
+++ b/ui/src/components/features/dashboard/DashboardTargetNoteModal.tsx
@@ -57,7 +57,7 @@ function forumDraftHref(chipId: string, targetId: string, cooldownId?: string | 
     content: [`Chip: ${chipId}`, `Target: ${targetLabel}`, "", "Notes:"].join("\n"),
   });
   if (cooldownId) params.set("cooldown_id", cooldownId);
-  return `/forum?${params.toString()}`;
+  return `/forum/new?${params.toString()}`;
 }
 
 function normalizeQid(value: string): string {

--- a/ui/src/components/features/dashboard/MetricNotePanel.tsx
+++ b/ui/src/components/features/dashboard/MetricNotePanel.tsx
@@ -78,7 +78,7 @@ function forumDraftHref(chipId: string, targetId: string, cooldownId?: string | 
     content: [`Chip: ${chipId}`, `Target: ${targetLabel}`, "", "Notes:"].join("\n"),
   });
   if (cooldownId) params.set("cooldown_id", cooldownId);
-  return `/forum?${params.toString()}`;
+  return `/forum/new?${params.toString()}`;
 }
 
 function normalizeQid(value: string): string {

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -130,6 +130,7 @@ function PostBody({
   canEdit: canEditOverride,
   onEdit,
   onDelete,
+  postAction = "delete",
   editing,
   editContent,
   editInitialBlocks,
@@ -146,7 +147,8 @@ function PostBody({
   currentUsername?: string;
   canEdit?: boolean;
   onEdit: () => void;
-  onDelete: () => void;
+  onDelete?: () => void;
+  postAction?: "delete" | "close";
   editing: boolean;
   /** Current markdown projection — used only to gate the Save button. */
   editContent: string;
@@ -162,6 +164,8 @@ function PostBody({
 }) {
   const canEdit = canEditOverride ?? currentUsername === post.username;
   const isAi = post.is_ai_reply || post.username === "qdash";
+  const ActionIcon = postAction === "close" ? Lock : Trash2;
+  const actionTitle = postAction === "close" ? "Close thread" : "Delete";
 
   return (
     <div
@@ -186,7 +190,7 @@ function PostBody({
             <span className="text-xs italic text-base-content/30">(edited)</span>
           )}
         </div>
-        {canEdit && !editing && !isAi && (
+        {canEdit && !editing && !isAi && onDelete && (
           <div className="flex items-center gap-1">
             <button
               className="btn btn-ghost btn-sm btn-square text-base-content/40 hover:text-primary"
@@ -196,11 +200,13 @@ function PostBody({
               <Pencil className="h-4 w-4" />
             </button>
             <button
-              className="btn btn-ghost btn-sm btn-square text-base-content/40 hover:text-error"
+              className={`btn btn-ghost btn-sm btn-square text-base-content/40 ${
+                postAction === "close" ? "hover:text-primary" : "hover:text-error"
+              }`}
               onClick={onDelete}
-              title="Delete"
+              title={actionTitle}
             >
-              <Trash2 className="h-4 w-4" />
+              <ActionIcon className="h-4 w-4" />
             </button>
           </div>
         )}
@@ -559,12 +565,8 @@ export function ForumDetailPage({ postId }: { postId: string }) {
     updateRootMetadata({ assigneeUsername: nextAssigneeUsername || null });
   };
 
-  const handleDelete = async (targetPostId: string, isRoot: boolean) => {
+  const handleDeleteReply = async (targetPostId: string) => {
     await deleteMutation.mutateAsync({ postId: targetPostId });
-    if (isRoot) {
-      router.push(forumReturnHref);
-      return;
-    }
     invalidateThread();
   };
 
@@ -664,7 +666,12 @@ export function ForumDetailPage({ postId }: { postId: string }) {
             currentUsername={currentUsername}
             canEdit={canManage}
             onEdit={handleStartEditRoot}
-            onDelete={() => handleDelete(post.id, true)}
+            onDelete={
+              post.is_closed
+                ? undefined
+                : () => closeMutation.mutate({ postId }, { onSuccess: invalidateThread })
+            }
+            postAction="close"
             editing={editingRoot}
             editContent={editRootContent}
             editInitialBlocks={editRootBlocks}
@@ -698,7 +705,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                     post={reply}
                     currentUsername={currentUsername}
                     onEdit={() => handleStartEditReply(reply)}
-                    onDelete={() => handleDelete(reply.id, false)}
+                    onDelete={() => handleDeleteReply(reply.id)}
                     editing={editingReplyId === reply.id}
                     editContent={editReplyContent}
                     editInitialBlocks={editReplyBlocks}

--- a/ui/src/components/features/forum/ForumLabelSelector.tsx
+++ b/ui/src/components/features/forum/ForumLabelSelector.tsx
@@ -4,44 +4,6 @@ import { Check, Tag } from "lucide-react";
 
 import { FORUM_LABELS, getForumLabel } from "./categories";
 
-type ForumLabelSelectorProps = {
-  selectedLabels: string[];
-  onToggle: (label: string) => void;
-  size?: "xs" | "sm";
-  disabled?: boolean;
-};
-
-export function ForumLabelSelector({
-  selectedLabels,
-  onToggle,
-  size = "xs",
-  disabled = false,
-}: ForumLabelSelectorProps) {
-  const sizeClass = size === "sm" ? "btn-sm h-8 min-h-8" : "btn-xs h-7 min-h-7";
-
-  return (
-    <div className="flex flex-wrap gap-1.5">
-      {FORUM_LABELS.map((item) => {
-        const selected = selectedLabels.includes(item.id);
-        return (
-          <button
-            key={item.id}
-            type="button"
-            aria-pressed={selected}
-            disabled={disabled}
-            className={`btn ${sizeClass} rounded-md border px-2 font-medium normal-case ${
-              selected ? item.buttonClass : "btn-ghost border-base-300 bg-base-100"
-            }`}
-            onClick={() => onToggle(item.id)}
-          >
-            {item.label}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
 type ForumLabelPickerProps = {
   selectedLabels: string[];
   onToggle: (label: string) => void;

--- a/ui/src/components/features/forum/ForumNewPage.tsx
+++ b/ui/src/components/features/forum/ForumNewPage.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, CalendarDays, Crosshair, Send, Tag, UserRound } from "lucide-react";
+
+import { useListChips } from "@/client/chip/chip";
+import { useListCooldowns } from "@/client/cooldown/cooldown";
+import {
+  getListForumPostsQueryKey,
+  useCreateForumPost,
+  useListForumCategories,
+} from "@/client/forum/forum";
+import { useListProjectMembers } from "@/client/projects/projects";
+import { UserAvatar } from "@/components/ui/UserAvatar";
+import { useAuth } from "@/contexts/AuthContext";
+import { useProject } from "@/contexts/ProjectContext";
+import { useForumAiReply } from "@/hooks/useForumAiReply";
+import { useImageUpload } from "@/hooks/useImageUpload";
+import { formatDateTimeCompact } from "@/lib/utils/datetime";
+
+import {
+  DEFAULT_FORUM_CATEGORIES,
+  getForumCategory,
+  toForumCategoryDefinition,
+} from "./categories";
+import { ForumLabelPicker } from "./ForumLabelSelector";
+import type { ForumBlockSnapshotGetter } from "./ForumBlockEditor";
+
+const ForumBlockEditor = dynamic(
+  () => import("./ForumBlockEditor").then((m) => ({ default: m.ForumBlockEditor })),
+  { ssr: false },
+);
+
+function normalizeTargetType(value: string | null | undefined): "qubit" | "coupling" | null {
+  return value === "qubit" || value === "coupling" ? value : null;
+}
+
+function formatCooldownPeriod(
+  cooldown: { started_at?: string | null; ended_at?: string | null } | undefined,
+): string {
+  if (!cooldown?.started_at) return "";
+  const start = formatDateTimeCompact(cooldown.started_at);
+  const end = cooldown.ended_at ? formatDateTimeCompact(cooldown.ended_at) : "ongoing";
+  return `${start} - ${end}`;
+}
+
+function parseLabels(value: string | null): string[] {
+  return (value ?? "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 1);
+}
+
+export function ForumNewPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { projectId } = useProject();
+  const { uploadImage } = useImageUpload("forum");
+  const { triggerAiReply } = useForumAiReply();
+  const editorSnapshotRef = useRef<ForumBlockSnapshotGetter | null>(null);
+  const fromQuery = searchParams.get("from");
+  const forumReturnHref = fromQuery ? `/forum?${fromQuery.replace(/^\?/, "")}` : "/forum";
+
+  const initialTargetType = normalizeTargetType(searchParams.get("target_type"));
+  const [category, setCategory] = useState(searchParams.get("category") ?? "qubit");
+  const [title, setTitle] = useState(searchParams.get("title") ?? "");
+  const [content, setContent] = useState(searchParams.get("content") ?? "");
+  const [contentBlocks, setContentBlocks] = useState<Record<string, unknown>[]>([]);
+  const [selectedLabels, setSelectedLabels] = useState<string[]>(() =>
+    parseLabels(searchParams.get("labels")),
+  );
+  const [targetDraftChipId, setTargetDraftChipId] = useState(searchParams.get("chip_id") ?? "");
+  const [targetDraftType, setTargetDraftType] = useState<"qubit" | "coupling">(
+    initialTargetType ?? (searchParams.get("category") === "coupling" ? "coupling" : "qubit"),
+  );
+  const [targetDraftId, setTargetDraftId] = useState(searchParams.get("target_id") ?? "");
+  const [cooldownDraftId, setCooldownDraftId] = useState(searchParams.get("cooldown_id") ?? "");
+  const [assigneeUsername, setAssigneeUsername] = useState("");
+
+  const { data: categoriesResponse } = useListForumCategories(undefined, {
+    query: { staleTime: 60_000 },
+  });
+  const categories = useMemo(
+    () =>
+      categoriesResponse?.data.categories.map(toForumCategoryDefinition) ??
+      DEFAULT_FORUM_CATEGORIES,
+    [categoriesResponse?.data.categories],
+  );
+  const selectedCategory = getForumCategory(category, categories);
+  const CategoryIcon = selectedCategory.icon;
+
+  const { data: chipsResponse } = useListChips({ query: { staleTime: 60_000 } });
+  const chips = useMemo(
+    () =>
+      [...(chipsResponse?.data.chips ?? [])].sort((a, b) => {
+        const aTime = a.installed_at ? new Date(a.installed_at).getTime() : 0;
+        const bTime = b.installed_at ? new Date(b.installed_at).getTime() : 0;
+        return bTime - aTime || b.chip_id.localeCompare(a.chip_id);
+      }),
+    [chipsResponse?.data.chips],
+  );
+
+  const { data: cooldownsResponse } = useListCooldowns(
+    { chip_id: targetDraftChipId || undefined },
+    { query: { enabled: !!targetDraftChipId, staleTime: 60_000 } },
+  );
+  const cooldowns = useMemo(
+    () =>
+      [...(cooldownsResponse?.data.cooldowns ?? [])].sort((a, b) => {
+        const aTime = a.started_at ? new Date(a.started_at).getTime() : 0;
+        const bTime = b.started_at ? new Date(b.started_at).getTime() : 0;
+        return bTime - aTime || b.cooldown_id.localeCompare(a.cooldown_id);
+      }),
+    [cooldownsResponse?.data.cooldowns],
+  );
+  const selectedCooldown = cooldowns.find((cooldown) => cooldown.cooldown_id === cooldownDraftId);
+
+  const { data: membersResponse } = useListProjectMembers(projectId ?? "", {
+    query: { enabled: !!projectId, staleTime: 60_000 },
+  });
+  const members = useMemo(
+    () => (membersResponse?.data.members ?? []).filter((member) => member.status === "active"),
+    [membersResponse?.data.members],
+  );
+
+  const createMutation = useCreateForumPost();
+
+  const toggleLabel = (label: string) => {
+    setSelectedLabels((current) => (current.includes(label) ? [] : [label]));
+  };
+
+  const clearTargetMetadata = () => {
+    setTargetDraftChipId("");
+    setTargetDraftType("qubit");
+    setTargetDraftId("");
+    setCooldownDraftId("");
+  };
+
+  const handleCreate = async () => {
+    const snapshot = await editorSnapshotRef.current?.();
+    const trimmedTitle = title.trim();
+    const trimmedContent = (snapshot?.markdown ?? content).trim();
+    const nextBlocks = snapshot?.blocks ?? contentBlocks;
+    if (!trimmedTitle || !trimmedContent) return;
+
+    const chipId = targetDraftChipId.trim();
+    const targetId = targetDraftId.trim();
+    const hasTarget = !!chipId && !!targetId;
+    const response = await createMutation.mutateAsync({
+      data: {
+        category,
+        title: trimmedTitle,
+        content: trimmedContent,
+        content_blocks: nextBlocks,
+        parent_id: null,
+        labels: selectedLabels,
+        assignee_username: assigneeUsername || null,
+        chip_id: hasTarget ? chipId : null,
+        target_type: hasTarget ? targetDraftType : null,
+        target_id: hasTarget ? targetId : null,
+        cooldown_id: cooldownDraftId || null,
+      },
+    });
+    queryClient.invalidateQueries({ queryKey: getListForumPostsQueryKey() });
+    if (/@qdash\b/i.test(trimmedContent)) {
+      triggerAiReply(response.data.id, trimmedContent, () => {
+        queryClient.invalidateQueries({ queryKey: getListForumPostsQueryKey() });
+      });
+    }
+    const detailHref = fromQuery
+      ? `/forum/${response.data.id}?from=${encodeURIComponent(fromQuery)}`
+      : `/forum/${response.data.id}`;
+    router.push(detailHref);
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <div className="mb-6 flex min-w-0 items-start gap-3">
+        <button
+          className="btn btn-square btn-ghost btn-sm shrink-0"
+          onClick={() => router.push(forumReturnHref)}
+          title="Back to Forum"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-start gap-2">
+            <span className="badge badge-outline mt-1 shrink-0">Draft</span>
+            <input
+              className="input input-bordered input-sm min-w-0 flex-1 text-xl font-bold"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Thread title"
+            />
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-base-content/50">
+            <span>Opened by {user?.username ?? "you"}</span>
+            <span>New forum thread</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="min-w-0 pb-8">
+          <div className="rounded-lg border border-base-300 bg-base-100 p-4">
+            <ForumBlockEditor
+              legacyMarkdown={content}
+              onChange={(blocks, markdown) => {
+                setContentBlocks(blocks);
+                setContent(markdown);
+              }}
+              onImageUpload={uploadImage}
+              snapshotRef={editorSnapshotRef}
+            />
+            <div className="mt-2 flex items-center justify-between gap-2">
+              <span className="text-xs text-base-content/50">
+                Type <kbd className="kbd kbd-xs">/</kbd> for blocks. Use{" "}
+                <span className="font-mono">@username</span> to mention members.
+              </span>
+              <button
+                type="button"
+                className="btn btn-sm btn-primary gap-2"
+                onClick={handleCreate}
+                disabled={!title.trim() || !content.trim() || createMutation.isPending}
+              >
+                {createMutation.isPending ? (
+                  <span className="loading loading-spinner loading-xs" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+                Post
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <aside className="space-y-5 border-t border-base-300 pt-4 lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
+          <section className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+              <CategoryIcon className="h-3.5 w-3.5" />
+              Category
+            </div>
+            <select
+              className="select select-bordered select-sm w-full"
+              value={category}
+              onChange={(event) => setCategory(event.target.value)}
+            >
+              {categories.map((item) => (
+                <option key={item.id} value={item.id}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </section>
+
+          <section className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+              <Crosshair className="h-3.5 w-3.5" />
+              Target
+            </div>
+            <div className="space-y-2">
+              <select
+                className="select select-bordered select-xs w-full"
+                value={targetDraftChipId}
+                onChange={(event) => {
+                  setTargetDraftChipId(event.target.value);
+                  setCooldownDraftId("");
+                }}
+              >
+                <option value="">Select chip</option>
+                {chips.map((chip) => (
+                  <option key={chip.chip_id} value={chip.chip_id}>
+                    {chip.chip_id}
+                  </option>
+                ))}
+              </select>
+              <div className="grid grid-cols-[96px_1fr] gap-2">
+                <select
+                  className="select select-bordered select-xs w-full"
+                  value={targetDraftType}
+                  onChange={(event) => {
+                    const nextType = event.target.value === "coupling" ? "coupling" : "qubit";
+                    setTargetDraftType(nextType);
+                    if (nextType === "coupling" && category === "qubit") setCategory("coupling");
+                    if (nextType === "qubit" && category === "coupling") setCategory("qubit");
+                  }}
+                >
+                  <option value="qubit">Qubit</option>
+                  <option value="coupling">Coupling</option>
+                </select>
+                <input
+                  className="input input-bordered input-xs w-full"
+                  value={targetDraftId}
+                  onChange={(event) => setTargetDraftId(event.target.value)}
+                  placeholder={targetDraftType === "coupling" ? "0-1" : "0"}
+                />
+              </div>
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-xs"
+                  onClick={clearTargetMetadata}
+                  disabled={!targetDraftChipId && !targetDraftId && !cooldownDraftId}
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+              <CalendarDays className="h-3.5 w-3.5" />
+              Cooldown
+            </div>
+            <select
+              className="select select-bordered select-xs w-full"
+              value={cooldownDraftId}
+              onChange={(event) => setCooldownDraftId(event.target.value)}
+              disabled={!targetDraftChipId}
+            >
+              <option value="">No cooldown</option>
+              {cooldowns.map((cooldown) => (
+                <option key={cooldown.cooldown_id} value={cooldown.cooldown_id}>
+                  {cooldown.cooldown_id}
+                  {formatCooldownPeriod(cooldown) ? ` - ${formatCooldownPeriod(cooldown)}` : ""}
+                </option>
+              ))}
+            </select>
+            {selectedCooldown && (
+              <div className="text-xs text-base-content/55">
+                {formatCooldownPeriod(selectedCooldown)}
+              </div>
+            )}
+          </section>
+
+          <section className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+              <UserRound className="h-3.5 w-3.5" />
+              Assignee
+            </div>
+            <select
+              className="select select-bordered select-xs w-full"
+              value={assigneeUsername}
+              onChange={(event) => setAssigneeUsername(event.target.value)}
+            >
+              <option value="">Unassigned</option>
+              {members.map((member) => (
+                <option key={member.username} value={member.username}>
+                  {member.display_name
+                    ? `${member.display_name} (@${member.username})`
+                    : member.username}
+                </option>
+              ))}
+            </select>
+          </section>
+
+          <section className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+              <Tag className="h-3.5 w-3.5" />
+              Labels
+            </div>
+            <ForumLabelPicker selectedLabels={selectedLabels} onToggle={toggleLabel} />
+          </section>
+
+          <section className="space-y-2">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase text-base-content/50">
+              <UserRound className="h-3.5 w-3.5" />
+              Author
+            </div>
+            <div className="flex items-center gap-2">
+              <UserAvatar
+                username={user?.username ?? "you"}
+                avatarKey={user?.avatar_key}
+                size={24}
+              />
+              <span className="text-sm font-medium">{user?.username ?? "you"}</span>
+            </div>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import dynamic from "next/dynamic";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -30,7 +29,6 @@ import {
   getListForumPostsQueryKey,
   useCloseForumPost,
   useCreateForumCategory,
-  useCreateForumPost,
   useDeleteForumCategory,
   useGetForumPost,
   useGetForumPostReplies,
@@ -46,8 +44,6 @@ import { PageHeader } from "@/components/ui/PageHeader";
 import { UserAvatar } from "@/components/ui/UserAvatar";
 import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
-import { useForumAiReply } from "@/hooks/useForumAiReply";
-import { useImageUpload } from "@/hooks/useImageUpload";
 import { formatDateTimeCompact, formatRelativeTime } from "@/lib/utils/datetime";
 import type { ForumPostResponse, ListForumPostsParams } from "@/schemas";
 
@@ -60,13 +56,8 @@ import {
   toForumCategoryDefinition,
   type ForumCategoryDefinition,
 } from "./categories";
-import { ForumLabelPicker, ForumLabelSelector } from "./ForumLabelSelector";
+import { ForumLabelPicker } from "./ForumLabelSelector";
 import { ForumBlockViewer } from "./ForumBlockEditor";
-
-const ForumBlockEditor = dynamic(
-  () => import("./ForumBlockEditor").then((m) => ({ default: m.ForumBlockEditor })),
-  { ssr: false },
-);
 
 const PAGE_SIZE = 30;
 
@@ -803,60 +794,28 @@ export function ForumPageContent() {
   const [skip, setSkip] = useState(
     () => (parseForumPage(searchParams.get("forum_page")) - 1) * PAGE_SIZE,
   );
-  const [showComposer, setShowComposer] = useState(false);
   const [showCategoryManager, setShowCategoryManager] = useState(false);
   const [selectedPostId, setSelectedPostId] = useState<string | null>(null);
-  const [hasAppliedDraftParams, setHasAppliedDraftParams] = useState(false);
-  const [draftTargetContext, setDraftTargetContext] = useState<ForumTargetContext | null>(null);
-  const [draftCooldownId, setDraftCooldownId] = useState<string | null>(null);
-  const [newCategory, setNewCategory] = useState("qubit");
-  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
-  const [title, setTitle] = useState("");
-  const [content, setContent] = useState("");
-  const [contentBlocks, setContentBlocks] = useState<Record<string, unknown>[]>([]);
   const [categoryKey, setCategoryKey] = useState("");
   const [categoryName, setCategoryName] = useState("");
   const [categoryDescription, setCategoryDescription] = useState("");
   const [categoryColor, setCategoryColor] = useState("neutral");
   const [categoryIcon, setCategoryIcon] = useState("message-square");
-  const { uploadImage } = useImageUpload("forum");
 
   useEffect(() => {
-    if (hasAppliedDraftParams) return;
-    const draftTitle = searchParams.get("title");
-    const draftContent = searchParams.get("content");
-    const draftCategory = searchParams.get("category");
-    const chipId = searchParams.get("chip_id");
-    const targetId = searchParams.get("target_id");
-    const targetType = normalizeTargetType(searchParams.get("target_type"));
-    const draftLabels = searchParams.get("labels");
-    const cooldownId = searchParams.get("cooldown_id");
-    if (!draftTitle && !draftContent && !draftCategory) {
-      setHasAppliedDraftParams(true);
-      return;
-    }
-    if (draftCategory) {
-      setNewCategory(draftCategory);
-      setCategory(draftCategory as CategoryFilter);
-    }
-    if (draftTitle) setTitle(draftTitle);
-    if (draftContent) setContent(draftContent);
-    if (draftLabels) {
-      setSelectedLabels(
-        draftLabels
-          .split(",")
-          .map((item) => item.trim())
-          .filter(Boolean),
-      );
-    }
-    if (chipId && targetId && targetType) {
-      setDraftTargetContext({ chipId, targetType, targetId });
-    }
-    if (cooldownId) setDraftCooldownId(cooldownId);
-    setContentBlocks([]);
-    setShowComposer(true);
-    setHasAppliedDraftParams(true);
-  }, [hasAppliedDraftParams, searchParams]);
+    const draftKeys = [
+      "title",
+      "content",
+      "category",
+      "chip_id",
+      "target_id",
+      "target_type",
+      "cooldown_id",
+      "labels",
+    ];
+    if (!draftKeys.some((key) => searchParams.has(key))) return;
+    router.replace(`/forum/new?${searchParams.toString()}`);
+  }, [router, searchParams]);
 
   const params: ListForumPostsParams = {
     skip,
@@ -882,12 +841,10 @@ export function ForumPageContent() {
     [categoriesResponse?.data.categories],
   );
 
-  const createMutation = useCreateForumPost();
   const createCategoryMutation = useCreateForumCategory();
   const deleteCategoryMutation = useDeleteForumCategory();
   const closeMutation = useCloseForumPost();
   const reopenMutation = useReopenForumPost();
-  const { triggerAiReply } = useForumAiReply();
 
   const invalidateList = () => {
     queryClient.invalidateQueries({ queryKey: getListForumPostsQueryKey() });
@@ -939,38 +896,6 @@ export function ForumPageContent() {
 
   const listReturnQuery = buildListQuery();
 
-  const submitThread = async () => {
-    const trimmedTitle = title.trim();
-    const trimmedContent = content.trim();
-    if (!trimmedTitle || !trimmedContent) return;
-
-    const response = await createMutation.mutateAsync({
-      data: {
-        category: newCategory,
-        title: trimmedTitle,
-        content: trimmedContent,
-        content_blocks: contentBlocks,
-        parent_id: null,
-        labels: selectedLabels,
-        chip_id: draftTargetContext?.chipId,
-        target_type: draftTargetContext?.targetType,
-        target_id: draftTargetContext?.targetId,
-        cooldown_id: draftCooldownId,
-      },
-    });
-    setTitle("");
-    setContent("");
-    setContentBlocks([]);
-    setSelectedLabels([]);
-    setShowComposer(false);
-    setDraftTargetContext(null);
-    setDraftCooldownId(null);
-    invalidateList();
-    if (/@qdash\b/i.test(trimmedContent)) {
-      triggerAiReply(response.data.id, trimmedContent, invalidateList);
-    }
-  };
-
   const setCategoryFilter = (nextCategory: CategoryFilter) => {
     setCategory(nextCategory);
     setSkip(0);
@@ -981,10 +906,6 @@ export function ForumPageContent() {
     setStatus(nextStatus);
     setSkip(0);
     replaceListQuery({ status: nextStatus, skip: 0 });
-  };
-
-  const toggleSelectedLabel = (label: string) => {
-    setSelectedLabels((current) => (current.includes(label) ? [] : [label]));
   };
 
   const setLabelFilterValue = (nextLabel: string) => {
@@ -1038,13 +959,17 @@ export function ForumPageContent() {
                 Categories
               </button>
             )}
-            <button
+            <Link
               className="btn btn-primary btn-sm gap-2"
-              onClick={() => setShowComposer((open) => !open)}
+              href={
+                listReturnQuery
+                  ? `/forum/new?from=${encodeURIComponent(listReturnQuery)}`
+                  : "/forum/new"
+              }
             >
-              {showComposer ? <X className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
-              {showComposer ? "Close" : "New Thread"}
-            </button>
+              <Plus className="h-4 w-4" />
+              New Thread
+            </Link>
           </div>
         }
       />
@@ -1233,12 +1158,6 @@ export function ForumPageContent() {
                               if (category === item.id) {
                                 setCategoryFilter("all");
                               }
-                              if (newCategory === item.id) {
-                                setNewCategory(
-                                  categories.find((candidate) => candidate.id !== item.id)?.id ??
-                                    "other",
-                                );
-                              }
                               invalidateCategories();
                             },
                           },
@@ -1252,76 +1171,6 @@ export function ForumPageContent() {
                   </div>
                 );
               })}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {showComposer && (
-        <div className="card bg-base-200 shadow-lg mb-4">
-          <div className="card-body">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <h2 className="card-title text-sm">New Thread</h2>
-              {draftTargetContext && (
-                <span className="badge badge-outline gap-1">
-                  <Crosshair className="h-3 w-3" />
-                  {formatTargetLabel(
-                    draftTargetContext.targetType,
-                    draftTargetContext.targetId,
-                  )} ·{" "}
-                  {draftTargetContext.chipId}
-                </span>
-              )}
-              {draftCooldownId && (
-                <span className="badge badge-outline">Cooldown · {draftCooldownId}</span>
-              )}
-            </div>
-            <div className="grid gap-3 sm:grid-cols-[220px_1fr]">
-              <select
-                className="select select-bordered select-sm w-full"
-                value={newCategory}
-                onChange={(event) => setNewCategory(event.target.value)}
-              >
-                {categories.map((item) => (
-                  <option key={item.id} value={item.id}>
-                    {item.label}
-                  </option>
-                ))}
-              </select>
-              <input
-                className="input input-bordered input-sm w-full"
-                value={title}
-                onChange={(event) => setTitle(event.target.value)}
-                placeholder="Thread title"
-              />
-            </div>
-            <ForumLabelSelector selectedLabels={selectedLabels} onToggle={toggleSelectedLabel} />
-            <ForumBlockEditor
-              key={showComposer ? "composer-open" : "composer-closed"}
-              legacyMarkdown={content}
-              onChange={(blocks, markdown) => {
-                setContentBlocks(blocks);
-                setContent(markdown);
-              }}
-              onImageUpload={uploadImage}
-            />
-            <div className="mt-2 flex items-center justify-between gap-2">
-              <span className="text-xs text-base-content/50">
-                Type <kbd className="kbd kbd-xs">/</kbd> for blocks (table, image, heading, list,
-                …). Use <span className="font-mono">@username</span> in text to mention members.
-              </span>
-              <button
-                type="button"
-                className="btn btn-sm btn-primary"
-                onClick={submitThread}
-                disabled={!title.trim() || !content.trim() || createMutation.isPending}
-              >
-                {createMutation.isPending ? (
-                  <span className="loading loading-spinner loading-xs" />
-                ) : (
-                  "Post"
-                )}
-              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add a dedicated `/forum/new` page for creating forum threads with the same detail-style layout as thread detail pages.
- Route forum and dashboard thread creation actions to the new page while preserving draft query parameters.
- Replace root thread deletion from the thread body with close behavior, keeping reply deletion available.

## Changes
- Added a detail-style thread creation page with title/body editor and sidebar metadata controls for category, target, cooldown, assignee, labels, and author.
- Changed forum list `New Thread` to navigate to `/forum/new` instead of opening an inline composer.
- Redirected legacy draft query parameters on `/forum` to `/forum/new`.
- Updated dashboard forum draft links to target `/forum/new`.
- Removed the now-unused `ForumLabelSelector` export and kept `ForumLabelPicker` as the common label control.

## Verification
- task knip
- task check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “New Forum Thread” page with draft creation, rich text editing, attachments, and sidebar options for category, target, assignee, labels, and cooldowns.
  * Forum “New Thread” actions now open the new page directly, preserving draft details and return context.

* **Bug Fixes**
  * Updated forum draft links in dashboard views to point to the new thread page.
  * Improved thread controls so replies can be deleted cleanly, and root posts now show clearer close/delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->