### PR TITLE
fix(ui): improve dashboard target summaries

### DIFF
--- a/ui/src/components/features/dashboard/DashboardCouplingGrid.tsx
+++ b/ui/src/components/features/dashboard/DashboardCouplingGrid.tsx
@@ -36,6 +36,8 @@ interface DashboardCouplingGridProps {
   /** Target-level notes keyed by qubit/coupling ID. */
   targetNotesByTarget?: Record<string, TargetNoteEntry>;
   metricKey?: string;
+  /** Presentation optimized for metric heatmaps or note summary topology. */
+  presentation?: "metric" | "summary";
   onCouplingClick?: (couplingId: string) => void;
 }
 
@@ -89,6 +91,7 @@ export function DashboardCouplingGrid({
   notesByTarget,
   targetNotesByTarget,
   metricKey,
+  presentation = "metric",
   onCouplingClick,
 }: DashboardCouplingGridProps) {
   const [hover, setHover] = useState<{
@@ -96,6 +99,7 @@ export function DashboardCouplingGrid({
     x: number;
     y: number;
   } | null>(null);
+  const isSummaryPresentation = presentation === "summary";
 
   const {
     muxSize = 2,
@@ -191,7 +195,11 @@ export function DashboardCouplingGrid({
             return (
               <div
                 key={`bg-${row}-${col}`}
-                className="absolute rounded-md bg-base-300/20"
+                className={`absolute rounded-md ${
+                  isSummaryPresentation
+                    ? "bg-base-200/25 border border-base-300/40"
+                    : "bg-base-300/20"
+                }`}
                 style={{
                   top: y,
                   left: x,
@@ -204,7 +212,11 @@ export function DashboardCouplingGrid({
           return (
             <div
               key={`qubit-${qid}`}
-              className="absolute rounded-md bg-base-300/40 flex items-start justify-start text-base-content/40"
+              className={`absolute rounded-md flex items-start justify-start ${
+                isSummaryPresentation
+                  ? "bg-base-100/60 border border-base-300/60 text-base-content/35"
+                  : "bg-base-300/40 text-base-content/40"
+              }`}
               style={{
                 top: y,
                 left: x,
@@ -239,10 +251,17 @@ export function DashboardCouplingGrid({
             !hasNote && !hasTargetNote && (crossMetricNotedTargets?.has(couplingId) ?? false);
           const Tag = onCouplingClick ? "button" : "div";
           const handleClick = () => onCouplingClick?.(couplingId);
+          const summaryChipClass = hasTargetNote
+            ? "bg-warning border-warning shadow-md opacity-95"
+            : hasForumDiscussion
+              ? "bg-info border-info shadow-md opacity-95"
+              : "bg-base-content/25 border-base-content/20 opacity-70 hover:opacity-100";
           const titleText =
-            (value !== null
-              ? `Q${qid1}→Q${qid2}: ${value.toFixed(4)} ${unit}`
-              : `Q${qid1}→Q${qid2}: No data`) +
+            (isSummaryPresentation
+              ? `Q${qid1}→Q${qid2}: pinned summary target`
+              : value !== null
+                ? `Q${qid1}→Q${qid2}: ${value.toFixed(4)} ${unit}`
+                : `Q${qid1}→Q${qid2}: No data`) +
             (hasNote
               ? " · has legacy metric note"
               : hasTargetNote
@@ -265,53 +284,66 @@ export function DashboardCouplingGrid({
                 });
               }}
               onMouseLeave={() => setHover(null)}
-              className={`absolute rounded-md shadow-sm flex flex-col items-center justify-center -translate-x-1/2 -translate-y-1/2 transition-all ${
-                onCouplingClick
-                  ? "cursor-pointer hover:ring-2 hover:ring-primary/60 hover:scale-105"
-                  : ""
-              } ${!bg ? "bg-base-300/60" : ""}`}
+              className={`absolute flex items-center justify-center transition-all ${
+                isSummaryPresentation
+                  ? "rounded-full"
+                  : "rounded-md shadow-sm flex-col -translate-x-1/2 -translate-y-1/2"
+              } ${onCouplingClick ? "cursor-pointer hover:ring-2 hover:ring-primary/60 hover:scale-105" : ""} ${
+                isSummaryPresentation ? `border ${summaryChipClass}` : !bg ? "bg-base-300/60" : ""
+              }`}
               style={{
                 top: centerY,
                 left: centerX,
-                width: cellSize * 0.72,
-                height: cellSize * 0.5,
-                backgroundColor: bg ?? undefined,
+                width: isSummaryPresentation ? cellSize * 0.74 : cellSize * 0.72,
+                height: isSummaryPresentation ? Math.max(6, cellSize * 0.12) : cellSize * 0.5,
+                backgroundColor: isSummaryPresentation ? undefined : (bg ?? undefined),
+                transform: isSummaryPresentation
+                  ? `translate(-50%, -50%) rotate(${arrowAngle}deg)`
+                  : undefined,
               }}
               aria-label={titleText}
             >
-              {value !== null ? (
+              {isSummaryPresentation ? (
+                <span className="sr-only">
+                  Q{qid1}→Q{qid2}
+                </span>
+              ) : value !== null ? (
                 <span className="text-[10px] font-bold text-white drop-shadow leading-none">
                   {value.toFixed(2)}
                 </span>
               ) : (
                 <span className="text-[9px] text-base-content/50 leading-none">—</span>
               )}
-              <svg
-                width="12"
-                height="5"
-                viewBox="0 0 18 7"
-                className="mt-px drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]"
-                style={{ transform: `rotate(${arrowAngle}deg)` }}
-              >
-                <line
-                  x1="1"
-                  y1="3.5"
-                  x2="14"
-                  y2="3.5"
-                  stroke={bg ? "white" : "currentColor"}
-                  strokeWidth="1.5"
-                />
-                <polyline
-                  points="11,0.5 16,3.5 11,6.5"
-                  fill="none"
-                  stroke={bg ? "white" : "currentColor"}
-                  strokeWidth="1.5"
-                  strokeLinejoin="round"
-                />
-              </svg>
+              {!isSummaryPresentation && (
+                <svg
+                  width="12"
+                  height="5"
+                  viewBox="0 0 18 7"
+                  className="mt-px drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]"
+                  style={{ transform: `rotate(${arrowAngle}deg)` }}
+                >
+                  <line
+                    x1="1"
+                    y1="3.5"
+                    x2="14"
+                    y2="3.5"
+                    stroke={bg ? "white" : "currentColor"}
+                    strokeWidth="1.5"
+                  />
+                  <polyline
+                    points="11,0.5 16,3.5 11,6.5"
+                    fill="none"
+                    stroke={bg ? "white" : "currentColor"}
+                    strokeWidth="1.5"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
               {(hasNote || hasTargetNote) && (
                 <span
-                  className="absolute -top-1 -right-1 rounded-full bg-warning text-warning-content p-0.5 shadow"
+                  className={`absolute rounded-full bg-warning text-warning-content p-0.5 shadow ${
+                    isSummaryPresentation ? "-top-2 -right-2" : "-top-1 -right-1"
+                  }`}
                   title={hasNote ? "Has legacy metric note" : "Has pinned summary"}
                 >
                   <StickyNote className="h-2.5 w-2.5" />
@@ -319,7 +351,9 @@ export function DashboardCouplingGrid({
               )}
               {hasCrossMetricNote && (
                 <span
-                  className="absolute -top-1 -right-1 rounded-full bg-base-100/90 text-base-content/60 p-0.5 shadow border border-base-300"
+                  className={`absolute rounded-full bg-base-100/90 text-base-content/60 p-0.5 shadow border border-base-300 ${
+                    isSummaryPresentation ? "-top-2 -right-2" : "-top-1 -right-1"
+                  }`}
                   title="Legacy note exists on another metric"
                 >
                   <StickyNote className="h-2.5 w-2.5" />
@@ -327,7 +361,9 @@ export function DashboardCouplingGrid({
               )}
               {hasForumDiscussion && (
                 <span
-                  className={`absolute -bottom-1 -right-1 rounded-full p-0.5 shadow ${forumMarkerClass(forumLabel)}`}
+                  className={`absolute rounded-full p-0.5 shadow ${
+                    isSummaryPresentation ? "-bottom-2 -right-2" : "-bottom-1 -right-1"
+                  } ${forumMarkerClass(forumLabel)}`}
                   title="Linked forum discussion"
                 >
                   <MessageSquare className="h-2.5 w-2.5" />

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -590,7 +590,7 @@ export function DashboardPageContent() {
                     unit=""
                     topologyId={topologyId}
                     colors={colors}
-                    maxCellSize={42}
+                    presentation="summary"
                     targetNotedQids={targetNotedQids}
                     forumLinkedQids={forumLinkedQids}
                     forumLinksByTarget={forumLinksByTarget}
@@ -628,7 +628,7 @@ export function DashboardPageContent() {
                     unit=""
                     topologyId={topologyId}
                     colors={colors}
-                    maxCellSize={42}
+                    presentation="summary"
                     reverseDirection={isReverseCouplingDirection}
                     targetNotedTargets={targetNotedCouplings}
                     forumLinkedTargets={forumLinkedCouplings}

--- a/ui/src/components/features/dashboard/DashboardQubitGrid.tsx
+++ b/ui/src/components/features/dashboard/DashboardQubitGrid.tsx
@@ -43,6 +43,8 @@ interface DashboardQubitGridProps {
   targetNotesByTarget?: Record<string, TargetNoteEntry>;
   /** The metric_key this grid renders, used to split current vs. other notes. */
   metricKey?: string;
+  /** Presentation optimized for metric heatmaps or note summary topology. */
+  presentation?: "metric" | "summary";
   /** Click handler when a qubit cell is clicked. */
   onQubitClick?: (qid: string) => void;
 }
@@ -93,6 +95,7 @@ export function DashboardQubitGrid({
   notesByTarget,
   targetNotesByTarget,
   metricKey,
+  presentation = "metric",
   onQubitClick,
 }: DashboardQubitGridProps) {
   const [hover, setHover] = useState<{
@@ -100,6 +103,7 @@ export function DashboardQubitGrid({
     x: number;
     y: number;
   } | null>(null);
+  const isSummaryPresentation = presentation === "summary";
   const {
     muxSize = 2,
     hasMux = false,
@@ -177,7 +181,16 @@ export function DashboardQubitGrid({
     >
       {cells.map(({ row, col, qid }) => {
         if (qid === undefined) {
-          return <div key={`${row}-${col}`} className="rounded-md bg-base-300/30 aspect-square" />;
+          return (
+            <div
+              key={`${row}-${col}`}
+              className={`rounded-md aspect-square ${
+                isSummaryPresentation
+                  ? "bg-base-200/40 border border-base-300/50"
+                  : "bg-base-300/30"
+              }`}
+            />
+          );
         }
         const metric = metricData?.[qid];
         const value = metric?.value ?? null;
@@ -189,8 +202,17 @@ export function DashboardQubitGrid({
         const hasCrossMetricNote =
           !hasNote && !hasTargetNote && (crossMetricNotedQids?.has(qid) ?? false);
         const handleClick = () => onQubitClick?.(qid);
+        const summaryTileClass = hasTargetNote
+          ? "bg-warning/10 border-warning/50 text-base-content"
+          : hasForumDiscussion
+            ? "bg-info/10 border-info/40 text-base-content"
+            : "bg-base-100 border-base-300 text-base-content";
         const titleText =
-          (value !== null ? `${qid}: ${value.toFixed(4)} ${unit}` : `${qid}: No data`) +
+          (isSummaryPresentation
+            ? `Q${qid}: pinned summary target`
+            : value !== null
+              ? `${qid}: ${value.toFixed(4)} ${unit}`
+              : `${qid}: No data`) +
           (hasNote
             ? " · has legacy metric note"
             : hasTargetNote
@@ -214,18 +236,22 @@ export function DashboardQubitGrid({
               });
             }}
             onMouseLeave={() => setHover(null)}
-            className={`aspect-square rounded-md flex flex-col items-center justify-center relative shadow-sm text-left ${
-              onQubitClick ? "cursor-pointer hover:ring-2 hover:ring-primary/60" : ""
-            }`}
-            style={{ backgroundColor: bg ?? undefined }}
+            className={`aspect-square rounded-md flex flex-col items-center justify-center relative shadow-sm text-left transition-all ${
+              isSummaryPresentation ? `border ${summaryTileClass}` : ""
+            } ${onQubitClick ? "cursor-pointer hover:ring-2 hover:ring-primary/60" : ""}`}
+            style={{ backgroundColor: isSummaryPresentation ? undefined : (bg ?? undefined) }}
             aria-label={titleText}
           >
             <span
-              className={`absolute top-0.5 left-0.5 text-[10px] font-semibold px-1 rounded leading-tight ${
-                bg ? "bg-black/30 text-white" : "bg-base-200 text-base-content"
-              }`}
+              className={
+                isSummaryPresentation
+                  ? "text-sm font-bold leading-none"
+                  : `absolute top-0.5 left-0.5 text-[10px] font-semibold px-1 rounded leading-tight ${
+                      bg ? "bg-black/30 text-white" : "bg-base-200 text-base-content"
+                    }`
+              }
             >
-              {qid}
+              {isSummaryPresentation ? `Q${qid}` : qid}
             </span>
             {(hasNote || hasTargetNote) && (
               <span
@@ -251,13 +277,14 @@ export function DashboardQubitGrid({
                 <MessageSquare className="h-3 w-3" />
               </span>
             )}
-            {value !== null ? (
-              <span className="text-[11px] font-bold text-white drop-shadow leading-tight mt-1.5">
-                {value.toFixed(2)}
-              </span>
-            ) : (
-              <span className="text-[10px] text-base-content/40 mt-1.5">N/A</span>
-            )}
+            {!isSummaryPresentation &&
+              (value !== null ? (
+                <span className="text-[11px] font-bold text-white drop-shadow leading-tight mt-1.5">
+                  {value.toFixed(2)}
+                </span>
+              ) : (
+                <span className="text-[10px] text-base-content/40 mt-1.5">N/A</span>
+              ))}
           </Tag>
         );
       })}

--- a/ui/src/components/features/dashboard/DashboardTargetNoteModal.tsx
+++ b/ui/src/components/features/dashboard/DashboardTargetNoteModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 
 import { ExternalLink, MessageSquarePlus, Pencil, Save, StickyNote, X } from "lucide-react";
@@ -142,11 +142,23 @@ export function DashboardTargetNoteModal({
 
   const [mode, setMode] = useState<"view" | "edit">(existing ? "view" : "edit");
   const [draft, setDraft] = useState(existing?.content ?? "");
+  const previousTargetIdRef = useRef(targetId);
 
   useEffect(() => {
-    setDraft(existing?.content ?? "");
-    setMode(existing ? "view" : "edit");
-  }, [existing, targetId]);
+    const targetChanged = previousTargetIdRef.current !== targetId;
+    previousTargetIdRef.current = targetId;
+
+    if (targetChanged) {
+      setDraft(existing?.content ?? "");
+      setMode(existing ? "view" : "edit");
+      return;
+    }
+
+    if (mode === "view") {
+      setDraft(existing?.content ?? "");
+      setMode(existing ? "view" : "edit");
+    }
+  }, [existing, mode, targetId]);
 
   const invalidate = () =>
     queryClient.invalidateQueries({
@@ -200,7 +212,7 @@ export function DashboardTargetNoteModal({
     <div
       className="modal modal-open"
       onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
+        if (mode === "view" && e.target === e.currentTarget) onClose();
       }}
     >
       <div className="modal-box w-full max-w-2xl p-0 overflow-hidden">

--- a/ui/src/components/features/dashboard/__tests__/DashboardTargetNoteModal.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardTargetNoteModal.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DashboardTargetNoteModal } from "@/components/features/dashboard/DashboardTargetNoteModal";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/client/forum/forum", () => ({
+  useListForumPosts: () => ({
+    data: { data: { posts: [] } },
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock("@/client/note/note", () => ({
+  getGetChipNotesSummaryQueryKey: () => ["chip-notes-summary"],
+  useDeleteCouplingNote: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useDeleteQubitNote: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useUpsertCouplingNote: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useUpsertQubitNote: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderModal(props?: Partial<React.ComponentProps<typeof DashboardTargetNoteModal>>) {
+  const queryClient = createQueryClient();
+  const onClose = props?.onClose ?? vi.fn();
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardTargetNoteModal
+        chipId="chip-1"
+        targetId="0"
+        existing={{ targetId: "0", content: "Current note", username: "tester", updatedAt: "" }}
+        onClose={onClose}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+
+  return { onClose };
+}
+
+describe("DashboardTargetNoteModal", () => {
+  it("keeps the modal open when the edit backdrop is clicked", () => {
+    const { onClose } = renderModal();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.click(document.querySelector(".modal") as HTMLElement);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not reset an in-progress edit when existing note props refresh", () => {
+    const queryClient = createQueryClient();
+    const onClose = vi.fn();
+    const initialProps = {
+      chipId: "chip-1",
+      targetId: "0",
+      existing: { targetId: "0", content: "Current note", username: "tester", updatedAt: "" },
+      onClose,
+    };
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <DashboardTargetNoteModal {...initialProps} />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Unsaved draft" } });
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <DashboardTargetNoteModal
+          {...initialProps}
+          existing={{
+            targetId: "0",
+            content: "Server refresh",
+            username: "tester",
+            updatedAt: "2026-07-09T00:00:00Z",
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("Unsaved draft");
+  });
+});


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Improves the dashboard Target Summaries UI so qubit and coupling summaries are easier to scan when no metric values are present.
- Keeps metric heatmap behavior unchanged and reduces accidental modal closure while editing pinned summaries.

## Changes
- DashboardPageContent: uses summary presentation for Target Summaries topology grids.
- DashboardQubitGrid and DashboardCouplingGrid: add a summary presentation mode with note/forum-focused visual states and less dense coupling markers.
- DashboardTargetNoteModal: preserves in-progress drafts during note refreshes and disables backdrop close while editing.
- DashboardTargetNoteModal tests: cover edit backdrop behavior and draft preservation.

Verification:
- task check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact summary presentation for dashboard qubit and coupling grids in the pinned “Target Summaries” view.
  * Improved labels, badges, and cell styling to better distinguish summary tiles from metric tiles.

* **Bug Fixes**
  * Prevented the note modal from closing when clicking the backdrop while editing.
  * Preserved unsaved note edits when the content refreshes in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->