### PR TITLE
ci(repo): skip Claude review for dependency branches

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,9 @@ jobs:
   claude-review:
     if: >
       github.event.pull_request.head.ref != 'develop' &&
-      github.event.pull_request.head.ref != 'main'
+      github.event.pull_request.head.ref != 'main' &&
+      !startsWith(github.event.pull_request.head.ref, 'dependabot/') &&
+      !startsWith(github.event.pull_request.head.ref, 'renovate/')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip Claude Code Review for Dependabot and Renovate branches
- Keep normal CI and secret scanning responsible for dependency-only updates

## Reason
Claude Code Review is currently failing with `is_error:true` on dependency update PRs even after the Betterleaks staged diff issue was fixed. These automated dependency PRs are low-signal for Claude review and should not block routine updates.

## Testing
- Pre-commit betterleaks passed during commit