### PR TITLE
fix: improve forum preview and Slack status notifications

### DIFF
--- a/src/qdash/api/services/slack_notification_service.py
+++ b/src/qdash/api/services/slack_notification_service.py
@@ -171,6 +171,14 @@ class SlackNotificationService:
         if not self.is_enabled():
             return
 
+        thread_record = SlackForumThreadDocument.find_by_post_id(str(post.id))
+        if thread_record is None:
+            logger.info(
+                "No Slack thread record found for root post %s; skipping status notification",
+                post.id,
+            )
+            return
+
         title = post.title or "Forum thread"
         title_text = f"#{post.number} {title}" if post.number is not None else title
         url = self._forum_post_url(post)
@@ -196,7 +204,9 @@ class SlackNotificationService:
 
         try:
             self._client().chat_postMessage(
-                channel=self._settings.slack_forum_channel_id,
+                channel=thread_record.channel_id,
+                thread_ts=thread_record.message_ts,
+                reply_broadcast=True,
                 text=text,
                 attachments=[{"color": color, "blocks": blocks}],
             )

--- a/tests/qdash/api/services/test_slack_notification_service.py
+++ b/tests/qdash/api/services/test_slack_notification_service.py
@@ -332,11 +332,18 @@ def test_notify_forum_reply_swallows_exceptions(init_db) -> None:
 
 
 def test_notify_forum_status_change_resolved_uses_forum_success_color(init_db) -> None:
-    """notify_forum_status_change uses the resolved-status color for resolved."""
+    """notify_forum_status_change replies to the root thread with the resolved color."""
     service = SlackNotificationService(settings=_settings())
     mock_client = MagicMock()
     mock_client.chat_postMessage.return_value = {"ts": "ts.001", "channel": "C0TESTCHAN"}
     post = _post()
+    post.insert()
+    SlackForumThreadDocument.record(
+        post_id=str(post.id),
+        project_id=post.project_id,
+        channel_id="C0ROOTCHAN",
+        message_ts="root.ts.000",
+    )
 
     with patch.object(service, "_client", return_value=mock_client):
         service.notify_forum_status_change(post=post, actor_username="alice", status="resolved")
@@ -344,7 +351,9 @@ def test_notify_forum_status_change_resolved_uses_forum_success_color(init_db) -
     call_kwargs = mock_client.chat_postMessage.call_args.kwargs
     assert call_kwargs["attachments"][0]["color"] == "#18794e"
     assert "Resolved" in str(call_kwargs["attachments"][0]["blocks"])
-    assert "thread_ts" not in call_kwargs  # top-level message, no thread
+    assert call_kwargs["channel"] == "C0ROOTCHAN"
+    assert call_kwargs["thread_ts"] == "root.ts.000"
+    assert call_kwargs["reply_broadcast"] is True
 
 
 def test_notify_forum_status_change_open_uses_forum_info_color(init_db) -> None:
@@ -353,6 +362,13 @@ def test_notify_forum_status_change_open_uses_forum_info_color(init_db) -> None:
     mock_client = MagicMock()
     mock_client.chat_postMessage.return_value = {"ts": "ts.002", "channel": "C0TESTCHAN"}
     post = _post()
+    post.insert()
+    SlackForumThreadDocument.record(
+        post_id=str(post.id),
+        project_id=post.project_id,
+        channel_id="C0ROOTCHAN",
+        message_ts="root.ts.000",
+    )
 
     with patch.object(service, "_client", return_value=mock_client):
         service.notify_forum_status_change(post=post, actor_username="alice", status="open")
@@ -360,6 +376,15 @@ def test_notify_forum_status_change_open_uses_forum_info_color(init_db) -> None:
     call_kwargs = mock_client.chat_postMessage.call_args.kwargs
     assert call_kwargs["attachments"][0]["color"] == "#3a5ccc"
     assert "Open" in str(call_kwargs["attachments"][0]["blocks"])
+
+
+def test_notify_forum_status_change_skips_when_no_thread_record(init_db) -> None:
+    """notify_forum_status_change sends nothing when the root Slack post is unknown."""
+    service = SlackNotificationService(settings=_settings())
+    mock_client = _mock_client()
+    with patch.object(service, "_client", return_value=mock_client):
+        service.notify_forum_status_change(post=_post(), actor_username="alice", status="resolved")
+    mock_client.chat_postMessage.assert_not_called()
 
 
 def test_notify_forum_status_change_skips_when_disabled(init_db) -> None:
@@ -376,5 +401,13 @@ def test_notify_forum_status_change_swallows_exceptions(init_db) -> None:
     service = SlackNotificationService(settings=_settings())
     mock_client = MagicMock()
     mock_client.chat_postMessage.side_effect = RuntimeError("oops")
+    post = _post()
+    post.insert()
+    SlackForumThreadDocument.record(
+        post_id=str(post.id),
+        project_id=post.project_id,
+        channel_id="C0ROOTCHAN",
+        message_ts="root.ts.000",
+    )
     with patch.object(service, "_client", return_value=mock_client):
-        service.notify_forum_status_change(post=_post(), actor_username="alice", status="resolved")
+        service.notify_forum_status_change(post=post, actor_username="alice", status="resolved")

--- a/ui/src/components/features/cryo/blocknote-theme.css
+++ b/ui/src/components/features/cryo/blocknote-theme.css
@@ -177,6 +177,20 @@
   border-color: var(--color-base-300);
 }
 
+/* Forum links: match the read-only preview while keeping the shared cryo
+   editor styling unchanged. */
+.forum-blocknote .bn-editor a {
+  color: var(--color-primary);
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  transition: opacity 0.15s ease;
+}
+
+.forum-blocknote .bn-editor a:hover {
+  opacity: 0.8;
+}
+
 /* Make sure the section doesn't itself clip floating menus */
 .wiring-blocknote {
   position: relative;

--- a/ui/src/components/features/forum/ForumBlockEditor.tsx
+++ b/ui/src/components/features/forum/ForumBlockEditor.tsx
@@ -262,7 +262,7 @@ export function ForumBlockEditor({
   }, [editor]);
 
   return (
-    <div className="wiring-blocknote">
+    <div className="forum-blocknote wiring-blocknote">
       <BlockNoteView
         editor={editor}
         editable={editable}

--- a/ui/src/components/features/forum/ForumBlockEditor.tsx
+++ b/ui/src/components/features/forum/ForumBlockEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useEffect, useState, type MutableRefObject } from "react";
+import { useEffect, useState, type MutableRefObject, type ReactNode } from "react";
 
 import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
@@ -67,24 +67,54 @@ type ForumBlock = Record<string, unknown> & {
   children?: ForumBlock[];
 };
 
-function textFromInlineContent(content: unknown): string {
+type ForumInlineContent = {
+  type?: string;
+  text?: unknown;
+  href?: unknown;
+  content?: unknown;
+};
+
+function safeLinkHref(href: unknown): string | null {
+  if (typeof href !== "string") return null;
+  const value = href.trim();
+  if (value.startsWith("/") || value.startsWith("#") || /^(https?:|mailto:)/i.test(value)) {
+    return value;
+  }
+  return null;
+}
+
+function renderInlineContent(content: unknown): ReactNode {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return "";
   return content
-    .map((item) => {
+    .map((item, index) => {
       if (typeof item === "string") return item;
-      if (item && typeof item === "object" && "text" in item) {
-        const text = (item as { text?: unknown }).text;
-        return typeof text === "string" ? text : "";
+      if (!item || typeof item !== "object") return "";
+
+      const inline = item as ForumInlineContent;
+      if (inline.type === "link") {
+        const children = renderInlineContent(inline.content);
+        const href = safeLinkHref(inline.href);
+        if (!href) return children;
+        return (
+          <a
+            key={index}
+            href={href}
+            className="break-words text-primary underline underline-offset-2 hover:text-primary/80"
+          >
+            {children}
+          </a>
+        );
       }
-      return "";
+
+      return typeof inline.text === "string" ? inline.text : "";
     })
-    .join("");
+    .filter((item) => item !== "");
 }
 
 function renderViewerBlock(block: ForumBlock, index: number) {
   const props = block.props ?? {};
-  const text = textFromInlineContent(block.content);
+  const content = renderInlineContent(block.content);
   const children = Array.isArray(block.children) ? block.children : [];
 
   if (block.type === "image") {
@@ -120,42 +150,42 @@ function renderViewerBlock(block: ForumBlock, index: number) {
     const className = level === 1 ? "text-xl" : level === 2 ? "text-lg" : "text-base";
     return (
       <h3 key={key} className={`my-2 font-semibold ${className}`}>
-        {text}
+        {content}
       </h3>
     );
   }
   if (block.type === "bulletListItem") {
     return (
       <li key={key} className="ml-5 list-disc">
-        {text}
+        {content}
       </li>
     );
   }
   if (block.type === "numberedListItem") {
     return (
       <li key={key} className="ml-5 list-decimal">
-        {text}
+        {content}
       </li>
     );
   }
   if (block.type === "quote") {
     return (
       <blockquote key={key} className="my-2 border-l-2 border-base-300 pl-3 text-base-content/70">
-        {text}
+        {content}
       </blockquote>
     );
   }
   if (block.type === "codeBlock") {
     return (
       <pre key={key} className="my-2 overflow-x-auto rounded bg-base-200 p-3 text-xs">
-        <code>{text}</code>
+        <code>{content}</code>
       </pre>
     );
   }
 
   return (
     <div key={key} className="my-1">
-      {text && <p>{text}</p>}
+      {content && <p>{content}</p>}
       {children.length > 0 && <div className="ml-4">{children.map(renderViewerBlock)}</div>}
     </div>
   );

--- a/ui/src/components/features/forum/__tests__/ForumBlockEditor.test.tsx
+++ b/ui/src/components/features/forum/__tests__/ForumBlockEditor.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ForumBlockViewer } from "../ForumBlockEditor";
+
+describe("ForumBlockViewer", () => {
+  afterEach(cleanup);
+
+  it("renders links in BlockNote inline content", () => {
+    render(
+      <ForumBlockViewer
+        blocks={[
+          {
+            id: "paragraph-1",
+            type: "paragraph",
+            content: [
+              { type: "text", text: "See ", styles: {} },
+              {
+                type: "link",
+                href: "https://example.com/docs",
+                content: [{ type: "text", text: "the documentation", styles: {} }],
+              },
+              { type: "text", text: " for details.", styles: {} },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "the documentation" });
+    expect(link.getAttribute("href")).toBe("https://example.com/docs");
+    expect(link.closest("p")?.textContent).toBe("See the documentation for details.");
+  });
+
+  it("renders unsafe link text without making it clickable", () => {
+    render(
+      <ForumBlockViewer
+        blocks={[
+          {
+            id: "paragraph-1",
+            type: "paragraph",
+            content: [
+              {
+                type: "link",
+                href: "javascript:alert(1)",
+                content: [{ type: "text", text: "unsafe link", styles: {} }],
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("unsafe link")).toBeTruthy();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Display BlockNote links correctly in forum previews and align their editing appearance.
- Keep forum status-change Slack notifications attached to the original Slack thread. No API contract, schema, configuration, or generated client changes.

## Changes

- Render safe links in `ForumBlockViewer` while preserving unsafe-link text without making it clickable.
- Match forum editor link styling to the read-only preview.
- Post forum status changes using the stored Slack `thread_ts` and broadcast the threaded reply.
- Skip status notifications when no matching Slack root-thread record exists.
- Add regression coverage for forum link rendering and threaded Slack status notifications.

## Verification

- `task check` (1,298 Python tests and 111 UI tests passed; leak scan skipped because `betterleaks` is not installed)
- Focused Slack notification tests: 33 passed
- TypeScript typecheck, lint, and formatting checks passed.