### PR TITLE
fix(ui): separate cooldown row actions

### DIFF
--- a/ui/src/components/features/cryo/CooldownItem.tsx
+++ b/ui/src/components/features/cryo/CooldownItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, useEffect, useMemo, useState } from "react";
+import { forwardRef, useEffect, useId, useMemo, useState } from "react";
 
 import { ChevronDown, ChevronRight, Plus, Trash2, X } from "lucide-react";
 
@@ -11,6 +11,7 @@ import {
   useUpdateCooldown,
 } from "@/client/cooldown/cooldown";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { formatDate, toIsoSeconds } from "@/lib/utils/datetime";
 
 import { CooldownWiringSection } from "./CooldownWiringSection";
@@ -61,6 +62,7 @@ export const CooldownItem = forwardRef<HTMLDivElement, CooldownItemProps>(functi
   const unassignMutation = useUnassignChipFromCooldown();
   const [chipToAdd, setChipToAdd] = useState("");
   const [confirmation, setConfirmation] = useState<"end" | "delete" | null>(null);
+  const contentId = useId();
   const isActive = !cooldown.ended_at;
 
   // Dates: click-to-edit
@@ -131,34 +133,39 @@ export const CooldownItem = forwardRef<HTMLDivElement, CooldownItemProps>(functi
         isActive ? "border-success/40 bg-success/5" : "border-base-300 bg-base-100"
       }`}
     >
-      {/* Header row — always visible, clickable to toggle */}
-      <button
-        type="button"
-        onClick={onToggle}
-        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-base-200/40 rounded-t-xl"
-        aria-expanded={expanded}
-      >
-        {expanded ? (
-          <ChevronDown className="h-4 w-4 flex-shrink-0 text-base-content/50" />
-        ) : (
-          <ChevronRight className="h-4 w-4 flex-shrink-0 text-base-content/50" />
-        )}
-        <div className="min-w-0 flex-1 flex items-center gap-2 flex-wrap">
-          <span className="font-mono font-semibold text-sm">{cooldown.cooldown_id}</span>
-          <span className={`badge badge-xs ${isActive ? "badge-success" : "badge-ghost"}`}>
-            {isActive ? "active" : "ended"}
+      <div className={`flex items-center ${expanded ? "rounded-t-xl" : "rounded-xl"}`}>
+        <button
+          type="button"
+          onClick={onToggle}
+          className={`min-w-0 flex flex-1 items-center gap-2 px-3 py-2 text-left hover:bg-base-200/40 ${
+            expanded ? "rounded-tl-xl" : "rounded-l-xl"
+          }`}
+          aria-expanded={expanded}
+          aria-controls={contentId}
+        >
+          {expanded ? (
+            <ChevronDown className="h-4 w-4 flex-shrink-0 text-base-content/50" />
+          ) : (
+            <ChevronRight className="h-4 w-4 flex-shrink-0 text-base-content/50" />
+          )}
+          <span className="min-w-0 flex flex-1 items-center gap-2 flex-wrap">
+            <span className="font-mono font-semibold text-sm">{cooldown.cooldown_id}</span>
+            <span className={`badge badge-xs ${isActive ? "badge-success" : "badge-ghost"}`}>
+              {isActive ? "active" : "ended"}
+            </span>
+            <span className="text-xs text-base-content/60 tabular-nums">
+              {formatDateRange(cooldown.started_at, cooldown.ended_at)}
+            </span>
+            <span className="text-xs text-base-content/50">
+              · {cooldown.chip_ids.length} chip
+              {cooldown.chip_ids.length !== 1 ? "s" : ""}
+            </span>
           </span>
-          <span className="text-xs text-base-content/60 tabular-nums">
-            {formatDateRange(cooldown.started_at, cooldown.ended_at)}
-          </span>
-          <span className="text-xs text-base-content/50">
-            · {cooldown.chip_ids.length} chip
-            {cooldown.chip_ids.length !== 1 ? "s" : ""}
-          </span>
-        </div>
-        <div className="flex gap-1 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+        </button>
+        <div className="flex gap-1 flex-shrink-0 pr-2">
           {isActive && (
             <button
+              type="button"
               className="btn btn-xs btn-warning"
               onClick={() => setConfirmation("end")}
               disabled={updateMutation.isPending}
@@ -167,20 +174,26 @@ export const CooldownItem = forwardRef<HTMLDivElement, CooldownItemProps>(functi
               End now
             </button>
           )}
-          <button
-            className="btn btn-xs btn-ghost text-error"
-            onClick={() => setConfirmation("delete")}
-            disabled={deleteMutation.isPending}
-            title="Delete this cool-down"
-          >
-            <Trash2 className="h-3 w-3" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="btn btn-xs btn-square btn-ghost text-error"
+                onClick={() => setConfirmation("delete")}
+                disabled={deleteMutation.isPending}
+                aria-label="Delete this cool-down"
+              >
+                <Trash2 className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Delete this cool-down</TooltipContent>
+          </Tooltip>
         </div>
-      </button>
+      </div>
 
       {/* Expanded body */}
       {expanded && (
-        <div className="px-4 pb-4 pt-1 space-y-4 border-t border-base-300">
+        <div id={contentId} className="px-4 pb-4 pt-1 space-y-4 border-t border-base-300">
           {/* Dates inline edit */}
           <div className="text-xs">
             <div className="text-base-content/60 font-semibold uppercase tracking-wide mb-1">


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Fix invalid nested button markup in cool-down rows by separating the expand control from row actions.
- Improve predictable pointer, keyboard, and assistive-technology behavior without changing API, schema, compatibility, or configuration.

## Changes

- Render the cool-down expand control and End/Delete actions as sibling interactive regions in `CooldownItem`.
- Associate the expand control with its content using `aria-expanded` and `aria-controls`.
- Add the shared tooltip and an accessible name to the icon-only delete action.
- Preserve the visible text treatment for the End now action and adjust row rounding for expanded and collapsed states.
- Verify 143 UI tests, TypeScript, lint, formatting, knip, and the production build.

## Verification note

- Tests were run with `NODE_OPTIONS=--no-experimental-webstorage` because Node 22 experimental Web Storage otherwise shadows jsdom localStorage in the existing auth tests.