### PR TITLE
fix(ui): prevent forum preview label overlap (#1211)

### DIFF
--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -449,7 +449,7 @@ function ForumThreadPreviewSidebar({
       </button>
 
       {postId && (
-        <div className="pr-12">
+        <div className="pr-8 pt-8">
           {isLoading ? (
             <div className="flex justify-center py-12">
               <span className="loading loading-spinner loading-lg" />

--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -449,7 +449,7 @@ function ForumThreadPreviewSidebar({
       </button>
 
       {postId && (
-        <div className="pr-8">
+        <div className="pr-12">
           {isLoading ? (
             <div className="flex justify-center py-12">
               <span className="loading loading-spinner loading-lg" />


### PR DESCRIPTION
## Ticket

- #1211

## Summary

- Reserves enough horizontal space for the forum preview close control so it no longer overlaps metadata labels.
- UI-only spacing change in `ForumThreadPreviewSidebar`; no API, schema, or configuration impact.

## Changes

- Increase the right padding on `ForumThreadPreviewSidebar` content to match the close button's occupied width.
- Verified with UI lint, formatting, TypeScript, tests, and a production build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved spacing in the forum thread preview sidebar when viewing a specific post by adding top padding (while keeping right padding consistent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->