### PR TITLE
Fix/workflow split view helpers collapse

### DIFF
--- a/ui/src/components/features/flow/FlowImportsPanel.tsx
+++ b/ui/src/components/features/flow/FlowImportsPanel.tsx
@@ -41,7 +41,8 @@ export function FlowImportsPanel({ compact = false }: FlowImportsPanelProps) {
   );
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden bg-base-300">
+    // h-full: fills height even in block-layout parents (e.g. react-resizable-panels Panel), where flex-1 has no effect
+    <div className="h-full flex-1 flex flex-col overflow-hidden bg-base-300">
       {/* File Tabs */}
       <div
         className={`flex bg-base-200 border-b border-base-300 overflow-x-auto ${

--- a/ui/src/components/features/flow/FlowImportsPanel.tsx
+++ b/ui/src/components/features/flow/FlowImportsPanel.tsx
@@ -41,7 +41,6 @@ export function FlowImportsPanel({ compact = false }: FlowImportsPanelProps) {
   );
 
   return (
-    // h-full: fills height even in block-layout parents (e.g. react-resizable-panels Panel), where flex-1 has no effect
     <div className="h-full flex-1 flex flex-col overflow-hidden bg-base-300">
       {/* File Tabs */}
       <div

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -1584,8 +1584,6 @@ export function WorkflowEditorPageContent() {
             </div>
           </div>
           {/* Editor with Tab Switcher */}
-          {/* min-w-0 (and minWidth: 0 on the split view panels) keeps Monaco's explicit px
-              widths from inflating the layout via min-content sizing */}
           <div className="flex-1 flex flex-col min-w-0">
             {/* Tab Bar */}
             <div className="flex items-end bg-base-200 border-b border-base-300 h-9">

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -1584,7 +1584,9 @@ export function WorkflowEditorPageContent() {
             </div>
           </div>
           {/* Editor with Tab Switcher */}
-          <div className="flex-1 flex flex-col">
+          {/* min-w-0 (and minWidth: 0 on the split view panels) keeps Monaco's explicit px
+              widths from inflating the layout via min-content sizing */}
+          <div className="flex-1 flex flex-col min-w-0">
             {/* Tab Bar */}
             <div className="flex items-end bg-base-200 border-b border-base-300 h-9">
               <button
@@ -1668,8 +1670,11 @@ export function WorkflowEditorPageContent() {
 
             {/* Tab Content */}
             {isSplitView ? (
-              <PanelGroup orientation="horizontal" style={{ flex: 1, overflow: "hidden" }}>
-                <Panel defaultSize="60%" minSize="20%" style={{ overflow: "hidden" }}>
+              <PanelGroup
+                orientation="horizontal"
+                style={{ flex: 1, minWidth: 0, overflow: "hidden" }}
+              >
+                <Panel defaultSize="60%" minSize="20%" style={{ overflow: "hidden", minWidth: 0 }}>
                   <Editor
                     height="100%"
                     language="python"
@@ -1687,7 +1692,7 @@ export function WorkflowEditorPageContent() {
                   />
                 </Panel>
                 <PanelResizeHandle className="w-1 bg-base-300 hover:bg-primary/50 transition-colors cursor-col-resize" />
-                <Panel defaultSize="40%" minSize="15%" style={{ overflow: "hidden" }}>
+                <Panel defaultSize="40%" minSize="15%" style={{ overflow: "hidden", minWidth: 0 }}>
                   <FlowImportsPanel />
                 </Panel>
               </PanelGroup>


### PR DESCRIPTION
# PR Title

fix(ui): prevent workflow split view layout overflow (#1232)

# PR Description

## Ticket

- close #1232

## Summary

- Toggling split view in the workflow editor inflated the flex layout beyond the viewport: Monaco reports explicit pixel widths, so the flex containers' min-content size grew past the window width. The helpers pane was pushed off-screen (the view appeared not to split) and the editor's scrollbar/minimap were clipped.
- UI-only fix in the workflow editor (`WorkflowEditorPageContent`, `FlowImportsPanel`); no API, schema, or config changes.

## Changes

- `WorkflowEditorPageContent`: add `min-w-0` to the editor column and `minWidth: 0` to the split view panel group and panels so the split layout stays contained within the viewport.
- `FlowImportsPanel`: fill the container height (`h-full`) so the helpers panel spans the full split pane instead of collapsing.
- Verified locally with Playwright against the dev server: split view renders side by side at 1600px and 1100px viewports without horizontal overflow, the resize handle drag works, and the helpers panel fills the pane height.
- No OpenAPI/generated client changes (no regeneration needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow editor layout stability in split view.
  - Prevented editor panels from expanding incorrectly or causing horizontal overflow.
  - Ensured the imports panel and editor areas properly fill available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->