### PR TITLE
feat(repo): add operational provenance client helpers

### DIFF
--- a/clients/typescript/src/client.ts
+++ b/clients/typescript/src/client.ts
@@ -32,6 +32,11 @@ import type {
   CandidateGateResponse,
   ChipMetricsResponse,
   ChipResponse,
+  DegradationTrendsResponse,
+  ExecutionComparisonResponse,
+  ExecutionLockStatusResponse,
+  RecalibrationRecommendationResponse,
+  RecentChangesResponse,
   CouplingResponse,
   ExecuteFlowResponse,
   ExecutionResponseDetail,
@@ -117,6 +122,22 @@ export interface TaskResultFigureOptions {
 }
 
 export interface QDashClientOptions extends TransportOptions {}
+
+export interface RecentChangesOptions {
+  parameterNames?: string[];
+  withinHours?: number;
+  limit?: number;
+}
+
+export interface DegradationTrendsOptions {
+  minStreak?: number;
+  limit?: number;
+  parameterNames?: string[];
+}
+
+export interface RecalibrationRecommendationsOptions {
+  maxDepth?: number;
+}
 
 function pathPart(value: string): string {
   return encodeURIComponent(value);
@@ -646,6 +667,59 @@ export class QDashClient {
 
   async getProvenanceStats(): Promise<ProvenanceStatsResponse> {
     return this.get("/provenance/stats");
+  }
+
+  async getExecutionLockStatus(): Promise<ExecutionLockStatusResponse> {
+    return this.get("/executions/lock-status");
+  }
+
+  async compareExecutions(
+    executionIdBefore: string,
+    executionIdAfter: string,
+  ): Promise<ExecutionComparisonResponse> {
+    return this.get(
+      "/provenance/compare",
+      query({
+        execution_id_before: executionIdBefore,
+        execution_id_after: executionIdAfter,
+      }),
+    );
+  }
+
+  async getRecentChanges(
+    options: RecentChangesOptions = {},
+  ): Promise<RecentChangesResponse> {
+    return this.get(
+      "/provenance/changes",
+      query({
+        parameter_names: options.parameterNames,
+        within_hours: options.withinHours,
+        limit: options.limit,
+      }),
+    );
+  }
+
+  async getDegradationTrends(
+    options: DegradationTrendsOptions = {},
+  ): Promise<DegradationTrendsResponse> {
+    return this.get(
+      "/provenance/degradation-trends",
+      query({
+        min_streak: options.minStreak,
+        limit: options.limit,
+        parameter_names: options.parameterNames,
+      }),
+    );
+  }
+
+  async getRecalibrationRecommendations(
+    entityId: string,
+    options: RecalibrationRecommendationsOptions = {},
+  ): Promise<RecalibrationRecommendationResponse> {
+    return this.get(
+      `/provenance/recommendations/${pathPart(entityId)}`,
+      query({ max_depth: options.maxDepth }),
+    );
   }
 
   private bindGeneratedApi(

--- a/clients/typescript/src/index.ts
+++ b/clients/typescript/src/index.ts
@@ -1,11 +1,14 @@
 export { QDashClient } from "./client.js";
 export type {
   CreateAgentSessionOptions,
+  DegradationTrendsOptions,
   DownloadedFile,
   ListTaskResultsOptions,
   PaginationOptions,
   PollOptions,
   QDashClientOptions,
+  RecentChangesOptions,
+  RecalibrationRecommendationsOptions,
   SubmitAgentActionOptions,
   TaskResultFigureOptions,
   TaskResultsTimeseriesOptions,

--- a/clients/typescript/tests/client.test.ts
+++ b/clients/typescript/tests/client.test.ts
@@ -72,6 +72,40 @@ describe("QDashClient", () => {
     expect(wait).toHaveBeenCalledTimes(1);
   });
 
+  it("exposes typed read-only operational provenance helpers", async () => {
+    const requests: Request[] = [];
+    const fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const request = new Request(input);
+      requests.push(request);
+      if (request.url.includes("lock-status")) return jsonResponse({ lock: false });
+      if (request.url.includes("provenance/compare")) return jsonResponse({ execution_id_before: "before", execution_id_after: "after", changed_parameters: [] });
+      if (request.url.includes("degradation-trends")) return jsonResponse({ trends: [], total_count: 0 });
+      if (request.url.includes("recommendations")) return jsonResponse({ source_entity_id: "entity", recommended_tasks: [] });
+      return jsonResponse({ changes: [], total_count: 0 });
+    });
+    const client = new QDashClient(
+      new QDashConfig({ baseUrl: "https://qdash.example/api", apiToken: "token" }),
+      { fetch },
+    );
+
+    await expect(client.getExecutionLockStatus()).resolves.toEqual({ lock: false });
+    await expect(client.compareExecutions("before", "after")).resolves.toMatchObject({ execution_id_before: "before" });
+    await expect(client.getRecentChanges({ parameterNames: ["t1"], withinHours: 24, limit: 5 })).resolves.toMatchObject({ total_count: 0 });
+    await expect(client.getDegradationTrends({ minStreak: 4 })).resolves.toMatchObject({ total_count: 0 });
+    await expect(client.getRecalibrationRecommendations("frequency:Q0:exec:task")).resolves.toMatchObject({ source_entity_id: "entity" });
+
+    expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
+      "/api/executions/lock-status",
+      "/api/provenance/compare",
+      "/api/provenance/changes",
+      "/api/provenance/degradation-trends",
+      "/api/provenance/recommendations/frequency%3AQ0%3Aexec%3Atask",
+    ]);
+    const changesUrl = new URL(requests[2]!.url);
+    expect(changesUrl.searchParams.get("parameter_names")).toBe("t1");
+    expect(changesUrl.searchParams.get("within_hours")).toBe("24");
+  });
+
   it("binds body operations from the Orval-generated API", async () => {
     let request: Request | undefined;
     const fetch = vi.fn(async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Add typed TypeScript client helpers for read-only execution lock and operational provenance endpoints.
- The change affects only the hand-written TypeScript client surface; API schemas and generated clients are unchanged, with no compatibility or configuration impact.

## Changes

- Add helpers for execution comparison, recent changes, degradation trends, recalibration recommendations, and execution lock status.
- Export option types for provenance query parameters.
- Add request-path, query serialization, response, and entity-ID encoding coverage.
- Verify with `task test-client-ts` (TypeScript compilation and 10 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TypeScript client methods for execution lock status, execution comparisons, recent provenance changes, degradation trends, and recalibration recommendations.
  * Added configurable filters for provenance and trend queries.
  * Exported new option types for TypeScript consumers.

* **Tests**
  * Added coverage for request paths, query parameters, and response handling across the new endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->