### PR TITLE
refactor(ui): add accessible tooltip primitive

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -13,6 +13,7 @@
         "@pierre/trees": "^1.0.0-beta.6",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
+        "@radix-ui/react-tooltip": "^1.2.16",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-table": "^9.1.2",
         "@types/dagre": "^0.7.54",
@@ -497,6 +498,8 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.3.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.5" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q=="],
 
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.16", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-id": "1.1.4", "@radix-ui/react-popper": "1.3.7", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-layout-effect": "1.1.4", "@radix-ui/react-visually-hidden": "1.2.11" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg=="],
+
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.4", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ=="],
 
     "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ=="],
@@ -510,6 +513,8 @@
     "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.4", "", { "dependencies": { "@radix-ui/rect": "1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ=="],
 
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.4", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.4" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.11", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.10" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.3", "", {}, "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,6 +26,7 @@
     "@pierre/trees": "^1.0.0-beta.6",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
+    "@radix-ui/react-tooltip": "^1.2.16",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-table": "^9.1.2",
     "@types/dagre": "^0.7.54",

--- a/ui/src/components/features/execution/ExecutionClient.tsx
+++ b/ui/src/components/features/execution/ExecutionClient.tsx
@@ -17,6 +17,7 @@ import { CancelExecutionModal } from "@/components/features/execution/CancelExec
 import { getCancelErrorMessage } from "@/components/features/execution/getCancelErrorMessage";
 import { ExecutionTopologyView } from "@/components/features/execution/ExecutionTopologyView";
 import { ExecutionDetailPageSkeleton } from "@/components/ui/Skeleton/PageSkeletons";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { useToast } from "@/components/ui/Toast";
 
 type FilterOption = {
@@ -245,14 +246,18 @@ export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailCl
               <span className="font-medium mr-1">End:</span>
               <time className="truncate">{formatDateTimeUtil(execution.end_at)}</time>
             </div>
-            <div
-              className="flex items-center text-base-content/70 tooltip tooltip-bottom"
-              data-tip={calculateDetailedDuration(execution.start_at, execution.end_at)}
-            >
-              <Clock className="mr-2 text-info/70 flex-shrink-0" size={14} />
-              <span className="font-medium mr-1">Duration:</span>
-              <span>{execution.elapsed_time}</span>
-            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="flex items-center text-base-content/70" tabIndex={0}>
+                  <Clock className="mr-2 text-info/70 flex-shrink-0" size={14} />
+                  <span className="font-medium mr-1">Duration:</span>
+                  <span>{execution.elapsed_time}</span>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {calculateDetailedDuration(execution.start_at, execution.end_at)}
+              </TooltipContent>
+            </Tooltip>
             <div className="flex items-center text-base-content/70 min-w-0">
               <UserRound className="mr-2 text-info/70 flex-shrink-0" size={14} />
               <span className="font-medium mr-1">User:</span>

--- a/ui/src/components/ui/GridZoomControls.tsx
+++ b/ui/src/components/ui/GridZoomControls.tsx
@@ -5,6 +5,8 @@ import { useEffect, useRef } from "react";
 import { Maximize, Maximize2, Minimize, ZoomIn, ZoomOut } from "lucide-react";
 import { useControls } from "react-zoom-pan-pinch";
 
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
+
 interface GridZoomControlsProps {
   isFullscreen?: boolean;
   /** Omit to hide the fullscreen toggle */
@@ -29,26 +31,64 @@ export function GridZoomControls({ isFullscreen, onToggleFullscreen }: GridZoomC
     <div className="absolute top-2 right-2 z-30 flex flex-col gap-1">
       {onToggleFullscreen && (
         <>
-          <button
-            onClick={onToggleFullscreen}
-            className={buttonClass}
-            title={isFullscreen ? "Exit fullscreen (Esc)" : "Fullscreen"}
-            aria-pressed={isFullscreen}
-          >
-            {isFullscreen ? <Minimize className="h-4 w-4" /> : <Maximize className="h-4 w-4" />}
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onToggleFullscreen}
+                className={buttonClass}
+                aria-label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+                aria-pressed={isFullscreen}
+              >
+                {isFullscreen ? <Minimize className="h-4 w-4" /> : <Maximize className="h-4 w-4" />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+              {isFullscreen ? "Exit fullscreen (Esc)" : "Fullscreen"}
+            </TooltipContent>
+          </Tooltip>
           <div className="h-px bg-base-content/20 mx-1" />
         </>
       )}
-      <button onClick={() => zoomIn()} className={buttonClass} title="Zoom in">
-        <ZoomIn className="h-4 w-4" />
-      </button>
-      <button onClick={() => zoomOut()} className={buttonClass} title="Zoom out">
-        <ZoomOut className="h-4 w-4" />
-      </button>
-      <button onClick={() => resetTransform()} className={buttonClass} title="Reset view">
-        <Maximize2 className="h-4 w-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => zoomIn()}
+            className={buttonClass}
+            aria-label="Zoom in"
+          >
+            <ZoomIn className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">Zoom in</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => zoomOut()}
+            className={buttonClass}
+            aria-label="Zoom out"
+          >
+            <ZoomOut className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">Zoom out</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => resetTransform()}
+            className={buttonClass}
+            aria-label="Reset view"
+          >
+            <Maximize2 className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="left">Reset view</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/ui/src/components/ui/Tooltip.tsx
+++ b/ui/src/components/ui/Tooltip.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import { forwardRef } from "react";
+import { twMerge } from "tailwind-merge";
+
+type TooltipProps = ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>;
+
+export function Tooltip(props: TooltipProps) {
+  return (
+    <TooltipPrimitive.Provider delayDuration={350} skipDelayDuration={150}>
+      <TooltipPrimitive.Root {...props} />
+    </TooltipPrimitive.Provider>
+  );
+}
+
+export const TooltipTrigger = TooltipPrimitive.Trigger;
+
+export const TooltipContent = forwardRef<
+  ElementRef<typeof TooltipPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, collisionPadding = 12, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
+      className={twMerge(
+        "z-[1400] max-w-72 rounded-lg border border-base-content/10 bg-base-100 px-2.5 py-1.5 text-xs text-base-content shadow-lg",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;

--- a/ui/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/ui/src/components/ui/__tests__/Tooltip.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
+
+describe("Tooltip", () => {
+  afterEach(() => cleanup());
+
+  it("renders accessible portal content for a trigger", () => {
+    render(
+      <Tooltip open>
+        <TooltipTrigger asChild>
+          <button type="button">Zoom in</button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-96">Increase the grid scale</TooltipContent>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Zoom in" });
+    const tooltip = screen.getByRole("tooltip");
+    expect(document.body.contains(tooltip)).toBe(true);
+    expect(trigger.getAttribute("aria-describedby")).toBe(tooltip.id);
+    expect(tooltip.className).toContain("max-w-96");
+    expect(tooltip.className).not.toContain("max-w-72");
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Add a shared Radix-based Tooltip primitive for short UI guidance that is available on both pointer hover and keyboard focus.
- Migrate reusable grid controls and execution duration details while leaving coordinate-driven data and DAG overlays as feature-specific tooltips.

## Changes

- Add a theme-aware `Tooltip` primitive with portal rendering and collision-aware positioning.
- Migrate fullscreen, zoom, and reset actions in `GridZoomControls`, adding explicit accessible labels for icon-only buttons.
- Migrate the execution duration detail in `ExecutionDetailClient` so keyboard users can access the expanded duration.
- Add a primitive test covering portal output, trigger association, and style overrides.
- Verify 134 UI tests, TypeScript, lint, formatting, knip, production build, and `bun audit` with no vulnerabilities.
