### PR TITLE
fix(ui): link forum related target to dashboard

### DIFF
--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -979,10 +979,12 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                 )}
               </div>
               <Link
-                href={`/provenance?qid=${encodeURIComponent(targetContext.targetId)}&tab=lineage`}
+                href={dashboardTargetHref(targetContext)}
                 className="btn btn-outline btn-xs w-full justify-start"
               >
-                Open provenance
+                {targetContext.targetType === "qubit"
+                  ? "Open qubit dashboard"
+                  : "Open coupling dashboard"}
               </Link>
             </section>
           )}


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updates the forum thread Related panel to send users back to the linked target dashboard instead of provenance.
- UI-only change; no API, schema, workflow, or generated client changes.

## Changes
- ForumDetailPage: replace the Related panel footer action with the existing linked target dashboard URL.
- Uses qubit/coupling-specific button text for the linked target action.

Verification:
- bun run lint
- bunx tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the “Related” section link to open the correct dashboard destination instead of a fixed provenance page.
  * Improved the link label so it now reflects the selected item type, making navigation clearer for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->