### PR TITLE
refactor(ui): improve icon action accessibility

### DIFF
--- a/ui/src/components/charts/TaskFigure.tsx
+++ b/ui/src/components/charts/TaskFigure.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { ZoomIn } from "lucide-react";
 
 import { useGetTaskResult } from "@/client/task/task";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { FigureLightbox } from "./FigureLightbox";
 
 interface TaskFigureProps {
@@ -48,17 +49,22 @@ function ExpandableImage({
       {/* eslint-disable-next-line @next/next/no-img-element -- dynamic API image with native sizing */}
       <img src={src} alt={alt} className={className} onError={() => setHasError(true)} />
       {!hideExpandButton && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            setIsOpen(true);
-          }}
-          className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity btn btn-xs btn-circle bg-base-100/80 shadow hover:bg-base-200"
-          title="Expand"
-        >
-          <ZoomIn className="h-3 w-3" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsOpen(true);
+              }}
+              className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity btn btn-xs btn-circle bg-base-100/80 shadow hover:bg-base-200"
+              aria-label="Expand figure"
+            >
+              <ZoomIn className="h-3 w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Expand figure</TooltipContent>
+        </Tooltip>
       )}
       {isOpen && (
         <FigureLightbox

--- a/ui/src/components/layout/MiniChatWindow.tsx
+++ b/ui/src/components/layout/MiniChatWindow.tsx
@@ -8,6 +8,7 @@ import { useAnalysisChat, type ChatMessage, type BlocksResult } from "@/hooks/us
 import { useAnalysisChatContext } from "@/contexts/AnalysisChatContext";
 import { ChatPlotlyChart } from "@/components/features/chat/ChatPlotlyChart";
 import { CodeBlock } from "@/components/features/chat/CodeBlock";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { useGetCopilotConfig } from "@/client/copilot/copilot";
 import {
   buildAnalysisModelOptions,
@@ -328,23 +329,47 @@ export function MiniChatWindow() {
           </span>
         </div>
         <div className="flex items-center gap-0.5">
-          <button
-            onClick={() => setMinimized((prev) => !prev)}
-            className="btn btn-ghost btn-xs btn-square"
-            title={minimized ? "Expand" : "Minimize"}
-          >
-            <Minus className="w-3 h-3" />
-          </button>
-          <button
-            onClick={handleExpand}
-            className="btn btn-ghost btn-xs btn-square"
-            title="Open in sidebar"
-          >
-            <Maximize2 className="w-3 h-3" />
-          </button>
-          <button onClick={closeMiniChat} className="btn btn-ghost btn-xs btn-square">
-            <X className="w-3.5 h-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setMinimized((prev) => !prev)}
+                className="btn btn-ghost btn-xs btn-square"
+                aria-label={minimized ? "Expand chat" : "Minimize chat"}
+              >
+                <Minus className="w-3 h-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {minimized ? "Expand chat" : "Minimize chat"}
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleExpand}
+                className="btn btn-ghost btn-xs btn-square"
+                aria-label="Open chat in sidebar"
+              >
+                <Maximize2 className="w-3 h-3" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open in sidebar</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={closeMiniChat}
+                className="btn btn-ghost btn-xs btn-square"
+                aria-label="Close chat"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Close chat</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/ui/src/components/ui/MarkdownEditor.tsx
+++ b/ui/src/components/ui/MarkdownEditor.tsx
@@ -14,6 +14,7 @@ import {
   Users,
 } from "lucide-react";
 import { MarkdownContent } from "./MarkdownContent";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./Tooltip";
 import { QdashBotAvatar, UserAvatar } from "./UserAvatar";
 
 export interface MentionCandidate {
@@ -393,28 +394,37 @@ export function MarkdownEditor({
           {/* Toolbar */}
           <div className="flex items-center gap-0.5 px-1 py-1 border border-base-300 border-b-0 rounded-t-none bg-base-200/50">
             {toolbarActions.map((action) => (
-              <button
-                key={action.title}
-                type="button"
-                className="btn btn-ghost btn-xs px-1.5"
-                title={action.title}
-                onClick={() => applyAction(action)}
-                disabled={disabled}
-              >
-                {action.icon}
-              </button>
+              <Tooltip key={action.title}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-xs px-1.5"
+                    aria-label={action.title}
+                    onClick={() => applyAction(action)}
+                    disabled={disabled}
+                  >
+                    {action.icon}
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{action.title}</TooltipContent>
+              </Tooltip>
             ))}
             {onImageUpload && (
               <>
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-xs px-1.5"
-                  title="Upload Image"
-                  onClick={() => fileInputRef.current?.click()}
-                  disabled={disabled}
-                >
-                  <ImageIcon className={ICON_SIZE} />
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="btn btn-ghost btn-xs px-1.5"
+                      aria-label="Upload image"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={disabled}
+                    >
+                      <ImageIcon className={ICON_SIZE} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">Upload image</TooltipContent>
+                </Tooltip>
                 <input
                   ref={fileInputRef}
                   type="file"

--- a/ui/src/components/ui/__tests__/MarkdownEditor.test.tsx
+++ b/ui/src/components/ui/__tests__/MarkdownEditor.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MarkdownEditor } from "@/components/ui/MarkdownEditor";
+
+describe("MarkdownEditor", () => {
+  afterEach(() => cleanup());
+
+  it("gives every icon-only toolbar action an accessible name", () => {
+    render(<MarkdownEditor value="" onChange={vi.fn()} onImageUpload={vi.fn()} />);
+
+    for (const name of [
+      "Bold",
+      "Italic",
+      "Strikethrough",
+      "Code",
+      "Link",
+      "Quote",
+      "Bullet List",
+      "Ordered List",
+      "Upload image",
+    ]) {
+      expect(screen.getByRole("button", { name })).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Improve icon-only actions by replacing native title-only guidance with the shared accessible Tooltip primitive and explicit accessible names.
- The change affects reusable Markdown editing, task figures, and the AI mini chat without changing their underlying actions.

## Changes

- Migrate all icon-only actions in `MarkdownEditor` to shared tooltips and add accessible labels.
- Make the `TaskFigure` expand action visible on keyboard focus and expose an accessible name and tooltip.
- Migrate minimize, open-in-sidebar, and close actions in `MiniChatWindow` to shared tooltips with explicit labels.
- Add a Markdown editor regression test that verifies accessible names for every toolbar action.
- Verify 135 UI tests, TypeScript, lint, formatting, knip, production build, and `bun audit` with no vulnerabilities.
