### PR TITLE
feat(ui): adopt Pierre file trees

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -9,6 +9,7 @@
         "@blocknote/mantine": "^0.52.1",
         "@blocknote/react": "^0.52.1",
         "@monaco-editor/react": "^4.7.0",
+        "@pierre/trees": "^1.0.0-beta.6",
         "@tanstack/react-query": "^5.101.4",
         "@types/dagre": "^0.7.54",
         "@xyflow/react": "^12.11.2",
@@ -444,6 +445,10 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.77.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.77.0", "", { "os": "win32", "cpu": "x64" }, "sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw=="],
+
+    "@pierre/theming": ["@pierre/theming@1.0.0", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-WsdrnhKfjeyXGDikZmN9pkpeZ5S/cl6EE72feiSc0tlynT1tMYqXqouhuv/foK+PY9OEnebOAVRQn3+rAstR8g=="],
+
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.6", "", { "dependencies": { "@pierre/theming": "1.0.0", "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-zxeuSFM9TveM7b5XofweJALCtm/tGYV9HZzdbf7Uf+kBxIlUyz24/EHaGRjB0dsmmfDQl2ETz7AWwJ15lhSnpw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.3", "", { "os": "android", "cpu": "arm64" }, "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw=="],
 
@@ -1214,6 +1219,10 @@
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,7 @@
     "@blocknote/mantine": "^0.52.1",
     "@blocknote/react": "^0.52.1",
     "@monaco-editor/react": "^4.7.0",
+    "@pierre/trees": "^1.0.0-beta.6",
     "@tanstack/react-query": "^5.101.4",
     "@types/dagre": "^0.7.54",
     "@xyflow/react": "^12.11.2",

--- a/ui/src/components/features/files/FilesPageContent.tsx
+++ b/ui/src/components/features/files/FilesPageContent.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState, useEffect, useMemo, type ReactElement } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -11,10 +11,6 @@ import {
   Check,
   Database,
   ExternalLink,
-  File,
-  FileJson,
-  Folder,
-  FolderOpen,
   GitPullRequestArrow,
   PanelLeft,
   Pencil,
@@ -42,6 +38,7 @@ import {
   gitPushConfig,
 } from "@/client/file/file";
 import { EditorPageSkeleton } from "@/components/ui/Skeleton/PageSkeletons";
+import { PierreFileTree } from "@/components/ui/PierreFileTree";
 import { useToast } from "@/components/ui/Toast";
 
 const Editor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
@@ -294,62 +291,6 @@ export function FilesPageContent() {
     return "plaintext";
   };
 
-  const getFileIcon = (node: FileTreeNode, isOpen = false) => {
-    if (node.type === "directory") {
-      return isOpen ? (
-        <FolderOpen className="inline-block mr-1 text-yellow-600" size={14} />
-      ) : (
-        <Folder className="inline-block mr-1 text-yellow-600" size={14} />
-      );
-    }
-
-    // File type specific icons
-    if (node.name.endsWith(".json")) {
-      return <FileJson className="inline-block mr-1 text-yellow-500" size={14} />;
-    }
-    if (node.name.endsWith(".yaml") || node.name.endsWith(".yml")) {
-      return <File className="inline-block mr-1 text-red-400" size={14} />;
-    }
-    if (node.name.endsWith(".toml")) {
-      return <File className="inline-block mr-1 text-purple-400" size={14} />;
-    }
-
-    return <File className="inline-block mr-1 text-gray-400" size={14} />;
-  };
-
-  const renderFileTree = (nodes: FileTreeNode[], level = 0): ReactElement[] => {
-    return nodes.map((node) => (
-      <div key={node.path}>
-        {node.type === "directory" ? (
-          <details className="group">
-            <summary
-              className="text-sm text-base-content/80 hover:bg-base-200 px-2 py-0.5 cursor-pointer select-none flex items-center list-none"
-              style={{ paddingLeft: `${level * 12 + 8}px` }}
-            >
-              <span className="mr-1 transition-transform group-open:rotate-90">▸</span>
-              {getFileIcon(node, true)}
-              <span className="truncate">{node.name}</span>
-            </summary>
-            {node.children && renderFileTree(node.children, level + 1)}
-          </details>
-        ) : (
-          <div
-            className={`text-sm px-2 py-0.5 cursor-pointer select-none flex items-center transition-colors ${
-              selectedFile === node.path
-                ? "bg-primary/20 text-base-content"
-                : "text-base-content/80 hover:bg-base-200"
-            }`}
-            style={{ paddingLeft: `${level * 12 + 20}px` }}
-            onClick={() => handleFileSelect(node.path)}
-          >
-            {getFileIcon(node)}
-            <span className="truncate">{node.name}</span>
-          </div>
-        )}
-      </div>
-    ));
-  };
-
   if (isTreeLoading) {
     return <EditorPageSkeleton />;
   }
@@ -533,14 +474,22 @@ export function FilesPageContent() {
             <div
               className={`${isSidebarVisible ? "w-48 sm:w-64" : "w-0"} flex flex-col transition-all duration-200 overflow-hidden`}
             >
-              <div className="flex-1 overflow-y-auto py-2">
+              <div className="flex min-h-0 flex-1 flex-col py-2">
                 <h2 className="text-xs font-bold text-base-content/60 mb-1 px-3 tracking-wider">
                   EXPLORER
                 </h2>
                 <div className="text-xs text-base-content/50 px-3 mb-2 uppercase tracking-wide">
                   Config Files
                 </div>
-                {fileTreeData && renderFileTree(fileTreeData)}
+                {fileTreeData && (
+                  <div className="min-h-0 flex-1">
+                    <PierreFileTree
+                      nodes={fileTreeData}
+                      onSelectFile={handleFileSelect}
+                      selectedPath={selectedFile}
+                    />
+                  </div>
+                )}
               </div>
             </div>
 

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -10,6 +10,7 @@ import type { SaveFlowRequest, ExecuteFlowResponse } from "@/schemas";
 import type { AxiosResponse } from "axios";
 
 import { useToast } from "@/components/ui/Toast";
+import { PierreFileTree } from "@/components/ui/PierreFileTree";
 
 import { useGetCurrentUser } from "@/client/auth/auth";
 import { useListChips } from "@/client/chip/chip";
@@ -1392,45 +1393,36 @@ export function WorkflowEditorPageContent() {
                       />
                     </div>
                   </div>
-                  <div className="flex-1 overflow-y-auto py-1">
-                    {filteredFlows.map((flow) => (
-                      <button
-                        key={flow.name}
-                        type="button"
-                        className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors ${
-                          flow.name === name
-                            ? "bg-primary/15 text-base-content"
-                            : "text-base-content/70 hover:bg-base-300"
-                        }`}
-                        onClick={() => {
-                          if (flow.name !== name) {
-                            router.push(`/workflow/${encodeURIComponent(flow.name)}`);
+                  <div className="min-h-0 flex-1 py-1">
+                    {filteredFlows.length > 0 && (
+                      <PierreFileTree
+                        nodes={filteredFlows.map((flow) => ({
+                          decoration:
+                            flow.name === name && isDirty
+                              ? {
+                                  color: "var(--color-warning)",
+                                  text: "●",
+                                  title: "Unsaved changes",
+                                }
+                              : flow.file_exists === false
+                                ? {
+                                    color: "var(--color-warning)",
+                                    text: "missing",
+                                    title: "Missing source file",
+                                  }
+                                : undefined,
+                          path: `${flow.name}.py`,
+                          type: "file",
+                        }))}
+                        onSelectFile={(path) => {
+                          const flowName = path.replace(/\.py$/, "");
+                          if (flowName !== name) {
+                            router.push(`/workflow/${encodeURIComponent(flowName)}`);
                           }
                         }}
-                        title={flow.description || flow.name}
-                      >
-                        <FileCode
-                          size={14}
-                          className={`shrink-0 ${flow.name === name ? "text-primary" : "text-info/60"}`}
-                        />
-                        <span className="min-w-0 flex-1 truncate font-mono text-xs">
-                          {flow.name}.py
-                        </span>
-                        {flow.file_exists === false && (
-                          <AlertTriangle
-                            size={13}
-                            className="shrink-0 text-warning"
-                            aria-label="Missing source file"
-                          />
-                        )}
-                        {flow.name === name && isDirty ? (
-                          <span
-                            className="h-2 w-2 rounded-full bg-warning"
-                            title="Unsaved changes"
-                          />
-                        ) : null}
-                      </button>
-                    ))}
+                        selectedPath={`${name}.py`}
+                      />
+                    )}
                     {filteredFlows.length === 0 && (
                       <div className="px-3 py-6 text-center text-xs text-base-content/40">
                         No flows match the filter.

--- a/ui/src/components/features/tasks/TasksPageContent.tsx
+++ b/ui/src/components/features/tasks/TasksPageContent.tsx
@@ -2,22 +2,10 @@
 
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
-import { useState, useEffect, useMemo, type ReactElement } from "react";
+import { useState, useEffect, useMemo } from "react";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  Braces,
-  Copy,
-  File,
-  FileCode2,
-  Folder,
-  FolderOpen,
-  ListTree,
-  PanelLeft,
-  Pencil,
-  Plus,
-  Save,
-} from "lucide-react";
+import { Braces, Copy, FileCode2, ListTree, PanelLeft, Pencil, Plus, Save } from "lucide-react";
 import { useToast } from "@/components/ui/Toast";
 
 import type {
@@ -42,6 +30,7 @@ import {
   listTaskInfo,
 } from "@/client/task-file/task-file";
 import { EditorPageSkeleton } from "@/components/ui/Skeleton/PageSkeletons";
+import { PierreFileTree } from "@/components/ui/PierreFileTree";
 
 const Editor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
 
@@ -232,56 +221,6 @@ export function TasksPageContent() {
     setHasUnsavedChanges(true);
   };
 
-  const getFileIcon = (node: TaskFileTreeNode, isOpen = false) => {
-    if (node.type === "directory") {
-      return isOpen ? (
-        <FolderOpen className="inline-block mr-1 text-yellow-600" size={14} />
-      ) : (
-        <Folder className="inline-block mr-1 text-yellow-600" size={14} />
-      );
-    }
-
-    // Python files
-    if (node.name.endsWith(".py")) {
-      return <FileCode2 className="inline-block mr-1 text-blue-400" size={14} />;
-    }
-
-    return <File className="inline-block mr-1 text-base-content/50" size={14} />;
-  };
-
-  const renderFileTree = (nodes: TaskFileTreeNode[], level = 0): ReactElement[] => {
-    return nodes.map((node) => (
-      <div key={node.path}>
-        {node.type === "directory" ? (
-          <details className="group" open={level === 0}>
-            <summary
-              className="text-sm text-base-content/80 hover:bg-base-200 px-2 py-0.5 cursor-pointer select-none flex items-center list-none"
-              style={{ paddingLeft: `${level * 12 + 8}px` }}
-            >
-              <span className="mr-1 transition-transform group-open:rotate-90">▸</span>
-              {getFileIcon(node, true)}
-              <span className="truncate">{node.name}</span>
-            </summary>
-            {node.children && renderFileTree(node.children, level + 1)}
-          </details>
-        ) : (
-          <div
-            className={`text-sm px-2 py-0.5 cursor-pointer select-none flex items-center transition-colors ${
-              selectedFile === `${selectedBackend}/${node.path}`
-                ? "bg-primary/20 text-base-content"
-                : "text-base-content/80 hover:bg-base-200"
-            }`}
-            style={{ paddingLeft: `${level * 12 + 20}px` }}
-            onClick={() => handleFileSelect(node.path)}
-          >
-            {getFileIcon(node)}
-            <span className="truncate">{node.name}</span>
-          </div>
-        )}
-      </div>
-    ));
-  };
-
   // Group tasks by task_type
   const groupedTasks = useMemo(() => {
     if (!taskListData?.tasks) return {};
@@ -469,7 +408,7 @@ export function TasksPageContent() {
               </div>
 
               {/* Content */}
-              <div className="flex-1 overflow-y-auto py-2">
+              <div className="flex min-h-0 flex-1 flex-col py-2">
                 {viewMode === null ? (
                   <div className="flex items-center justify-center py-4">
                     <span className="loading loading-spinner loading-sm"></span>
@@ -489,7 +428,15 @@ export function TasksPageContent() {
                     ) : treeError ? (
                       <div className="text-xs text-red-400 px-3">Error loading tree</div>
                     ) : (
-                      fileTreeData && renderFileTree(fileTreeData)
+                      fileTreeData && (
+                        <div className="min-h-0 flex-1">
+                          <PierreFileTree
+                            nodes={fileTreeData}
+                            onSelectFile={handleFileSelect}
+                            selectedPath={selectedFile?.replace(`${selectedBackend}/`, "")}
+                          />
+                        </div>
+                      )
                     )}
                   </>
                 ) : (

--- a/ui/src/components/ui/PierreFileTree.tsx
+++ b/ui/src/components/ui/PierreFileTree.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { FileTree, useFileTree } from "@pierre/trees/react";
+import { useEffect, useMemo, useRef, type CSSProperties } from "react";
+
+import { DARK_THEMES } from "@/constants/themes";
+import { useTheme } from "@/contexts/ThemeContext";
+
+export interface PierreFileTreeNode {
+  children?: PierreFileTreeNode[] | null;
+  decoration?: {
+    color?: string;
+    text: string;
+    title?: string;
+  };
+  path: string;
+  type: string;
+}
+
+interface PierreFileTreeProps {
+  nodes: PierreFileTreeNode[];
+  onSelectFile: (path: string) => void;
+  selectedPath?: string | null;
+}
+
+function collectTreePaths(nodes: PierreFileTreeNode[]): {
+  decorations: Map<string, NonNullable<PierreFileTreeNode["decoration"]>>;
+  files: Set<string>;
+  paths: string[];
+} {
+  const decorations = new Map<string, NonNullable<PierreFileTreeNode["decoration"]>>();
+  const files = new Set<string>();
+  const paths: string[] = [];
+
+  const visit = (items: PierreFileTreeNode[]) => {
+    for (const item of items) {
+      const path = item.type === "directory" ? `${item.path.replace(/\/$/, "")}/` : item.path;
+      paths.push(path);
+      if (item.type === "file") files.add(item.path);
+      if (item.decoration) decorations.set(item.path, item.decoration);
+      if (item.children) visit(item.children);
+    }
+  };
+
+  visit(nodes);
+  return { decorations, files, paths };
+}
+
+function PierreFileTreeInstance({ nodes, onSelectFile, selectedPath }: PierreFileTreeProps) {
+  const { theme } = useTheme();
+  const isDarkTheme = DARK_THEMES.includes(theme);
+  const { decorations, files, paths } = useMemo(() => collectTreePaths(nodes), [nodes]);
+  const onSelectFileRef = useRef(onSelectFile);
+  const decorationsRef = useRef(decorations);
+  onSelectFileRef.current = onSelectFile;
+  decorationsRef.current = decorations;
+
+  const { model } = useFileTree({
+    flattenEmptyDirectories: true,
+    initialExpansion: 1,
+    initialSelectedPaths: selectedPath ? [selectedPath] : [],
+    onSelectionChange: (selectedPaths) => {
+      const selectedFile = Array.from(selectedPaths)
+        .reverse()
+        .find((path) => files.has(path));
+      if (selectedFile) onSelectFileRef.current(selectedFile);
+    },
+    paths,
+    renderRowDecoration: ({ item }) => decorationsRef.current.get(item.path) ?? null,
+    search: true,
+  });
+
+  useEffect(() => {
+    if (!selectedPath || model.getSelectedPaths().includes(selectedPath)) return;
+
+    for (const path of model.getSelectedPaths()) model.getItem(path)?.deselect();
+    model.getItem(selectedPath)?.select();
+  }, [model, selectedPath]);
+
+  return (
+    <FileTree
+      aria-label="File explorer"
+      className="block h-full min-h-0 w-full"
+      model={model}
+      style={
+        {
+          colorScheme: isDarkTheme ? "dark" : "light",
+          "--trees-accent-override": "var(--color-primary)",
+          "--trees-bg-muted-override": "var(--color-base-200)",
+          "--trees-bg-override": "var(--color-base-100)",
+          "--trees-border-color-override": "var(--color-base-300)",
+          "--trees-fg-muted-override":
+            "color-mix(in oklab, var(--color-base-content) 60%, transparent)",
+          "--trees-fg-override": "var(--color-base-content)",
+          "--trees-focus-ring-color-override": "var(--color-primary)",
+          "--trees-input-bg-override": "var(--color-base-200)",
+          "--trees-search-bg-override": "var(--color-base-200)",
+          "--trees-search-fg-override": "var(--color-base-content)",
+          "--trees-selected-bg-override":
+            "color-mix(in oklab, var(--color-primary) 20%, var(--color-base-100))",
+          "--trees-selected-fg-override": "var(--color-base-content)",
+        } as CSSProperties
+      }
+    />
+  );
+}
+
+export function PierreFileTree(props: PierreFileTreeProps) {
+  const treeKey = collectTreePaths(props.nodes).paths.join("\0");
+
+  return <PierreFileTreeInstance key={treeKey} {...props} />;
+}


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Replace the hand-built file explorers with a shared Pierre Trees integration for consistent navigation, search, selection, and compact path rendering.
- Affects the Files, Tasks, and Workflow Editor UI only; no API contracts, schemas, generated clients, or configuration formats change.

## Changes

- Add a theme-aware `PierreFileTree` component with QDash light/dark theme support, controlled selection synchronization, and row decorations.
- Update `FilesPageContent` and `TasksPageContent` to use the shared tree while preserving file loading and unsaved-change safeguards.
- Update `WorkflowEditorPageContent` to use the shared tree while preserving missing-file and unsaved-change indicators.
- Add `@pierre/trees` and update the Bun lockfile.

## Verification

- `task check`
- `task ci-ui-build`
- 1,328 Python tests and 119 UI tests passed
- Bun audit and Betterleaks scan passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared file-tree interface across Files, Tasks, and Workflow pages.
  * Added file-tree search, directory navigation, synchronized selection, and theme-aware styling.
  * Workflow files now display `.py` paths with unsaved and missing-file indicators.
  * Added improved scrolling and flexible sidebar layouts for larger file trees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->