### PR TITLE
refactor(ui): migrate form dialogs to Radix

### DIFF
--- a/ui/src/components/features/admin/CreateUserModal.tsx
+++ b/ui/src/components/features/admin/CreateUserModal.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/Dialog";
+
 type CreateUserModalProps = {
   onClose: () => void;
   onSave: (userData: {
@@ -55,9 +57,9 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
     localError || (error ? "Failed to create user. Username may already exist." : null);
 
   return (
-    <dialog className="modal modal-open">
-      <div className="modal-box">
-        <h3 className="font-bold text-lg mb-4">Create New User</h3>
+    <Dialog open onOpenChange={(open) => !open && !isLoading && onClose()}>
+      <DialogContent>
+        <DialogTitle className="mb-4">Create New User</DialogTitle>
 
         {displayError && (
           <div className="alert alert-error mb-4">
@@ -163,19 +165,21 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
         )}
 
         <div className="modal-action">
-          <button className="btn" onClick={onClose}>
+          <button type="button" className="btn" onClick={onClose} disabled={isLoading}>
             {temporaryPassword ? "Close" : "Cancel"}
           </button>
           {!temporaryPassword && (
-            <button className="btn btn-primary" onClick={handleSave} disabled={isLoading}>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={handleSave}
+              disabled={isLoading}
+            >
               {isLoading ? <span className="loading loading-spinner loading-sm" /> : "Create User"}
             </button>
           )}
         </div>
-      </div>
-      <form method="dialog" className="modal-backdrop">
-        <button onClick={onClose}>close</button>
-      </form>
-    </dialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/features/admin/EditUserModal.tsx
+++ b/ui/src/components/features/admin/EditUserModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/Dialog";
 import type { SystemRole, UserListItem } from "@/schemas";
 
 import { useResetPassword } from "@/client/auth/auth";
@@ -35,6 +36,7 @@ export function EditUserModal({
   const [passwordSuccess, setPasswordSuccess] = useState(false);
 
   const resetPasswordMutation = useResetPassword();
+  const isPending = isLoading || resetPasswordMutation.isPending;
 
   const handleSave = () => {
     onSave({
@@ -76,9 +78,9 @@ export function EditUserModal({
   };
 
   return (
-    <dialog className="modal modal-open">
-      <div className="modal-box max-w-2xl">
-        <h3 className="font-bold text-lg mb-4">Edit User: {user.username}</h3>
+    <Dialog open onOpenChange={(open) => !open && !isPending && onClose()}>
+      <DialogContent className="max-w-2xl">
+        <DialogTitle className="mb-4">Edit User: {user.username}</DialogTitle>
 
         <div className="space-y-4">
           <div className="form-control">
@@ -210,17 +212,19 @@ export function EditUserModal({
         </div>
 
         <div className="modal-action">
-          <button className="btn" onClick={onClose}>
+          <button type="button" className="btn" onClick={onClose} disabled={isPending}>
             Cancel
           </button>
-          <button className="btn btn-primary" onClick={handleSave} disabled={isLoading}>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleSave}
+            disabled={isPending}
+          >
             {isLoading ? <span className="loading loading-spinner loading-sm" /> : "Save Changes"}
           </button>
         </div>
-      </div>
-      <form method="dialog" className="modal-backdrop">
-        <button onClick={onClose}>close</button>
-      </form>
-    </dialog>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/features/chip/modals/CreateChipModal.tsx
+++ b/ui/src/components/features/chip/modals/CreateChipModal.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useCreateChip, getListChipsQueryKey } from "@/client/chip/chip";
 import { useListTopologies } from "@/client/topology/topology";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/Dialog";
 
 interface TopologyItem {
   id: string;
@@ -67,28 +68,6 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
 
   const queryClient = useQueryClient();
 
-  // Handle keyboard navigation
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
-  // Focus management and keyboard handling
-  useEffect(() => {
-    if (isOpen) {
-      inputRef.current?.focus();
-      document.addEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = "";
-    };
-  }, [isOpen, handleKeyDown]);
   const createChipMutation = useCreateChip({
     mutation: {
       onSuccess: (data) => {
@@ -149,19 +128,15 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
     }
   };
 
-  if (!isOpen) return null;
-
   return (
-    <div
-      className="modal modal-open"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="create-chip-title"
-    >
-      <div className="modal-box">
-        <h3 id="create-chip-title" className="font-bold text-lg mb-4">
-          Create New Chip
-        </h3>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          inputRef.current?.focus();
+        }}
+      >
+        <DialogTitle className="mb-4">Create New Chip</DialogTitle>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* Chip ID Input */}
@@ -267,8 +242,7 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
             </button>
           </div>
         </form>
-      </div>
-      <div className="modal-backdrop" onClick={handleClose} aria-label="Close modal"></div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Continue the incremental Radix Dialog migration for user and chip creation/editing forms.
- UI-only refactor that preserves existing form behavior while standardizing focus, keyboard dismissal, Portal rendering, and pending-state protection.

## Changes
- Migrate `CreateUserModal` and `EditUserModal` to the shared Dialog primitive.
- Migrate `CreateChipModal` and remove its custom Escape listener, body scroll lock, and focus lifecycle.
- Prevent dismissing forms while create, save, or password-reset operations are pending.
- Keep the compound chip management dialog out of scope for a later migration.

## Validation
- `task check` (1,330 Python tests and 123 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)