### PR TITLE
ci(repo): enable claude code review comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,26 +3,14 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -36,9 +24,18 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
+            Review this pull request with a focus on:
+            - Bugs, behavioral regressions, and edge cases
+            - Missing or weak tests for the changed behavior
+            - Security, data handling, and permission risks
+            - Consistency with existing QDash patterns and conventions
+
+            Post findings as GitHub PR comments. Use inline comments for specific
+            code issues and a concise top-level comment when no blocking issues are found.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updates the Claude Code Review workflow so automated PR reviews can post progress, top-level comments, and inline findings.
- CI-only change; no application, API, workflow engine, schema, or generated client changes.

## Changes
- Grants pull-requests: write and issues: write permissions needed for PR comments.
- Enables Claude Code progress tracking for pull request review runs.
- Replaces the code-review plugin command with an explicit review prompt and scoped GitHub commenting/diff tools.
- Keeps the existing CLAUDE_CODE_OAUTH_TOKEN authentication because that is the configured repository secret.