### PR TITLE
refactor(ui): standardize confirmation dialogs

### DIFF
--- a/ui/src/components/features/cryo/CooldownItem.tsx
+++ b/ui/src/components/features/cryo/CooldownItem.tsx
@@ -10,6 +10,7 @@ import {
   useUnassignChipFromCooldown,
   useUpdateCooldown,
 } from "@/client/cooldown/cooldown";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { formatDate, toIsoSeconds } from "@/lib/utils/datetime";
 
 import { CooldownWiringSection } from "./CooldownWiringSection";
@@ -59,6 +60,7 @@ export const CooldownItem = forwardRef<HTMLDivElement, CooldownItemProps>(functi
   const assignMutation = useAssignChipToCooldown();
   const unassignMutation = useUnassignChipFromCooldown();
   const [chipToAdd, setChipToAdd] = useState("");
+  const [confirmation, setConfirmation] = useState<"end" | "delete" | null>(null);
   const isActive = !cooldown.ended_at;
 
   // Dates: click-to-edit
@@ -89,20 +91,18 @@ export const CooldownItem = forwardRef<HTMLDivElement, CooldownItemProps>(functi
     onChange();
   };
 
-  const handleEnd = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!confirm(`End cool-down ${cooldown.cooldown_id} now?`)) return;
+  const handleEnd = async () => {
     await updateMutation.mutateAsync({
       cooldownId: cooldown.cooldown_id,
       data: { ended_at: new Date().toISOString() },
     });
+    setConfirmation(null);
     onChange();
   };
 
-  const handleDelete = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (!confirm(`Delete cool-down ${cooldown.cooldown_id}?`)) return;
+  const handleDelete = async () => {
     await deleteMutation.mutateAsync({ cooldownId: cooldown.cooldown_id });
+    setConfirmation(null);
     onChange();
   };
 
@@ -160,7 +160,7 @@ export const CooldownItem = forwardRef<HTMLDivElement, CooldownItemProps>(functi
           {isActive && (
             <button
               className="btn btn-xs btn-warning"
-              onClick={handleEnd}
+              onClick={() => setConfirmation("end")}
               disabled={updateMutation.isPending}
               title="End this cool-down (warm-up)"
             >
@@ -169,7 +169,7 @@ export const CooldownItem = forwardRef<HTMLDivElement, CooldownItemProps>(functi
           )}
           <button
             className="btn btn-xs btn-ghost text-error"
-            onClick={handleDelete}
+            onClick={() => setConfirmation("delete")}
             disabled={deleteMutation.isPending}
             title="Delete this cool-down"
           >
@@ -305,6 +305,20 @@ export const CooldownItem = forwardRef<HTMLDivElement, CooldownItemProps>(functi
           />
         </div>
       )}
+      <ConfirmDialog
+        open={confirmation !== null}
+        title={confirmation === "end" ? "End cool-down?" : "Delete cool-down?"}
+        description={
+          confirmation === "end"
+            ? `End cool-down ${cooldown.cooldown_id} now?`
+            : `Delete cool-down ${cooldown.cooldown_id}? This action cannot be undone.`
+        }
+        confirmLabel={confirmation === "end" ? "End cool-down" : "Delete cool-down"}
+        onConfirm={confirmation === "end" ? handleEnd : handleDelete}
+        onOpenChange={(open) => !open && setConfirmation(null)}
+        pending={updateMutation.isPending || deleteMutation.isPending}
+        destructive={confirmation === "delete"}
+      />
     </div>
   );
 });

--- a/ui/src/components/features/cryo/CryostatCard.tsx
+++ b/ui/src/components/features/cryo/CryostatCard.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
 
 import { useDeleteCryostat } from "@/client/cryostat/cryostat";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { formatDate } from "@/lib/utils/datetime";
 
 import { CooldownItem } from "./CooldownItem";
@@ -102,6 +103,7 @@ export function CryostatCard({
   const [expandedId, setExpandedId] = useState<string | null>(() => {
     return activeCooldown?.cooldown_id ?? sortedCooldowns[0]?.cooldown_id ?? null;
   });
+  const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false);
 
   const itemRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
@@ -123,10 +125,8 @@ export function CryostatCard({
   }, [activeCooldown, expandedId]);
 
   const handleDelete = async () => {
-    if (!confirm(`Delete cryostat ${cryo.cryo_id}? Existing cool-downs are not affected.`)) {
-      return;
-    }
     await deleteCryostat.mutateAsync({ cryoId: cryo.cryo_id });
+    setDeleteConfirmationOpen(false);
     onChange();
   };
 
@@ -168,7 +168,7 @@ export function CryostatCard({
         </div>
         <button
           className="btn btn-ghost btn-xs text-error flex-shrink-0"
-          onClick={handleDelete}
+          onClick={() => setDeleteConfirmationOpen(true)}
           disabled={deleteCryostat.isPending}
           title="Delete cryostat"
         >
@@ -231,6 +231,16 @@ export function CryostatCard({
           </div>
         )}
       </div>
+      <ConfirmDialog
+        open={deleteConfirmationOpen}
+        title="Delete cryostat?"
+        description={`Delete cryostat ${cryo.cryo_id}? Existing cool-downs are not affected.`}
+        confirmLabel="Delete cryostat"
+        onConfirm={handleDelete}
+        onOpenChange={setDeleteConfirmationOpen}
+        pending={deleteCryostat.isPending}
+        destructive
+      />
     </section>
   );
 }

--- a/ui/src/components/features/files/FilesPageContent.tsx
+++ b/ui/src/components/features/files/FilesPageContent.tsx
@@ -41,6 +41,7 @@ import {
 import { EditorPageSkeleton } from "@/components/ui/Skeleton/PageSkeletons";
 import { PierreFileTree } from "@/components/ui/PierreFileTree";
 import { FileDiffReviewDialog } from "@/components/ui/FileDiffReviewDialog";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { useToast } from "@/components/ui/Toast";
 
 const Editor = dynamic(() => import("@monaco-editor/react"), { ssr: false });
@@ -98,6 +99,8 @@ export function FilesPageContent() {
   const [fileContent, setFileContent] = useState("");
   const [cursorPosition, setCursorPosition] = useState({ line: 1, column: 1 });
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [pendingFilePath, setPendingFilePath] = useState<string | null>(null);
+  const [pullConfirmationOpen, setPullConfirmationOpen] = useState(false);
   const [commitMessage, setCommitMessage] = useState("");
   const [isEditorLocked, setIsEditorLocked] = useState(true);
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
@@ -162,6 +165,7 @@ export function FilesPageContent() {
   const pullMutation = useMutation({
     mutationFn: () => gitPullConfig().then((res: AxiosResponse<GitPullConfig200>) => res.data),
     onSuccess: (data: GitPullConfig200) => {
+      setPullConfirmationOpen(false);
       toast.success(
         `Git pull successful! Updated to commit: ${(data.commit as string) || "unknown"}`,
       );
@@ -235,18 +239,19 @@ export function FilesPageContent() {
     }
   }, [fileContentData]);
 
-  const handleFileSelect = (path: string) => {
-    if (hasUnsavedChanges) {
-      if (
-        !confirm("You have unsaved changes. Do you want to discard them and open another file?")
-      ) {
-        return;
-      }
-    }
+  const selectFile = (path: string) => {
     setSelectedFile(path);
     setHasUnsavedChanges(false);
     setIsEditorLocked(true); // Lock editor when opening new file
     setImportResult(null); // Clear import result when selecting new file
+  };
+
+  const handleFileSelect = (path: string) => {
+    if (hasUnsavedChanges) {
+      setPendingFilePath(path);
+      return;
+    }
+    selectFile(path);
   };
 
   const handleImportToQDash = () => {
@@ -275,9 +280,8 @@ export function FilesPageContent() {
 
   const handlePull = () => {
     if (hasUnsavedChanges) {
-      if (!confirm("You have unsaved changes. Git pull will overwrite them. Continue?")) {
-        return;
-      }
+      setPullConfirmationOpen(true);
+      return;
     }
     pullMutation.mutate();
   };
@@ -675,6 +679,28 @@ export function FilesPageContent() {
           </div>
         </div>
       </div>
+      <ConfirmDialog
+        open={pendingFilePath !== null}
+        title="Discard unsaved changes?"
+        description="Your unsaved changes will be lost when you open another file."
+        confirmLabel="Discard and open"
+        onConfirm={() => {
+          if (pendingFilePath) selectFile(pendingFilePath);
+          setPendingFilePath(null);
+        }}
+        onOpenChange={(open) => !open && setPendingFilePath(null)}
+        destructive
+      />
+      <ConfirmDialog
+        open={pullConfirmationOpen}
+        title="Discard changes and pull?"
+        description="Git pull will overwrite your unsaved changes."
+        confirmLabel="Discard and pull"
+        onConfirm={() => pullMutation.mutate()}
+        onOpenChange={setPullConfirmationOpen}
+        pending={pullMutation.isPending}
+        destructive
+      />
     </>
   );
 }

--- a/ui/src/components/features/flow/FlowSchedulePanel.tsx
+++ b/ui/src/components/features/flow/FlowSchedulePanel.tsx
@@ -3,8 +3,11 @@
 import { useState } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
 
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { useToast } from "@/components/ui/Toast";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { dateToDateInput, formatDateTime } from "@/lib/utils/datetime";
 
 import type { ScheduleFlowRequest, FlowScheduleSummary } from "@/schemas";
@@ -27,6 +30,7 @@ export function FlowSchedulePanel({ flowName }: FlowSchedulePanelProps) {
   const [scheduledTime, setScheduledTime] = useState("");
   const [scheduleType, setScheduleType] = useState<"cron" | "one-time">("cron");
   const [isActive, setIsActive] = useState(true);
+  const [scheduleToDeleteId, setScheduleToDeleteId] = useState<string | null>(null);
 
   // Fetch schedules for this flow
   const { data: schedulesData, isLoading } = useQuery({
@@ -61,6 +65,7 @@ export function FlowSchedulePanel({ flowName }: FlowSchedulePanelProps) {
       queryClient.invalidateQueries({ queryKey: ["flow-schedules", flowName] });
       queryClient.invalidateQueries({ queryKey: ["flow-schedules"] });
       toast.success("Schedule deleted successfully!");
+      setScheduleToDeleteId(null);
     },
     onError: (error: Error) => {
       toast.error(`Failed to delete schedule: ${error.message}`);
@@ -124,10 +129,9 @@ export function FlowSchedulePanel({ flowName }: FlowSchedulePanelProps) {
     }
   };
 
-  const handleDeleteSchedule = (scheduleId: string) => {
-    if (confirm("Are you sure you want to delete this schedule?")) {
-      deleteScheduleMutation.mutate({ scheduleId });
-    }
+  const handleConfirmDeleteSchedule = () => {
+    if (!scheduleToDeleteId) return;
+    deleteScheduleMutation.mutate({ scheduleId: scheduleToDeleteId });
   };
 
   return (
@@ -334,14 +338,20 @@ export function FlowSchedulePanel({ flowName }: FlowSchedulePanelProps) {
                       />
                     </label>
                   )}
-                  <button
-                    onClick={() => handleDeleteSchedule(schedule.schedule_id)}
-                    className="btn btn-xs btn-ghost text-error"
-                    disabled={deleteScheduleMutation.isPending}
-                    title="Delete"
-                  >
-                    🗑
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => setScheduleToDeleteId(schedule.schedule_id)}
+                        className="btn btn-xs btn-square btn-ghost text-error"
+                        disabled={deleteScheduleMutation.isPending}
+                        aria-label="Delete schedule"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete schedule</TooltipContent>
+                  </Tooltip>
                 </div>
               </div>
             </div>
@@ -369,6 +379,17 @@ export function FlowSchedulePanel({ flowName }: FlowSchedulePanelProps) {
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        open={scheduleToDeleteId !== null}
+        title="Delete schedule?"
+        description="This schedule will be permanently deleted. This action cannot be undone."
+        confirmLabel="Delete schedule"
+        onConfirm={handleConfirmDeleteSchedule}
+        onOpenChange={(open) => !open && setScheduleToDeleteId(null)}
+        pending={deleteScheduleMutation.isPending}
+        destructive
+      />
     </div>
   );
 }

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -35,7 +35,7 @@ import {
   useUpdateForumPost,
 } from "@/client/forum/forum";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { QdashBotAvatar, UserAvatar } from "@/components/ui/UserAvatar";
 import { useAuth } from "@/contexts/AuthContext";
@@ -1166,38 +1166,16 @@ export function ForumDetailPage({ postId }: { postId: string }) {
         </aside>
       </div>
 
-      <Dialog
+      <ConfirmDialog
         open={replyToDeleteId !== null}
-        onOpenChange={(open) => {
-          if (!open && !isDeletingReply) setReplyToDeleteId(null);
-        }}
-      >
-        <DialogContent className="max-w-md">
-          <DialogTitle>Delete reply?</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-base-content/70">
-            This reply will be permanently deleted. This action cannot be undone.
-          </DialogDescription>
-          <div className="modal-action">
-            <button
-              type="button"
-              className="btn btn-ghost"
-              onClick={() => setReplyToDeleteId(null)}
-              disabled={isDeletingReply}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="btn btn-error"
-              onClick={handleConfirmDeleteReply}
-              disabled={isDeletingReply}
-            >
-              {isDeletingReply && <span className="loading loading-spinner loading-xs" />}
-              Delete reply
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
+        title="Delete reply?"
+        description="This reply will be permanently deleted. This action cannot be undone."
+        confirmLabel="Delete reply"
+        onConfirm={handleConfirmDeleteReply}
+        onOpenChange={(open) => !open && setReplyToDeleteId(null)}
+        pending={isDeletingReply}
+        destructive
+      />
     </div>
   );
 }

--- a/ui/src/components/features/issues/IssueDetailPage.tsx
+++ b/ui/src/components/features/issues/IssueDetailPage.tsx
@@ -13,7 +13,7 @@ import { useIssueAiReply } from "@/hooks/useIssueAiReply";
 import type { IssueResponse } from "@/schemas";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";
 import { MarkdownEditor } from "@/components/ui/MarkdownEditor";
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { QdashBotAvatar, UserAvatar } from "@/components/ui/UserAvatar";
 import { useImageUpload } from "@/hooks/useImageUpload";
@@ -597,38 +597,16 @@ export function IssueDetailPage({ issueId }: { issueId: string }) {
         />
       </div>
 
-      <Dialog
+      <ConfirmDialog
         open={replyToDeleteId !== null}
-        onOpenChange={(open) => {
-          if (!open && !isDeletingReply) setReplyToDeleteId(null);
-        }}
-      >
-        <DialogContent className="max-w-md">
-          <DialogTitle>Delete reply?</DialogTitle>
-          <DialogDescription className="mt-2 text-sm text-base-content/70">
-            This reply will be permanently deleted. This action cannot be undone.
-          </DialogDescription>
-          <div className="modal-action">
-            <button
-              type="button"
-              className="btn btn-ghost"
-              onClick={() => setReplyToDeleteId(null)}
-              disabled={isDeletingReply}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="btn btn-error"
-              onClick={handleConfirmDeleteReply}
-              disabled={isDeletingReply}
-            >
-              {isDeletingReply && <span className="loading loading-spinner loading-xs" />}
-              Delete reply
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
+        title="Delete reply?"
+        description="This reply will be permanently deleted. This action cannot be undone."
+        confirmLabel="Delete reply"
+        onConfirm={handleConfirmDeleteReply}
+        onOpenChange={(open) => !open && setReplyToDeleteId(null)}
+        pending={isDeletingReply}
+        destructive
+      />
     </div>
   );
 }

--- a/ui/src/components/features/tasks/TasksPageContent.tsx
+++ b/ui/src/components/features/tasks/TasksPageContent.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Braces, Copy, FileCode2, ListTree, PanelLeft, Pencil, Plus, Save } from "lucide-react";
 import { useToast } from "@/components/ui/Toast";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 import type {
   TaskFileTreeNode,
@@ -47,6 +48,10 @@ export function TasksPageContent() {
   const [fileContent, setFileContent] = useState("");
   const [cursorPosition, setCursorPosition] = useState({ line: 1, column: 1 });
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [pendingNavigation, setPendingNavigation] = useState<{
+    type: "backend" | "file";
+    value: string;
+  } | null>(null);
   const [isEditorLocked, setIsEditorLocked] = useState(true);
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
 
@@ -154,12 +159,7 @@ export function TasksPageContent() {
     }
   }, [fileContentData]);
 
-  const handleBackendChange = (backend: string) => {
-    if (hasUnsavedChanges) {
-      if (!confirm("You have unsaved changes. Do you want to discard them and switch backends?")) {
-        return;
-      }
-    }
+  const changeBackend = (backend: string) => {
     setSelectedBackend(backend);
     setSelectedFile(null);
     setFileContent("");
@@ -167,19 +167,28 @@ export function TasksPageContent() {
     setIsEditorLocked(true);
   };
 
-  const handleFileSelect = (path: string) => {
+  const handleBackendChange = (backend: string) => {
     if (hasUnsavedChanges) {
-      if (
-        !confirm("You have unsaved changes. Do you want to discard them and open another file?")
-      ) {
-        return;
-      }
+      setPendingNavigation({ type: "backend", value: backend });
+      return;
     }
+    changeBackend(backend);
+  };
+
+  const selectFile = (path: string) => {
     // Prepend backend name to get full path
     const fullPath = `${selectedBackend}/${path}`;
     setSelectedFile(fullPath);
     setHasUnsavedChanges(false);
     setIsEditorLocked(true);
+  };
+
+  const handleFileSelect = (path: string) => {
+    if (hasUnsavedChanges) {
+      setPendingNavigation({ type: "file", value: path });
+      return;
+    }
+    selectFile(path);
   };
 
   const handleTaskClick = (task: TaskInfo) => {
@@ -576,6 +585,25 @@ export function TasksPageContent() {
           </div>
         </div>
       </div>
+      <ConfirmDialog
+        open={pendingNavigation !== null}
+        title="Discard unsaved changes?"
+        description={
+          pendingNavigation?.type === "backend"
+            ? "Your unsaved changes will be lost when you switch backends."
+            : "Your unsaved changes will be lost when you open another file."
+        }
+        confirmLabel={
+          pendingNavigation?.type === "backend" ? "Discard and switch" : "Discard and open"
+        }
+        onConfirm={() => {
+          if (pendingNavigation?.type === "backend") changeBackend(pendingNavigation.value);
+          if (pendingNavigation?.type === "file") selectFile(pendingNavigation.value);
+          setPendingNavigation(null);
+        }}
+        onOpenChange={(open) => !open && setPendingNavigation(null)}
+        destructive
+      />
     </>
   );
 }

--- a/ui/src/components/ui/ConfirmDialog.tsx
+++ b/ui/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description: ReactNode;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+  pending?: boolean;
+  destructive?: boolean;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+  onOpenChange,
+  pending = false,
+  destructive = false,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => !pending && onOpenChange(nextOpen)}>
+      <DialogContent className="max-w-md">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription className="mt-2 text-sm text-base-content/70">
+          {description}
+        </DialogDescription>
+        <div className="modal-action">
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={pending}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={`btn ${destructive ? "btn-error" : "btn-primary"}`}
+            onClick={onConfirm}
+            disabled={pending}
+          >
+            {pending && <span className="loading loading-spinner loading-xs" />}
+            {confirmLabel}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/ui/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  afterEach(() => cleanup());
+
+  it("confirms or cancels the requested action", () => {
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmDialog
+        open
+        title="Delete schedule?"
+        description="This action cannot be undone."
+        confirmLabel="Delete schedule"
+        onConfirm={onConfirm}
+        onOpenChange={onOpenChange}
+        destructive
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete schedule" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("locks actions while confirmation is pending", () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Delete schedule?"
+        description="This action cannot be undone."
+        confirmLabel="Delete schedule"
+        onConfirm={vi.fn()}
+        onOpenChange={vi.fn()}
+        pending
+        destructive
+      />,
+    );
+
+    expect((screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(
+      (screen.getByRole("button", { name: "Delete schedule" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Replace browser-native confirmations and duplicated destructive dialogs with one accessible shared confirmation primitive.
- Standardize focus management, pending-state locking, action styling, and confirmation language across Flow, Cryo, Files, Tasks, Issues, and Forum UI. No API, schema, compatibility, or configuration changes are involved.

## Changes

- Add a shared `ConfirmDialog` built on the existing Radix `Dialog`, with destructive and pending variants plus component tests.
- Replace schedule deletion confirmation in `FlowSchedulePanel` and use a Lucide delete action with the shared tooltip.
- Replace cryostat deletion and cool-down end/delete browser confirmations in the Cryo screens.
- Replace unsaved-file and Git pull browser confirmations in `FilesPageContent`.
- Replace unsaved backend/file navigation confirmations in `TasksPageContent`.
- Reuse `ConfirmDialog` for the existing Issue and Forum reply deletion flows.
- Remove all remaining browser `confirm()` calls from UI components.

## Verification

- `NODE_OPTIONS=--no-experimental-webstorage bun run test:run` (143 tests)
- `bun run lint`
- `bun run fmt:check`
- `bunx tsc --noEmit`
- `bun run knip`
- `bun run build`