### PR TITLE
fix(repo): publish TypeScript client tarball by path

### DIFF
--- a/.github/workflows/publish-qdash-typescript-client.yml
+++ b/.github/workflows/publish-qdash-typescript-client.yml
@@ -86,7 +86,7 @@ jobs:
           path: dist
 
       - name: Publish package
-        run: npm publish dist/oqtopus-team-qdash-client-*.tgz --access public --provenance
+        run: npm publish ./dist/oqtopus-team-qdash-client-*.tgz --access public --provenance
         env:
           # Used only to bootstrap the package before npm Trusted Publishing can be configured.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Fix the TypeScript client release workflow failing with npm `EALLOWGIT`.

## Changes

- Prefix the downloaded tarball path with `./` so npm treats it as a local package file instead of a GitHub shorthand dependency.
- Verify the exact path form with `npm publish --dry-run ./dist/oqtopus-team-qdash-client-*.tgz --access public`.