### PR TITLE
refactor(ui): adopt Radix Dialog primitives

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -11,6 +11,7 @@
         "@monaco-editor/react": "^4.7.0",
         "@pierre/diffs": "^1.3.5",
         "@pierre/trees": "^1.0.0-beta.6",
+        "@radix-ui/react-dialog": "^1.1.23",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-table": "^9.1.2",
         "@types/dagre": "^0.7.54",
@@ -456,6 +457,38 @@
 
     "@pierre/trees": ["@pierre/trees@1.0.0-beta.6", "", { "dependencies": { "@pierre/theming": "1.0.0", "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-zxeuSFM9TveM7b5XofweJALCtm/tGYV9HZzdbf7Uf+kBxIlUyz24/EHaGRjB0dsmmfDQl2ETz7AWwJ15lhSnpw=="],
 
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
+
+    "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
+
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.2.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA=="],
+
+    "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.23", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-focus-guards": "1.1.6", "@radix-ui/react-focus-scope": "1.1.16", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-layout-effect": "1.1.4", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA=="],
+
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-effect-event": "0.0.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w=="],
+
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.6", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.16", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ=="],
+
+    "@radix-ui/react-id": ["@radix-ui/react-id@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.17", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.10", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw=="],
+
+    "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.10", "", { "dependencies": { "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg=="],
+
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
+
+    "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.5", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg=="],
+
+    "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.3", "", { "os": "android", "cpu": "arm64" }, "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA=="],
@@ -715,6 +748,8 @@
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@pierre/diffs": "^1.3.5",
     "@pierre/trees": "^1.0.0-beta.6",
+    "@radix-ui/react-dialog": "^1.1.23",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^9.1.2",
     "@types/dagre": "^0.7.54",

--- a/ui/src/components/features/admin/AdminConfirmDialogs.tsx
+++ b/ui/src/components/features/admin/AdminConfirmDialogs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 import type { ProjectListItem, UserListItem } from "@/schemas";
 
 type DeleteUserDialogProps = {
@@ -11,26 +12,23 @@ type DeleteUserDialogProps = {
 
 export function DeleteUserDialog({ user, isLoading, onClose, onConfirm }: DeleteUserDialogProps) {
   return (
-    <dialog className="modal modal-open">
-      <div className="modal-box">
-        <h3 className="font-bold text-lg">Confirm Delete</h3>
-        <p className="py-4">
+    <Dialog open onOpenChange={(open) => !open && !isLoading && onClose()}>
+      <DialogContent>
+        <DialogTitle>Confirm Delete</DialogTitle>
+        <DialogDescription className="py-4">
           Are you sure you want to delete user <span className="font-bold">{user.username}</span>?
           This action cannot be undone.
-        </p>
+        </DialogDescription>
         <div className="modal-action">
-          <button className="btn" onClick={onClose}>
+          <button type="button" className="btn" onClick={onClose} disabled={isLoading}>
             Cancel
           </button>
-          <button className="btn btn-error" onClick={onConfirm} disabled={isLoading}>
+          <button type="button" className="btn btn-error" onClick={onConfirm} disabled={isLoading}>
             {isLoading ? <span className="loading loading-spinner loading-sm" /> : "Delete"}
           </button>
         </div>
-      </div>
-      <form method="dialog" className="modal-backdrop">
-        <button onClick={onClose}>close</button>
-      </form>
-    </dialog>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -48,12 +46,12 @@ export function BulkDeleteUsersDialog({
   onConfirm,
 }: BulkDeleteUsersDialogProps) {
   return (
-    <dialog className="modal modal-open">
-      <div className="modal-box">
-        <h3 className="font-bold text-lg">Delete Selected Users</h3>
-        <p className="py-4">
+    <Dialog open onOpenChange={(open) => !open && !isLoading && onClose()}>
+      <DialogContent>
+        <DialogTitle>Delete Selected Users</DialogTitle>
+        <DialogDescription className="py-4">
           Delete {users.length} selected user{users.length !== 1 ? "s" : ""}?
-        </p>
+        </DialogDescription>
         <p className="text-sm text-base-content/60">
           Owned projects and project memberships for these users will also be removed.
         </p>
@@ -70,18 +68,15 @@ export function BulkDeleteUsersDialog({
           </div>
         </div>
         <div className="modal-action">
-          <button className="btn" onClick={onClose}>
+          <button type="button" className="btn" onClick={onClose} disabled={isLoading}>
             Cancel
           </button>
-          <button className="btn btn-error" onClick={onConfirm} disabled={isLoading}>
+          <button type="button" className="btn btn-error" onClick={onConfirm} disabled={isLoading}>
             {isLoading ? <span className="loading loading-spinner loading-sm" /> : "Delete Users"}
           </button>
         </div>
-      </div>
-      <form method="dialog" className="modal-backdrop">
-        <button onClick={onClose}>close</button>
-      </form>
-    </dialog>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -99,27 +94,24 @@ export function DeleteProjectDialog({
   onConfirm,
 }: DeleteProjectDialogProps) {
   return (
-    <dialog className="modal modal-open">
-      <div className="modal-box">
-        <h3 className="font-bold text-lg">Confirm Delete Project</h3>
-        <p className="py-4">
+    <Dialog open onOpenChange={(open) => !open && !isLoading && onClose()}>
+      <DialogContent>
+        <DialogTitle>Confirm Delete Project</DialogTitle>
+        <DialogDescription className="py-4">
           Are you sure you want to delete project <span className="font-bold">{project.name}</span>?
-        </p>
+        </DialogDescription>
         <p className="text-sm text-base-content/60">
           This will also remove all project memberships. This action cannot be undone.
         </p>
         <div className="modal-action">
-          <button className="btn" onClick={onClose}>
+          <button type="button" className="btn" onClick={onClose} disabled={isLoading}>
             Cancel
           </button>
-          <button className="btn btn-error" onClick={onConfirm} disabled={isLoading}>
+          <button type="button" className="btn btn-error" onClick={onConfirm} disabled={isLoading}>
             {isLoading ? <span className="loading loading-spinner loading-sm" /> : "Delete"}
           </button>
         </div>
-      </div>
-      <form method="dialog" className="modal-backdrop">
-        <button onClick={onClose}>close</button>
-      </form>
-    </dialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/features/chip/AiReviewConfirmModal.tsx
+++ b/ui/src/components/features/chip/AiReviewConfirmModal.tsx
@@ -2,6 +2,7 @@
 
 import { Bot, X } from "lucide-react";
 
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 import type { ModelOverride } from "@/lib/copilotModels";
 
 interface ModelOption {
@@ -33,8 +34,6 @@ export function AiReviewConfirmModal({
   onConfirm,
   onClose,
 }: AiReviewConfirmModalProps) {
-  if (!isOpen) return null;
-
   const selectedModel =
     modelOptions.find((option) => option.key === selectedModelKey) ?? modelOptions[0];
   const modelName = selectedModel?.model
@@ -42,12 +41,12 @@ export function AiReviewConfirmModal({
     : selectedModel?.label || "Configured model";
 
   return (
-    <div className="modal modal-open">
-      <div className="modal-box max-w-lg rounded-lg">
+    <Dialog open={isOpen} onOpenChange={(open) => !open && !isSubmitting && onClose()}>
+      <DialogContent className="max-w-lg rounded-lg">
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-center gap-2">
             <Bot className="h-5 w-5 text-primary" />
-            <h3 className="font-semibold text-lg">Request AI review</h3>
+            <DialogTitle className="font-semibold">Request AI review</DialogTitle>
           </div>
           <button
             type="button"
@@ -59,6 +58,9 @@ export function AiReviewConfirmModal({
             <X className="h-4 w-4" />
           </button>
         </div>
+        <DialogDescription className="sr-only">
+          Choose a model and request an AI review for the selected task results.
+        </DialogDescription>
 
         <div className="mt-4 space-y-3 text-sm">
           <div className="rounded-md bg-base-200 px-3 py-2">
@@ -116,7 +118,7 @@ export function AiReviewConfirmModal({
             Request review
           </button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/features/chip/DownloadConfirmModal.tsx
+++ b/ui/src/components/features/chip/DownloadConfirmModal.tsx
@@ -3,6 +3,8 @@
 import { Bot, Database, FileJson, FileText, Image, X } from "lucide-react";
 import type { ReactNode } from "react";
 
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+
 export interface DownloadOptions {
   figureImages: boolean;
   jsonFigures: boolean;
@@ -40,8 +42,6 @@ export function DownloadConfirmModal({
   onConfirm,
   onClose,
 }: DownloadConfirmModalProps) {
-  if (!isOpen) return null;
-
   const selectedItemCount =
     (options.figureImages ? counts.figureImages : 0) +
     (options.jsonFigures ? counts.jsonFigures : 0) +
@@ -54,16 +54,17 @@ export function DownloadConfirmModal({
   };
 
   return (
-    <div className="modal modal-open">
-      <div className="modal-box max-w-lg">
+    <Dialog open={isOpen} onOpenChange={(open) => !open && !isSubmitting && onClose()}>
+      <DialogContent className="max-w-lg">
         <div className="flex items-start justify-between gap-3">
           <div>
-            <h3 className="font-semibold text-lg">Download task artifacts</h3>
-            <p className="text-sm text-base-content/70 mt-1">
+            <DialogTitle className="font-semibold">Download task artifacts</DialogTitle>
+            <DialogDescription className="text-sm text-base-content/70 mt-1">
               {selectedCount} task result{selectedCount === 1 ? "" : "s"} selected
-            </p>
+            </DialogDescription>
           </div>
           <button
+            type="button"
             className="btn btn-sm btn-ghost btn-circle"
             onClick={onClose}
             disabled={isSubmitting}
@@ -112,10 +113,11 @@ export function DownloadConfirmModal({
         </div>
 
         <div className="modal-action">
-          <button className="btn btn-ghost" onClick={onClose} disabled={isSubmitting}>
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={isSubmitting}>
             Cancel
           </button>
           <button
+            type="button"
             className="btn btn-primary"
             onClick={onConfirm}
             disabled={isSubmitting || selectedItemCount === 0}
@@ -124,11 +126,8 @@ export function DownloadConfirmModal({
             Download
           </button>
         </div>
-      </div>
-      <button className="modal-backdrop" onClick={isSubmitting ? undefined : onClose}>
-        close
-      </button>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/ui/src/components/features/execution/CancelExecutionModal.tsx
+++ b/ui/src/components/features/execution/CancelExecutionModal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+
 export interface CancelExecutionModalProps {
   isOpen: boolean;
   isPending: boolean;
@@ -13,20 +15,18 @@ export function CancelExecutionModal({
   onConfirm,
   onClose,
 }: CancelExecutionModalProps) {
-  if (!isOpen) return null;
-
   return (
-    <div className="modal modal-open">
-      <div className="modal-box">
-        <h3 className="font-bold text-lg">Cancel Execution</h3>
-        <p className="py-4">
+    <Dialog open={isOpen} onOpenChange={(open) => !open && !isPending && onClose()}>
+      <DialogContent>
+        <DialogTitle>Cancel Execution</DialogTitle>
+        <DialogDescription className="py-4">
           Are you sure you want to cancel this execution? This action cannot be undone.
-        </p>
+        </DialogDescription>
         <div className="modal-action">
-          <button className="btn btn-ghost" onClick={onClose} disabled={isPending}>
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={isPending}>
             Close
           </button>
-          <button className="btn btn-error" onClick={onConfirm} disabled={isPending}>
+          <button type="button" className="btn btn-error" onClick={onConfirm} disabled={isPending}>
             {isPending ? (
               <span className="loading loading-spinner loading-sm" />
             ) : (
@@ -34,8 +34,7 @@ export function CancelExecutionModal({
             )}
           </button>
         </div>
-      </div>
-      <div className="modal-backdrop" onClick={() => !isPending && onClose()} />
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/features/execution/__tests__/CancelExecutionModal.test.tsx
+++ b/ui/src/components/features/execution/__tests__/CancelExecutionModal.test.tsx
@@ -27,6 +27,7 @@ describe("CancelExecutionModal", () => {
   it("renders the confirmation content when open", () => {
     render(<CancelExecutionModal isOpen isPending={false} onConfirm={vi.fn()} onClose={vi.fn()} />);
 
+    expect(screen.getByRole("dialog").classList.contains("modal-box")).toBe(false);
     expect(screen.getByText(confirmText)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Cancel Execution" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Close" })).toBeTruthy();
@@ -52,15 +53,11 @@ describe("CancelExecutionModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onClose when the backdrop is clicked and not pending", () => {
+  it("calls onClose when Escape is pressed and not pending", () => {
     const onClose = vi.fn();
-    const { container } = render(
-      <CancelExecutionModal isOpen isPending={false} onConfirm={vi.fn()} onClose={onClose} />,
-    );
+    render(<CancelExecutionModal isOpen isPending={false} onConfirm={vi.fn()} onClose={onClose} />);
 
-    const backdrop = container.querySelector(".modal-backdrop");
-    expect(backdrop).toBeTruthy();
-    fireEvent.click(backdrop as Element);
+    fireEvent.keyDown(document, { key: "Escape" });
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -68,7 +65,7 @@ describe("CancelExecutionModal", () => {
   it("disables the actions and shows a spinner while pending", () => {
     const onConfirm = vi.fn();
     const onClose = vi.fn();
-    const { container } = render(
+    const { baseElement } = render(
       <CancelExecutionModal isOpen isPending onConfirm={onConfirm} onClose={onClose} />,
     );
 
@@ -77,12 +74,10 @@ describe("CancelExecutionModal", () => {
       expect((button as HTMLButtonElement).disabled).toBe(true);
     }
     // The confirm label is replaced by a loading spinner.
-    expect(container.querySelector(".loading-spinner")).toBeTruthy();
+    expect(baseElement.querySelector(".loading-spinner")).toBeTruthy();
 
-    // Backdrop clicks are ignored while pending.
-    const backdrop = container.querySelector(".modal-backdrop");
-    expect(backdrop).toBeTruthy();
-    fireEvent.click(backdrop as Element);
+    // Escape is ignored while pending.
+    fireEvent.keyDown(document, { key: "Escape" });
     expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/components/ui/Dialog.tsx
+++ b/ui/src/components/ui/Dialog.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import { forwardRef } from "react";
+
+function mergeClassNames(...classNames: Array<string | undefined>): string {
+  return classNames.filter(Boolean).join(" ");
+}
+
+export const Dialog = DialogPrimitive.Root;
+
+const DialogOverlay = forwardRef<
+  ElementRef<typeof DialogPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={mergeClassNames("fixed inset-0 z-50 bg-black/40", className)}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = forwardRef<
+  ElementRef<typeof DialogPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPrimitive.Portal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={mergeClassNames(
+        "fixed left-1/2 top-1/2 z-50 max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-3xl border border-base-content/10 bg-base-100 p-6 text-base-content shadow-2xl",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPrimitive.Portal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogTitle = forwardRef<
+  ElementRef<typeof DialogPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={mergeClassNames("font-bold text-lg", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = forwardRef<
+  ElementRef<typeof DialogPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={className} {...props} />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;

--- a/ui/src/components/ui/FileDiffReviewDialog.tsx
+++ b/ui/src/components/ui/FileDiffReviewDialog.tsx
@@ -4,6 +4,8 @@ import dynamic from "next/dynamic";
 
 import { GitCompareArrows, X } from "lucide-react";
 
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "./Dialog";
+
 const PierreDiffViewer = dynamic(
   () => import("@/components/ui/PierreDiffViewer").then((module) => module.PierreDiffViewer),
   {
@@ -31,18 +33,18 @@ export function FileDiffReviewDialog({
   onClose,
   open,
 }: FileDiffReviewDialogProps) {
-  if (!open) return null;
-
   return (
-    <div className="modal modal-open z-50" role="dialog" aria-modal="true">
-      <div className="modal-box flex h-[min(85dvh,56rem)] w-11/12 max-w-6xl flex-col p-0">
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+      <DialogContent className="flex h-[min(85dvh,56rem)] max-w-6xl flex-col !overflow-hidden p-0">
         <div className="flex items-center justify-between border-b border-base-300 px-4 py-3">
           <div className="min-w-0">
-            <h2 className="flex items-center gap-2 font-semibold">
+            <DialogTitle className="flex items-center gap-2 font-semibold text-base">
               <GitCompareArrows size={18} className="text-primary" />
               Review saved changes
-            </h2>
-            <p className="truncate font-mono text-xs text-base-content/60">{filename}</p>
+            </DialogTitle>
+            <DialogDescription className="truncate font-mono text-xs text-base-content/60">
+              {filename}
+            </DialogDescription>
           </div>
           <button
             type="button"
@@ -63,13 +65,7 @@ export function FileDiffReviewDialog({
             Close
           </button>
         </div>
-      </div>
-      <button
-        type="button"
-        className="modal-backdrop"
-        onClick={onClose}
-        aria-label="Close diff review"
-      />
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Introduce a shared Radix Dialog primitive and migrate the first set of confirmation/review dialogs away from custom modal behavior.
- UI-only refactor that preserves DaisyUI styling while improving focus management, keyboard dismissal, Portal rendering, and accessible labeling.

## Changes
- Add `@radix-ui/react-dialog` and a reusable `Dialog` component family.
- Migrate execution cancellation, AI review, artifact download, admin deletion, and file diff review dialogs.
- Prevent dismissing destructive dialogs while their actions are pending.
- Update `CancelExecutionModal` coverage for Escape dismissal and pending-state protection.
- Leave complex history/detail modals unchanged for a later incremental migration.

## Validation
- `task check` (1,330 Python tests and 123 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared dialog experience with consistent layout, accessibility support, and dismissal behavior.
  - Updated confirmation, download, cancellation, AI review, and file-diff dialogs to use the standardized interface.

- **Bug Fixes**
  - Prevented dialogs from closing while actions are processing.
  - Disabled relevant controls during loading to avoid duplicate submissions.
  - Improved keyboard handling, including Escape-key behavior during pending operations.

- **Tests**
  - Updated dialog tests to verify keyboard dismissal and pending-state protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->