### PR TITLE
refactor(ui): use TanStack Table for data grids

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -12,6 +12,7 @@
         "@pierre/diffs": "^1.3.5",
         "@pierre/trees": "^1.0.0-beta.6",
         "@tanstack/react-query": "^5.101.4",
+        "@tanstack/react-table": "^9.1.2",
         "@types/dagre": "^0.7.54",
         "@xyflow/react": "^12.11.2",
         "axios": "^1.18.1",
@@ -545,7 +546,11 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.7.7", "", { "dependencies": { "@tanstack/store": "0.7.7", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg=="],
 
+    "@tanstack/react-table": ["@tanstack/react-table@9.1.2", "", { "dependencies": { "@tanstack/react-store": "^0.11.0", "@tanstack/table-core": "9.1.2" }, "peerDependencies": { "react": ">=18" } }, "sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg=="],
+
     "@tanstack/store": ["@tanstack/store@0.7.7", "", {}, "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@9.1.2", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -1545,6 +1550,10 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tanstack/react-table/@tanstack/react-store": ["@tanstack/react-store@0.11.1", "", { "dependencies": { "@tanstack/store": "0.11.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ=="],
+
+    "@tanstack/table-core/@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
+
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@tiptap/react/@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
@@ -1592,6 +1601,8 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "@tanstack/react-table/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
 
     "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,6 +25,7 @@
     "@pierre/diffs": "^1.3.5",
     "@pierre/trees": "^1.0.0-beta.6",
     "@tanstack/react-query": "^5.101.4",
+    "@tanstack/react-table": "^9.1.2",
     "@types/dagre": "^0.7.54",
     "@xyflow/react": "^12.11.2",
     "axios": "^1.18.1",

--- a/ui/src/components/ui/DataTable.tsx
+++ b/ui/src/components/ui/DataTable.tsx
@@ -1,24 +1,37 @@
 import type { ReactNode } from "react";
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
+
+import {
+  columnFilteringFeature,
+  createFilteredRowModel,
+  createPaginatedRowModel,
+  createSortedRowModel,
+  filterFn_includesString,
+  globalFilteringFeature,
+  rowPaginationFeature,
+  rowSortingFeature,
+  tableFeatures,
+  useTable,
+} from "@tanstack/react-table";
+
+import type { ColumnDef } from "@tanstack/react-table";
 
 import { EmptyState } from "./EmptyState";
 
-interface Column {
+interface DataTableColumn<TData extends object> {
   key: string;
   label: string;
   sortable?: boolean;
   className?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic render function for flexible column types
-  render?: (value: any, row: any) => ReactNode;
+  // Cell values vary by dynamic analysis columns; row data remains strongly typed.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render?: (value: any, row: TData) => ReactNode;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic data table accepts flexible row structures
-type DataRow = Record<string, any>;
-
-interface DataTableProps {
+interface DataTableProps<TData extends object> {
   title: string;
-  data: DataRow[];
-  columns: Column[];
+  data: TData[];
+  columns: DataTableColumn<TData>[];
   searchable?: boolean;
   searchPlaceholder?: string;
   searchKey?: string;
@@ -28,12 +41,30 @@ interface DataTableProps {
   emptyMessage?: string;
 }
 
-type SortDirection = "asc" | "desc";
+interface DataTableColumnMeta {
+  className?: string;
+}
+
+const dataTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  filteredRowModel: createFilteredRowModel(),
+  filterFns: { includesString: filterFn_includesString },
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  rowPaginationFeature,
+  paginatedRowModel: createPaginatedRowModel(),
+  columnMeta: {} as DataTableColumnMeta,
+});
+
+function getCellValue<TData extends object>(row: TData, key: string): unknown {
+  return Reflect.get(row, key);
+}
 
 /**
- * Reusable data table component with sorting, filtering, and pagination
+ * Reusable data table backed by TanStack Table for sorting, filtering, and pagination.
  */
-export function DataTable({
+export function DataTable<TData extends object>({
   title,
   data,
   columns,
@@ -44,76 +75,57 @@ export function DataTable({
   actions,
   className = "",
   emptyMessage = "No data available",
-}: DataTableProps) {
-  const [filter, setFilter] = useState("");
-  const [currentPage, setCurrentPage] = useState(1);
-  const [sortField, setSortField] = useState<string>("");
-  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+}: DataTableProps<TData>) {
+  const tableColumns = useMemo<ColumnDef<typeof dataTableFeatures, TData, unknown>[]>(
+    () =>
+      columns.map((column) => ({
+        id: column.key,
+        accessorFn: (row: TData) => getCellValue(row, column.key),
+        header: column.label,
+        enableSorting: column.sortable ?? false,
+        enableGlobalFilter: column.key === searchKey,
+        meta: { className: column.className },
+        cell: ({ getValue, row }) => {
+          const value = getValue();
+          return column.render ? column.render(value, row.original) : String(value ?? "");
+        },
+      })),
+    [columns, searchKey],
+  );
 
-  // Handle sort
-  const handleSort = (field: string) => {
-    if (!columns.find((col) => col.key === field)?.sortable) return;
+  const table = useTable({
+    features: dataTableFeatures,
+    data,
+    columns: tableColumns,
+    initialState: { pagination: { pageIndex: 0, pageSize } },
+    globalFilterFn: "includesString",
+    getColumnCanGlobalFilter: (column) => column.id === searchKey,
+    enableMultiSort: false,
+    enableSortingRemoval: false,
+    sortDescFirst: true,
+  });
 
-    if (sortField === field) {
-      setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
-    } else {
-      setSortField(field);
-      setSortDirection("desc");
-    }
-    setCurrentPage(1);
-  };
-
-  // Filtered and sorted data
-  const processedData = useMemo(() => {
-    let filtered = data;
-
-    // Apply search filter
-    if (searchable && filter && searchKey) {
-      filtered = data.filter((row) =>
-        String(row[searchKey]).toLowerCase().includes(filter.toLowerCase()),
-      );
-    }
-
-    // Apply sorting
-    if (sortField) {
-      filtered = [...filtered].sort((a, b) => {
-        const aVal = a[sortField];
-        const bVal = b[sortField];
-        const direction = sortDirection === "asc" ? 1 : -1;
-
-        // Handle different data types
-        if (typeof aVal === "number" && typeof bVal === "number") {
-          return direction * (aVal - bVal);
-        }
-
-        return direction * String(aVal).localeCompare(String(bVal));
-      });
-    }
-
-    return filtered;
-  }, [data, filter, sortField, sortDirection, searchable, searchKey]);
-
-  // Pagination
-  const totalPages = Math.ceil(processedData.length / pageSize);
-  const paginatedData = processedData.slice((currentPage - 1) * pageSize, currentPage * pageSize);
+  const filter = String(table.state.globalFilter ?? "");
+  const processedRows = table.getPrePaginatedRowModel().rows;
+  const visibleRows = table.getRowModel().rows;
+  const totalPages = table.getPageCount();
+  const currentPage = table.state.pagination.pageIndex + 1;
 
   const handleFilterChange = (value: string) => {
-    setFilter(value);
-    setCurrentPage(1);
+    table.setGlobalFilter(value);
+    table.setPageIndex(0);
   };
 
   return (
     <div
       className={`card bg-base-100 shadow-xl rounded-xl p-4 sm:p-8 border border-base-300 ${className}`}
     >
-      {/* Header */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 mb-4 sm:mb-6">
         <div className="flex flex-wrap items-center gap-2 sm:gap-4">
           <h2 className="text-lg sm:text-2xl font-semibold">{title}</h2>
           {actions}
         </div>
 
-        {/* Search and Info */}
         <div className="flex items-center gap-2 sm:gap-4 w-full sm:w-auto">
           {searchable && (
             <div className="form-control flex-1 sm:flex-none">
@@ -122,19 +134,18 @@ export function DataTable({
                 placeholder={searchPlaceholder}
                 className="input input-bordered input-xs sm:input-sm w-full sm:w-64"
                 value={filter}
-                onChange={(e) => handleFilterChange(e.target.value)}
+                onChange={(event) => handleFilterChange(event.target.value)}
               />
             </div>
           )}
           <div className="text-xs sm:text-sm text-base-content/70 whitespace-nowrap">
-            {filter ? `${processedData.length} filtered` : `${data.length} total`}
+            {filter ? `${processedRows.length} filtered` : `${data.length} total`}
           </div>
         </div>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto -mx-4 sm:mx-0" style={{ minHeight: "300px" }}>
-        {processedData.length === 0 ? (
+      <div className="overflow-x-auto -mx-4 sm:mx-0 min-h-[300px]">
+        {processedRows.length === 0 ? (
           <EmptyState
             title={filter ? "No results found" : emptyMessage}
             description={filter ? "Try adjusting your search criteria." : undefined}
@@ -145,77 +156,100 @@ export function DataTable({
           <>
             <table className="table table-xs sm:table-compact table-zebra w-full border border-base-300 bg-base-100">
               <thead className="sticky top-0 bg-base-200">
-                <tr>
-                  {columns.map((column) => (
-                    <th
-                      key={column.key}
-                      className={`${column.className || "text-center"} text-xs sm:text-sm px-2 sm:px-4 ${
-                        column.sortable ? "cursor-pointer hover:bg-base-300" : ""
-                      }`}
-                      onClick={() => column.sortable && handleSort(column.key)}
-                    >
-                      <div className="flex items-center gap-1 justify-center">
-                        <span className="truncate max-w-[80px] sm:max-w-none">{column.label}</span>
-                        {column.sortable && sortField === column.key && (
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            className={`w-3 h-3 sm:w-4 sm:h-4 transition-transform flex-shrink-0 ${
-                              sortDirection === "desc" ? "rotate-180" : ""
-                            }`}
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          >
-                            <path d="M18 15l-6-6-6 6" />
-                          </svg>
-                        )}
-                      </div>
-                    </th>
-                  ))}
-                </tr>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                      const canSort = header.column.getCanSort();
+                      const sortDirection = header.column.getIsSorted();
+                      const meta = header.column.columnDef.meta;
+                      return (
+                        <th
+                          key={header.id}
+                          className={`${meta?.className || "text-center"} text-xs sm:text-sm px-2 sm:px-4 ${
+                            canSort ? "cursor-pointer hover:bg-base-300" : ""
+                          }`}
+                          onClick={header.column.getToggleSortingHandler()}
+                          aria-sort={
+                            sortDirection === "asc"
+                              ? "ascending"
+                              : sortDirection === "desc"
+                                ? "descending"
+                                : undefined
+                          }
+                        >
+                          <div className="flex items-center gap-1 justify-center">
+                            <span className="truncate max-w-[80px] sm:max-w-none">
+                              {header.isPlaceholder ? null : <table.FlexRender header={header} />}
+                            </span>
+                            {canSort && sortDirection && (
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                className={`w-3 h-3 sm:w-4 sm:h-4 transition-transform flex-shrink-0 ${
+                                  sortDirection === "desc" ? "rotate-180" : ""
+                                }`}
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                aria-hidden="true"
+                              >
+                                <path d="M18 15l-6-6-6 6" />
+                              </svg>
+                            )}
+                          </div>
+                        </th>
+                      );
+                    })}
+                  </tr>
+                ))}
               </thead>
               <tbody>
-                {paginatedData.map((row, index) => (
-                  <tr key={index} className="transition-colors hover:bg-base-200/80">
-                    {columns.map((column) => (
-                      <td
-                        key={column.key}
-                        className={`${column.className || "text-center"} text-xs sm:text-sm px-2 sm:px-4`}
-                      >
-                        {column.render
-                          ? column.render(row[column.key], row)
-                          : String(row[column.key] || "")}
-                      </td>
-                    ))}
+                {visibleRows.map((row) => (
+                  <tr key={row.id} className="transition-colors hover:bg-base-200/80">
+                    {row.getAllCells().map((cell) => {
+                      const meta = cell.column.columnDef.meta;
+                      return (
+                        <td
+                          key={cell.id}
+                          className={`${meta?.className || "text-center"} text-xs sm:text-sm px-2 sm:px-4`}
+                        >
+                          <table.FlexRender cell={cell} />
+                        </td>
+                      );
+                    })}
                   </tr>
                 ))}
               </tbody>
             </table>
 
-            {/* Pagination */}
             {totalPages > 1 && (
               <div className="flex flex-col sm:flex-row justify-between items-center gap-2 mt-4 px-4 sm:px-0">
                 <div className="text-xs sm:text-sm text-base-content/70">
-                  {Math.min(pageSize, processedData.length)} / {processedData.length}
+                  {visibleRows.length} / {processedRows.length}
                 </div>
                 <div className="join">
                   <button
+                    type="button"
                     className="join-item btn btn-xs sm:btn-sm"
-                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                    disabled={currentPage === 1}
+                    onClick={() => table.previousPage()}
+                    disabled={!table.getCanPreviousPage()}
                   >
                     Prev
                   </button>
-                  <button className="join-item btn btn-xs sm:btn-sm btn-disabled">
+                  <button
+                    type="button"
+                    className="join-item btn btn-xs sm:btn-sm btn-disabled"
+                    disabled
+                  >
                     {currentPage}/{totalPages}
                   </button>
                   <button
+                    type="button"
                     className="join-item btn btn-xs sm:btn-sm"
-                    onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                    disabled={currentPage === totalPages}
+                    onClick={() => table.nextPage()}
+                    disabled={!table.getCanNextPage()}
                   >
                     Next
                   </button>

--- a/ui/src/components/ui/__tests__/DataTable.test.tsx
+++ b/ui/src/components/ui/__tests__/DataTable.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DataTable } from "@/components/ui/DataTable";
+
+interface TestRow {
+  name: string;
+  note: string;
+  value: number;
+}
+
+const rows: TestRow[] = [
+  { name: "Alpha", note: "first", value: 1 },
+  { name: "Bravo", note: "second", value: 3 },
+  { name: "Charlie", note: "hidden match", value: 2 },
+];
+
+const columns = [
+  { key: "name", label: "Name", sortable: true },
+  {
+    key: "value",
+    label: "Value",
+    sortable: true,
+    render: (value: number) => `#${value}`,
+  },
+];
+
+afterEach(cleanup);
+
+describe("DataTable", () => {
+  it("sorts descending on the first sortable header click", () => {
+    render(<DataTable title="Results" data={rows} columns={columns} pageSize={10} />);
+
+    fireEvent.click(screen.getByRole("columnheader", { name: "Value" }));
+
+    const renderedRows = screen.getAllByRole("row").slice(1);
+    expect(within(renderedRows[0]).getByText("Bravo")).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Value" }).getAttribute("aria-sort")).toBe(
+      "descending",
+    );
+  });
+
+  it("filters only by the configured search column", () => {
+    render(<DataTable title="Results" data={rows} columns={columns} searchable searchKey="name" />);
+
+    const search = screen.getByPlaceholderText("Search...");
+    fireEvent.change(search, { target: { value: "brav" } });
+    expect(screen.getByText("Bravo")).toBeTruthy();
+    expect(screen.queryByText("Alpha")).toBeNull();
+    expect(screen.getByText("1 filtered")).toBeTruthy();
+
+    fireEvent.change(search, { target: { value: "hidden match" } });
+    expect(screen.getByText("No results found")).toBeTruthy();
+  });
+
+  it("paginates rows with TanStack Table state", () => {
+    render(<DataTable title="Results" data={rows} columns={columns} pageSize={2} />);
+
+    expect(screen.getByText("2 / 3")).toBeTruthy();
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.queryByText("Charlie")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(screen.getByText("Charlie")).toBeTruthy();
+    expect(screen.getByText("2/2")).toBeTruthy();
+    expect(screen.getByRole<HTMLButtonElement>("button", { name: "Next" }).disabled).toBe(true);
+  });
+
+  it("renders custom cells without hiding zero values", () => {
+    const zeroRows = [{ name: "Zero", note: "", value: 0 }];
+    render(<DataTable title="Results" data={zeroRows} columns={columns} />);
+
+    expect(screen.getByText("#0")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Replace the custom DataTable state and row processing with TanStack Table while preserving the existing component API and visual design.
- UI-only internal refactor with focused coverage for sorting, filtering, pagination, and custom cell rendering.

## Changes
- Add `@tanstack/react-table` as the shared table engine.
- Migrate `DataTable` sorting, global filtering, and pagination to TanStack Table.
- Improve table semantics with `aria-sort`, explicit button types, accurate visible-row counts, and correct zero-value rendering.
- Add focused `DataTable` component tests.

## Validation
- `task check` (1,330 Python tests and 123 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)