### PR TITLE
style(ui): keep workflow activity bar badge inside the button box (#1273)

### DIFF
--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -1317,7 +1317,7 @@ export function WorkflowEditorPageContent() {
                         openSidePanel(item.id);
                       }
                     }}
-                    className={`btn btn-ghost btn-sm btn-square relative rounded-sm ${
+                    className={`btn btn-ghost btn-sm btn-square relative h-9 w-9 rounded-sm ${
                       isActive ? "bg-base-300 text-primary" : "text-base-content/60"
                     }`}
                     title={item.label}
@@ -1325,7 +1325,7 @@ export function WorkflowEditorPageContent() {
                   >
                     <Icon size={18} />
                     {item.count ? (
-                      <span className="absolute -right-0.5 -top-0.5 min-w-4 rounded-full bg-primary px-1 text-[10px] leading-4 text-primary-content">
+                      <span className="absolute right-0 top-0 min-w-4 rounded-full bg-primary px-1 text-[10px] leading-4 text-primary-content">
                         {item.count > 99 ? "99+" : item.count}
                       </span>
                     ) : null}
@@ -1340,7 +1340,7 @@ export function WorkflowEditorPageContent() {
                   setShowCommandPalette(true);
                   setCommandSearch("");
                 }}
-                className="btn btn-ghost btn-sm btn-square rounded-sm text-base-content/60"
+                className="btn btn-ghost btn-sm btn-square h-9 w-9 rounded-sm text-base-content/60"
                 title="Command Palette"
                 aria-label="Command Palette"
               >


### PR DESCRIPTION
## Ticket

close #1273

## Summary

- On the workflow editor page, the count badge on the activity bar buttons was cut off along its top and right edges. `globals.css` sets `overflow: hidden` on `.btn`, and the badge was anchored at `-right-0.5 -top-0.5`, so the part that hung outside the 32px button was clipped away.
- UI only, limited to the activity bar in `WorkflowEditorPageContent`. No API, schema, or generated client changes.

## Changes

- `WorkflowEditorPageContent`: grew the activity bar buttons from `btn-square` (32px) to `h-9 w-9` (36px) and moved the badge from `-right-0.5 -top-0.5` to `right-0 top-0`, so it now sits inside the button box and is no longer reached by the `overflow: hidden` clip.
- Applied the same size to the Command Palette button at the bottom of the rail so the column stays uniform.
- The icon stays at `size={18}` and the button radius stays at 8px, both unchanged.

### Note on the badge position

- The badge does not move relative to the icon. Both button edges shift out by 2px, and the icon center shifts by the same 2px, so the badge keeps its previous offset from the icon corner. Measured in the browser, that offset is 8px right and 8px up before and after.
- Only the button hit area grows, by 4px in each direction.

## Verification

- Checked on `/workflow/64Q2` against live data, with the Explorer and Properties badges both showing a count.
  - Buttons measure 36x36 with an 8px radius, and icons measure 18x18.
  - The badge now sits 1px inside the button box on the top and right. Before the change it hung 1px outside on both, which is where the clipping came from.
- `bun run lint`, `bun run fmt:check`, and `bunx tsc --noEmit` pass.

### Out of scope

- While checking the result, the digit inside the badge turned out to sit about 0.56px below the badge center. That comes from `leading-4` centering the font metrics box rather than the digit itself, and it predates this PR. Left alone here to keep the change focused on the clipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the size of activity bar and command palette buttons.
  * Improved activity count badge alignment by positioning it consistently in the top-right corner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->