### PR TITLE
style(ui): match flow graph height to task detail panel (#1242)

### DIFF
--- a/ui/src/components/features/execution/ExecutionDAG.tsx
+++ b/ui/src/components/features/execution/ExecutionDAG.tsx
@@ -335,19 +335,18 @@ export function ExecutionDAG({ tasks }: ExecutionDAGProps) {
   const { nodes, edges } = getLayoutedElements();
 
   return (
-    <div className="flex gap-4 relative">
+    <div className={`flex gap-4 relative ${isMaximized ? "" : "h-[600px]"}`}>
       <ReactFlowProvider>
         <div
           style={{
             width: selectedTask ? "70%" : "100%",
-            height: isMaximized ? "90vh" : "400px",
             position: isMaximized ? "fixed" : "relative",
             top: isMaximized ? "5vh" : "auto",
             left: isMaximized ? "5vw" : "auto",
             right: isMaximized ? "5vw" : "auto",
             zIndex: isMaximized ? 50 : "auto",
           }}
-          className={isMaximized ? "bg-base-100 p-4 rounded-lg shadow-xl" : ""}
+          className={isMaximized ? "h-[90vh] bg-base-100 p-4 rounded-lg shadow-xl" : "h-full"}
         >
           <FlowContent
             nodes={nodes}
@@ -365,9 +364,10 @@ export function ExecutionDAG({ tasks }: ExecutionDAGProps) {
       {selectedTask && (
         <div
           className={`bg-base-100 p-4 rounded-lg shadow overflow-y-auto ${
-            isMaximized ? "fixed right-8 top-[5vh] w-[400px] z-50 max-h-[90vh]" : "w-[30%]"
+            isMaximized
+              ? "fixed right-8 top-[5vh] w-[400px] z-50 h-auto max-h-[90vh]"
+              : "w-[30%] h-full"
           }`}
-          style={{ height: isMaximized ? "auto" : "600px" }}
         >
           <div className="flex justify-between items-center mb-4">
             <h3 className="text-lg font-semibold">{selectedTask.name}</h3>


### PR DESCRIPTION
# PR Description

## Ticket

close #1242

## Summary

- On the execution detail page, the "Execution Flow" graph was 400px tall while the task detail panel next to it was 600px, so selecting a node left about 200px of empty space under the graph.
- UI only, limited to `ExecutionDAG`. No API, schema, or generated client changes. Fullscreen behavior is unchanged.

## Changes

- `ExecutionDAG`: moved the height decision from the two child elements to the row wrapper, which now carries `h-[600px]` when not maximized. The graph and the detail panel both use `h-full`, so their bottom edges always line up.
- Removed the hardcoded inline `height: 400px` from the graph container and `height: 600px` from the detail panel. Fullscreen keeps its previous sizing (`h-[90vh]` for the graph, `h-auto max-h-[90vh]` for the panel).
- The graph is now 600px even with no node selected, so more of the DAG is visible at once.

### Note on the 600px value

- 600px carries over the value the detail panel already used. Matching the taller of the two removes the gap and keeps the card height identical to before when a node is selected, which keeps the diff minimal.
- A viewport based height (`h-[calc(100vh-22rem)] min-h-[500px]`, following `ProvenanceGraph`) was considered and set aside for now.

## Verification

- Checked against live data on `/execution/64Q2/20260807-003` (20 tasks): with a node selected, both panes measure `top: 332 / bottom: 932 / height: 600`.
- Fullscreen toggle and exit still behave as before.
- `bun run lint`, `bun run fmt:check`, and `bunx tsc --noEmit` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved execution DAG sizing and layout behavior.
  * Maximized views now use more available screen space.
  * Selected-task panels adjust their height more effectively in normal and maximized modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->