### PR TITLE
refactor(ui): migrate small dialogs to Radix

### DIFF
--- a/ui/src/components/features/cryo/CryoPageContent.tsx
+++ b/ui/src/components/features/cryo/CryoPageContent.tsx
@@ -16,6 +16,7 @@ import {
   useListCryostats,
 } from "@/client/cryostat/cryostat";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/Dialog";
 import { PageContainer } from "@/components/ui/PageContainer";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { useQueryClient } from "@tanstack/react-query";
@@ -174,7 +175,7 @@ function NewCryostatModal({ onClose, onCreated }: { onClose: () => void; onCreat
   };
 
   return (
-    <ModalShell title="New cryostat" onClose={onClose}>
+    <ModalShell title="New cryostat" onClose={onClose} pending={create.isPending}>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <Field label="Cryo ID" required>
           <input
@@ -255,7 +256,7 @@ function NewCooldownModal({
   };
 
   return (
-    <ModalShell title={`New cool-down · ${cryoId}`} onClose={onClose}>
+    <ModalShell title={`New cool-down · ${cryoId}`} onClose={onClose} pending={create.isPending}>
       <Field label="Cooldown ID" required>
         <input
           className="input input-sm input-bordered w-full"
@@ -283,28 +284,31 @@ function ModalShell({
   title,
   onClose,
   children,
+  pending = false,
 }: {
   title: string;
   onClose: () => void;
   children: React.ReactNode;
+  pending?: boolean;
 }) {
   return (
-    <div
-      className="modal modal-open"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div className="modal-box w-full max-w-2xl">
+    <Dialog open onOpenChange={(open) => !open && !pending && onClose()}>
+      <DialogContent className="max-w-2xl">
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-lg font-bold">{title}</h3>
-          <button className="btn btn-ghost btn-sm btn-square" onClick={onClose} aria-label="Close">
+          <DialogTitle>{title}</DialogTitle>
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm btn-square"
+            onClick={onClose}
+            disabled={pending}
+            aria-label="Close"
+          >
             <X className="h-4 w-4" />
           </button>
         </div>
         {children}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -345,10 +349,15 @@ function ModalFooter({
 }) {
   return (
     <div className="modal-action mt-4">
-      <button className="btn btn-sm btn-ghost" onClick={onCancel}>
+      <button type="button" className="btn btn-sm btn-ghost" onClick={onCancel} disabled={pending}>
         Cancel
       </button>
-      <button className="btn btn-sm btn-primary" onClick={onSubmit} disabled={disabled}>
+      <button
+        type="button"
+        className="btn btn-sm btn-primary"
+        onClick={onSubmit}
+        disabled={disabled}
+      >
         {pending ? "Creating…" : submitLabel}
       </button>
     </div>

--- a/ui/src/components/features/metrics/TaskResultExcludeButton.tsx
+++ b/ui/src/components/features/metrics/TaskResultExcludeButton.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { Ban, RotateCcw } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSetTaskResultExcluded } from "@/client/task-result/task-result";
 import { formatDateTime } from "@/lib/utils/datetime";
 import { isChipMetricsQuery } from "@/lib/utils/queryInvalidation";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 
 interface TaskResultExcludeButtonProps {
   taskId: string;
@@ -24,23 +25,12 @@ export function TaskResultExcludeButton({
 }: TaskResultExcludeButtonProps) {
   const [open, setOpen] = useState(false);
   const [reason, setReason] = useState(excludedReason ?? "");
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const queryClient = useQueryClient();
   const mutation = useSetTaskResultExcluded();
 
   useEffect(() => {
     setReason(excludedReason ?? "");
   }, [excludedReason, taskId]);
-
-  useEffect(() => {
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-    if (open && !dialog.open) {
-      dialog.showModal();
-    } else if (!open && dialog.open) {
-      dialog.close();
-    }
-  }, [open]);
 
   const invalidateMetrics = async () => {
     await queryClient.invalidateQueries({ predicate: isChipMetricsQuery });
@@ -108,13 +98,16 @@ export function TaskResultExcludeButton({
         <Ban className="h-3 w-3" />
         Exclude this measurement
       </button>
-      <dialog ref={dialogRef} className="modal" onClose={() => setOpen(false)}>
-        <div className="modal-box">
-          <h3 className="font-bold text-base mb-2">Exclude this measurement</h3>
-          <p className="text-sm text-base-content/70 mb-3">
+      <Dialog
+        open={open}
+        onOpenChange={(nextOpen) => !nextOpen && !mutation.isPending && setOpen(false)}
+      >
+        <DialogContent>
+          <DialogTitle className="text-base mb-2">Exclude this measurement</DialogTitle>
+          <DialogDescription className="text-sm text-base-content/70 mb-3">
             Excluded measurements are skipped on the dashboard and metrics screens. Raw data is
             preserved and you can restore it later.
-          </p>
+          </DialogDescription>
           <label className="label">
             <span className="label-text text-sm">Reason (optional)</span>
           </label>
@@ -148,11 +141,8 @@ export function TaskResultExcludeButton({
               Exclude
             </button>
           </div>
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Continue the Radix Dialog migration for small creation and measurement dialogs.
- UI-only refactor with pending-state dismissal protection.

## Changes
- Migrate cryostat and cool-down creation dialogs.
- Migrate the task-result exclusion dialog and remove native `showModal()` lifecycle code.
- Prevent dismissing dialogs while mutations are pending.

## Validation
- `task check` (1,330 Python tests and 123 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)