### PR TITLE
refactor(ui): migrate operation dialogs to Radix

### DIFF
--- a/ui/src/components/features/import/SeedParametersPanel.tsx
+++ b/ui/src/components/features/import/SeedParametersPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { ChipSelector } from "@/components/selectors/ChipSelector";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 import { useCompareSeedValues, useImportSeedParameters } from "@/client/calibration/calibration";
 import type { SeedImportSource } from "@/schemas";
 
@@ -508,17 +509,20 @@ export function SeedParametersPanel() {
 
         {/* Overwrite Confirmation Dialog */}
         {confirmDialog.open && (
-          <div className="modal modal-open">
-            <div className="modal-box">
+          <Dialog
+            open
+            onOpenChange={(open) => !open && !importMutation.isPending && handleCancelImport()}
+          >
+            <DialogContent>
               <div className="flex items-start gap-3">
                 <AlertTriangle className="h-6 w-6 text-warning flex-shrink-0 mt-1" />
                 <div>
-                  <h3 className="font-bold text-lg">Confirm Overwrite</h3>
-                  <p className="py-4">
+                  <DialogTitle>Confirm Overwrite</DialogTitle>
+                  <DialogDescription className="py-4">
                     This will overwrite{" "}
                     <span className="font-bold text-warning">{confirmDialog.diffCount}</span>{" "}
                     existing calibration value(s) with YAML seed values.
-                  </p>
+                  </DialogDescription>
                   <p className="text-sm text-base-content/70">
                     Existing measured values will be replaced. This action cannot be undone.
                   </p>
@@ -526,6 +530,7 @@ export function SeedParametersPanel() {
               </div>
               <div className="modal-action">
                 <button
+                  type="button"
                   className="btn btn-ghost"
                   onClick={handleCancelImport}
                   disabled={importMutation.isPending}
@@ -533,6 +538,7 @@ export function SeedParametersPanel() {
                   Cancel
                 </button>
                 <button
+                  type="button"
                   className="btn btn-warning"
                   onClick={handleConfirmImport}
                   disabled={importMutation.isPending}
@@ -547,9 +553,8 @@ export function SeedParametersPanel() {
                   )}
                 </button>
               </div>
-            </div>
-            <div className="modal-backdrop" onClick={handleCancelImport}></div>
-          </div>
+            </DialogContent>
+          </Dialog>
         )}
       </div>
     </div>

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -40,6 +40,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
 import { formatDateTime, formatRelativeTime } from "@/lib/utils/datetime";
 import { useToast } from "@/components/ui/Toast";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 
 const REANALYZABLE_TASKS = new Set(["CheckResonatorSpectroscopy", "CheckQubitSpectroscopy"]);
 
@@ -756,9 +757,20 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
 
       {/* Re-execute Confirmation Modal */}
       {showReExecuteModal && taskResult && (
-        <div className="modal modal-open">
-          <div className="modal-box max-w-2xl">
-            <h3 className="font-bold text-lg">Re-execute Task</h3>
+        <Dialog
+          open
+          onOpenChange={(open) => {
+            if (!open && !reExecuteLoading) {
+              setShowReExecuteModal(false);
+              setReExecuteError(null);
+            }
+          }}
+        >
+          <DialogContent className="max-w-2xl">
+            <DialogTitle>Re-execute Task</DialogTitle>
+            <DialogDescription className="sr-only">
+              Review and override task parameters before re-execution.
+            </DialogDescription>
             <div className="py-4 space-y-3">
               <p className="text-sm text-base-content/70">
                 Re-execute task <span className="font-semibold">{taskResult.task_name}</span> for
@@ -857,6 +869,7 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
             </div>
             <div className="modal-action">
               <button
+                type="button"
                 className="btn btn-ghost"
                 onClick={() => {
                   setShowReExecuteModal(false);
@@ -867,6 +880,7 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
                 Cancel
               </button>
               <button
+                type="button"
                 className="btn btn-primary"
                 onClick={handleReExecute}
                 disabled={reExecuteLoading}
@@ -881,17 +895,8 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
                 )}
               </button>
             </div>
-          </div>
-          <div
-            className="modal-backdrop"
-            onClick={() => {
-              if (!reExecuteLoading) {
-                setShowReExecuteModal(false);
-                setReExecuteError(null);
-              }
-            }}
-          />
-        </div>
+          </DialogContent>
+        </Dialog>
       )}
     </div>
   );


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Migrate import overwrite and task re-execution dialogs to the shared Radix Dialog primitive.
- UI-only wrapper refactor preserving parameter editing, validation, and mutation behavior.

## Changes
- Migrate seed parameter overwrite confirmation.
- Migrate task re-execution parameter dialog.
- Add accessible titles and descriptions.
- Prevent dismissal while import or re-execution mutations are pending.

## Validation
- `task check` (1,330 Python tests and 125 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)