### PR TITLE
fix(ui): show forum label colors on dashboard

### DIFF
--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -54,12 +54,27 @@ type MetricMap = { [key: string]: MetricValueLike };
 
 const FALLBACK_COLORS = ["#440154", "#31688e", "#35b779", "#fde724"];
 
-const FORUM_LABEL_PRIORITY = ["discussion", "mtg", "info", "resolved"] as const;
+const FORUM_LABEL_PRIORITY = [
+  "anomaly",
+  "review",
+  "discussion",
+  "mtg",
+  "info",
+  "resolved",
+] as const;
 
 function representativeForumLabel(labels: string[] | undefined): string {
   const values = new Set(labels ?? []);
-  const label = FORUM_LABEL_PRIORITY.find((item) => values.has(item)) ?? "info";
-  return label === "mtg" ? "discussion" : label;
+  const label = FORUM_LABEL_PRIORITY.find((item) => values.has(item));
+  if (label === "discussion" || label === "mtg" || label === "info" || label === "resolved") {
+    return "review";
+  }
+  return label ?? "review";
+}
+
+function mergeForumMarkerLabel(current: string | undefined, labels: string[] | undefined): string {
+  const next = representativeForumLabel(labels);
+  return current === "anomaly" || next === "anomaly" ? "anomaly" : next;
 }
 
 function coverageOf(
@@ -261,7 +276,7 @@ export function DashboardPageContent() {
     const targets: Record<string, string> = {};
     (forumPostsResponse?.data.posts ?? []).forEach((post) => {
       if (post.target_type === "qubit" && post.target_id) {
-        targets[post.target_id] = representativeForumLabel(post.labels);
+        targets[post.target_id] = mergeForumMarkerLabel(targets[post.target_id], post.labels);
       }
     });
     return targets;
@@ -271,7 +286,7 @@ export function DashboardPageContent() {
     const targets: Record<string, string> = {};
     (forumPostsResponse?.data.posts ?? []).forEach((post) => {
       if (post.target_type === "coupling" && post.target_id) {
-        targets[post.target_id] = representativeForumLabel(post.labels);
+        targets[post.target_id] = mergeForumMarkerLabel(targets[post.target_id], post.labels);
       }
     });
     return targets;

--- a/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
@@ -8,6 +8,7 @@ const mockSetSelectionMode = vi.fn();
 const mockSetStartDate = vi.fn();
 const mockSetEndDate = vi.fn();
 const mockSetQuickRange = vi.fn();
+const mockForumPosts = vi.hoisted(() => vi.fn<() => unknown[]>(() => []));
 
 vi.mock("@/client/chip/chip", () => ({
   useListChips: () => ({
@@ -39,7 +40,7 @@ vi.mock("@/client/cooldown/cooldown", () => ({
 
 vi.mock("@/client/forum/forum", () => ({
   useListForumPosts: () => ({
-    data: { data: { posts: [], total: 0, skip: 0, limit: 200 } },
+    data: { data: { posts: mockForumPosts(), total: 0, skip: 0, limit: 200 } },
   }),
 }));
 
@@ -217,32 +218,79 @@ vi.mock("@/components/features/dashboard/DashboardMetricModal", () => ({
 }));
 
 vi.mock("@/components/features/dashboard/DashboardQubitGrid", () => ({
-  DashboardQubitGrid: ({ onQubitClick }: { onQubitClick?: (qid: string) => void }) => (
-    <button type="button" onClick={() => onQubitClick?.("0")}>
-      Open qubit
-    </button>
+  DashboardQubitGrid: ({
+    forumLinkedQids,
+    onQubitClick,
+  }: {
+    forumLinkedQids?: Record<string, string>;
+    onQubitClick?: (qid: string) => void;
+  }) => (
+    <div>
+      <span data-testid="qubit-forum-label">{forumLinkedQids?.["0"] ?? "none"}</span>
+      <button type="button" onClick={() => onQubitClick?.("0")}>
+        Open qubit
+      </button>
+    </div>
   ),
 }));
 
 vi.mock("@/components/features/dashboard/DashboardCouplingGrid", () => ({
   DashboardCouplingGrid: ({
+    forumLinkedTargets,
     onCouplingClick,
   }: {
+    forumLinkedTargets?: Record<string, string>;
     onCouplingClick?: (couplingId: string) => void;
   }) => (
-    <button type="button" onClick={() => onCouplingClick?.("0-1")}>
-      Open coupling
-    </button>
+    <div>
+      <span data-testid="coupling-forum-label">{forumLinkedTargets?.["0-1"] ?? "none"}</span>
+      <button type="button" onClick={() => onCouplingClick?.("0-1")}>
+        Open coupling
+      </button>
+    </div>
   ),
 }));
 
 describe("DashboardPageContent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockForumPosts.mockReturnValue([]);
   });
 
   afterEach(() => {
     cleanup();
+  });
+
+  it("maps forum labels to dashboard marker labels", () => {
+    mockForumPosts.mockReturnValue([
+      {
+        id: "forum-0",
+        target_type: "qubit",
+        target_id: "0",
+        labels: ["anomaly"],
+      },
+      {
+        id: "forum-1",
+        target_type: "qubit",
+        target_id: "0",
+        labels: ["review"],
+      },
+      {
+        id: "forum-2",
+        target_type: "coupling",
+        target_id: "0-1",
+        labels: ["anomaly"],
+      },
+    ]);
+
+    render(<DashboardPageContent />);
+
+    expect(screen.getAllByTestId("qubit-forum-label").map((item) => item.textContent)).toContain(
+      "anomaly",
+    );
+    expect(screen.getAllByTestId("coupling-forum-label").map((item) => item.textContent)).toContain(
+      "anomaly",
+    );
   });
 
   it("opens the pinned summary modal from the empty qubit topology", () => {


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Fixes dashboard forum markers so `review` and `anomaly` use the same highlight colors as their forum labels.
- Keeps legacy labels mapped to review and prioritizes anomaly when a target has multiple linked forum threads.

## Changes
- Updates `DashboardPageContent` forum marker label aggregation for `review` and `anomaly`.
- Adds dashboard coverage for forum marker label mapping.

Verification:
- `bunx vitest run src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx`
- `bun run fmt:check`
- `bun run lint`
- `bunx tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how forum-linked dashboard labels are assigned, making label selection more consistent when multiple posts point to the same target.
  * Updated label handling so `anomaly` is preserved and prioritized, while other related labels are grouped more predictably.
  * Refined dashboard label display behavior so forum-linked items show the expected labels in both qubit and coupling views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->