### PR TITLE
feat(ui): add command palette navigation

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -19,6 +19,7 @@
         "@types/dagre": "^0.7.54",
         "@xyflow/react": "^12.11.2",
         "axios": "^1.18.1",
+        "cmdk": "^1.1.1",
         "dagre": "^0.8.5",
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
@@ -825,6 +826,8 @@
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,7 @@
     "@types/dagre": "^0.7.54",
     "@xyflow/react": "^12.11.2",
     "axios": "^1.18.1",
+    "cmdk": "^1.1.1",
     "dagre": "^0.8.5",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -5,13 +5,20 @@ import { useRouter, useParams } from "next/navigation";
 import { useState, useEffect, useCallback, useRef } from "react";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-
 import type { SaveFlowRequest, ExecuteFlowResponse } from "@/schemas";
 import type { AxiosResponse } from "axios";
 
 import { useToast } from "@/components/ui/Toast";
 import { PierreFileTree } from "@/components/ui/PierreFileTree";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/Command";
 
 import { useGetCurrentUser } from "@/client/auth/auth";
 import { useListChips } from "@/client/chip/chip";
@@ -30,7 +37,7 @@ import {
   ChevronRight,
   Clock,
   Columns2,
-  Command,
+  Command as CommandIcon,
   FileCode,
   FilePlus2,
   FolderOpen,
@@ -124,13 +131,10 @@ export function WorkflowEditorPageContent() {
   const [activeSidePanel, setActiveSidePanel] = useState<SidePanel>("explorer");
   const [sidebarSearch, setSidebarSearch] = useState("");
   const [showCommandPalette, setShowCommandPalette] = useState(false);
-  const [commandSearch, setCommandSearch] = useState("");
-  const [selectedCommandIndex, setSelectedCommandIndex] = useState(0);
   const [fontSize, setFontSize] = useState(14);
   const [selection, setSelection] = useState({ lines: 0, chars: 0 });
   const [isBottomPanelOpen, setIsBottomPanelOpen] = useState(false);
   const [wordWrap, setWordWrap] = useState<"on" | "off">("on");
-  const commandInputRef = useRef<HTMLInputElement>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const editorRef = useRef<any>(null);
 
@@ -330,7 +334,6 @@ export function WorkflowEditorPageContent() {
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "p") {
         e.preventDefault();
         setShowCommandPalette(true);
-        setCommandSearch("");
       }
       // Ctrl/Cmd + = → Zoom In
       if ((e.metaKey || e.ctrlKey) && (e.key === "=" || e.key === "+")) {
@@ -352,14 +355,10 @@ export function WorkflowEditorPageContent() {
         e.preventDefault();
         setIsBottomPanelOpen((prev) => !prev);
       }
-      // Escape → close command palette
-      if (e.key === "Escape" && showCommandPalette) {
-        setShowCommandPalette(false);
-      }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [showCommandPalette]);
+  }, []);
 
   // Sync fontSize and wordWrap to editor
   useEffect(() => {
@@ -367,13 +366,6 @@ export function WorkflowEditorPageContent() {
       editorRef.current.updateOptions({ fontSize, wordWrap });
     }
   }, [fontSize, wordWrap]);
-
-  // Focus command palette input when opened
-  useEffect(() => {
-    if (showCommandPalette) {
-      requestAnimationFrame(() => commandInputRef.current?.focus());
-    }
-  }, [showCommandPalette]);
 
   // Command palette actions
   const commands = [
@@ -529,14 +521,6 @@ export function WorkflowEditorPageContent() {
       enabled: true,
     },
   ];
-
-  const filteredCommands = commands.filter((cmd) =>
-    cmd.label.toLowerCase().includes(commandSearch.toLowerCase()),
-  );
-
-  useEffect(() => {
-    setSelectedCommandIndex(0);
-  }, [commandSearch, showCommandPalette]);
 
   const executeCommand = (cmd: (typeof commands)[0]) => {
     if (!cmd.enabled) return;
@@ -886,15 +870,12 @@ export function WorkflowEditorPageContent() {
             <div className="flex flex-col items-center gap-1 py-2">
               <button
                 type="button"
-                onClick={() => {
-                  setShowCommandPalette(true);
-                  setCommandSearch("");
-                }}
+                onClick={() => setShowCommandPalette(true)}
                 className="btn btn-ghost btn-sm btn-square h-9 w-9 rounded-sm text-base-content/60"
                 title="Command Palette"
                 aria-label="Command Palette"
               >
-                <Command size={18} />
+                <CommandIcon size={18} />
               </button>
             </div>
           </div>
@@ -1362,99 +1343,51 @@ export function WorkflowEditorPageContent() {
               type="button"
               onClick={() => {
                 setShowCommandPalette(true);
-                setCommandSearch("");
               }}
               className="hover:bg-primary-content/20 px-1.5 py-0.5 rounded transition-colors cursor-pointer hidden sm:flex items-center gap-1 opacity-70 hover:opacity-100"
               title="Command Palette"
             >
-              <Command size={10} />
+              <CommandIcon size={10} />
               <span>⌘⇧P</span>
             </button>
           </div>
         </div>
 
         {/* Command Palette */}
-        {showCommandPalette && (
-          <div
-            className="fixed inset-0 z-50 flex justify-center pt-[15vh]"
-            onClick={() => setShowCommandPalette(false)}
-          >
-            <div className="absolute inset-0 bg-black/50" />
-            <div
-              className="relative w-full max-w-lg h-fit bg-base-200 rounded-lg shadow-2xl border border-base-300 overflow-hidden"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="flex items-center gap-2 px-3 py-2 border-b border-base-300">
-                <Search size={14} className="text-base-content/40 shrink-0" />
-                <input
-                  id="workflow-command-palette-search"
-                  name="workflowCommandPaletteSearch"
-                  ref={commandInputRef}
-                  type="text"
-                  placeholder="Type a command..."
-                  className="flex-1 bg-transparent text-sm text-base-content outline-none placeholder:text-base-content/40"
-                  value={commandSearch}
-                  onChange={(e) => setCommandSearch(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "ArrowDown") {
-                      e.preventDefault();
-                      if (filteredCommands.length === 0) return;
-                      setSelectedCommandIndex((prev) =>
-                        Math.min(prev + 1, filteredCommands.length - 1),
-                      );
-                    }
-                    if (e.key === "ArrowUp") {
-                      e.preventDefault();
-                      if (filteredCommands.length === 0) return;
-                      setSelectedCommandIndex((prev) => Math.max(prev - 1, 0));
-                    }
-                    if (e.key === "Enter" && filteredCommands.length > 0) {
-                      executeCommand(filteredCommands[selectedCommandIndex] || filteredCommands[0]);
-                    }
-                    if (e.key === "Escape") {
-                      setShowCommandPalette(false);
-                    }
-                  }}
-                />
-              </div>
-              <div className="max-h-64 overflow-y-auto py-1">
-                {filteredCommands.map((cmd) => (
-                  <button
-                    key={cmd.id}
-                    type="button"
-                    onClick={() => executeCommand(cmd)}
-                    disabled={!cmd.enabled}
-                    onMouseEnter={() =>
-                      setSelectedCommandIndex(
-                        filteredCommands.findIndex((command) => command.id === cmd.id),
-                      )
-                    }
-                    className={`w-full flex items-center gap-3 px-3 py-2 text-sm text-left transition-colors ${
-                      cmd.enabled
-                        ? "text-base-content hover:bg-base-300 cursor-pointer"
-                        : "text-base-content/30 cursor-not-allowed"
-                    } ${
-                      filteredCommands[selectedCommandIndex]?.id === cmd.id ? "bg-base-300" : ""
-                    }`}
-                  >
-                    <cmd.icon size={14} className="shrink-0 opacity-60" />
-                    <span className="flex-1">{cmd.label}</span>
-                    {cmd.shortcut && (
-                      <kbd className="text-xs text-base-content/40 bg-base-300 px-1.5 py-0.5 rounded">
-                        {cmd.shortcut}
-                      </kbd>
-                    )}
-                  </button>
-                ))}
-                {filteredCommands.length === 0 && (
-                  <div className="px-3 py-4 text-sm text-base-content/40 text-center">
-                    No matching commands
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        )}
+        <CommandDialog
+          open={showCommandPalette}
+          onOpenChange={setShowCommandPalette}
+          title="Command Palette"
+          description="Search for an editor command, then press Enter to run it."
+        >
+          <Command loop label="Workflow commands">
+            <CommandInput
+              id="workflow-command-palette-search"
+              name="workflowCommandPaletteSearch"
+              placeholder="Type a command..."
+            />
+            <CommandList>
+              <CommandEmpty>No matching commands</CommandEmpty>
+              {commands.map((cmd) => (
+                <CommandItem
+                  key={cmd.id}
+                  value={cmd.label}
+                  keywords={[cmd.id]}
+                  disabled={!cmd.enabled}
+                  onSelect={() => executeCommand(cmd)}
+                >
+                  <cmd.icon size={14} className="shrink-0 opacity-60" aria-hidden="true" />
+                  <span className="flex-1">{cmd.label}</span>
+                  {cmd.shortcut && (
+                    <kbd className="rounded bg-base-300 px-1.5 py-0.5 text-xs text-base-content/40">
+                      {cmd.shortcut}
+                    </kbd>
+                  )}
+                </CommandItem>
+              ))}
+            </CommandList>
+          </Command>
+        </CommandDialog>
 
         {/* Mobile FAB / Speed Dial - only visible on mobile */}
         <div className="fab fixed bottom-20 right-4 z-30 sm:hidden">

--- a/ui/src/components/layout/GlobalCommandPalette.tsx
+++ b/ui/src/components/layout/GlobalCommandPalette.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { getNavigationSections } from "@/components/layout/navigation";
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/Command";
+import { useAuth } from "@/contexts/AuthContext";
+import { useProject } from "@/contexts/ProjectContext";
+
+export function GlobalCommandPalette() {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { canEdit } = useProject();
+  const [open, setOpen] = useState(false);
+  const sections = getNavigationSections({
+    canEdit,
+    isAdmin: user?.system_role === "admin",
+  });
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setOpen((current) => !current);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const navigate = (href: string) => {
+    setOpen(false);
+    router.push(href);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="btn btn-ghost btn-sm gap-2 text-base-content/60"
+        aria-label="Open navigation search"
+      >
+        <Search size={15} aria-hidden="true" />
+        <span className="hidden sm:inline">Navigate</span>
+        <kbd className="hidden rounded border border-base-300 bg-base-200 px-1.5 py-0.5 text-xs font-normal md:inline">
+          ⌘K
+        </kbd>
+      </button>
+
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="Navigate"
+        description="Search for a page to open."
+      >
+        <Command loop label="QDash navigation">
+          <CommandInput placeholder="Search pages..." />
+          <CommandList>
+            <CommandEmpty>No matching pages</CommandEmpty>
+            {sections.map((section) => {
+              const items = section.items.filter((item) => item.visible !== false);
+              if (items.length === 0) return null;
+
+              return (
+                <CommandGroup key={section.label} heading={section.label}>
+                  {items.map((item) => (
+                    <CommandItem
+                      key={item.href}
+                      value={item.label}
+                      keywords={[item.href, section.label]}
+                      onSelect={() => navigate(item.href)}
+                    >
+                      <item.icon size={15} className="shrink-0 opacity-60" aria-hidden="true" />
+                      <span>{item.label}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              );
+            })}
+          </CommandList>
+        </Command>
+      </CommandDialog>
+    </>
+  );
+}

--- a/ui/src/components/layout/Navbar/index.tsx
+++ b/ui/src/components/layout/Navbar/index.tsx
@@ -12,6 +12,7 @@ import {
 import { EnvironmentBadge } from "@/components/ui/EnvironmentBadge";
 import { useProject } from "@/contexts/ProjectContext";
 import { useSidebar } from "@/contexts/SidebarContext";
+import { GlobalCommandPalette } from "@/components/layout/GlobalCommandPalette";
 
 function HiddenIcon() {
   const { toggleMobileSidebar } = useSidebar();
@@ -103,6 +104,7 @@ export function Navbar() {
         <HiddenIcon />
         <ProjectSelector />
         <EnvironmentBadge className="badge-sm sm:badge-md" />
+        <GlobalCommandPalette />
       </div>
     </nav>
   );

--- a/ui/src/components/layout/Sidebar/index.tsx
+++ b/ui/src/components/layout/Sidebar/index.tsx
@@ -6,36 +6,16 @@ import { usePathname, useRouter } from "next/navigation";
 import { Fragment, useCallback, useState } from "react";
 
 import {
-  BarChart3,
-  BookMarked,
   BookOpen,
   ChevronLeft,
   ChevronRight,
-  Code,
-  Cpu,
-  Download,
   FileJson2,
-  Files,
-  GitBranch,
-  Inbox,
-  LayoutDashboard,
-  LayoutGrid,
-  ClipboardList,
-  Snowflake,
-  ListTodo,
   LogOut,
-  Brain,
-  CircleDot,
-  MessagesSquare,
   Moon,
   Settings,
-  ShieldCheck,
-  Bot,
-  ClipboardCheck,
   Sun,
   Workflow,
   X,
-  Zap,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
@@ -47,18 +27,10 @@ import { useProject } from "@/contexts/ProjectContext";
 import { useSidebar } from "@/contexts/SidebarContext";
 import { useUnreadNotificationCount } from "@/hooks/useNotifications";
 import { DARK_THEMES } from "@/constants/themes";
+import { getNavigationSections } from "@/components/layout/navigation";
+import type { NavItem, NavSection } from "@/components/layout/navigation";
 
 const PREFECT_URL = process.env.NEXT_PUBLIC_PREFECT_URL || "http://127.0.0.1:4200";
-
-type NavItem = {
-  href: string;
-  label: string;
-  title?: string;
-  icon: LucideIcon;
-  match?: "exact" | "prefix";
-  badge?: number;
-  visible?: boolean;
-};
 
 type ExternalNavItem = {
   href: string;
@@ -66,11 +38,6 @@ type ExternalNavItem = {
   title?: string;
   icon: LucideIcon;
   visible?: boolean;
-};
-
-type NavSection = {
-  label: string;
-  items: NavItem[];
 };
 
 function SectionHeader({ label, visible }: { label: string; visible: boolean }) {
@@ -220,105 +187,11 @@ export function Sidebar() {
     }`;
 
   const sectionHeaderVisible = isOpen || isMobileOpen;
-  const navSections: NavSection[] = [
-    {
-      label: "Overview",
-      items: [
-        {
-          href: "/inbox",
-          label: "Inbox",
-          icon: Inbox,
-          badge: unreadNotifications,
-        },
-        { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-        { href: "/metrics", label: "Metrics", icon: LayoutGrid },
-        { href: "/chip", label: "Chip", icon: Cpu },
-        { href: "/analysis", label: "Analysis", icon: BarChart3 },
-        { href: "/chat", label: "AI Chat", icon: Bot },
-        {
-          href: "/provenance",
-          label: "Provenance",
-          icon: GitBranch,
-        },
-      ],
-    },
-    {
-      label: "Operate",
-      items: [
-        {
-          href: "/workflow",
-          label: "Workflow",
-          icon: Code,
-          match: "prefix",
-          visible: canEdit,
-        },
-        { href: "/execution", label: "Execution", icon: Zap },
-        {
-          href: "/task-results",
-          label: "Task Results",
-          icon: ClipboardList,
-          match: "prefix",
-        },
-        {
-          href: "/tasks",
-          label: "Tasks",
-          icon: ListTodo,
-          visible: canEdit,
-        },
-        { href: "/cryo", label: "Cryo", icon: Snowflake },
-        { href: "/import", label: "Import", icon: Download },
-      ],
-    },
-    {
-      label: "Collaborate",
-      items: [
-        { href: "/issues", label: "Issues", icon: CircleDot, match: "prefix" },
-        {
-          href: "/forum",
-          label: "Forum",
-          icon: MessagesSquare,
-          match: "prefix",
-        },
-        {
-          href: "/issue-knowledge",
-          label: "Knowledge",
-          icon: Brain,
-          match: "prefix",
-        },
-        {
-          href: "/ai-reviews",
-          label: "AI Reviews",
-          icon: ClipboardCheck,
-          match: "prefix",
-        },
-        {
-          href: "/task-knowledge",
-          label: "Task Knowledge",
-          icon: BookMarked,
-          match: "prefix",
-        },
-      ],
-    },
-    {
-      label: "Manage",
-      items: [
-        {
-          href: "/files",
-          label: "Files",
-          icon: Files,
-          match: "prefix",
-          visible: canEdit,
-        },
-        { href: "/settings", label: "Settings", icon: Settings },
-        {
-          href: "/admin",
-          label: "Admin",
-          icon: ShieldCheck,
-          visible: isAdmin,
-        },
-      ],
-    },
-  ];
+  const navSections: NavSection[] = getNavigationSections({
+    canEdit,
+    isAdmin,
+    unreadNotifications,
+  });
   const externalItems: ExternalNavItem[] = [
     {
       href: "https://oqtopus-team.github.io/qdash/",

--- a/ui/src/components/layout/__tests__/GlobalCommandPalette.test.tsx
+++ b/ui/src/components/layout/__tests__/GlobalCommandPalette.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GlobalCommandPalette } from "@/components/layout/GlobalCommandPalette";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { system_role: "user" } }),
+}));
+
+vi.mock("@/contexts/ProjectContext", () => ({
+  useProject: () => ({ canEdit: false }),
+}));
+
+describe("GlobalCommandPalette", () => {
+  afterEach(() => {
+    cleanup();
+    push.mockReset();
+  });
+
+  it("opens with the platform shortcut and navigates to a selected page", () => {
+    render(<GlobalCommandPalette />);
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: "QDash navigation" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("option", { name: "Dashboard" }));
+
+    expect(push).toHaveBeenCalledWith("/dashboard");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("hides pages unavailable to the current user", () => {
+    render(<GlobalCommandPalette />);
+    fireEvent.click(screen.getByRole("button", { name: "Open navigation search" }));
+
+    expect(screen.queryByRole("option", { name: "Workflow" })).toBeNull();
+    expect(screen.queryByRole("option", { name: "Admin" })).toBeNull();
+    expect(screen.getByRole("option", { name: "Settings" })).toBeTruthy();
+  });
+});

--- a/ui/src/components/layout/navigation.ts
+++ b/ui/src/components/layout/navigation.ts
@@ -1,0 +1,101 @@
+import {
+  BarChart3,
+  BookMarked,
+  Bot,
+  Brain,
+  CircleDot,
+  ClipboardCheck,
+  ClipboardList,
+  Code,
+  Cpu,
+  Download,
+  Files,
+  GitBranch,
+  Inbox,
+  LayoutDashboard,
+  LayoutGrid,
+  ListTodo,
+  MessagesSquare,
+  Settings,
+  ShieldCheck,
+  Snowflake,
+  Zap,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export type NavItem = {
+  href: string;
+  label: string;
+  title?: string;
+  icon: LucideIcon;
+  match?: "exact" | "prefix";
+  badge?: number;
+  visible?: boolean;
+};
+
+export type NavSection = {
+  label: string;
+  items: NavItem[];
+};
+
+interface NavigationOptions {
+  canEdit: boolean;
+  isAdmin: boolean;
+  unreadNotifications?: number;
+}
+
+export function getNavigationSections({
+  canEdit,
+  isAdmin,
+  unreadNotifications = 0,
+}: NavigationOptions): NavSection[] {
+  return [
+    {
+      label: "Overview",
+      items: [
+        { href: "/inbox", label: "Inbox", icon: Inbox, badge: unreadNotifications },
+        { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+        { href: "/metrics", label: "Metrics", icon: LayoutGrid },
+        { href: "/chip", label: "Chip", icon: Cpu },
+        { href: "/analysis", label: "Analysis", icon: BarChart3 },
+        { href: "/chat", label: "AI Chat", icon: Bot },
+        { href: "/provenance", label: "Provenance", icon: GitBranch },
+      ],
+    },
+    {
+      label: "Operate",
+      items: [
+        {
+          href: "/workflow",
+          label: "Workflow",
+          icon: Code,
+          match: "prefix",
+          visible: canEdit,
+        },
+        { href: "/execution", label: "Execution", icon: Zap },
+        { href: "/task-results", label: "Task Results", icon: ClipboardList, match: "prefix" },
+        { href: "/tasks", label: "Tasks", icon: ListTodo, visible: canEdit },
+        { href: "/cryo", label: "Cryo", icon: Snowflake },
+        { href: "/import", label: "Import", icon: Download },
+      ],
+    },
+    {
+      label: "Collaborate",
+      items: [
+        { href: "/issues", label: "Issues", icon: CircleDot, match: "prefix" },
+        { href: "/forum", label: "Forum", icon: MessagesSquare, match: "prefix" },
+        { href: "/issue-knowledge", label: "Knowledge", icon: Brain, match: "prefix" },
+        { href: "/ai-reviews", label: "AI Reviews", icon: ClipboardCheck, match: "prefix" },
+        { href: "/task-knowledge", label: "Task Knowledge", icon: BookMarked, match: "prefix" },
+      ],
+    },
+    {
+      label: "Manage",
+      items: [
+        { href: "/files", label: "Files", icon: Files, match: "prefix", visible: canEdit },
+        { href: "/settings", label: "Settings", icon: Settings },
+        { href: "/admin", label: "Admin", icon: ShieldCheck, visible: isAdmin },
+      ],
+    },
+  ];
+}

--- a/ui/src/components/ui/Command.tsx
+++ b/ui/src/components/ui/Command.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+import type { ComponentPropsWithoutRef, ElementRef } from "react";
+import { forwardRef } from "react";
+import { twMerge } from "tailwind-merge";
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
+
+export const Command = forwardRef<
+  ElementRef<typeof CommandPrimitive>,
+  ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive ref={ref} className={twMerge("text-base-content", className)} {...props} />
+));
+Command.displayName = CommandPrimitive.displayName;
+
+export const CommandInput = forwardRef<
+  ElementRef<typeof CommandPrimitive.Input>,
+  ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center gap-2 border-b border-base-300 px-3 py-2">
+    <Search size={14} className="shrink-0 text-base-content/40" aria-hidden="true" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={twMerge(
+        "flex-1 bg-transparent text-sm text-base-content outline-none placeholder:text-base-content/40",
+        className,
+      )}
+      {...props}
+    />
+  </div>
+));
+CommandInput.displayName = CommandPrimitive.Input.displayName;
+
+export const CommandList = forwardRef<
+  ElementRef<typeof CommandPrimitive.List>,
+  ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={twMerge("max-h-64 overflow-y-auto py-1", className)}
+    {...props}
+  />
+));
+CommandList.displayName = CommandPrimitive.List.displayName;
+
+export const CommandEmpty = forwardRef<
+  ElementRef<typeof CommandPrimitive.Empty>,
+  ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className={twMerge("px-3 py-4 text-center text-sm text-base-content/40", className)}
+    {...props}
+  />
+));
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
+export const CommandItem = forwardRef<
+  ElementRef<typeof CommandPrimitive.Item>,
+  ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={twMerge(
+      "flex cursor-pointer items-center gap-3 px-3 py-2 text-sm text-base-content outline-none transition-colors data-[selected=true]:bg-base-300 data-[disabled=true]:cursor-not-allowed data-[disabled=true]:text-base-content/30",
+      className,
+    )}
+    {...props}
+  />
+));
+CommandItem.displayName = CommandPrimitive.Item.displayName;
+
+export const CommandGroup = forwardRef<
+  ElementRef<typeof CommandPrimitive.Group>,
+  ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={twMerge(
+      "[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-base-content/40",
+      className,
+    )}
+    {...props}
+  />
+));
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
+
+interface CommandDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+export function CommandDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+}: CommandDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="top-[15vh] max-w-lg translate-y-0 overflow-hidden rounded-lg border-base-300 bg-base-200 p-0">
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogDescription className="sr-only">{description}</DialogDescription>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/ui/__tests__/Command.test.tsx
+++ b/ui/src/components/ui/__tests__/Command.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/Command";
+
+describe("Command", () => {
+  afterEach(() => cleanup());
+
+  it("filters and selects commands", () => {
+    const onSelect = vi.fn();
+
+    render(
+      <Command label="Search commands">
+        <CommandInput />
+        <CommandList>
+          <CommandEmpty>No commands found</CommandEmpty>
+          <CommandItem value="Save Flow" onSelect={onSelect}>
+            Save Flow
+          </CommandItem>
+          <CommandItem value="Execute Flow">Execute Flow</CommandItem>
+        </CommandList>
+      </Command>,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Search commands" }), {
+      target: { value: "save" },
+    });
+
+    expect(screen.getByText("Save Flow")).toBeTruthy();
+    expect(screen.queryByText("Execute Flow")).toBeNull();
+
+    fireEvent.click(screen.getByText("Save Flow"));
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+
+  it("renders dialog content in a portal", () => {
+    render(
+      <CommandDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Quick actions"
+        description="Search available actions"
+      >
+        <Command>Commands</Command>
+      </CommandDialog>,
+    );
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByText("Quick actions")).toBeTruthy();
+    expect(screen.getByText("Search available actions")).toBeTruthy();
+  });
+});

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -1,1 +1,10 @@
 import "@testing-library/jest-dom/vitest";
+
+class ResizeObserverMock implements ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+globalThis.ResizeObserver = ResizeObserverMock;
+HTMLElement.prototype.scrollIntoView = () => undefined;


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Add reusable cmdk-based command primitives and replace the Workflow Editor's custom command palette implementation.
- Add a permission-aware global navigation palette opened with Cmd/Ctrl+K; UI-only change with no API or schema impact.

## Changes

- Add shared Command primitives backed by cmdk and Radix Dialog.
- Update WorkflowEditorPageContent to use the shared command palette while retaining Cmd/Ctrl+Shift+P for editor actions.
- Add a Navbar navigation palette for quickly opening QDash pages with Cmd/Ctrl+K.
- Share navigation definitions between Sidebar and the global palette so labels and permissions stay aligned.
- Add interaction and accessibility coverage for command filtering, selection, shortcuts, and permission visibility.
- Verify formatting, lint, TypeScript, 149 Vitest tests, Knip, production build, and dependency audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global command palette accessible from the navigation bar or with ⌘/Ctrl+K.
  * Search and navigate available pages with permission-aware visibility and notification badges.
  * Standardized command palette dialogs and search controls across the application.
  * Improved sidebar navigation organization and consistency.

* **Bug Fixes**
  * Restricted Workflow and Admin navigation options for users without the required access.

* **Tests**
  * Added coverage for command palette search, navigation, shortcuts, permissions, and dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->