### PR TITLE
ci(repo): notify slack about third-party issues, PRs, and comments

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,46 @@
+name: Notify Slack
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{ !endsWith(github.actor, '[bot]') &&
+          !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+            github.event.comment.author_association ||
+            github.event.pull_request.author_association ||
+            github.event.issue.author_association) }}
+    env:
+      KIND: >-
+        ${{ github.event_name == 'issues' && 'Issue opened' ||
+        github.event_name == 'pull_request_target' && 'PR opened' ||
+        github.event.issue.pull_request && 'PR commented' || 'Issue commented' }}
+      ACTOR: ${{ github.actor }}
+      URL: >-
+        ${{ github.event.comment.html_url ||
+        github.event.pull_request.html_url ||
+        github.event.issue.html_url }}
+      TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+      BODY: ${{ github.event.comment.body || github.event.pull_request.body || github.event.issue.body }}
+    steps:
+      - name: Send to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg kind "$KIND" \
+            --arg actor "$ACTOR" \
+            --arg url "$URL" \
+            --arg title "$TITLE" \
+            --arg body "$BODY" \
+            '{text: "*\($kind)* by \($actor)\n<\($url)|\($title)>\n\($body | .[0:300])"}')
+          curl -sS --fail-with-body -X POST -H "Content-Type: application/json" -d "$PAYLOAD" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
# Title

ci(repo): notify slack about third-party issues, PRs, and comments (#1256)

# Description

## Ticket

close #1256

## Summary

- Add a GitHub Actions workflow that posts a Slack message when someone outside the team opens an issue, opens a PR, or comments on an issue or PR.
- Team activity stays quiet: org members, repository collaborators, and bots are filtered out. No backend or third-party service is needed; delivery uses a Slack incoming webhook.

## Changes

- Add `.github/workflows/notify-slack.yml` triggered by `issues`, `pull_request_target`, and `issue_comment` events.
- Skip notifications when the author association is `OWNER`, `MEMBER`, or `COLLABORATOR`, or when the actor is a `[bot]` account.
- Build the message (`Issue opened` / `Issue commented` / `PR opened` / `PR commented`, author, link, first 300 chars of body) with `jq` from environment variables, following GitHub's script injection guidance, so event text is never evaluated by the shell.
- Use `pull_request_target` without checkout so the webhook secret is available for PRs opened from forks.
- Requires the `SLACK_WEBHOOK_URL` repository secret (Slack app manifest: `yugo/issues/1256/slack-app-manifest.json`).
