### PR TITLE
fix(ui): move forum status actions to detail view

### DIFF
--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -8,14 +8,12 @@ import {
   CalendarDays,
   Crosshair,
   ExternalLink,
-  Lock,
   MessageSquare,
   Pencil,
   Plus,
   Settings,
   Tag,
   Trash2,
-  Unlock,
   UserRound,
   X,
   XCircle,
@@ -28,14 +26,12 @@ import {
   getGetForumPostQueryKey,
   getListForumCategoriesQueryKey,
   getListForumPostsQueryKey,
-  useCloseForumPost,
   useCreateForumCategory,
   useDeleteForumCategory,
   useGetForumPost,
   useGetForumPostReplies,
   useListForumCategories,
   useListForumPosts,
-  useReopenForumPost,
   useUpdateForumPost,
 } from "@/client/forum/forum";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -147,19 +143,13 @@ function postTargetContext(post: ForumPostResponse): ForumTargetContext | null {
 function ForumThreadCard({
   post,
   categories,
-  canManage,
   isSelected,
   onSelect,
-  onClose,
-  onReopen,
 }: {
   post: ForumPostResponse;
   categories: ForumCategoryDefinition[];
-  canManage: boolean;
   isSelected: boolean;
   onSelect: () => void;
-  onClose: (postId: string) => void;
-  onReopen: (postId: string) => void;
 }) {
   const category = getForumCategory(post.category, categories);
   const targetContext = postTargetContext(post);
@@ -257,34 +247,6 @@ function ForumThreadCard({
           </div>
         </div>
       </div>
-
-      {canManage && (
-        <div className="flex justify-end border-t border-base-300 px-3 py-2 sm:px-4">
-          {isTerminal ? (
-            <button
-              className="btn btn-ghost btn-xs gap-1"
-              onClick={(event) => {
-                event.stopPropagation();
-                onReopen(post.id);
-              }}
-            >
-              <Unlock className="h-3 w-3" />
-              Reopen
-            </button>
-          ) : (
-            <button
-              className="btn btn-ghost btn-xs gap-1"
-              onClick={(event) => {
-                event.stopPropagation();
-                onClose(post.id);
-              }}
-            >
-              <Lock className="h-3 w-3" />
-              Close
-            </button>
-          )}
-        </div>
-      )}
     </article>
   );
 }
@@ -888,13 +850,6 @@ export function ForumPageContent() {
 
   const createCategoryMutation = useCreateForumCategory();
   const deleteCategoryMutation = useDeleteForumCategory();
-  const closeMutation = useCloseForumPost();
-  const reopenMutation = useReopenForumPost();
-
-  const invalidateList = () => {
-    queryClient.invalidateQueries({ queryKey: getListForumPostsQueryKey() });
-  };
-
   const invalidateCategories = () => {
     queryClient.invalidateQueries({
       queryKey: getListForumCategoriesQueryKey(),
@@ -1285,15 +1240,8 @@ export function ForumPageContent() {
                 key={post.id}
                 post={post}
                 categories={categories}
-                canManage={isOwner || user?.username === post.username}
                 isSelected={selectedPostId === post.id}
                 onSelect={() => setSelectedPostId(post.id)}
-                onClose={(postId) =>
-                  closeMutation.mutate({ postId }, { onSuccess: invalidateList })
-                }
-                onReopen={(postId) =>
-                  reopenMutation.mutate({ postId }, { onSuccess: invalidateList })
-                }
               />
             ))}
           </div>


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Remove forum status mutation actions from the thread list so status changes are handled only in the detail view.
- UI-only change with low risk; no API, schema, configuration, or generated client changes.

## Changes

- Remove the Close and Reopen controls from `ForumPageContent` thread cards.
- Remove the list-only mutation hooks and callback props that supported those controls.
- Keep status badges and status filtering available in the forum list.

## Verification

- `bunx oxfmt --check src/components/features/forum/ForumPageContent.tsx`
- `bun run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed thread close and reopen controls from forum thread cards.
  * Simplified forum thread listings by eliminating related management actions and status icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->