### PR TITLE
refactor(ui): share image preview dialog

### DIFF
--- a/ui/src/components/features/chat/CopilotChatPage.tsx
+++ b/ui/src/components/features/chat/CopilotChatPage.tsx
@@ -24,6 +24,7 @@ import remarkGfm from "remark-gfm";
 import { useCopilotChat, type CopilotMessage, type CopilotSession } from "@/hooks/useCopilotChat";
 import { ChatPlotlyChart } from "@/components/features/chat/ChatPlotlyChart";
 import { CodeBlock } from "@/components/features/chat/CodeBlock";
+import { ImagePreviewDialog } from "@/components/ui/ImagePreviewDialog";
 import { useGetCopilotConfig } from "@/client/copilot/copilot";
 import {
   buildChatModelOptions,
@@ -104,12 +105,7 @@ function AssessmentBadge({ assessment }: { assessment: string | null }) {
 
 function ImageSentBadge({ imagesSent }: { imagesSent: BlocksResult["images_sent"] }) {
   const [previewSrc, setPreviewSrc] = useState<string | null>(null);
-  const modalRef = useRef<HTMLDialogElement>(null);
-
-  const openPreview = useCallback((src: string) => {
-    setPreviewSrc(src);
-    modalRef.current?.showModal();
-  }, []);
+  const openPreview = useCallback((src: string) => setPreviewSrc(src), []);
 
   if (!imagesSent) return null;
   const { experiment_figure, experiment_figure_paths, expected_images, task_name } = imagesSent;
@@ -166,19 +162,7 @@ function ImageSentBadge({ imagesSent }: { imagesSent: BlocksResult["images_sent"
           );
         })}
       </div>
-      <dialog ref={modalRef} className="modal">
-        <div className="modal-box max-w-3xl p-4">
-          {previewSrc && (
-            <>
-              {/* eslint-disable-next-line @next/next/no-img-element -- modal preview uses arbitrary remote/API dimensions */}
-              <img src={previewSrc} alt="Preview" className="w-full h-auto" />
-            </>
-          )}
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
+      <ImagePreviewDialog src={previewSrc} onClose={() => setPreviewSrc(null)} />
     </div>
   );
 }

--- a/ui/src/components/features/metrics/AnalysisChatPanel.tsx
+++ b/ui/src/components/features/metrics/AnalysisChatPanel.tsx
@@ -28,6 +28,7 @@ import {
 import { useAnalysisChatContext, type ChatSession } from "@/contexts/AnalysisChatContext";
 import { ChatPlotlyChart } from "@/components/features/chat/ChatPlotlyChart";
 import { CodeBlock } from "@/components/features/chat/CodeBlock";
+import { ImagePreviewDialog } from "@/components/ui/ImagePreviewDialog";
 import { useGetCopilotConfig } from "@/client/copilot/copilot";
 import {
   buildAnalysisModelOptions,
@@ -134,12 +135,7 @@ function parseBlocksContent(content: string): BlocksResult | null {
 
 function ImageSentBadge({ imagesSent }: { imagesSent: BlocksResult["images_sent"] }) {
   const [previewSrc, setPreviewSrc] = useState<string | null>(null);
-  const modalRef = useRef<HTMLDialogElement>(null);
-
-  const openPreview = useCallback((src: string) => {
-    setPreviewSrc(src);
-    modalRef.current?.showModal();
-  }, []);
+  const openPreview = useCallback((src: string) => setPreviewSrc(src), []);
 
   if (!imagesSent) return null;
   const { experiment_figure, experiment_figure_paths, expected_images, task_name } = imagesSent;
@@ -196,19 +192,7 @@ function ImageSentBadge({ imagesSent }: { imagesSent: BlocksResult["images_sent"
           );
         })}
       </div>
-      <dialog ref={modalRef} className="modal">
-        <div className="modal-box max-w-3xl p-4">
-          {previewSrc && (
-            <>
-              {/* eslint-disable-next-line @next/next/no-img-element -- modal preview uses arbitrary remote/API dimensions */}
-              <img src={previewSrc} alt="Preview" className="w-full h-auto" />
-            </>
-          )}
-        </div>
-        <form method="dialog" className="modal-backdrop">
-          <button>close</button>
-        </form>
-      </dialog>
+      <ImagePreviewDialog src={previewSrc} onClose={() => setPreviewSrc(null)} />
     </div>
   );
 }

--- a/ui/src/components/ui/ImagePreviewDialog.tsx
+++ b/ui/src/components/ui/ImagePreviewDialog.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "./Dialog";
+
+interface ImagePreviewDialogProps {
+  alt?: string;
+  onClose: () => void;
+  src: string | null;
+}
+
+export function ImagePreviewDialog({ alt = "Preview", onClose, src }: ImagePreviewDialogProps) {
+  return (
+    <Dialog open={src !== null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-3xl p-4">
+        <DialogTitle className="sr-only">Image preview</DialogTitle>
+        <DialogDescription className="sr-only">
+          Expanded preview of the selected image.
+        </DialogDescription>
+        {src && (
+          // eslint-disable-next-line @next/next/no-img-element -- preview supports runtime API image URLs
+          <img src={src} alt={alt} className="h-auto w-full" />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/ui/__tests__/ImagePreviewDialog.test.tsx
+++ b/ui/src/components/ui/__tests__/ImagePreviewDialog.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ImagePreviewDialog } from "@/components/ui/ImagePreviewDialog";
+
+afterEach(cleanup);
+
+describe("ImagePreviewDialog", () => {
+  it("renders only when an image source is provided", () => {
+    const { rerender } = render(<ImagePreviewDialog src={null} onClose={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    rerender(<ImagePreviewDialog src="/preview.png" alt="Result" onClose={vi.fn()} />);
+    expect(screen.getByRole("img", { name: "Result" })).toBeTruthy();
+  });
+
+  it("requests close when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(<ImagePreviewDialog src="/preview.png" onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Consolidate duplicate chat image preview modals into a shared Radix Dialog component.
- UI-only refactor that removes imperative native dialog handling and keeps preview behavior consistent.

## Changes
- Add a reusable `ImagePreviewDialog` with accessible labeling.
- Use it in `CopilotChatPage` and `AnalysisChatPanel`.
- Remove duplicated `showModal()` refs and native backdrop markup.
- Add focused tests for conditional rendering and Escape dismissal.

## Validation
- `task check` (1,330 Python tests and 125 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)