### PR TITLE
refactor(ui): use yaml serializer for exports

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -39,6 +39,7 @@
         "sharp": "^0.35.3",
         "tailwind-merge": "^3.6.0",
         "theme-change": "^3.0.4",
+        "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -51,7 +51,8 @@
     "remark-gfm": "^4.0.1",
     "sharp": "^0.35.3",
     "tailwind-merge": "^3.6.0",
-    "theme-change": "^3.0.4"
+    "theme-change": "^3.0.4",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",

--- a/ui/src/components/features/metrics/MetricsYamlDownloadButton.tsx
+++ b/ui/src/components/features/metrics/MetricsYamlDownloadButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Download } from "lucide-react";
+import { stringify } from "yaml";
 
 interface MetricConfig {
   key: string;
@@ -25,33 +26,7 @@ interface MetricsYamlDownloadButtonProps {
   disabled?: boolean;
 }
 
-const YAML_SPECIAL_CHARS = [
-  ":",
-  "#",
-  "[",
-  "]",
-  "{",
-  "}",
-  "&",
-  "*",
-  "!",
-  "|",
-  ">",
-  "'",
-  '"',
-  "%",
-  "@",
-  "`",
-];
-
-function escapeYamlString(value: string): string {
-  if (YAML_SPECIAL_CHARS.some((char) => value.includes(char)) || value.trim() !== value) {
-    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-  }
-  return `"${value}"`;
-}
-
-function buildYaml(
+export function buildMetricsYaml(
   chipId: string,
   metricConfig: MetricConfig,
   selectionMode: string,
@@ -63,17 +38,6 @@ function buildYaml(
     selectionMode === "average" &&
     Object.values(metricData).some((v) => v.stddev !== null && v.stddev !== undefined);
 
-  const lines: string[] = [
-    `chip_id: ${escapeYamlString(chipId)}`,
-    `metric: ${metricConfig.key}`,
-    `title: ${escapeYamlString(metricConfig.title)}`,
-    `unit: ${escapeYamlString(metricConfig.unit)}`,
-    `selection_mode: ${selectionMode}`,
-    `time_range: ${escapeYamlString(timeRange)}`,
-    `timestamp: ${escapeYamlString(timestamp)}`,
-    `data:`,
-  ];
-
   const entries = Object.entries(metricData)
     .filter(([, v]) => v.value !== null)
     .sort(([a], [b]) => {
@@ -83,19 +47,28 @@ function buildYaml(
       return a.localeCompare(b);
     });
 
-  if (hasStddev) {
-    for (const [entityId, { value, stddev }] of entries) {
-      lines.push(`  ${escapeYamlString(entityId)}:`);
-      lines.push(`    value: ${value}`);
-      lines.push(`    stddev: ${stddev != null && isFinite(stddev) ? stddev : "null"}`);
-    }
-  } else {
-    for (const [entityId, { value }] of entries) {
-      lines.push(`  ${escapeYamlString(entityId)}: ${value}`);
-    }
-  }
+  const data = Object.fromEntries(
+    entries.map(([entityId, { value, stddev }]) => [
+      entityId,
+      hasStddev
+        ? {
+            value,
+            stddev: stddev != null && Number.isFinite(stddev) ? stddev : null,
+          }
+        : value,
+    ]),
+  );
 
-  return lines.join("\n") + "\n";
+  return stringify({
+    chip_id: chipId,
+    metric: metricConfig.key,
+    title: metricConfig.title,
+    unit: metricConfig.unit,
+    selection_mode: selectionMode,
+    time_range: timeRange,
+    timestamp,
+    data,
+  });
 }
 
 export function MetricsYamlDownloadButton({
@@ -109,7 +82,7 @@ export function MetricsYamlDownloadButton({
   const handleDownload = () => {
     if (!chipId || !metricData || !metricConfig) return;
 
-    const yaml = buildYaml(chipId, metricConfig, selectionMode, timeRange, metricData);
+    const yaml = buildMetricsYaml(chipId, metricConfig, selectionMode, timeRange, metricData);
 
     const blob = new Blob([yaml], { type: "text/yaml;charset=utf-8" });
 

--- a/ui/src/components/features/metrics/__tests__/MetricsYamlDownloadButton.test.ts
+++ b/ui/src/components/features/metrics/__tests__/MetricsYamlDownloadButton.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+import { buildMetricsYaml } from "@/components/features/metrics/MetricsYamlDownloadButton";
+
+describe("buildMetricsYaml", () => {
+  it("serializes special strings and sorted metric values as valid YAML", () => {
+    const yaml = buildMetricsYaml(
+      "chip:01",
+      { key: "t1", title: "T1 # average", unit: "µs", scale: 1 },
+      "latest",
+      " last 7 days ",
+      {
+        "10": { value: 20 },
+        "2": { value: 10 },
+        skipped: { value: null },
+      },
+    );
+
+    expect(parse(yaml)).toMatchObject({
+      chip_id: "chip:01",
+      metric: "t1",
+      title: "T1 # average",
+      unit: "µs",
+      selection_mode: "latest",
+      time_range: " last 7 days ",
+      data: {
+        "2": 10,
+        "10": 20,
+      },
+    });
+    expect(yaml.indexOf('"2"')).toBeLessThan(yaml.indexOf('"10"'));
+  });
+
+  it("includes finite standard deviations for average data", () => {
+    const yaml = buildMetricsYaml(
+      "chip-1",
+      { key: "t2", title: "T2", unit: "µs", scale: 1 },
+      "average",
+      "30d",
+      {
+        q0: { value: 12, stddev: 0.5 },
+        q1: { value: 14, stddev: Number.POSITIVE_INFINITY },
+      },
+    );
+
+    expect(parse(yaml).data).toEqual({
+      q0: { value: 12, stddev: 0.5 },
+      q1: { value: 14, stddev: null },
+    });
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Replace the hand-written metrics YAML serializer with the maintained `yaml` package.
- Reduce custom escaping and indentation logic while producing standards-compliant YAML for special strings and numeric data. This is UI-only with no API or schema changes.

## Changes

- Add `yaml` as a direct UI dependency.
- Build the metrics export as structured data and serialize it with `stringify`.
- Preserve entity ordering, omit null metric values, and normalize non-finite standard deviations to null.
- Add tests that parse generated exports and cover special strings, whitespace, Unicode, null values, numeric entity ordering, and average-data standard deviations.

## Verification

- `NODE_OPTIONS=--no-experimental-webstorage bun run test:run` (145 tests)
- `bun run lint`
- `bun run fmt`
- `bunx tsc --noEmit`
- `bun run knip`
- `bun audit` (no vulnerabilities)
- `bun run build`