### PR TITLE
refactor(ui): improve chat action tooltips

### DIFF
--- a/ui/src/components/features/chat/CopilotChatPage.tsx
+++ b/ui/src/components/features/chat/CopilotChatPage.tsx
@@ -25,6 +25,7 @@ import { useCopilotChat, type CopilotMessage, type CopilotSession } from "@/hook
 import { ChatPlotlyChart } from "@/components/features/chat/ChatPlotlyChart";
 import { CodeBlock } from "@/components/features/chat/CodeBlock";
 import { ImagePreviewDialog } from "@/components/ui/ImagePreviewDialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { useGetCopilotConfig } from "@/client/copilot/copilot";
 import {
   buildChatModelOptions,
@@ -273,15 +274,19 @@ function SessionListItem({
             <span className="text-base-content/30">{formatTime(session.updatedAt)}</span>
           </div>
         </button>
-        <button
-          type="button"
-          onClick={onDelete}
-          className="btn btn-ghost btn-xs btn-square opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0 text-base-content/40 hover:text-error"
-          title="Delete session"
-          aria-label={`Delete ${session.title}`}
-        >
-          <Trash2 className="w-3 h-3" />
-        </button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onDelete}
+              className="btn btn-ghost btn-xs btn-square opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0 text-base-content/40 hover:text-error"
+              aria-label={`Delete ${session.title}`}
+            >
+              <Trash2 className="w-3 h-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Delete session</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );
@@ -392,13 +397,19 @@ export function CopilotChatPage() {
               <MessageSquare className="w-4 h-4 text-base-content/60" />
               <span className="text-sm font-semibold">Sessions</span>
             </div>
-            <button
-              onClick={() => setShowSessionSidebar(false)}
-              className="btn btn-ghost btn-xs btn-square"
-              title="Hide sessions"
-            >
-              <PanelLeftClose className="w-4 h-4" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setShowSessionSidebar(false)}
+                  className="btn btn-ghost btn-xs btn-square"
+                  aria-label="Hide sessions"
+                >
+                  <PanelLeftClose className="w-4 h-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Hide sessions</TooltipContent>
+            </Tooltip>
           </div>
 
           {/* New Session Button */}
@@ -432,13 +443,19 @@ export function CopilotChatPage() {
         {/* Chat Header */}
         <div className="flex items-center gap-2 px-4 py-2.5 border-b border-base-300/50 bg-base-100">
           {!showSessionSidebar && (
-            <button
-              onClick={() => setShowSessionSidebar(true)}
-              className="btn btn-ghost btn-sm btn-square"
-              title="Show sessions"
-            >
-              <PanelLeftOpen className="w-4 h-4" />
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => setShowSessionSidebar(true)}
+                  className="btn btn-ghost btn-sm btn-square"
+                  aria-label="Show sessions"
+                >
+                  <PanelLeftOpen className="w-4 h-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Show sessions</TooltipContent>
+            </Tooltip>
           )}
           <div className="flex items-center gap-2.5 flex-1 min-w-0">
             <div className="w-6 h-6 rounded-lg chat-avatar-bot flex items-center justify-center">
@@ -447,14 +464,14 @@ export function CopilotChatPage() {
             <h2 className="text-sm font-bold truncate">{activeSession?.title || "AI Chat"}</h2>
           </div>
           {modelOptions.length > 1 && (
-            <label className="flex items-center gap-1 mr-1" title="Chat model">
+            <label className="flex items-center gap-1 mr-1">
               <Cpu className="w-3.5 h-3.5 text-base-content/40" />
+              <span className="sr-only">Chat model</span>
               <select
                 className="select select-bordered select-xs w-44 text-xs truncate appearance-auto"
                 value={selectedModel.key}
                 onChange={(event) => handleModelChange(event.target.value)}
                 disabled={isLoading}
-                title={selectedModel.label}
               >
                 {modelOptions.map((option) => (
                   <option key={option.key} value={option.key}>
@@ -465,14 +482,22 @@ export function CopilotChatPage() {
             </label>
           )}
           {messages.length > 0 && (
-            <button
-              onClick={clearActiveSession}
-              className="btn btn-ghost btn-xs gap-1 text-base-content/50 hover:text-error"
-              title="Clear messages"
-            >
-              <Trash2 className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">Clear</span>
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={clearActiveSession}
+                  className="btn btn-ghost btn-xs gap-1 text-base-content/50 hover:text-error"
+                  aria-label="Clear messages"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                  <span className="hidden sm:inline" aria-hidden="true">
+                    Clear
+                  </span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Clear messages</TooltipContent>
+            </Tooltip>
           )}
         </div>
 


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Make Copilot Chat icon actions consistently discoverable for pointer and keyboard users through the shared Radix tooltip primitive.
- This is a UI-only accessibility refinement with no API, schema, compatibility, or configuration changes.

## Changes

- Add shared tooltips and accessible names to session deletion and sidebar visibility actions in `CopilotChatPage`.
- Add a shared tooltip and explicit accessible name to the clear-messages action.
- Give the chat model selector an accessible label instead of relying on native `title` text.
- Verify 137 UI tests, TypeScript, lint, formatting, knip, and the production build.

## Verification note

- Tests were run with `NODE_OPTIONS=--no-experimental-webstorage` because Node 22 experimental Web Storage otherwise shadows jsdom localStorage in the existing auth tests.