### PR TITLE
fix(ui): prevent region zoom double toggle

### DIFF
--- a/ui/src/components/ui/RegionZoomToggle.tsx
+++ b/ui/src/components/ui/RegionZoomToggle.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ZoomIn } from "lucide-react";
+
 interface RegionZoomToggleProps {
   enabled: boolean;
   onToggle: (enabled: boolean) => void;
@@ -7,33 +9,17 @@ interface RegionZoomToggleProps {
 
 export function RegionZoomToggle({ enabled, onToggle }: RegionZoomToggleProps) {
   return (
-    <div
+    <label
       className={`flex items-center gap-3 p-3 rounded-lg border-2 transition-all duration-200 cursor-pointer select-none ${
         enabled
           ? "bg-primary/10 border-primary"
           : "bg-base-200/50 border-base-300 hover:border-primary/50"
       }`}
-      onClick={() => onToggle(!enabled)}
     >
       <div
         className={`p-2 rounded-lg ${enabled ? "bg-primary text-primary-content" : "bg-base-300"}`}
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <circle cx="11" cy="11" r="8" />
-          <path d="m21 21-4.3-4.3" />
-          <path d="M11 8v6" />
-          <path d="M8 11h6" />
-        </svg>
+        <ZoomIn size={20} aria-hidden="true" />
       </div>
       <div className="flex-1">
         <div className="flex items-center gap-2">
@@ -49,12 +35,9 @@ export function RegionZoomToggle({ enabled, onToggle }: RegionZoomToggleProps) {
       <input
         type="checkbox"
         checked={enabled}
-        onChange={(e) => {
-          e.stopPropagation();
-          onToggle(e.target.checked);
-        }}
+        onChange={(event) => onToggle(event.target.checked)}
         className="toggle toggle-primary"
       />
-    </div>
+    </label>
   );
 }

--- a/ui/src/components/ui/__tests__/RegionZoomToggle.test.tsx
+++ b/ui/src/components/ui/__tests__/RegionZoomToggle.test.tsx
@@ -1,0 +1,31 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
+
+describe("RegionZoomToggle", () => {
+  afterEach(() => cleanup());
+
+  it("enables region zoom once when the label is clicked", () => {
+    const onToggle = vi.fn();
+    render(<RegionZoomToggle enabled={false} onToggle={onToggle} />);
+
+    fireEvent.click(screen.getByText("Region Zoom"));
+
+    expect(onToggle).toHaveBeenCalledOnce();
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it("disables region zoom from the checkbox", () => {
+    const onToggle = vi.fn();
+    render(<RegionZoomToggle enabled onToggle={onToggle} />);
+
+    const checkbox = screen.getByRole("checkbox", { name: /Region Zoom/ });
+    expect((checkbox as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(checkbox);
+
+    expect(onToggle).toHaveBeenCalledOnce();
+    expect(onToggle).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Prevent the Region Zoom control from toggling twice when its checkbox is clicked.
- Use native form semantics so pointer and keyboard interactions follow the same path; this is UI-only with no API, schema, compatibility, or configuration changes.

## Changes

- Replace the clickable wrapper and nested checkbox handlers in `RegionZoomToggle` with a native label and controlled checkbox.
- Replace the custom zoom SVG with the established Lucide `ZoomIn` icon.
- Add tests proving label and checkbox interactions emit exactly one state change.
- Verify 141 UI tests, TypeScript, lint, formatting, knip, and the production build.

## Verification note

- Tests were run with `NODE_OPTIONS=--no-experimental-webstorage` because Node 22 experimental Web Storage otherwise shadows jsdom localStorage in the existing auth tests.