### PR TITLE
feat(config): add configuration mode support for Qubex experiments

### DIFF
--- a/.env.example.qubex
+++ b/.env.example.qubex
@@ -49,6 +49,9 @@ SLACK_CHANNEL_ID=
 SLACK_APP_TOKEN=
 ENABLE_LOCAL_CODEX_AGENT=false
 
+# Qubex Experiment configuration mode (optional, defaults to qubex library default)
+# QUBEX_CONFIGURATION_MODE=ge-ef-cr
+
 # qubex-config repository (optional, for dynamic configuration management)
 CONFIG_REPO_URL=
 GITHUB_TOKEN=

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/configure.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/configure.py
@@ -36,12 +36,15 @@ class Configure(QubexTask):
         ]
 
         print(labels)
-        exp.system_manager.load(
-            chip_id=exp.chip_id,
-            config_dir=exp.config_path,
-            params_dir=exp.params_path,
-            targets_to_exclude=labels,
-        )
+        load_kwargs: dict[str, object] = {
+            "chip_id": exp.chip_id,
+            "config_dir": exp.config_path,
+            "params_dir": exp.params_path,
+            "targets_to_exclude": labels,
+        }
+        if hasattr(exp, "configuration_mode"):
+            load_kwargs["configuration_mode"] = exp.configuration_mode
+        exp.system_manager.load(**load_kwargs)
         print(f"[Configure] Pushing system_manager for {label} (box_ids={exp.box_ids})")
         exp.system_manager.push(box_ids=exp.box_ids, confirm=False)
         print(f"[Configure] Done for {label}")

--- a/src/qdash/workflow/engine/backend/fake_qubex/__init__.py
+++ b/src/qdash/workflow/engine/backend/fake_qubex/__init__.py
@@ -10,8 +10,8 @@ from .simulation import (
 try:
     from qubex import PulseSchedule, pulse
 except ImportError:
-    PulseSchedule = None  # type: ignore[assignment]
-    pulse = None  # type: ignore[assignment]
+    PulseSchedule = None  # type: ignore[assignment,unused-ignore]
+    pulse = None  # type: ignore[assignment,unused-ignore]
 
 Experiment = FakeExperiment
 

--- a/src/qdash/workflow/engine/backend/qubex.py
+++ b/src/qdash/workflow/engine/backend/qubex.py
@@ -96,6 +96,11 @@ class QubexBackend(BaseBackend):
                 calib_note_path=self._config.get(
                     "note_path", str(qubex_paths.default_calib_note_path)
                 ),
+                **(
+                    {"configuration_mode": self._config["configuration_mode"]}
+                    if "configuration_mode" in self._config
+                    else {}
+                ),
             )
             self._exp.connect()
 

--- a/src/qdash/workflow/engine/config.py
+++ b/src/qdash/workflow/engine/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -42,6 +43,9 @@ class CalibConfig:
     skip_execution: bool = False  # Skip Execution creation (for wrapper/parent sessions)
     force_update_params: bool = False  # Force backend params update regardless of R² validation
     persist_output_parameters: bool = True  # Write task outputs to calibration/backend stores
+    configuration_mode: str | None = field(
+        default_factory=lambda: os.environ.get("QUBEX_CONFIGURATION_MODE")
+    )
     default_run_parameters: dict[str, Any] = field(
         default_factory=dict
     )  # Default run parameters for all tasks (e.g., {"interval": {"value": "300 * 1024", "value_type": "int"}})

--- a/src/qdash/workflow/engine/orchestrator.py
+++ b/src/qdash/workflow/engine/orchestrator.py
@@ -226,6 +226,9 @@ class CalibOrchestrator:
         if config.muxes is not None:
             session_config["muxes"] = config.muxes
 
+        if config.configuration_mode is not None:
+            session_config["configuration_mode"] = config.configuration_mode
+
         backend = create_backend(
             backend=config.backend_name,
             config=session_config,

--- a/src/qdash/workflow/engine/scheduler/cr_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/cr_scheduler.py
@@ -265,7 +265,12 @@ class CRScheduler:
                 raise FileNotFoundError(msg)
 
             yaml_data = yaml.safe_load(wiring_path.read_text())
-            self._wiring_config = yaml_data[self.chip_id]
+            if self.chip_id in yaml_data:
+                self._wiring_config = yaml_data[self.chip_id]
+            else:
+                # New YAML format: top-level keys are group names (e.g., "A2"),
+                # each mapping to a list of MUX configs. Flatten all lists.
+                self._wiring_config = [entry for group in yaml_data.values() for entry in group]
 
         return self._wiring_config
 

--- a/src/qdash/workflow/engine/scheduler/one_qubit_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/one_qubit_scheduler.py
@@ -131,7 +131,12 @@ class OneQubitScheduler:
                 raise FileNotFoundError(msg)
 
             yaml_data = yaml.safe_load(wiring_path.read_text())
-            self._wiring_config = yaml_data[self.chip_id]
+            if self.chip_id in yaml_data:
+                self._wiring_config = yaml_data[self.chip_id]
+            else:
+                # New YAML format: top-level keys are group names (e.g., "A2"),
+                # each mapping to a list of MUX configs. Flatten all lists.
+                self._wiring_config = [entry for group in yaml_data.values() for entry in group]
 
         return self._wiring_config
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduced configuration mode support for Qubex experiments to enhance flexibility in experiment setups.
- This change impacts configuration management and allows for dynamic adjustments based on the specified mode.

## Changes
- Added `QUBEX_CONFIGURATION_MODE` environment variable for optional configuration.
- Updated the experiment loading process to include configuration mode if specified.
- Enhanced the calibration configuration to support the new configuration mode.
- Adjusted wiring configuration loading to accommodate new YAML formats.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Qubex experiment configuration mode support through environment settings.
  * Passed configuration mode settings through calibration workflows and backend connections when configured.
  * Added support for wiring configurations organized by groups, in addition to chip-based layouts.

* **Bug Fixes**
  * Improved compatibility when Qubex is unavailable.
  * Preserved target exclusions while loading experiment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->