### PR TITLE
fix(api): broadcast forum replies to Slack channel

### DIFF
--- a/src/qdash/api/services/slack_notification_service.py
+++ b/src/qdash/api/services/slack_notification_service.py
@@ -119,7 +119,7 @@ class SlackNotificationService:
         root_post_id: str,
         actor_username: str,
     ) -> None:
-        """Send a Slack thread reply notification for a forum reply."""
+        """Send a Slack thread reply and broadcast it to the channel."""
         if not self.is_enabled():
             return
 
@@ -147,6 +147,7 @@ class SlackNotificationService:
             self._client().chat_postMessage(
                 channel=thread_record.channel_id,
                 thread_ts=thread_record.message_ts,
+                reply_broadcast=True,
                 text=text,
                 blocks=blocks,
             )

--- a/tests/qdash/api/services/test_slack_notification_service.py
+++ b/tests/qdash/api/services/test_slack_notification_service.py
@@ -257,9 +257,9 @@ def test_notify_forum_reply_skips_when_no_thread_record(init_db) -> None:
     mock_client.chat_postMessage.assert_not_called()
 
 
-def test_notify_forum_reply_sends_threaded_message_when_record_exists(init_db) -> None:
+def test_notify_forum_reply_broadcasts_threaded_message_when_record_exists(init_db) -> None:
     # First, create a thread record
-    """notify_forum_reply posts into the recorded Slack thread."""
+    """notify_forum_reply posts into the Slack thread and broadcasts to its channel."""
     root = _post()
     root.insert()
     SlackForumThreadDocument.record(
@@ -284,6 +284,7 @@ def test_notify_forum_reply_sends_threaded_message_when_record_exists(init_db) -
     call_kwargs = mock_client.chat_postMessage.call_args.kwargs
     assert call_kwargs["channel"] == "C0ROOTCHAN"
     assert call_kwargs["thread_ts"] == "root.ts.000"
+    assert call_kwargs["reply_broadcast"] is True
     assert "bob" in str(call_kwargs)
 
 


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Broadcast Slack notifications for forum replies to the channel timeline while preserving the existing Slack thread.
- Limited to API notification behavior; no API contract, configuration, or generated client changes.

## Changes

- Enable Slack reply broadcasting for forum reply notifications.
- Add regression coverage for the channel broadcast option.
- Verified with `uv run pytest tests/qdash/api/services/test_slack_notification_service.py tests/qdash/api/services/test_forum_slack_notifications.py -q` (32 passed).