### PR TITLE
fix(ui): keep histogram stats row width constant while dragging threshold

### DIFF
--- a/ui/src/components/features/analysis/HistogramView.tsx
+++ b/ui/src/components/features/analysis/HistogramView.tsx
@@ -864,7 +864,10 @@ export function HistogramView() {
                 </div>
               </div>
               {/* Desktop: Stats component */}
-              <div className="stats stats-horizontal shadow w-full hidden sm:inline-grid">
+              {/* grid-auto-columns:1fr keeps every column an equal, fixed width so the
+                  row doesn't reflow when the Yield value width changes while dragging
+                  the threshold slider (see issue #757). */}
+              <div className="stats stats-horizontal shadow w-full hidden sm:inline-grid [grid-auto-columns:1fr]">
                 <div className="stat py-2">
                   <div className="stat-title text-xs">Count</div>
                   <div className="stat-value text-primary text-lg">{statistics.count}</div>


### PR DESCRIPTION
## Ticket
Closes #757

## Summary
The histogram stats row (Count / Mean / Median / Min-Max / Yield) vibrated while dragging the threshold slider: the Yield value width changes (e.g. 100.0% → 0.0%) and DaisyUI's content-sized columns reflowed every column (~17px shift).

## Changes
- Fix the desktop stats columns to equal width with `grid-auto-columns:1fr`, so column widths stay constant regardless of the Yield value.

## Verification

https://github.com/user-attachments/assets/27f392f9-97e4-4d90-a330-d0306ce448f7




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop statistics layout to prevent columns from shifting when adjusting the threshold slider.
  * Histogram statistics now remain evenly aligned as yield values change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->