### PR TITLE
ci(repo): make Claude review best effort

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -47,3 +48,7 @@ jobs:
           claude_args: |
             --max-turns 10
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*)"
+
+      - name: Report Claude Code Review failure
+        if: steps.claude-review.outcome == 'failure'
+        run: echo "::warning::Claude Code Review failed before posting a review. Treating it as best-effort so PR checks are not blocked. See the claude-review step logs for details."


### PR DESCRIPTION
## Summary
- Keep Claude Code Review as a best-effort review step
- Do not fail the PR check when the external Claude action exits before producing a review
- Emit a GitHub Actions warning so the failed review step is still visible in logs

## Reason
After the develop merge, #1223 and #1213 still fail in `claude-review` with Claude Code initializing and then returning `is_error:true` with zero cost before posting comments. Other CI checks pass, so this should not block PRs while the upstream/action-level issue is investigated.

## Testing
- Pre-commit betterleaks passed during commit