### PR TITLE
refactor(ui): migrate figure lightbox to Dialog

### DIFF
--- a/ui/src/components/charts/FigureLightbox.tsx
+++ b/ui/src/components/charts/FigureLightbox.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import dynamic from "next/dynamic";
 import { TransformWrapper, TransformComponent, useControls } from "react-zoom-pan-pinch";
 import { X, ZoomIn, ZoomOut, Maximize2, LineChart, Image } from "lucide-react";
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 
 const PlotlyRenderer = dynamic(
   () => import("@/components/charts/PlotlyRenderer").then((mod) => mod.PlotlyRenderer),
@@ -33,9 +36,11 @@ function LightboxControls({
     <div className="absolute top-4 right-4 z-50 flex gap-2">
       {jsonFigurePath && (
         <button
+          type="button"
           onClick={onToggleInteractive}
           className="btn btn-sm bg-base-100/90 shadow-lg hover:bg-base-200 gap-1"
           title={isInteractive ? "Static View" : "Interactive View"}
+          aria-label={isInteractive ? "Switch to static view" : "Switch to interactive view"}
         >
           {isInteractive ? (
             <>
@@ -52,36 +57,60 @@ function LightboxControls({
       )}
       {!isInteractive && (
         <>
-          <button
-            onClick={() => zoomIn()}
-            className="btn btn-sm btn-circle bg-base-100/90 shadow-lg hover:bg-base-200"
-            title="Zoom in"
-          >
-            <ZoomIn className="h-4 w-4" />
-          </button>
-          <button
-            onClick={() => zoomOut()}
-            className="btn btn-sm btn-circle bg-base-100/90 shadow-lg hover:bg-base-200"
-            title="Zoom out"
-          >
-            <ZoomOut className="h-4 w-4" />
-          </button>
-          <button
-            onClick={() => resetTransform()}
-            className="btn btn-sm btn-circle bg-base-100/90 shadow-lg hover:bg-base-200"
-            title="Reset zoom"
-          >
-            <Maximize2 className="h-4 w-4" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => zoomIn()}
+                className="btn btn-sm btn-circle bg-base-100/90 shadow-lg hover:bg-base-200"
+                aria-label="Zoom in"
+              >
+                <ZoomIn className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Zoom in</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => zoomOut()}
+                className="btn btn-sm btn-circle bg-base-100/90 shadow-lg hover:bg-base-200"
+                aria-label="Zoom out"
+              >
+                <ZoomOut className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Zoom out</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => resetTransform()}
+                className="btn btn-sm btn-circle bg-base-100/90 shadow-lg hover:bg-base-200"
+                aria-label="Reset zoom"
+              >
+                <Maximize2 className="h-4 w-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Reset zoom</TooltipContent>
+          </Tooltip>
         </>
       )}
-      <button
-        onClick={onClose}
-        className="btn btn-sm btn-circle bg-base-100/90 shadow-lg hover:bg-base-200"
-        title="Close"
-      >
-        <X className="h-4 w-4" />
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={onClose}
+            className="btn btn-sm btn-circle bg-base-100/90 shadow-lg hover:bg-base-200"
+            aria-label="Close figure"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Close figure</TooltipContent>
+      </Tooltip>
     </div>
   );
 }
@@ -89,70 +118,56 @@ function LightboxControls({
 export function FigureLightbox({ src, alt, jsonFigurePath, onClose }: FigureLightboxProps) {
   const [isInteractive, setIsInteractive] = useState(false);
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    },
-    [onClose],
-  );
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [handleKeyDown]);
-
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <TransformWrapper
-        initialScale={1}
-        minScale={0.5}
-        maxScale={5}
-        wheel={{ step: 0.1 }}
-        doubleClick={{ mode: "zoomIn", step: 0.7 }}
-        disabled={isInteractive}
-      >
-        <LightboxControls
-          onClose={onClose}
-          jsonFigurePath={jsonFigurePath}
-          isInteractive={isInteractive}
-          onToggleInteractive={() => setIsInteractive((v) => !v)}
-        />
-        {isInteractive && jsonFigurePath ? (
-          <div className="flex items-center justify-center w-screen h-screen">
-            <div className="bg-white rounded-xl p-4 shadow-lg max-w-[90vw] max-h-[90vh] overflow-auto">
-              <PlotlyRenderer
-                fullPath={`/api/executions/figure?path=${encodeURIComponent(jsonFigurePath)}`}
-              />
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="h-[calc(100dvh-2rem)] max-h-none max-w-none overflow-hidden rounded-2xl bg-neutral/95 p-0">
+        <DialogTitle className="sr-only">Figure preview</DialogTitle>
+        <DialogDescription className="sr-only">
+          Expanded figure with pan, zoom, and optional interactive controls.
+        </DialogDescription>
+        <TransformWrapper
+          initialScale={1}
+          minScale={0.5}
+          maxScale={5}
+          wheel={{ step: 0.1 }}
+          doubleClick={{ mode: "zoomIn", step: 0.7 }}
+          disabled={isInteractive}
+        >
+          <LightboxControls
+            onClose={onClose}
+            jsonFigurePath={jsonFigurePath}
+            isInteractive={isInteractive}
+            onToggleInteractive={() => setIsInteractive((v) => !v)}
+          />
+          {isInteractive && jsonFigurePath ? (
+            <div className="flex h-full w-full items-center justify-center">
+              <div className="max-h-[90%] max-w-[90%] overflow-auto rounded-xl bg-base-100 p-4 shadow-lg">
+                <PlotlyRenderer
+                  fullPath={`/api/executions/figure?path=${encodeURIComponent(jsonFigurePath)}`}
+                />
+              </div>
             </div>
-          </div>
-        ) : (
-          <TransformComponent
-            wrapperStyle={{
-              width: "100vw",
-              height: "100vh",
-            }}
-            contentStyle={{
-              width: "100%",
-              height: "100%",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            {/* eslint-disable-next-line @next/next/no-img-element -- pan/zoom relies on native image sizing */}
-            <img
-              src={src}
-              alt={alt || "Figure"}
-              className="max-w-[90vw] max-h-[90vh] object-contain"
-            />
-          </TransformComponent>
-        )}
-      </TransformWrapper>
-    </div>
+          ) : (
+            <TransformComponent
+              wrapperStyle={{ width: "100%", height: "100%" }}
+              contentStyle={{
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element -- pan/zoom relies on native image sizing */}
+              <img
+                src={src}
+                alt={alt || "Figure"}
+                className="max-h-[90%] max-w-[90%] object-contain"
+              />
+            </TransformComponent>
+          )}
+        </TransformWrapper>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/ui/src/components/charts/__tests__/FigureLightbox.test.tsx
+++ b/ui/src/components/charts/__tests__/FigureLightbox.test.tsx
@@ -1,0 +1,27 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FigureLightbox } from "@/components/charts/FigureLightbox";
+
+describe("FigureLightbox", () => {
+  afterEach(() => cleanup());
+
+  it("exposes figure controls inside an accessible dialog", () => {
+    render(<FigureLightbox src="/figure.png" alt="Calibration result" onClose={vi.fn()} />);
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByRole("img", { name: "Calibration result" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Zoom in" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Zoom out" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Reset zoom" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Close figure" })).toBeTruthy();
+  });
+
+  it("requests close from the labeled close action", () => {
+    const onClose = vi.fn();
+    render(<FigureLightbox src="/figure.png" onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close figure" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Move the interactive figure lightbox onto the shared Dialog primitive so expanded figures receive consistent focus management, dismissal, and focus restoration.
- Preserve image pan/zoom and Plotly interactive switching while improving theme compatibility and icon-action accessibility.

## Changes

- Replace the custom full-screen overlay and document-level Escape listener in `FigureLightbox` with the shared Radix-based `Dialog`.
- Add an accessible title and description for the expanded figure experience.
- Migrate zoom, reset, and close controls to shared tooltips with explicit accessible labels.
- Replace the fixed white Plotly container with DaisyUI semantic background colors.
- Add tests covering the dialog structure, labeled controls, image alternative text, and close action.
- Verify 137 UI tests, TypeScript, lint, formatting, knip, production build, and `bun audit` with no vulnerabilities.
