### PR TITLE
ci(repo): unify release tags

### DIFF
--- a/.github/git-pr-release.erb
+++ b/.github/git-pr-release.erb
@@ -1,10 +1,8 @@
 release: <%= Time.now.strftime('%Y-%m-%d %H:%M') %>
-> [!CAUTION]
-> **Create Merge Commit** is recommended to merge this PR.
-> before merging, update the appropriate version of `pyproject.toml`
-> you can use the following command to update the version.
-> update-version="x.y.z"
-> comment in the PR.
+> [!NOTE]
+> **Create Merge Commit** is recommended to merge this PR. After merging, create and push a
+> `v<version>` tag on `main`. The tag creates the GitHub Release and publishes both clients with
+> the same version.
 
 <% pull_requests.each do |pr| -%>
 - #<%= pr.number %> <%= pr.mention %>

--- a/.github/workflows/publish-qdash-client.yml
+++ b/.github/workflows/publish-qdash-client.yml
@@ -10,7 +10,7 @@ on:
       - ".github/workflows/publish-qdash-client.yml"
   push:
     tags:
-      - "qdash-client-v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 permissions:
@@ -48,7 +48,7 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/qdash-client-v')
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish-qdash-typescript-client.yml
+++ b/.github/workflows/publish-qdash-typescript-client.yml
@@ -10,7 +10,7 @@ on:
       - ".github/workflows/publish-qdash-typescript-client.yml"
   push:
     tags:
-      - "qdash-client-ts-v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 permissions:
@@ -44,9 +44,9 @@ jobs:
         run: bun run check
 
       - name: Set release version
-        if: startsWith(github.ref, 'refs/tags/qdash-client-ts-v')
+        if: startsWith(github.ref, 'refs/tags/v')
         working-directory: clients/typescript
-        run: npm version "${GITHUB_REF_NAME#qdash-client-ts-v}" --no-git-tag-version
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version
 
       - name: Build package
         working-directory: clients/typescript
@@ -65,7 +65,7 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/qdash-client-ts-v')
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
       id-token: write

--- a/clients/typescript/README.md
+++ b/clients/typescript/README.md
@@ -130,4 +130,4 @@ bun run check
 bun run build
 ```
 
-The first publish uses a temporary `NPM_TOKEN` repository secret because npm requires the package to exist before Trusted Publishing can be configured. After the first publish, configure `publish-qdash-typescript-client.yml` as the package trusted publisher and delete the secret. Release tags use `qdash-client-ts-v<version>`; the workflow derives the package version from the tag.
+The first publish uses a temporary `NPM_TOKEN` repository secret because npm requires the package to exist before Trusted Publishing can be configured. After the first publish, configure `publish-qdash-typescript-client.yml` as the package trusted publisher and delete the secret. QDash uses a single `v<version>` release tag for the application and both clients; the workflow derives the package version from that tag.

--- a/src/qdash/client/README.md
+++ b/src/qdash/client/README.md
@@ -30,12 +30,13 @@ The distribution name is `qdash-client`, but the Python import path is `qdash.cl
 `qdash-client` project on PyPI to trust this GitHub repository and the
 `.github/workflows/publish-qdash-client.yml` workflow.
 
-Release tags use the `qdash-client-v<version>` format. Do not edit a package version in
-`pyproject.toml`; the package version is derived from the matching Git tag at build time.
+QDash uses a single `v<version>` release tag for the application and its clients. Do not edit a
+package version in `pyproject.toml`; the package version is derived from that Git tag at build
+time. Creating the tag also publishes the TypeScript client and creates the GitHub Release.
 
 ```bash
-git tag qdash-client-v<version>
-git push origin qdash-client-v<version>
+git tag v<version>
+git push origin v<version>
 ```
 
 ## Minimal Quick Start

--- a/src/qdash/client/pyproject.toml
+++ b/src/qdash/client/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.version]
 source = "vcs"
-tag-pattern = "^qdash-client-v(?P<version>\\d+\\.\\d+\\.\\d+)$"
+tag-pattern = "^v(?P<version>\\d+\\.\\d+\\.\\d+)$"
 fallback-version = "0.0.0"
 
 [tool.hatch.version.raw-options]
@@ -30,7 +30,7 @@ version_scheme = "no-guess-dev"
 local_scheme = "no-local-version"
 
 [tool.hatch.version.raw-options.scm.git]
-describe_command = "git describe --dirty --tags --long --match qdash-client-v*"
+describe_command = "git describe --dirty --tags --long --match v[0-9]*"
 
 [tool.hatch.build]
 exclude = [


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Use the application `v<version>` tag as the single release trigger for QDash and both client packages.
- Python and TypeScript clients will now publish with the same version as the GitHub Release; legacy client-specific tags remain historical only.

## Changes

- Trigger the PyPI and npm publishing workflows from `vX.Y.Z` tags.
- Derive the Python and TypeScript package versions from the unified tag.
- Update client publishing documentation and the release PR instructions.
- Verified the Python client build, TypeScript client checks, workflow YAML parsing, and the full `task check` suite.