### PR TITLE
ci(repo): skip claude review for branch sync prs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   claude-review:
+    if: >
+      github.event.pull_request.head.ref != 'develop' &&
+      github.event.pull_request.head.ref != 'main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Skips Claude Code Review only when the PR source branch is develop or main.
- Regular feature and fix PRs targeting develop continue to receive Claude review comments.

## Changes
- Adds a job-level guard using github.event.pull_request.head.ref.
- Leaves the pull_request trigger and base branch behavior unchanged.