### PR TITLE
fix(repo): stabilize release PR generation

### DIFF
--- a/.github/scripts/git-pr-release.rb
+++ b/.github/scripts/git-pr-release.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require "git/pr/release"
+
+module GitPrReleaseQueryBatching
+  # GitHub counts the URL-encoded search query toward its 256-character limit. The upstream
+  # 256-character batch size therefore overflows once spaces and qualifiers are encoded.
+  MAX_QUERY_LENGTH = 180
+  QUALIFIER_COUNT = 3
+
+  # OptionParser passes false for a --no-* option, while git-pr-release 2.5.0 assigns that value
+  # directly to @no_fetch. Consume it here and apply the intended behavior after initialization.
+  NO_FETCH = ARGV.delete("--no-fetch")
+
+  def initialize
+    super
+    @no_fetch = true if NO_FETCH
+  end
+
+  def search_issue_numbers(query)
+    tokens = query.split
+    qualifiers = tokens.shift(QUALIFIER_COUNT)
+    query_base = qualifiers.join(" ")
+    batches = tokens.each_with_object([query_base]) do |sha, queries|
+      candidate = "#{queries.last} #{sha}"
+      if candidate.length >= MAX_QUERY_LENGTH
+        queries << "#{query_base} #{sha}"
+      else
+        queries[-1] = candidate
+      end
+    end
+
+    batches.flat_map { |batch| super(batch) }.uniq
+  end
+end
+
+Git::Pr::Release::CLI.prepend(GitPrReleaseQueryBatching)
+Git::Pr::Release::CLI.start

--- a/.github/workflows/git-pr-release.yaml
+++ b/.github/workflows/git-pr-release.yaml
@@ -13,8 +13,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3
-      - run: gem install --no-document git-pr-release
-      - run: git-pr-release --squashed
+      - run: gem install --no-document git-pr-release --version 2.5.0
+      - name: Create or update release PR
+        run: ruby .github/scripts/git-pr-release.rb --squashed --no-fetch
         env:
           GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_PR_RELEASE_BRANCH_PRODUCTION: main


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Prevent `git-pr-release --squashed` from exceeding GitHub’s 256-character search limit when many commits are pending release.
- Keep the existing release PR format and Ruby-based workflow while making generation deterministic for larger releases.

## Changes

- Pin `git-pr-release` to version 2.5.0.
- Add a compatibility wrapper that splits encoded GitHub search queries at a safe size.
- Correct the upstream `--no-fetch` option behavior and use checkout-provided remote refs in CI.
- Reproduce and successfully dry-run the v1.8.36 to v1.8.37 range containing 33 commits.
- Verify Ruby syntax, workflow YAML, and the full `task check` suite (1330 Python and 126 UI tests).