### PR TITLE
refactor(ui): migrate task detail dialog to Radix

### DIFF
--- a/ui/src/components/features/chip/modals/TaskDetailModal.tsx
+++ b/ui/src/components/features/chip/modals/TaskDetailModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useRef } from "react";
 import { CheckCircle, AlertTriangle, Clock, HelpCircle, GitBranch } from "lucide-react";
 
 import type { Task } from "@/schemas";
@@ -12,6 +12,7 @@ import { TaskFigure } from "@/components/charts/TaskFigure";
 import { TaskResultAiReviewNote } from "@/components/features/metrics/TaskResultAiReviewNote";
 import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
 import { ReanalysisPanel } from "@/components/features/qubit/ReanalysisPanel";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 import {
   formatDate as formatDateUtil,
   formatTime as formatTimeUtil,
@@ -59,7 +60,6 @@ export function TaskDetailModal({
   const router = useRouter();
   const [viewMode, setViewMode] = useState<"static" | "interactive">("static");
   const [subIndex, setSubIndex] = useState(initialSubIndex);
-  const modalRef = useRef<HTMLDialogElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const resolveQid = (taskQid: string, qidRole?: string): string => {
@@ -77,33 +77,6 @@ export function TaskDetailModal({
     const q = encodeURIComponent(qidValue);
     return `/provenance?tab=lineage&parameter=${p}&qid=${q}`;
   };
-
-  // Handle keyboard navigation
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
-  // Focus management and keyboard handling
-  useEffect(() => {
-    if (isOpen) {
-      // Focus the close button when modal opens
-      closeButtonRef.current?.focus();
-      // Add keyboard listener
-      document.addEventListener("keydown", handleKeyDown);
-      // Prevent body scroll
-      document.body.style.overflow = "hidden";
-    }
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-      document.body.style.overflow = "";
-    };
-  }, [isOpen, handleKeyDown]);
 
   // Use generated API client hook when taskId is provided
   const {
@@ -215,23 +188,22 @@ export function TaskDetailModal({
     variant === "detailed" && taskName ? `Task Details - ${taskName}` : `Result for QID ${qid}`;
 
   return (
-    <dialog
-      ref={modalRef}
-      className="modal modal-open modal-bottom sm:modal-middle"
-      aria-labelledby="modal-title"
-      aria-modal="true"
-      role="dialog"
-    >
-      <div
-        className="modal-box w-full sm:w-11/12 max-w-[112rem] h-[90vh] sm:h-[95vh] p-0 bg-base-100 overflow-hidden flex flex-col"
-        onClick={(event) => event.stopPropagation()}
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+        className="max-sm:top-auto max-sm:bottom-0 max-sm:translate-y-0 max-sm:rounded-b-none w-full max-w-[112rem] h-[90vh] sm:h-[95vh] p-0 !overflow-hidden flex flex-col"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          closeButtonRef.current?.focus();
+        }}
       >
         <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-base-300 flex items-center justify-between">
           <div className="min-w-0 flex-1">
-            <h2 id="modal-title" className="text-lg sm:text-2xl font-bold truncate">
+            <DialogTitle className="text-lg sm:text-2xl font-bold truncate">
               {modalTitle}
-            </h2>
-            <p className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">QID {qid}</p>
+            </DialogTitle>
+            <DialogDescription className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
+              QID {qid}
+            </DialogDescription>
           </div>
           <div className="flex items-center gap-2 flex-shrink-0 ml-2">
             {getStatusBadge(task.status)}
@@ -866,12 +838,7 @@ export function TaskDetailModal({
             </button>
           )}
         </div>
-      </div>
-      <form method="dialog" className="modal-backdrop">
-        <button onClick={onClose} aria-label="Close modal">
-          close
-        </button>
-      </form>
-    </dialog>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Migrate the final native `<dialog>` task detail modal to the shared Radix Dialog primitive.
- UI-only wrapper refactor preserving task content, navigation, and responsive presentation.

## Changes
- Remove custom Escape handling, body scroll locking, dialog ref, and native backdrop form.
- Delegate focus trapping, scroll locking, Escape, backdrop, and Portal behavior to Radix.
- Preserve initial focus on Close and the mobile bottom-sheet / desktop centered layout.
- Add accessible title and QID description associations.

## Validation
- `task check` (1,330 Python tests and 125 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)