### PR TITLE
refactor(ui): migrate history dialogs to Radix

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -35,6 +35,7 @@
         "react18-json-view": "0.2.10",
         "remark-gfm": "^4.0.1",
         "sharp": "^0.35.3",
+        "tailwind-merge": "^3.6.0",
         "theme-change": "^3.0.4",
       },
       "devDependencies": {
@@ -1442,6 +1443,8 @@
     "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -48,6 +48,7 @@
     "react18-json-view": "0.2.10",
     "remark-gfm": "^4.0.1",
     "sharp": "^0.35.3",
+    "tailwind-merge": "^3.6.0",
     "theme-change": "^3.0.4"
   },
   "devDependencies": {

--- a/ui/src/components/features/chip/modals/CouplingTaskHistoryModal.tsx
+++ b/ui/src/components/features/chip/modals/CouplingTaskHistoryModal.tsx
@@ -26,6 +26,7 @@ import { TaskResultIssues } from "@/components/features/metrics/TaskResultIssues
 import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
 import type { AnalysisContext } from "@/hooks/useAnalysisChat";
 import { useAnalysisChatContext } from "@/contexts/AnalysisChatContext";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 
 const PlotlyRenderer = dynamic(
   () => import("@/components/charts/PlotlyRenderer").then((mod) => mod.PlotlyRenderer),
@@ -613,24 +614,21 @@ export function CouplingTaskHistoryModal({
   if (!isOpen) return null;
 
   return (
-    <div
-      className="modal modal-open modal-bottom sm:modal-middle"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div
-        className="modal-box w-full sm:w-11/12 max-w-[112rem] h-[90vh] sm:h-[95vh] bg-base-100 p-0 overflow-hidden flex flex-col"
-        onClick={(event) => event.stopPropagation()}
-      >
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-sm:top-auto max-sm:bottom-0 max-sm:translate-y-0 max-sm:rounded-b-none w-full max-w-[112rem] h-[90vh] sm:h-[95vh] p-0 !overflow-hidden flex flex-col">
         <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-base-300 flex items-center justify-between">
           <div className="min-w-0 flex-1">
-            <h2 className="text-lg sm:text-2xl font-bold truncate">{taskName}</h2>
-            <p className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
+            <DialogTitle className="text-lg sm:text-2xl font-bold truncate">{taskName}</DialogTitle>
+            <DialogDescription className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
               Coupling {couplingId}
-            </p>
+            </DialogDescription>
           </div>
-          <button onClick={onClose} className="btn btn-sm btn-circle btn-ghost flex-shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-sm btn-circle btn-ghost flex-shrink-0"
+            aria-label="Close"
+          >
             ✕
           </button>
         </div>
@@ -667,7 +665,7 @@ export function CouplingTaskHistoryModal({
             />
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/features/chip/modals/TaskDetailModal.tsx
+++ b/ui/src/components/features/chip/modals/TaskDetailModal.tsx
@@ -116,28 +116,36 @@ export function TaskDetailModal({
   // Loading state
   if (loading && !taskProp) {
     return (
-      <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 backdrop-blur-sm">
-        <div className="bg-base-100 rounded-xl p-8">
-          <span className="loading loading-spinner loading-lg"></span>
-          <p className="mt-4 text-center">Loading task details...</p>
-        </div>
-      </div>
+      <Dialog open onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="max-w-sm text-center">
+          <DialogTitle className="sr-only">Loading task details</DialogTitle>
+          <DialogDescription asChild>
+            <div>
+              <span className="loading loading-spinner loading-lg" />
+              <p className="mt-4">Loading task details...</p>
+            </div>
+          </DialogDescription>
+        </DialogContent>
+      </Dialog>
     );
   }
 
   // Error state
   if (error) {
     return (
-      <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 backdrop-blur-sm p-4">
-        <div className="bg-base-100 rounded-xl p-8 max-w-md">
-          <div className="alert alert-error">
-            <span>Error: {error}</span>
-          </div>
-          <button onClick={onClose} className="btn btn-primary mt-4 w-full">
+      <Dialog open onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="max-w-md">
+          <DialogTitle>Task details unavailable</DialogTitle>
+          <DialogDescription asChild>
+            <div className="alert alert-error mt-4">
+              <span>Error: {error}</span>
+            </div>
+          </DialogDescription>
+          <button type="button" onClick={onClose} className="btn btn-primary mt-4 w-full">
             Close
           </button>
-        </div>
-      </div>
+        </DialogContent>
+      </Dialog>
     );
   }
 

--- a/ui/src/components/features/chip/modals/TaskHistoryModal.tsx
+++ b/ui/src/components/features/chip/modals/TaskHistoryModal.tsx
@@ -26,6 +26,7 @@ import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
 import type { AnalysisContext } from "@/hooks/useAnalysisChat";
 import { useAnalysisChatContext } from "@/contexts/AnalysisChatContext";
 import { AnalysisChatPanel } from "@/components/features/metrics/AnalysisChatPanel";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 
 interface TaskHistoryModalProps {
   chipId: string;
@@ -592,24 +593,25 @@ export function TaskHistoryModal({
   if (!isOpen) return null;
 
   return (
-    <div
-      className="modal modal-open modal-bottom sm:modal-middle"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div
-        className={`modal-box w-full bg-base-100 p-0 h-[90vh] sm:h-[95vh] overflow-hidden flex flex-col transition-[max-width] duration-300 ease-in-out ${
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+        className={`max-sm:top-auto max-sm:bottom-0 max-sm:translate-y-0 max-sm:rounded-b-none w-full p-0 h-[90vh] sm:h-[95vh] !overflow-hidden flex flex-col transition-[max-width] duration-300 ease-in-out ${
           isChatOpen ? "sm:w-[96vw] max-w-[112rem]" : "sm:w-11/12 max-w-[112rem]"
         }`}
-        onClick={(event) => event.stopPropagation()}
       >
         <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-base-300 flex items-center justify-between">
           <div className="min-w-0 flex-1">
-            <h2 className="text-lg sm:text-2xl font-bold truncate">{taskName}</h2>
-            <p className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">QID {qid}</p>
+            <DialogTitle className="text-lg sm:text-2xl font-bold truncate">{taskName}</DialogTitle>
+            <DialogDescription className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
+              QID {qid}
+            </DialogDescription>
           </div>
-          <button onClick={onClose} className="btn btn-sm btn-circle btn-ghost flex-shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-sm btn-circle btn-ghost flex-shrink-0"
+            aria-label="Close"
+          >
             ✕
           </button>
         </div>
@@ -660,7 +662,7 @@ export function TaskHistoryModal({
             </div>
           )}
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/features/execution/ExecutionTaskDetailModal.tsx
+++ b/ui/src/components/features/execution/ExecutionTaskDetailModal.tsx
@@ -15,6 +15,7 @@ import { ParametersTable } from "@/components/features/metrics/ParametersTable";
 import { TaskResultAiReviewNote } from "@/components/features/metrics/TaskResultAiReviewNote";
 import { TaskResultIssues } from "@/components/features/metrics/TaskResultIssues";
 import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 import { useAnalysisChatContext } from "@/contexts/AnalysisChatContext";
 import type { AnalysisContext } from "@/hooks/useAnalysisChat";
 import { formatDateTime, formatDateTimeCompact } from "@/lib/utils/datetime";
@@ -353,26 +354,23 @@ export function ExecutionTaskDetailModal({
   );
 
   return (
-    <div
-      className="modal modal-open modal-bottom sm:modal-middle"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-    >
-      <div
-        className="modal-box w-full sm:w-11/12 max-w-[112rem] h-[90vh] sm:h-[95vh] bg-base-100 p-0 overflow-hidden flex flex-col"
-        onClick={(event) => event.stopPropagation()}
-      >
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-sm:top-auto max-sm:bottom-0 max-sm:translate-y-0 max-sm:rounded-b-none w-full max-w-[112rem] h-[90vh] sm:h-[95vh] p-0 !overflow-hidden flex flex-col">
         <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-base-300 flex items-center justify-between">
           <div className="min-w-0 flex-1">
-            <h2 className="text-lg sm:text-2xl font-bold truncate">
+            <DialogTitle className="text-lg sm:text-2xl font-bold truncate">
               {selectedTask?.name || "Task Details"}
-            </h2>
-            <p className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
+            </DialogTitle>
+            <DialogDescription className="text-sm sm:text-base text-base-content/70 mt-0.5 sm:mt-1">
               {qid.includes("-") ? "Coupling" : "QID"} {qid}
-            </p>
+            </DialogDescription>
           </div>
-          <button onClick={onClose} className="btn btn-sm btn-circle btn-ghost flex-shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-sm btn-circle btn-ghost flex-shrink-0"
+            aria-label="Close"
+          >
             ✕
           </button>
         </div>
@@ -386,7 +384,7 @@ export function ExecutionTaskDetailModal({
             details={renderTaskDetails()}
           />
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/ui/Dialog.tsx
+++ b/ui/src/components/ui/Dialog.tsx
@@ -3,9 +3,10 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import type { ComponentPropsWithoutRef, ElementRef } from "react";
 import { forwardRef } from "react";
+import { twMerge } from "tailwind-merge";
 
 function mergeClassNames(...classNames: Array<string | undefined>): string {
-  return classNames.filter(Boolean).join(" ");
+  return twMerge(...classNames);
 }
 
 export const Dialog = DialogPrimitive.Root;
@@ -16,7 +17,7 @@ const DialogOverlay = forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
-    className={mergeClassNames("fixed inset-0 z-50 bg-black/40", className)}
+    className={mergeClassNames("fixed inset-0 z-[1200] bg-black/40", className)}
     {...props}
   />
 ));
@@ -31,7 +32,7 @@ export const DialogContent = forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={mergeClassNames(
-        "fixed left-1/2 top-1/2 z-50 max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-3xl border border-base-content/10 bg-base-100 p-6 text-base-content shadow-2xl",
+        "fixed left-1/2 top-1/2 z-[1200] max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-3xl border border-base-content/10 bg-base-100 p-6 text-base-content shadow-2xl",
         className,
       )}
       {...props}

--- a/ui/src/components/ui/__tests__/Dialog.test.tsx
+++ b/ui/src/components/ui/__tests__/Dialog.test.tsx
@@ -1,0 +1,27 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+
+describe("DialogContent", () => {
+  afterEach(() => cleanup());
+
+  it("allows callers to override conflicting layout classes", () => {
+    render(
+      <Dialog open>
+        <DialogContent className="max-w-[112rem] overflow-hidden rounded-none">
+          <DialogTitle>Task history</DialogTitle>
+          <DialogDescription>History details</DialogDescription>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("max-w-[112rem]");
+    expect(dialog.className).toContain("overflow-hidden");
+    expect(dialog.className).toContain("rounded-none");
+    expect(dialog.className).not.toContain("max-w-lg");
+    expect(dialog.className).not.toContain("overflow-y-auto");
+    expect(dialog.className).not.toContain("rounded-3xl");
+  });
+});


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Complete the Dialog migration by moving the remaining execution and task history modals to Radix.
- UI-only wrapper refactor preserving history, task details, issue panels, and Analysis Chat split view.

## Changes
- Migrate Execution Task Detail, Qubit Task History, and Coupling Task History dialogs.
- Preserve mobile bottom-sheet and desktop 95vh layouts, including chat-expanded width.
- Add accessible titles, descriptions, and close labels.
- Remove the final custom `.modal-open`, native `<dialog>`, and `showModal()` usages from UI components.

## Validation
- `task check` (1,330 Python tests and 125 UI tests passed)
- `task ci-ui-build`
- `bun audit` (no vulnerabilities found)
- Verified no remaining native/custom modal wrappers via repository search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated task detail and history modals with a consistent dialog experience.
  - Improved dialog accessibility with clear titles and descriptions.
  - Standardized open and close behavior across modal views.
  - Ensured dialogs remain visible above other interface elements.
  - Preserved responsive layouts, loading states, error messages, task content, and close controls.
  - Improved support for custom dialog sizing, spacing, and overflow layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->