### PR TITLE
style(ui): align summary topology viewports on the dashboard (#1217)

### DIFF
--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -54,8 +54,8 @@ interface MetricValueLike {
 type MetricMap = { [key: string]: MetricValueLike };
 
 const FALLBACK_COLORS = ["#440154", "#31688e", "#35b779", "#fde724"];
-const SUMMARY_TOPOLOGY_SCROLL_CLASS =
-  "max-h-[min(62vh,34rem)] overflow-auto overscroll-contain rounded-md border border-base-300 bg-base-100/60 p-3";
+const SUMMARY_TOPOLOGY_VIEWPORT_CLASS = "grow rounded-md border border-base-300 bg-base-100/60 p-3";
+const SUMMARY_TOPOLOGY_HEADER_CLASS = "flex flex-wrap items-center justify-between gap-2 min-h-8";
 const MIGRATED_METRIC_NOTES_TO_LATEST_CD_MARKER =
   "<!-- qdash:migrated-metric-notes-to-latest-cooldown -->";
 
@@ -584,12 +584,12 @@ export function DashboardPageContent() {
               title="Target Summaries"
               description="Use these empty topologies for pinned target summaries. Create forum topics for individual issues, images, and discussion."
             >
-              <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 items-start">
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between gap-2">
+              <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 items-stretch">
+                <div className="flex flex-col gap-2">
+                  <div className={SUMMARY_TOPOLOGY_HEADER_CLASS}>
                     <h4 className="text-sm font-semibold">Qubit summaries</h4>
                   </div>
-                  <div className={SUMMARY_TOPOLOGY_SCROLL_CLASS}>
+                  <div className={SUMMARY_TOPOLOGY_VIEWPORT_CLASS}>
                     <DashboardQubitGrid
                       metricData={null}
                       unit=""
@@ -607,8 +607,8 @@ export function DashboardPageContent() {
                     />
                   </div>
                 </div>
-                <div className="space-y-2">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex flex-col gap-2">
+                  <div className={SUMMARY_TOPOLOGY_HEADER_CLASS}>
                     <div className="flex items-center gap-2">
                       <h4 className="text-sm font-semibold">Coupling summaries</h4>
                     </div>
@@ -630,7 +630,7 @@ export function DashboardPageContent() {
                       </span>
                     </button>
                   </div>
-                  <div className={SUMMARY_TOPOLOGY_SCROLL_CLASS}>
+                  <div className={SUMMARY_TOPOLOGY_VIEWPORT_CLASS}>
                     <DashboardCouplingGrid
                       metricData={noteCouplingTopologyData}
                       unit=""


### PR DESCRIPTION
## Ticket

- close #1217

## Summary

- The two topology viewports in the Target Summaries card did not line up. The right header carries the Forward direction toggle (`btn-sm`, 32px tall) while the left header only has a heading (20px), so the right viewport sat 12px lower than the left one.
- Both viewports also scrolled vertically by a few pixels. Their height cap of `min(62vh, 34rem)` resolves to 409px on a 660px viewport, just short of the 422px needed by an 8x8 topology grid. The cap is now removed so each viewport fits its grid.
- UI only. No API, schema, or generated client changes, so `task generate` was not needed.

## Changes

- `DashboardPageContent` (Target Summaries card): both column headers now share `SUMMARY_TOPOLOGY_HEADER_CLASS`, which reserves `min-h-8` to match the height of the `btn-sm` direction toggle.
- Switched the columns from `space-y-2` to `flex flex-col gap-2` and the grid from `items-start` to `items-stretch`, with `grow` on each viewport. Top and bottom edges stay aligned even when the two grids render at different heights.
- Renamed `SUMMARY_TOPOLOGY_SCROLL_CLASS` to `SUMMARY_TOPOLOGY_VIEWPORT_CLASS` and dropped `max-h-[min(62vh,34rem)] overflow-auto overscroll-contain`, so the viewport sizes itself to the topology grid instead of scrolling.

## Verification

- Measured both viewports on the dashboard at a 604px viewport height: identical top and bottom offsets (168 / 592) and no vertical scrolling on either side. Before the change they were 12px apart.
- Checked the Forward and Reverse states, a short window where the old cap applied, and the single column layout below the `xl` breakpoint.
- `bun run test:run` (111 tests), `bun run lint`, `bun run fmt:check`, and `tsc --noEmit` all pass.

## Note for reviewers

- Without the height cap, the card grows with the chip size. The viewport height is `rows * 48 + (rows - 1) * 2 + 24`, so roughly 422px for 64Q, 622px for 144Q, and 822px for 256Q. The qubit grid shrinks to the column width, so the coupling grid drives the height.
- Only 64Q chips exist in the local environment, so larger topologies were not verified on a real chip. If very large chips need to stay compact, scaling the cell size to the available height would be the follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the pinned summary topology layout to remain fixed within the viewport without unwanted scrolling.
  * Updated qubit and coupling summary sections for more consistent vertical sizing and alignment.
  * Preserved existing topology and direction controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->