### PR TITLE
refactor(ui): migrate dropdown menus to Radix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ Prefer focused tests for narrow changes, then broader checks when touching share
 - Use named exports for ordinary components, hooks, utilities, and contexts. `page.tsx` and `layout.tsx` use default exports.
 - Use imports from established aliases and locations, especially `@/contexts/*`, `@/hooks/useUrlState` or `@/hooks/url-state`, and `@/lib/utils/*`.
 - Keep reusable primitives in `ui/src/components/ui/`, feature UI in `ui/src/components/features/`, charts in `ui/src/components/charts/`, and layout in `ui/src/components/layout/`.
+- Keep DaisyUI as the visual and theme foundation. Use the established Radix-based primitives in `ui/src/components/ui/` for interactions that need robust focus management, keyboard navigation, portals, dismissal, or collision-aware positioning.
+- Do not treat Radix as a wholesale DaisyUI replacement. Prefer DaisyUI for buttons, cards, inputs, badges, tables, and semantic colors; add a headless primitive only when the interaction behavior requires it.
 - Use TanStack Query for server state and `nuqs` for URL query state when matching existing patterns.
 - Use Lucide React icons where an icon is appropriate.
 - Follow `docs/development/ui/guidelines.md` and `docs/development/ui/design-policy.md` for implementation and visual design details.

--- a/docs/development/ui/design-policy.md
+++ b/docs/development/ui/design-policy.md
@@ -182,6 +182,19 @@ QDash uses DaisyUI's semantic color system. **Never use hardcoded colors**.
 
 ## Component Design
 
+### Interaction and Visual Layers
+
+DaisyUI remains QDash's visual foundation. Radix UI supplies behavior for complex interactive components; it does not replace the DaisyUI design system.
+
+Use this decision rule:
+
+1. Start with DaisyUI classes and semantic colors for appearance.
+2. For modal focus management, keyboard-operated menus, portal rendering, dismissal behavior, or viewport collision handling, use the shared Radix-based primitive under `ui/src/components/ui/`.
+3. Keep feature components independent of Radix implementation details by importing shared components such as `Dialog` and `DropdownMenu`.
+4. Preserve DaisyUI semantic colors in headless primitives. Do not introduce fixed light- or dark-mode colors.
+
+Avoid raw DaisyUI CSS dropdown or modal patterns when a shared Radix primitive already exists. Also avoid replacing simple buttons, cards, inputs, badges, or tables with unstyled headless components.
+
 ### DaisyUI Component Classes
 
 Use DaisyUI's component classes as the foundation:
@@ -554,4 +567,3 @@ const ranks = {
 <button className="bg-blue-500">Submit</button>       // Use btn-primary
 <span className="text-green-500">Success!</span>      // Use text-success
 ```
-

--- a/docs/development/ui/guidelines.md
+++ b/docs/development/ui/guidelines.md
@@ -16,7 +16,8 @@
 | Library              | Purpose                                |
 | -------------------- | -------------------------------------- |
 | Tailwind CSS         | Utility-first CSS framework            |
-| DaisyUI              | Component library built on Tailwind    |
+| DaisyUI              | Visual components, themes, and semantic colors |
+| Radix UI             | Headless primitives for complex interaction behavior |
 | plotly.js-dist-min   | Plotly chart rendering                 |
 | XYFlow               | Node-based diagrams and workflows      |
 | Lucide React         | Icon components (see [design-policy.md](design-policy.md)) |
@@ -203,6 +204,26 @@ export function useData() { ... }           // Too generic
 ---
 
 ## Component Design
+
+### DaisyUI and Radix Responsibilities
+
+QDash uses DaisyUI and Radix UI together rather than migrating wholesale from one to the other.
+
+- Use DaisyUI for the visual system: buttons, cards, form controls, badges, tables, loading states, themes, and semantic colors.
+- Use an established Radix-based component from `ui/src/components/ui/` when an interaction needs focus trapping or restoration, keyboard navigation, portals, outside-click or Escape dismissal, or collision-aware positioning.
+- Style Radix primitives with Tailwind and DaisyUI semantic colors so they remain consistent across light and dark themes.
+- Reuse `Dialog` and `DropdownMenu` instead of importing Radix packages directly in feature components.
+- Do not add a new headless primitive merely to replace a working DaisyUI visual component. Confirm that the interaction has behavioral or accessibility requirements first.
+
+Typical choices:
+
+| UI need | Preferred foundation |
+| ------- | -------------------- |
+| Button, card, input, badge, table | DaisyUI |
+| Modal dialog | Shared Radix `Dialog` primitive |
+| Action or multi-select menu | Shared Radix `DropdownMenu` primitive |
+| Page-specific spacing and layout | Tailwind CSS |
+| Select, popover, tooltip, or collapsible | Evaluate behavior first; introduce a shared headless primitive only when needed |
 
 ### Component Organization
 

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -12,6 +12,7 @@
         "@pierre/diffs": "^1.3.5",
         "@pierre/trees": "^1.0.0-beta.6",
         "@radix-ui/react-dialog": "^1.1.23",
+        "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-table": "^9.1.2",
         "@types/dagre": "^0.7.54",
@@ -460,13 +461,21 @@
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.7", "", {}, "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q=="],
 
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.15", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA=="],
+
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.1.15", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA=="],
+
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.5", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA=="],
 
     "@radix-ui/react-context": ["@radix-ui/react-context@1.2.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA=="],
 
     "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.23", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-focus-guards": "1.1.6", "@radix-ui/react-focus-scope": "1.1.16", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-layout-effect": "1.1.4", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA=="],
 
+    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg=="],
+
     "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-effect-event": "0.0.5" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w=="],
+
+    "@radix-ui/react-dropdown-menu": ["@radix-ui/react-dropdown-menu@2.1.24", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-menu": "2.1.24", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-controllable-state": "1.2.6" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g=="],
 
     "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.6", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ=="],
 
@@ -474,11 +483,17 @@
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA=="],
 
+    "@radix-ui/react-menu": ["@radix-ui/react-menu@2.1.24", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-focus-guards": "1.1.6", "@radix-ui/react-focus-scope": "1.1.16", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-popper": "1.3.7", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-roving-focus": "1.1.19", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-use-callback-ref": "1.1.4", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA=="],
+
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.3.7", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-layout-effect": "1.1.4", "@radix-ui/react-use-rect": "1.1.4", "@radix-ui/react-use-size": "1.1.4", "@radix-ui/rect": "1.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg=="],
+
     "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.17", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ=="],
 
     "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.10", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw=="],
 
     "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.10", "", { "dependencies": { "@radix-ui/react-slot": "1.3.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg=="],
+
+    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-is-hydrated": "0.1.3", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
 
@@ -488,7 +503,15 @@
 
     "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.5", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg=="],
 
+    "@radix-ui/react-use-is-hydrated": ["@radix-ui/react-use-is-hydrated@0.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw=="],
+
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.4", "", { "dependencies": { "@radix-ui/rect": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.3", "", {}, "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.3", "", { "os": "android", "cpu": "arm64" }, "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -25,6 +25,7 @@
     "@pierre/diffs": "^1.3.5",
     "@pierre/trees": "^1.0.0-beta.6",
     "@radix-ui/react-dialog": "^1.1.23",
+    "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^9.1.2",
     "@types/dagre": "^0.7.54",

--- a/ui/src/components/features/chip/modals/TaskDetailModal.tsx
+++ b/ui/src/components/features/chip/modals/TaskDetailModal.tsx
@@ -14,6 +14,12 @@ import { TaskResultMemo } from "@/components/features/metrics/TaskResultMemo";
 import { ReanalysisPanel } from "@/components/features/qubit/ReanalysisPanel";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
+import {
   formatDate as formatDateUtil,
   formatTime as formatTimeUtil,
   formatDateTime as formatDateTimeUtil,
@@ -700,48 +706,46 @@ export function TaskDetailModal({
                                     <div className="flex items-center gap-2 text-xs text-base-content/60">
                                       <span>↳ from</span>
                                       {paramValue.execution_id ? (
-                                        <div className="dropdown dropdown-top">
-                                          <button tabIndex={0} className="link link-primary">
-                                            {paramValue.task_name ||
-                                              `Execution ${paramValue.execution_id.slice(0, 8)}`}
-                                          </button>
-                                          <ul
-                                            tabIndex={0}
-                                            className="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-48 border border-base-300"
+                                        <DropdownMenu>
+                                          <DropdownMenuTrigger asChild>
+                                            <button type="button" className="link link-primary">
+                                              {paramValue.task_name ||
+                                                `Execution ${paramValue.execution_id.slice(0, 8)}`}
+                                            </button>
+                                          </DropdownMenuTrigger>
+                                          <DropdownMenuContent
+                                            side="top"
+                                            align="start"
+                                            className="w-48"
                                           >
-                                            <li>
-                                              <button
-                                                onClick={() => {
-                                                  router.push(
-                                                    `/executions/${paramValue.execution_id}`,
-                                                  );
-                                                }}
-                                              >
-                                                View Execution
-                                              </button>
-                                            </li>
-                                            <li>
-                                              <button
-                                                onClick={() => {
-                                                  const pv = paramValue as Record<string, unknown>;
-                                                  const parameterName =
-                                                    (pv?.parameter_name as string | undefined) ||
-                                                    key;
-                                                  const resolvedQid = resolveQid(
-                                                    qid,
-                                                    pv?.qid_role as string | undefined,
-                                                  );
-                                                  router.push(
-                                                    buildProvenanceUrl(parameterName, resolvedQid),
-                                                  );
-                                                  onClose();
-                                                }}
-                                              >
-                                                View Lineage
-                                              </button>
-                                            </li>
-                                          </ul>
-                                        </div>
+                                            <DropdownMenuItem
+                                              onSelect={() => {
+                                                router.push(
+                                                  `/executions/${paramValue.execution_id}`,
+                                                );
+                                              }}
+                                            >
+                                              View Execution
+                                            </DropdownMenuItem>
+                                            <DropdownMenuItem
+                                              onSelect={() => {
+                                                const pv = paramValue as Record<string, unknown>;
+                                                const parameterName =
+                                                  (pv?.parameter_name as string | undefined) || key;
+                                                const resolvedQid = resolveQid(
+                                                  qid,
+                                                  pv?.qid_role as string | undefined,
+                                                );
+                                                router.push(
+                                                  buildProvenanceUrl(parameterName, resolvedQid),
+                                                );
+                                                onClose();
+                                              }}
+                                            >
+                                              View Lineage
+                                            </DropdownMenuItem>
+                                          </DropdownMenuContent>
+                                        </DropdownMenu>
                                       ) : (
                                         <span>Unknown source</span>
                                       )}

--- a/ui/src/components/features/forum/ForumLabelSelector.tsx
+++ b/ui/src/components/features/forum/ForumLabelSelector.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { Check, Tag } from "lucide-react";
+import { Tag } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
 
 import { FORUM_LABELS, getForumLabel } from "./categories";
 
@@ -19,46 +28,38 @@ export function ForumLabelPicker({
 
   return (
     <div className="flex min-w-0 flex-wrap items-center gap-2">
-      <div className="dropdown dropdown-bottom">
-        <button
-          type="button"
-          tabIndex={0}
-          className="btn btn-outline btn-sm gap-2 rounded-md normal-case"
-          disabled={disabled}
-        >
-          <Tag className="h-4 w-4" />
-          Labels
-          {selectedLabels.length > 0 && (
-            <span className="badge badge-sm badge-neutral">{selectedLabels.length}</span>
-          )}
-        </button>
-        <div
-          tabIndex={0}
-          className="dropdown-content z-[20] mt-2 w-64 rounded-lg border border-base-300 bg-base-100 p-2 shadow-xl"
-        >
-          <div className="border-b border-base-300 px-2 pb-2 text-xs font-semibold text-base-content/70">
-            Apply labels
-          </div>
-          <div className="mt-1 max-h-64 overflow-auto">
-            {FORUM_LABELS.map((item) => {
-              const selected = selectedLabels.includes(item.id);
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-base-200"
-                  onClick={() => onToggle(item.id)}
-                >
-                  <span className="flex h-4 w-4 items-center justify-center">
-                    {selected && <Check className="h-4 w-4" />}
-                  </span>
-                  <span className={`badge badge-sm ${item.badgeClass}`}>{item.label}</span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="btn btn-outline btn-sm gap-2 rounded-md normal-case"
+            disabled={disabled}
+          >
+            <Tag className="h-4 w-4" />
+            Labels
+            {selectedLabels.length > 0 && (
+              <span className="badge badge-sm badge-neutral">{selectedLabels.length}</span>
+            )}
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="max-h-72 w-64">
+          <DropdownMenuLabel>Apply labels</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {FORUM_LABELS.map((item) => {
+            const selected = selectedLabels.includes(item.id);
+            return (
+              <DropdownMenuCheckboxItem
+                key={item.id}
+                checked={selected}
+                onCheckedChange={() => onToggle(item.id)}
+                onSelect={(event) => event.preventDefault()}
+              >
+                <span className={`badge badge-sm ${item.badgeClass}`}>{item.label}</span>
+              </DropdownMenuCheckboxItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
       {selectedDefinitions.length > 0 ? (
         <div className="flex min-w-0 flex-wrap gap-1.5">
           {selectedDefinitions.map((item) => (

--- a/ui/src/components/features/import/SeedParametersPanel.tsx
+++ b/ui/src/components/features/import/SeedParametersPanel.tsx
@@ -15,6 +15,12 @@ import {
 
 import { ChipSelector } from "@/components/selectors/ChipSelector";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
 import { useCompareSeedValues, useImportSeedParameters } from "@/client/calibration/calibration";
 import type { SeedImportSource } from "@/schemas";
 
@@ -470,40 +476,38 @@ export function SeedParametersPanel() {
         {/* Import Actions */}
         {data && (counts.new > 0 || counts.different > 0) && (
           <div className="card-actions justify-end mt-4 pt-4 border-t border-base-300">
-            <div className="dropdown dropdown-end">
-              <div tabIndex={0} role="button" className="btn btn-primary gap-2">
-                {importMutation.isPending ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    Importing...
-                  </>
-                ) : (
-                  <>
-                    <Database className="h-4 w-4" />
-                    Import
-                    <ChevronDown className="h-4 w-4" />
-                  </>
-                )}
-              </div>
-              <ul
-                tabIndex={0}
-                className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-56"
-              >
-                <li>
-                  <button onClick={() => requestImport("all")} disabled={importMutation.isPending}>
-                    Import All New/Different ({counts.new + counts.different})
-                  </button>
-                </li>
-                <li>
-                  <button
-                    onClick={() => requestImport("selected")}
-                    disabled={importMutation.isPending || selectedCount === 0}
-                  >
-                    Import Selected Only ({selectedCount})
-                  </button>
-                </li>
-              </ul>
-            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button type="button" className="btn btn-primary gap-2">
+                  {importMutation.isPending ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Importing...
+                    </>
+                  ) : (
+                    <>
+                      <Database className="h-4 w-4" />
+                      Import
+                      <ChevronDown className="h-4 w-4" />
+                    </>
+                  )}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-64">
+                <DropdownMenuItem
+                  onSelect={() => requestImport("all")}
+                  disabled={importMutation.isPending}
+                >
+                  Import All New/Different ({counts.new + counts.different})
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => requestImport("selected")}
+                  disabled={importMutation.isPending || selectedCount === 0}
+                >
+                  Import Selected Only ({selectedCount})
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         )}
 

--- a/ui/src/components/layout/Navbar/index.tsx
+++ b/ui/src/components/layout/Navbar/index.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { Folder, FolderLock } from "lucide-react";
+import { ChevronDown, Folder, FolderLock } from "lucide-react";
 
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
 import { EnvironmentBadge } from "@/components/ui/EnvironmentBadge";
 import { useProject } from "@/contexts/ProjectContext";
 import { useSidebar } from "@/contexts/SidebarContext";
@@ -47,61 +54,45 @@ function ProjectSelector() {
   }
 
   return (
-    <>
-      <div className="dropdown dropdown-bottom">
-        <div tabIndex={0} role="button" className="btn btn-ghost btn-sm gap-2">
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" className="btn btn-ghost btn-sm gap-2">
           {currentProject ? (
             <Folder size={16} aria-hidden="true" />
           ) : (
             <FolderLock size={16} aria-hidden="true" />
           )}
           <span className="max-w-32 truncate">{currentProject?.name ?? "No projects"}</span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="w-3 h-3"
+          <ChevronDown className="h-3 w-3" aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="max-h-80 w-64">
+        {projects.length === 0 && (
+          <DropdownMenuLabel className="flex flex-col items-start gap-0.5 py-2">
+            <span className="font-medium text-base-content">No projects available</span>
+            <span className="font-normal text-base-content/60">
+              Ask an owner or admin for an invitation.
+            </span>
+          </DropdownMenuLabel>
+        )}
+        {projects.map((project) => (
+          <DropdownMenuItem
+            key={project.project_id}
+            className={`flex-col items-start gap-0.5 ${
+              currentProject?.project_id === project.project_id ? "bg-primary/10 text-primary" : ""
+            }`}
+            onSelect={() => switchProject(project.project_id)}
           >
-            <path strokeLinecap="round" strokeLinejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
-          </svg>
-        </div>
-        <ul
-          tabIndex={0}
-          className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-64 max-h-80 overflow-y-auto"
-        >
-          {projects.length === 0 && (
-            <li>
-              <span className="menu-disabled flex flex-col items-start">
-                <span className="font-medium">No projects available</span>
-                <span className="text-xs opacity-60">Ask an owner or admin for an invitation.</span>
+            <span className="font-medium truncate w-full text-left">{project.name}</span>
+            {project.description && (
+              <span className="text-xs opacity-60 truncate w-full text-left">
+                {project.description}
               </span>
-            </li>
-          )}
-          {projects.map((project) => (
-            <li key={project.project_id}>
-              <button
-                className={`flex flex-col items-start ${
-                  currentProject?.project_id === project.project_id ? "active" : ""
-                }`}
-                onClick={() => {
-                  switchProject(project.project_id);
-                  (document.activeElement as HTMLElement)?.blur();
-                }}
-              >
-                <span className="font-medium truncate w-full text-left">{project.name}</span>
-                {project.description && (
-                  <span className="text-xs opacity-60 truncate w-full text-left">
-                    {project.description}
-                  </span>
-                )}
-              </button>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </>
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/ui/src/components/ui/DropdownMenu.tsx
+++ b/ui/src/components/ui/DropdownMenu.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check } from "lucide-react";
+import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import { forwardRef } from "react";
+import { twMerge } from "tailwind-merge";
+
+export const DropdownMenu = DropdownMenuPrimitive.Root;
+export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+export const DropdownMenuContent = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 6, collisionPadding = 12, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
+      className={twMerge(
+        "z-[1300] min-w-48 overflow-y-auto rounded-xl border border-base-content/10 bg-base-100 p-1.5 text-base-content shadow-xl outline-none",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+export const DropdownMenuItem = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={twMerge(
+      "flex cursor-default select-none items-center gap-2 rounded-lg px-2.5 py-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[highlighted]:bg-base-200 data-[highlighted]:text-base-content",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+export const DropdownMenuCheckboxItem = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={twMerge(
+      "relative flex cursor-default select-none items-center rounded-lg py-2 pl-8 pr-2.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-40 data-[highlighted]:bg-base-200 data-[highlighted]:text-base-content",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-4 w-4 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+export const DropdownMenuLabel = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Label>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={twMerge("px-2.5 py-1.5 text-xs font-semibold text-base-content/60", className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+export const DropdownMenuSeparator = forwardRef<
+  ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={twMerge("-mx-1 my-1 h-px bg-base-300", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;

--- a/ui/src/components/ui/__tests__/DropdownMenu.test.tsx
+++ b/ui/src/components/ui/__tests__/DropdownMenu.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
+
+describe("DropdownMenu", () => {
+  afterEach(() => cleanup());
+
+  it("renders menu content in a portal with shared styles", () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Actions</DropdownMenuTrigger>
+        <DropdownMenuContent className="min-w-72">
+          <DropdownMenuItem>View execution</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    const menu = screen.getByRole("menu");
+    expect(document.body.contains(menu)).toBe(true);
+    expect(menu.className).toContain("min-w-72");
+    expect(menu.className).not.toContain("min-w-48");
+    expect(screen.getByRole("menuitem", { name: "View execution" })).toBeTruthy();
+  });
+
+  it("exposes checkbox state for multi-select menus", () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <DropdownMenu open>
+        <DropdownMenuTrigger>Labels</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuCheckboxItem checked onCheckedChange={onCheckedChange}>
+            Calibration
+          </DropdownMenuCheckboxItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: "Calibration" }).getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Replace the remaining DaisyUI CSS dropdowns with a shared Radix Dropdown Menu primitive for consistent keyboard navigation, focus restoration, dismissal, and viewport-aware positioning.
- The change affects project selection, forum labels, seed import actions, and task parameter source actions; existing actions and data behavior remain unchanged.

## Changes

- Add a theme-aware `DropdownMenu` primitive with shared content, item, checkbox, label, and separator styles.
- Migrate the Navbar project selector and preserve the active project state.
- Migrate `ForumLabelPicker` and keep the menu open while selecting multiple labels.
- Migrate import actions in `SeedParametersPanel` and source actions in `TaskDetailModal`.
- Add primitive tests covering portal rendering, style overrides, and checkbox state.
- Document the DaisyUI visual layer and Radix interaction layer responsibilities in `AGENTS.md` and the UI development guides.
- Verify 133 UI tests, TypeScript, lint, formatting, knip, production build, and `bun audit` with no vulnerabilities.
- Browser-based visual verification was not run because no in-app browser session was available.
