### PR TITLE
style(forum): replace lock icon with checkmark for resolved button

### DIFF
--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -8,7 +8,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
   CalendarDays,
-  Lock,
+  Check,
   MessageSquare,
   Pencil,
   Crosshair,
@@ -167,7 +167,7 @@ function PostBody({
 }) {
   const canEdit = canEditOverride ?? currentUsername === post.username;
   const isAi = post.is_ai_reply || post.username === "qdash";
-  const ActionIcon = postAction === "close" ? Lock : Trash2;
+  const ActionIcon = postAction === "close" ? Check : Trash2;
   const actionTitle = postAction === "close" ? "Close thread" : "Delete";
 
   return (


### PR DESCRIPTION
## Ticket
Fixes #1212

## Summary
Replaced the padlock icon with a checkmark for the forum "Resolved" action button to make its purpose much clearer to users.

## Changes
- Updated `ForumDetailPage.tsx` to use the `Check` icon from `lucide-react` instead of `Lock`.
- Applied the new icon specifically when the forum action is set to "close" (resolve).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the close-thread action icon to use a checkmark, making the action clearer in the forum post interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->