### PR TITLE
fix(ui): auto-select active cooldown

### DIFF
--- a/ui/src/components/selectors/CooldownSelector/index.tsx
+++ b/ui/src/components/selectors/CooldownSelector/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import Select, { type SingleValue } from "react-select";
 
@@ -55,7 +55,37 @@ export function CooldownSelector({
     labels: options.map((o) => o.label),
     placeholder,
   });
-  const selectedOption = options.find((option) => option.value === selectedCooldownId) ?? null;
+  const isControlled = selectedCooldownId !== undefined;
+  const [internalSelectedCooldownId, setInternalSelectedCooldownId] = useState<string | null>(null);
+  const effectiveSelectedCooldownId = isControlled
+    ? selectedCooldownId
+    : internalSelectedCooldownId;
+  const selectedOption =
+    options.find((option) => option.value === effectiveSelectedCooldownId) ?? null;
+  const autoPickedKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isControlled) setInternalSelectedCooldownId(null);
+    autoPickedKeyRef.current = null;
+  }, [chipId, isControlled]);
+
+  useEffect(() => {
+    if (!chipId) return;
+    if (effectiveSelectedCooldownId) {
+      autoPickedKeyRef.current = chipId + ":" + effectiveSelectedCooldownId;
+      return;
+    }
+
+    const activeCooldown = cooldowns.find((cooldown) => !cooldown.ended_at);
+    if (!activeCooldown) return;
+
+    const autoPickKey = chipId + ":" + activeCooldown.cooldown_id;
+    if (autoPickedKeyRef.current === autoPickKey) return;
+
+    autoPickedKeyRef.current = autoPickKey;
+    if (!isControlled) setInternalSelectedCooldownId(activeCooldown.cooldown_id);
+    onPick(activeCooldown);
+  }, [chipId, cooldowns, effectiveSelectedCooldownId, isControlled, onPick]);
 
   if (!chipId) return null;
   if (isLoading) {
@@ -74,6 +104,7 @@ export function CooldownSelector({
     if (!option) return;
     const cd = cooldowns.find((c) => c.cooldown_id === option.value);
     if (!cd) return;
+    if (!isControlled) setInternalSelectedCooldownId(cd.cooldown_id);
     onPick(cd);
   };
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Makes CooldownSelector automatically pick the chip's active cooldown when no cooldown is already selected.
- UI-only change; no API, schema, workflow, or generated client changes.

## Changes
- CooldownSelector: auto-picks the active cooldown returned by the cooldown list when selection is empty.
- Supports uncontrolled selector usage by keeping the auto-selected cooldown visible in the selector.
- Keeps controlled usage intact by respecting selectedCooldownId from parent state.

Verification:
- bun run lint
- bunx tsc --noEmit
- bun run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cool-down selection now works in both controlled and uncontrolled modes.
  * The selector can automatically choose the active cool-down for a chip and keeps the chosen item in sync as the selection context changes.

* **Bug Fixes**
  * Prevents repeated automatic re-selection of the same cool-down.
  * Ignores ended cool-downs when determining the active choice.
  * Improves behavior when switching between different chips or selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->