### PR TITLE
refactor(ui): replace native modal dialogs

### DIFF
--- a/ui/src/components/features/chat/ChatPlotlyChart.tsx
+++ b/ui/src/components/features/chat/ChatPlotlyChart.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { Component, type ReactNode, useCallback, useRef, useState } from "react";
+import { Component, type ReactNode, useCallback, useState } from "react";
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 
 const Plot = dynamic(() => import("@/components/charts/Plot"), { ssr: false });
 
@@ -35,15 +37,12 @@ class ChartErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundar
 
 export function ChatPlotlyChart({ data, layout }: ChatPlotlyChartProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const dialogRef = useRef<HTMLDialogElement>(null);
 
   const openLightbox = useCallback(() => {
     setIsExpanded(true);
-    dialogRef.current?.showModal();
   }, []);
 
   const closeLightbox = useCallback(() => {
-    dialogRef.current?.close();
     setIsExpanded(false);
   }, []);
 
@@ -103,18 +102,19 @@ export function ChatPlotlyChart({ data, layout }: ChatPlotlyChartProps) {
         </div>
       </ChartErrorBoundary>
 
-      <dialog ref={dialogRef} className="modal" onClose={() => setIsExpanded(false)}>
-        <div className="modal-box w-11/12 max-w-5xl h-[80vh] flex flex-col p-4">
+      <Dialog open={isExpanded} onOpenChange={setIsExpanded}>
+        <DialogContent className="max-w-5xl h-[80vh] flex flex-col p-4 !overflow-hidden">
           <div className="flex justify-between items-center mb-2">
-            <h3 className="font-bold text-sm">
+            <DialogTitle className="text-sm">
               {typeof layout.title === "string"
                 ? layout.title
                 : (((layout.title as Record<string, unknown>)?.text as string) ?? "Chart")}
-            </h3>
+            </DialogTitle>
             <button type="button" onClick={closeLightbox} className="btn btn-sm btn-ghost">
               ✕
             </button>
           </div>
+          <DialogDescription className="sr-only">Expanded interactive chart.</DialogDescription>
           <div className="flex-1 min-h-0">
             {isExpanded && (
               <ChartErrorBoundary>
@@ -138,11 +138,8 @@ export function ChatPlotlyChart({ data, layout }: ChatPlotlyChartProps) {
               </ChartErrorBoundary>
             )}
           </div>
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button type="submit">close</button>
-        </form>
-      </dialog>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/ui/src/components/features/cryo/CooldownWiringHistory.tsx
+++ b/ui/src/components/features/cryo/CooldownWiringHistory.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useQueryClient } from "@tanstack/react-query";
@@ -12,6 +12,7 @@ import {
 } from "@/client/cooldown-wiring/cooldown-wiring";
 import { formatDateTime, formatRelativeTime } from "@/lib/utils/datetime";
 import type { CooldownWiringEventResponse } from "@/schemas";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 
 interface CooldownWiringHistoryProps {
   cooldownId: string;
@@ -19,7 +20,7 @@ interface CooldownWiringHistoryProps {
 
 export function CooldownWiringHistory({ cooldownId }: CooldownWiringHistoryProps) {
   const queryClient = useQueryClient();
-  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
   const [comment, setComment] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -40,7 +41,7 @@ export function CooldownWiringHistory({ cooldownId }: CooldownWiringHistoryProps
   const openModal = () => {
     setComment("");
     setError(null);
-    dialogRef.current?.showModal();
+    setDialogOpen(true);
   };
 
   const submit = async () => {
@@ -54,7 +55,7 @@ export function CooldownWiringHistory({ cooldownId }: CooldownWiringHistoryProps
         cooldownId,
         data: { comment: trimmed },
       });
-      dialogRef.current?.close();
+      setDialogOpen(false);
     } catch {
       setError("Failed to save checkpoint. Please try again.");
     }
@@ -91,12 +92,15 @@ export function CooldownWiringHistory({ cooldownId }: CooldownWiringHistoryProps
         </ul>
       )}
 
-      <dialog ref={dialogRef} className="modal">
-        <div className="modal-box max-w-md">
-          <h3 className="font-semibold text-sm mb-2">Save wiring checkpoint</h3>
-          <p className="text-xs text-base-content/60 mb-3">
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(open) => !open && !createCheckpoint.isPending && setDialogOpen(false)}
+      >
+        <DialogContent className="max-w-md">
+          <DialogTitle className="font-semibold text-sm mb-2">Save wiring checkpoint</DialogTitle>
+          <DialogDescription className="text-xs text-base-content/60 mb-3">
             Capture the current wiring as a snapshot. Briefly describe what changed (required).
-          </p>
+          </DialogDescription>
           <textarea
             className="textarea textarea-bordered w-full text-sm"
             rows={3}
@@ -112,11 +116,14 @@ export function CooldownWiringHistory({ cooldownId }: CooldownWiringHistoryProps
             </div>
           )}
           <div className="modal-action">
-            <form method="dialog">
-              <button type="submit" className="btn btn-sm btn-ghost">
-                Cancel
-              </button>
-            </form>
+            <button
+              type="button"
+              className="btn btn-sm btn-ghost"
+              onClick={() => setDialogOpen(false)}
+              disabled={createCheckpoint.isPending}
+            >
+              Cancel
+            </button>
             <button
               type="button"
               className="btn btn-sm btn-primary"
@@ -126,11 +133,8 @@ export function CooldownWiringHistory({ cooldownId }: CooldownWiringHistoryProps
               {createCheckpoint.isPending ? "Saving…" : "Save checkpoint"}
             </button>
           </div>
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button type="submit">close</button>
-        </form>
-      </dialog>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Replace two directly managed native dialogs with the shared Radix Dialog primitive.
- UI-only refactor that removes imperative modal lifecycle code and standardizes accessibility and dismissal.

## Changes
- Migrate the expanded chat chart lightbox.
- Migrate the cooldown wiring checkpoint dialog.
- Remove `showModal()`, `close()`, dialog refs, and native backdrop forms.
- Prevent dismissing the wiring dialog while a checkpoint is being saved.

## Validation
- `task check` (1,330 Python tests and 123 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)