### PR TITLE
refactor(ui): migrate metrics detail dialogs to Radix

### DIFF
--- a/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/CouplingMetricsGrid.tsx
@@ -7,6 +7,7 @@ import { TransformWrapper, TransformComponent, useControls } from "react-zoom-pa
 import { ArrowRightLeft, GitBranch, ZoomIn, ZoomOut, Maximize2, Move } from "lucide-react";
 
 import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 import { useGridLayout } from "@/hooks/useGridLayout";
 import { useTopologyConfig } from "@/hooks/useTopologyConfig";
 import { getQubitGridPosition, type TopologyLayoutParams } from "@/lib/utils/grid-position";
@@ -710,14 +711,9 @@ export function CouplingMetricsGrid({
       </div>
 
       {/* Coupling Detail Modal with History */}
-      <div
-        className={`modal modal-bottom sm:modal-middle ${isModalOpen ? "modal-open" : ""}`}
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setSelectedCouplingInfo(null);
-        }}
-      >
-        <div
-          className="modal-box w-full bg-base-100 p-0 h-[90vh] sm:h-[95vh] overflow-hidden flex flex-col"
+      <Dialog open={isModalOpen} onOpenChange={(open) => !open && setSelectedCouplingInfo(null)}>
+        <DialogContent
+          className="max-sm:top-auto max-sm:bottom-0 max-sm:translate-y-0 max-sm:rounded-b-none w-full p-0 h-[90vh] sm:h-[95vh] !overflow-hidden flex flex-col"
           style={{ maxWidth: "1800px" }}
         >
           {selectedCouplingInfo && (
@@ -725,16 +721,17 @@ export function CouplingMetricsGrid({
               {/* Modal Header */}
               <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-base-300 flex items-center justify-between">
                 <div className="min-w-0 flex-1">
-                  <h2 className="text-lg sm:text-2xl font-bold truncate">
+                  <DialogTitle className="text-lg sm:text-2xl font-bold truncate">
                     {selectedCouplingInfo.couplingId} - {title}
-                  </h2>
-                  <p className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
+                  </DialogTitle>
+                  <DialogDescription className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
                     {selectedCouplingInfo.metric.value !== null
                       ? `${selectedCouplingInfo.metric.value.toFixed(4)} ${unit}`
                       : "No data"}
-                  </p>
+                  </DialogDescription>
                 </div>
                 <button
+                  type="button"
                   onClick={() => setSelectedCouplingInfo(null)}
                   className="btn btn-ghost btn-sm btn-circle flex-shrink-0 ml-2"
                 >
@@ -765,6 +762,7 @@ export function CouplingMetricsGrid({
                 </Link>
                 <div className="flex gap-2">
                   <button
+                    type="button"
                     onClick={() => setSelectedCouplingInfo(null)}
                     className="btn btn-ghost btn-sm sm:btn-md"
                   >
@@ -774,8 +772,8 @@ export function CouplingMetricsGrid({
               </div>
             </>
           )}
-        </div>
-      </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -8,6 +8,7 @@ import { TransformWrapper, TransformComponent, useControls } from "react-zoom-pa
 import { GitBranch, ZoomIn, ZoomOut, Maximize2, Move } from "lucide-react";
 
 import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 import { useGridLayout } from "@/hooks/useGridLayout";
 import { useTopologyConfig } from "@/hooks/useTopologyConfig";
 import { getQubitGridPosition, type TopologyLayoutParams } from "@/lib/utils/grid-position";
@@ -769,30 +770,26 @@ export function QubitMetricsGrid({
       </div>
 
       {/* Qubit Detail Modal */}
-      <div
-        className={`modal modal-bottom sm:modal-middle ${isModalOpen ? "modal-open" : ""}`}
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setSelectedQubitInfo(null);
-        }}
-      >
-        <div
-          className="modal-box w-full bg-base-100 p-0 h-[90vh] sm:h-[95vh] overflow-hidden flex flex-col"
+      <Dialog open={isModalOpen} onOpenChange={(open) => !open && setSelectedQubitInfo(null)}>
+        <DialogContent
+          className="max-sm:top-auto max-sm:bottom-0 max-sm:translate-y-0 max-sm:rounded-b-none w-full p-0 h-[90vh] sm:h-[95vh] !overflow-hidden flex flex-col"
           style={{ maxWidth: "1800px" }}
         >
           {selectedQubitInfo && (
             <>
               <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-base-300 flex items-center justify-between">
                 <div className="min-w-0 flex-1">
-                  <h2 className="text-lg sm:text-2xl font-bold truncate">
+                  <DialogTitle className="text-lg sm:text-2xl font-bold truncate">
                     {selectedQubitInfo.qid} - {title}
-                  </h2>
-                  <p className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
+                  </DialogTitle>
+                  <DialogDescription className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
                     {selectedQubitInfo.metric.value !== null
                       ? `${selectedQubitInfo.metric.value.toFixed(4)}${selectedQubitInfo.metric.stddev != null ? ` ± ${selectedQubitInfo.metric.stddev.toFixed(4)}` : ""} ${unit}`
                       : "No data"}
-                  </p>
+                  </DialogDescription>
                 </div>
                 <button
+                  type="button"
                   onClick={() => setSelectedQubitInfo(null)}
                   className="btn btn-ghost btn-sm btn-circle flex-shrink-0 ml-2"
                 >
@@ -819,6 +816,7 @@ export function QubitMetricsGrid({
                 </Link>
                 <div className="flex gap-2">
                   <button
+                    type="button"
                     onClick={() => setSelectedQubitInfo(null)}
                     className="btn btn-ghost btn-sm sm:btn-md"
                   >
@@ -834,8 +832,8 @@ export function QubitMetricsGrid({
               </div>
             </>
           )}
-        </div>
-      </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Migrate the paired Qubit and Coupling metric detail modals to the shared Radix Dialog primitive.
- UI-only wrapper refactor preserving metric histories, navigation links, and responsive layout.

## Changes
- Use selected metric state as controlled Dialog open state.
- Standardize Escape, backdrop, Close, focus, scroll lock, and Portal behavior.
- Preserve mobile bottom-sheet and desktop centered 95vh presentation.
- Add accessible metric titles and value descriptions.

## Validation
- `task check` (1,330 Python tests and 125 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)