### PR TITLE
refactor(ui): standardize form validation

### DIFF
--- a/docs/development/ui/guidelines.md
+++ b/docs/development/ui/guidelines.md
@@ -323,6 +323,14 @@ export function DataTable({ data, columns }: { data: any; columns: any }) {
 
 ## State Management
 
+### Form State and Validation
+
+Use React Hook Form with Zod for forms that have validation, multiple fields, or submission value
+normalization. Keep UI-only state such as password visibility outside the form. Prefer field-level error
+messages connected with `aria-describedby`; reserve alerts and toasts for submission or server errors.
+
+Simple search fields, toggles, and single-value controls do not need a form library.
+
 ### Server State with TanStack Query
 
 Use TanStack Query for all API data fetching:

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -8,6 +8,7 @@
         "@blocknote/core": "^0.52.1",
         "@blocknote/mantine": "^0.52.1",
         "@blocknote/react": "^0.52.1",
+        "@hookform/resolvers": "^5.7.1",
         "@monaco-editor/react": "^4.7.0",
         "@pierre/diffs": "^1.3.5",
         "@pierre/trees": "^1.0.0-beta.6",
@@ -31,6 +32,7 @@
         "plotly.js-dist-min": "^3.7.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "react-hook-form": "^7.85.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.12.2",
         "react-select": "^5.10.2",
@@ -42,6 +44,7 @@
         "tailwind-merge": "^3.6.0",
         "theme-change": "^3.0.4",
         "yaml": "^2.9.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.3",
@@ -200,6 +203,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
 
     "@handlewithcare/prosemirror-inputrules": ["@handlewithcare/prosemirror-inputrules@0.1.4", "", { "dependencies": { "prosemirror-history": "^1.4.1", "prosemirror-transform": "^1.0.0" }, "peerDependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-view": "^1.0.0" } }, "sha512-GMqlBeG2MKM+tXEFd2N+wIv5z4VvJTg8JtfJUrdjvFq2W6v+AW8oTgiWyFw8L3iEQwvtQcVJxU873iB0LXUNNw=="],
+
+    "@hookform/resolvers": ["@hookform/resolvers@5.7.1", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "@sinclair/typebox": ">=0.25.24", "@standard-schema/spec": "^1.0.0", "@typeschema/main": ">=0.13.7", "@vinejs/vine": "^2.0.0 || ^3.0.0 || ^4.0.0", "ajv": "^8.12.0", "ajv-errors": "^3.0.0", "ajv-formats": "^2.1.1", "arktype": "^2.0.0", "ata-validator": "^1.2.0", "class-transformer": ">=0.4.0", "class-validator": ">=0.12.0", "computed-types": "^1.0.0", "effect": "^3.10.3", "fluentvalidation-ts": "^3.0.0", "fp-ts": "^2.7.0", "io-ts": "^2.0.0", "joi": "^17.0.0", "nope-validator": ">=0.12.0", "react-hook-form": "^7.55.0", "superstruct": ">=0.12.0", "typanion": "^3.3.2", "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc", "vest": ">=3.0.0", "yup": "^1.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@sinclair/typebox", "@standard-schema/spec", "@typeschema/main", "@vinejs/vine", "ajv", "ajv-errors", "ajv-formats", "arktype", "ata-validator", "class-transformer", "class-validator", "computed-types", "effect", "fluentvalidation-ts", "fp-ts", "io-ts", "joi", "nope-validator", "superstruct", "typanion", "valibot", "vest", "yup", "zod"] }, "sha512-8wS/P4UDr5sQDe4nFaV51TVyfDPrWgNIXweqG0Bs9Z5LSuzKLb+RQNPvkN2oHM5SRrJyWrVH/F+LOUcFjUyvwQ=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -570,6 +575,8 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -1370,6 +1377,8 @@
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
     "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
+
+    "react-hook-form": ["react-hook-form@7.85.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-U2MTriFXnclmV4rOE20p2DcRFv5WEg3FIcBFOKcOLFHDVvGIMPvLTkTWefUsonmlaVy23khVDxDWym6uJVGOzw=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
     "@blocknote/core": "^0.52.1",
     "@blocknote/mantine": "^0.52.1",
     "@blocknote/react": "^0.52.1",
+    "@hookform/resolvers": "^5.7.1",
     "@monaco-editor/react": "^4.7.0",
     "@pierre/diffs": "^1.3.5",
     "@pierre/trees": "^1.0.0-beta.6",
@@ -44,6 +45,7 @@
     "plotly.js-dist-min": "^3.7.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "react-hook-form": "^7.85.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.12.2",
     "react-select": "^5.10.2",
@@ -54,7 +56,8 @@
     "sonner": "^2.0.8",
     "tailwind-merge": "^3.6.0",
     "theme-change": "^3.0.4",
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.3",

--- a/ui/src/components/features/admin/CreateUserModal.tsx
+++ b/ui/src/components/features/admin/CreateUserModal.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/Dialog";
 
@@ -16,30 +19,43 @@ type CreateUserModalProps = {
   error: Error | unknown | null;
 };
 
+const createUserSchema = z.object({
+  username: z.string().trim().min(1, "Username is required"),
+  displayName: z.string().transform((value) => value.trim() || undefined),
+  organization: z.string().transform((value) => value.trim() || undefined),
+  createDefaultProject: z.boolean(),
+});
+
+type CreateUserFormInput = z.input<typeof createUserSchema>;
+type CreateUserFormData = z.output<typeof createUserSchema>;
+
 export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUserModalProps) {
-  const [username, setUsername] = useState("");
-  const [displayName, setDisplayName] = useState("");
-  const [organization, setOrganization] = useState("");
-  const [createDefaultProject, setCreateDefaultProject] = useState(false);
-  const [localError, setLocalError] = useState<string | null>(null);
   const [temporaryPassword, setTemporaryPassword] = useState<string | null>(null);
+  const [createdUsername, setCreatedUsername] = useState("");
   const [copied, setCopied] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<CreateUserFormInput, unknown, CreateUserFormData>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: {
+      username: "",
+      displayName: "",
+      organization: "",
+      createDefaultProject: false,
+    },
+  });
 
-  const handleSave = async () => {
-    setLocalError(null);
-
-    if (!username.trim()) {
-      setLocalError("Username is required");
-      return;
-    }
-
+  const handleSave = async (data: CreateUserFormData) => {
     try {
       const generatedPassword = await onSave({
-        username: username.trim(),
-        display_name: displayName.trim() || undefined,
-        organization: organization.trim() || undefined,
-        create_default_project: createDefaultProject,
+        username: data.username,
+        display_name: data.displayName,
+        organization: data.organization,
+        create_default_project: data.createDefaultProject,
       });
+      setCreatedUsername(data.username);
       setTemporaryPassword(generatedPassword);
     } catch {
       // Error is handled by the mutation.
@@ -53,8 +69,7 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const displayError =
-    localError || (error ? "Failed to create user. Username may already exist." : null);
+  const displayError = error ? "Failed to create user. Username may already exist." : null;
 
   return (
     <Dialog open onOpenChange={(open) => !open && !isLoading && onClose()}>
@@ -71,8 +86,8 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
           <div className="space-y-4">
             <div className="alert alert-success">
               <span>
-                User <span className="font-mono font-semibold">{username}</span> was created. Share
-                this temporary password securely.
+                User <span className="font-mono font-semibold">{createdUsername}</span> was created.
+                Share this temporary password securely.
               </span>
             </div>
             <div className="form-control">
@@ -101,18 +116,25 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
             </div>
           </div>
         ) : (
-          <div className="space-y-4">
+          <form className="space-y-4" onSubmit={handleSubmit(handleSave)} noValidate>
             <div className="form-control">
               <label className="label">
                 <span className="label-text font-medium">Username *</span>
               </label>
               <input
                 type="text"
-                className="input input-bordered w-full"
-                value={username}
-                onChange={(event) => setUsername(event.target.value)}
+                className={`input input-bordered w-full ${errors.username ? "input-error" : ""}`}
                 placeholder="Enter username"
+                autoComplete="username"
+                aria-invalid={Boolean(errors.username)}
+                aria-describedby={errors.username ? "create-user-username-error" : undefined}
+                {...register("username")}
               />
+              {errors.username && (
+                <p id="create-user-username-error" className="mt-1 text-sm text-error">
+                  {errors.username.message}
+                </p>
+              )}
             </div>
 
             <div className="form-control">
@@ -122,9 +144,9 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
               <input
                 type="text"
                 className="input input-bordered w-full"
-                value={displayName}
-                onChange={(event) => setDisplayName(event.target.value)}
                 placeholder="Enter display name (optional)"
+                autoComplete="name"
+                {...register("displayName")}
               />
               <label className="label">
                 <span className="label-text-alt text-base-content/60">
@@ -140,9 +162,9 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
               <input
                 type="text"
                 className="input input-bordered w-full"
-                value={organization}
-                onChange={(event) => setOrganization(event.target.value)}
                 placeholder="Enter organization or affiliation (optional)"
+                autoComplete="organization"
+                {...register("organization")}
               />
             </div>
             <label className="form-control cursor-pointer rounded-lg border border-base-300 bg-base-100 p-3">
@@ -150,8 +172,7 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
                 <input
                   type="checkbox"
                   className="checkbox checkbox-primary mt-1"
-                  checked={createDefaultProject}
-                  onChange={(event) => setCreateDefaultProject(event.target.checked)}
+                  {...register("createDefaultProject")}
                 />
                 <div>
                   <div className="font-medium">Create default project</div>
@@ -161,24 +182,28 @@ export function CreateUserModal({ onClose, onSave, isLoading, error }: CreateUse
                 </div>
               </div>
             </label>
-          </div>
+            <div className="modal-action">
+              <button type="button" className="btn" onClick={onClose} disabled={isLoading}>
+                Cancel
+              </button>
+              <button type="submit" className="btn btn-primary" disabled={isLoading}>
+                {isLoading ? (
+                  <span className="loading loading-spinner loading-sm" />
+                ) : (
+                  "Create User"
+                )}
+              </button>
+            </div>
+          </form>
         )}
 
-        <div className="modal-action">
-          <button type="button" className="btn" onClick={onClose} disabled={isLoading}>
-            {temporaryPassword ? "Close" : "Cancel"}
-          </button>
-          {!temporaryPassword && (
-            <button
-              type="button"
-              className="btn btn-primary"
-              onClick={handleSave}
-              disabled={isLoading}
-            >
-              {isLoading ? <span className="loading loading-spinner loading-sm" /> : "Create User"}
+        {temporaryPassword && (
+          <div className="modal-action">
+            <button type="button" className="btn" onClick={onClose} disabled={isLoading}>
+              Close
             </button>
-          )}
-        </div>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/ui/src/components/features/admin/__tests__/CreateUserModal.test.tsx
+++ b/ui/src/components/features/admin/__tests__/CreateUserModal.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CreateUserModal } from "@/components/features/admin/CreateUserModal";
+
+describe("CreateUserModal", () => {
+  afterEach(() => cleanup());
+
+  it("shows an inline validation error for an empty username", async () => {
+    const onSave = vi.fn();
+    render(<CreateUserModal onClose={vi.fn()} onSave={onSave} isLoading={false} error={null} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create User" }));
+
+    expect(await screen.findByText("Username is required")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Enter username").getAttribute("aria-invalid")).toBe("true");
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("normalizes values and displays the generated password", async () => {
+    const onSave = vi.fn().mockResolvedValue("temporary-secret");
+    render(<CreateUserModal onClose={vi.fn()} onSave={onSave} isLoading={false} error={null} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Enter username"), {
+      target: { value: "  alice  " },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Enter display name (optional)"), {
+      target: { value: "  Alice Q.  " },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Enter organization or affiliation (optional)"), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByRole("checkbox", { name: /Create default project/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Create User" }));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        username: "alice",
+        display_name: "Alice Q.",
+        organization: undefined,
+        create_default_project: true,
+      }),
+    );
+    expect(await screen.findByDisplayValue("temporary-secret")).toBeTruthy();
+    expect(screen.getByText("alice")).toBeTruthy();
+  });
+});

--- a/ui/src/components/features/chip/modals/CreateChipModal.test.tsx
+++ b/ui/src/components/features/chip/modals/CreateChipModal.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CreateChipModal } from "@/components/features/chip/modals/CreateChipModal";
+
+const mocks = vi.hoisted(() => ({ mutate: vi.fn() }));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/client/chip/chip", () => ({
+  getListChipsQueryKey: () => ["chips"],
+  useCreateChip: () => ({ mutate: mocks.mutate, isPending: false }),
+}));
+
+vi.mock("@/client/topology/topology", () => ({
+  useListTopologies: () => ({
+    isLoading: false,
+    data: {
+      data: {
+        topologies: [{ id: "grid-64", name: "64-qubit grid", num_qubits: 64 }],
+      },
+    },
+  }),
+}));
+
+describe("CreateChipModal", () => {
+  afterEach(() => {
+    cleanup();
+    mocks.mutate.mockReset();
+  });
+
+  it("validates the chip ID inline", async () => {
+    render(<CreateChipModal isOpen onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Create Chip" }));
+
+    expect(await screen.findByText("Chip ID is required")).toBeTruthy();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it("submits the normalized chip and selected topology", async () => {
+    render(<CreateChipModal isOpen onClose={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText("e.g., 64Q, Chip001"), {
+      target: { value: "  chip-01  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Chip" }));
+
+    await waitFor(() =>
+      expect(mocks.mutate).toHaveBeenCalledWith({
+        data: { chip_id: "chip-01", size: 64, topology_id: "grid-64" },
+      }),
+    );
+  });
+});

--- a/ui/src/components/features/chip/modals/CreateChipModal.tsx
+++ b/ui/src/components/features/chip/modals/CreateChipModal.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -20,11 +23,28 @@ interface CreateChipModalProps {
   onSuccess?: (chipId: string) => void;
 }
 
+const createChipSchema = z.object({
+  chipId: z.string().trim().min(1, "Chip ID is required"),
+  topologyId: z.string().min(1, "Please select a topology template"),
+});
+
+type CreateChipFormData = z.infer<typeof createChipSchema>;
+
 export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalProps) {
-  const [chipId, setChipId] = useState("");
-  const [selectedTopologyId, setSelectedTopologyId] = useState<string>("");
-  const [error, setError] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setError,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<CreateChipFormData>({
+    resolver: zodResolver(createChipSchema),
+    defaultValues: { chipId: "", topologyId: "" },
+  });
+  const selectedTopologyId = watch("topologyId");
 
   // Fetch available topologies
   const { data: topologiesData, isLoading: isLoadingTopologies } = useListTopologies(undefined, {
@@ -62,9 +82,9 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
     if (!selectedTopologyId && topologies.length > 0) {
       // Default to first 64-qubit topology or first available
       const default64 = topologies.find((t) => t.num_qubits === 64);
-      setSelectedTopologyId(default64?.id ?? topologies[0].id);
+      setValue("topologyId", default64?.id ?? topologies[0].id, { shouldValidate: true });
     }
-  }, [topologies, selectedTopologyId]);
+  }, [setValue, topologies, selectedTopologyId]);
 
   const queryClient = useQueryClient();
 
@@ -80,81 +100,70 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
         }
 
         // Reset form and close modal
-        setChipId("");
-        setSelectedTopologyId("");
-        setError(null);
+        reset();
+        setServerError(null);
         onClose();
       },
       onError: (err: Error) => {
         const axiosErr = err as Error & {
           response?: { data?: { detail?: string } };
         };
-        setError(axiosErr.response?.data?.detail || "Failed to create chip");
+        setServerError(axiosErr.response?.data?.detail || "Failed to create chip");
       },
     },
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    // Validation
-    if (!chipId.trim()) {
-      setError("Chip ID is required");
-      return;
-    }
-
+  const submit = (data: CreateChipFormData) => {
+    setServerError(null);
     if (!selectedTopology) {
-      setError("Please select a topology template");
+      setError("topologyId", { message: "Please select a topology template" });
       return;
     }
 
     // Create chip
     createChipMutation.mutate({
       data: {
-        chip_id: chipId.trim(),
+        chip_id: data.chipId,
         size: selectedTopology.num_qubits,
-        topology_id: selectedTopologyId,
+        topology_id: data.topologyId,
       },
     });
   };
 
   const handleClose = () => {
     if (!createChipMutation.isPending) {
-      setChipId("");
-      setSelectedTopologyId("");
-      setError(null);
+      reset();
+      setServerError(null);
       onClose();
     }
   };
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          inputRef.current?.focus();
-        }}
-      >
+      <DialogContent>
         <DialogTitle className="mb-4">Create New Chip</DialogTitle>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit(submit)} className="space-y-4" noValidate>
           {/* Chip ID Input */}
           <div className="form-control">
             <label className="label" htmlFor="chip-id-input">
               <span className="label-text">Chip ID</span>
             </label>
             <input
-              ref={inputRef}
               id="chip-id-input"
               type="text"
               placeholder="e.g., 64Q, Chip001"
-              className="input input-bordered w-full"
-              value={chipId}
-              onChange={(e) => setChipId(e.target.value)}
+              className={`input input-bordered w-full ${errors.chipId ? "input-error" : ""}`}
               disabled={createChipMutation.isPending}
-              aria-describedby={error ? "chip-error" : undefined}
+              aria-invalid={Boolean(errors.chipId)}
+              aria-describedby={errors.chipId ? "chip-id-error" : undefined}
+              {...register("chipId")}
             />
+            {errors.chipId && (
+              <p id="chip-id-error" className="mt-1 text-sm text-error">
+                {errors.chipId.message}
+              </p>
+            )}
           </div>
 
           {/* Topology Template Selection */}
@@ -170,10 +179,11 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
             ) : (
               <select
                 id="topology-select"
-                className="select select-bordered w-full"
-                value={selectedTopologyId}
-                onChange={(e) => setSelectedTopologyId(e.target.value)}
+                className={`select select-bordered w-full ${errors.topologyId ? "select-error" : ""}`}
                 disabled={createChipMutation.isPending}
+                aria-invalid={Boolean(errors.topologyId)}
+                aria-describedby={errors.topologyId ? "topology-error" : undefined}
+                {...register("topologyId")}
               >
                 {groupedTopologies.map(([size, topos]) => (
                   <optgroup key={size} label={`${size} Qubits`}>
@@ -186,6 +196,11 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
                 ))}
               </select>
             )}
+            {errors.topologyId && (
+              <p id="topology-error" className="mt-1 text-sm text-error">
+                {errors.topologyId.message}
+              </p>
+            )}
             {selectedTopology && (
               <label className="label">
                 <span className="label-text-alt text-base-content/60">
@@ -196,7 +211,7 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
           </div>
 
           {/* Error Message */}
-          {error && (
+          {serverError && (
             <div id="chip-error" className="alert alert-error" role="alert">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -212,7 +227,7 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
                   d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
                 />
               </svg>
-              <span>{error}</span>
+              <span>{serverError}</span>
             </div>
           )}
 

--- a/ui/src/components/features/settings/PasswordChangeCard/PasswordChangeCard.test.tsx
+++ b/ui/src/components/features/settings/PasswordChangeCard/PasswordChangeCard.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PasswordChangeCard } from "@/components/features/settings/PasswordChangeCard";
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/client/auth/auth", () => ({
+  getGetCurrentUserQueryKey: () => ["current-user"],
+  useChangePassword: () => ({ mutate: mocks.mutate, isPending: false }),
+}));
+
+vi.mock("@/components/ui/Toast", () => ({ useToast: () => mocks.toast }));
+
+describe("PasswordChangeCard", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows field errors instead of submitting invalid passwords", async () => {
+    render(<PasswordChangeCard />);
+    fireEvent.change(screen.getByPlaceholderText("Enter current password"), {
+      target: { value: "current" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Enter new password"), {
+      target: { value: "next-password" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Confirm new password"), {
+      target: { value: "different" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Change Password" }));
+
+    expect(await screen.findByText("New passwords do not match")).toBeTruthy();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  it("submits validated password values", async () => {
+    render(<PasswordChangeCard />);
+    fireEvent.change(screen.getByPlaceholderText("Enter current password"), {
+      target: { value: "current" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Enter new password"), {
+      target: { value: "next-password" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Confirm new password"), {
+      target: { value: "next-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Change Password" }));
+
+    await waitFor(() =>
+      expect(mocks.mutate).toHaveBeenCalledWith({
+        data: { current_password: "current", new_password: "next-password" },
+      }),
+    );
+  });
+});

--- a/ui/src/components/features/settings/PasswordChangeCard/index.tsx
+++ b/ui/src/components/features/settings/PasswordChangeCard/index.tsx
@@ -1,65 +1,105 @@
 "use client";
 
-import { useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
+import { Eye, EyeOff, Info } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
 
 import { getGetCurrentUserQueryKey, useChangePassword } from "@/client/auth/auth";
 import { useToast } from "@/components/ui/Toast";
 
-const EyeIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
-    className="w-5 h-5"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
-    />
-    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-  </svg>
-);
+const passwordChangeSchema = z
+  .object({
+    currentPassword: z.string().min(1, "Current password is required"),
+    newPassword: z.string().min(4, "New password must be at least 4 characters"),
+    confirmPassword: z.string().min(1, "Please confirm your new password"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "New passwords do not match",
+    path: ["confirmPassword"],
+  });
 
-const EyeSlashIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 24 24"
-    strokeWidth={1.5}
-    stroke="currentColor"
-    className="w-5 h-5"
-  >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
-    />
-  </svg>
-);
+type PasswordChangeFormData = z.infer<typeof passwordChangeSchema>;
+type PasswordField = keyof PasswordChangeFormData;
+
+interface PasswordInputProps {
+  field: PasswordField;
+  label: string;
+  placeholder: string;
+  visible: boolean;
+  onToggleVisibility: () => void;
+  register: ReturnType<typeof useForm<PasswordChangeFormData>>["register"];
+  error?: string;
+}
+
+function PasswordInput({
+  field,
+  label,
+  placeholder,
+  visible,
+  onToggleVisibility,
+  register,
+  error,
+}: PasswordInputProps) {
+  const errorId = `${field}-error`;
+
+  return (
+    <div className="form-control w-full">
+      <label className="label" htmlFor={field}>
+        <span className="label-text">{label}</span>
+      </label>
+      <label
+        className={`input input-bordered flex w-full items-center gap-2 ${error ? "input-error" : ""}`}
+      >
+        <input
+          id={field}
+          type={visible ? "text" : "password"}
+          className="grow"
+          placeholder={placeholder}
+          autoComplete={field === "currentPassword" ? "current-password" : "new-password"}
+          aria-invalid={Boolean(error)}
+          aria-describedby={error ? errorId : undefined}
+          {...register(field)}
+        />
+        <button
+          type="button"
+          className="btn btn-ghost btn-xs btn-square"
+          onClick={onToggleVisibility}
+          aria-label={`${visible ? "Hide" : "Show"} ${label.toLowerCase()}`}
+        >
+          {visible ? <EyeOff size={18} aria-hidden="true" /> : <Eye size={18} aria-hidden="true" />}
+        </button>
+      </label>
+      {error && (
+        <p id={errorId} className="mt-1 text-sm text-error">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
 
 export function PasswordChangeCard() {
   const queryClient = useQueryClient();
   const toast = useToast();
-  const [currentPassword, setCurrentPassword] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
-  const [showNewPassword, setShowNewPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [visibleFields, setVisibleFields] = useState<Set<PasswordField>>(new Set());
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<PasswordChangeFormData>({
+    resolver: zodResolver(passwordChangeSchema),
+    defaultValues: { currentPassword: "", newPassword: "", confirmPassword: "" },
+  });
   const changePasswordMutation = useChangePassword({
     mutation: {
       onSuccess: () => {
         toast.success("Password changed successfully!");
-        setCurrentPassword("");
-        setNewPassword("");
-        setConfirmPassword("");
-        queryClient.invalidateQueries({
-          queryKey: getGetCurrentUserQueryKey(),
-        });
+        reset();
+        queryClient.invalidateQueries({ queryKey: getGetCurrentUserQueryKey() });
       },
       onError: (error: unknown) => {
         const errorMessage =
@@ -71,126 +111,72 @@ export function PasswordChangeCard() {
     },
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const toggleVisibility = (field: PasswordField) => {
+    setVisibleFields((current) => {
+      const next = new Set(current);
+      if (next.has(field)) next.delete(field);
+      else next.add(field);
+      return next;
+    });
+  };
 
-    if (newPassword !== confirmPassword) {
-      toast.error("New passwords do not match");
-      return;
-    }
-
-    if (newPassword.length < 4) {
-      toast.error("New password must be at least 4 characters");
-      return;
-    }
-
+  const submit = (data: PasswordChangeFormData) => {
     changePasswordMutation.mutate({
-      data: {
-        current_password: currentPassword,
-        new_password: newPassword,
-      },
+      data: { current_password: data.currentPassword, new_password: data.newPassword },
     });
   };
 
   return (
     <div className="card bg-base-200 shadow-lg">
       <div className="card-body">
-        <h2 className="card-title text-xl mb-4">Change Password</h2>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <label className="form-control w-full">
-            <div className="label">
-              <span className="label-text">Current Password</span>
-            </div>
-            <label className="input input-bordered flex items-center gap-2 w-full">
-              <input
-                type={showCurrentPassword ? "text" : "password"}
-                value={currentPassword}
-                onChange={(e) => setCurrentPassword(e.target.value)}
-                className="grow"
-                placeholder="Enter current password"
-                required
-              />
-              <button
-                type="button"
-                className="btn btn-ghost btn-xs btn-square"
-                onClick={() => setShowCurrentPassword(!showCurrentPassword)}
-              >
-                {showCurrentPassword ? <EyeSlashIcon /> : <EyeIcon />}
-              </button>
-            </label>
-          </label>
-
-          <label className="form-control w-full">
-            <div className="label">
-              <span className="label-text">New Password</span>
-            </div>
-            <label className="input input-bordered flex items-center gap-2 w-full">
-              <input
-                type={showNewPassword ? "text" : "password"}
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-                className="grow"
-                placeholder="Enter new password"
-                required
-                minLength={4}
-              />
-              <button
-                type="button"
-                className="btn btn-ghost btn-xs btn-square"
-                onClick={() => setShowNewPassword(!showNewPassword)}
-              >
-                {showNewPassword ? <EyeSlashIcon /> : <EyeIcon />}
-              </button>
-            </label>
-          </label>
-
-          <label className="form-control w-full">
-            <div className="label">
-              <span className="label-text">Confirm New Password</span>
-            </div>
-            <label className="input input-bordered flex items-center gap-2 w-full">
-              <input
-                type={showConfirmPassword ? "text" : "password"}
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                className="grow"
-                placeholder="Confirm new password"
-                required
-                minLength={4}
-              />
-              <button
-                type="button"
-                className="btn btn-ghost btn-xs btn-square"
-                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-              >
-                {showConfirmPassword ? <EyeSlashIcon /> : <EyeIcon />}
-              </button>
-            </label>
-          </label>
+        <h2 className="card-title mb-4 text-xl">Change Password</h2>
+        <form onSubmit={handleSubmit(submit)} className="flex flex-col gap-4" noValidate>
+          <PasswordInput
+            field="currentPassword"
+            label="Current Password"
+            placeholder="Enter current password"
+            visible={visibleFields.has("currentPassword")}
+            onToggleVisibility={() => toggleVisibility("currentPassword")}
+            register={register}
+            error={errors.currentPassword?.message}
+          />
+          <PasswordInput
+            field="newPassword"
+            label="New Password"
+            placeholder="Enter new password"
+            visible={visibleFields.has("newPassword")}
+            onToggleVisibility={() => toggleVisibility("newPassword")}
+            register={register}
+            error={errors.newPassword?.message}
+          />
+          <PasswordInput
+            field="confirmPassword"
+            label="Confirm New Password"
+            placeholder="Confirm new password"
+            visible={visibleFields.has("confirmPassword")}
+            onToggleVisibility={() => toggleVisibility("confirmPassword")}
+            register={register}
+            error={errors.confirmPassword?.message}
+          />
 
           <div className="alert alert-info mt-2">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              className="stroke-current shrink-0 w-6 h-6"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              ></path>
-            </svg>
+            <Info className="h-6 w-6 shrink-0" aria-hidden="true" />
             <span className="text-sm">Password must be at least 4 characters long.</span>
           </div>
 
           <button
             type="submit"
-            className={`btn btn-primary mt-2 ${changePasswordMutation.isPending ? "loading" : ""}`}
+            className="btn btn-primary mt-2"
             disabled={changePasswordMutation.isPending}
           >
-            {changePasswordMutation.isPending ? "Changing..." : "Change Password"}
+            {changePasswordMutation.isPending ? (
+              <>
+                <span className="loading loading-spinner loading-sm" aria-hidden="true" />
+                Changing...
+              </>
+            ) : (
+              "Change Password"
+            )}
           </button>
         </form>
       </div>


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Introduce React Hook Form and Zod as the standard validation approach for non-trivial UI forms.
- Migrate three representative forms with field-level accessible errors; UI-only change with no API or schema impact.

## Changes

- Migrate Admin CreateUserModal to schema-driven validation and normalized submission values.
- Migrate Chip CreateChipModal while preserving topology defaults and separating field errors from API errors.
- Migrate Settings PasswordChangeCard with matching-password validation, autocomplete metadata, and Lucide visibility controls.
- Add focused interaction tests for invalid and successful submissions across all three forms.
- Document when to use React Hook Form and Zod in the UI guidelines.
- Verify formatting, lint, TypeScript, 155 Vitest tests, Knip, production build, and dependency audit.