### PR TITLE
feat(ui): compact dashboard controls

### DIFF
--- a/ui/src/components/features/dashboard/DashboardChipNoteCard.tsx
+++ b/ui/src/components/features/dashboard/DashboardChipNoteCard.tsx
@@ -36,7 +36,7 @@ export function DashboardChipNoteCard({ chipId, noteScopeParams }: DashboardChip
 
   useEffect(() => {
     setDraft(note?.content ?? "");
-    setMode(note?.content?.trim() ? "view" : "edit");
+    setMode("view");
   }, [
     note?.content,
     chipId,
@@ -69,7 +69,7 @@ export function DashboardChipNoteCard({ chipId, noteScopeParams }: DashboardChip
 
   const handleCancel = () => {
     setDraft(note?.content ?? "");
-    setMode(note?.content?.trim() ? "view" : "edit");
+    setMode("view");
   };
 
   return (
@@ -84,7 +84,7 @@ export function DashboardChipNoteCard({ chipId, noteScopeParams }: DashboardChip
             Chip-level context for the selected cooldown.
           </div>
         </div>
-        {mode === "view" && (
+        {mode === "view" && hasNote && (
           <button
             className="btn btn-sm btn-outline gap-1"
             onClick={() => setMode("edit")}
@@ -97,7 +97,7 @@ export function DashboardChipNoteCard({ chipId, noteScopeParams }: DashboardChip
         )}
       </div>
 
-      <div className="p-4 space-y-3">
+      <div className={`${mode === "view" && !hasNote ? "p-3" : "p-4"} space-y-3`}>
         {isLoading ? (
           <div className="text-sm text-base-content/60">Loading...</div>
         ) : mode === "view" && hasNote ? (
@@ -110,6 +110,20 @@ export function DashboardChipNoteCard({ chipId, noteScopeParams }: DashboardChip
               {note?.updated_at && <span>· {formatDateTime(note.updated_at)}</span>}
             </div>
           </>
+        ) : mode === "view" ? (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-base-content/60">
+              Add cooldown context, handoff details, or observations for your team.
+            </p>
+            <button
+              className="btn btn-sm btn-outline shrink-0 gap-1.5"
+              onClick={() => setMode("edit")}
+              type="button"
+            >
+              <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+              Add note
+            </button>
+          </div>
         ) : (
           <>
             <MarkdownEditor
@@ -130,12 +144,10 @@ export function DashboardChipNoteCard({ chipId, noteScopeParams }: DashboardChip
               )}
             </div>
             <div className="flex justify-end gap-2">
-              {hasNote && (
-                <button className="btn btn-sm btn-ghost gap-1" onClick={handleCancel} type="button">
-                  <X className="h-3.5 w-3.5" />
-                  Cancel
-                </button>
-              )}
+              <button className="btn btn-sm btn-ghost gap-1" onClick={handleCancel} type="button">
+                <X className="h-3.5 w-3.5" />
+                Cancel
+              </button>
               <button
                 className="btn btn-sm btn-primary gap-1"
                 onClick={handleSave}

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import { ArrowRightLeft } from "lucide-react";
+import { ArrowRightLeft, ChevronDown } from "lucide-react";
 
 import { useListChips, useGetChip } from "@/client/chip/chip";
 import { useListCooldowns } from "@/client/cooldown/cooldown";
@@ -427,6 +427,7 @@ export function DashboardPageContent() {
   } | null>(null);
   const [editingTargetNote, setEditingTargetNote] = useState<string | null>(null);
   const [couplingDirection, setCouplingDirection] = useState<"forward" | "reverse">("forward");
+  const [showTargetSummaries, setShowTargetSummaries] = useState(false);
   const isReverseCouplingDirection = couplingDirection === "reverse";
 
   const editingLegacyMetricNote =
@@ -606,78 +607,109 @@ export function DashboardPageContent() {
             <DashboardChipNoteCard chipId={selectedChip} noteScopeParams={noteScopeParams} />
 
             {/* Pinned summary topology */}
-            <Card
-              variant="default"
-              padding="md"
-              title="Target Summaries"
-              description="Use these empty topologies for pinned target summaries. Create forum topics for individual issues, images, and discussion."
-            >
-              <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 items-stretch">
-                <div className="flex flex-col gap-2">
-                  <div className={SUMMARY_TOPOLOGY_HEADER_CLASS}>
-                    <h4 className="text-sm font-semibold">Qubit summaries</h4>
-                  </div>
-                  <div className={SUMMARY_TOPOLOGY_VIEWPORT_CLASS}>
-                    <DashboardQubitGrid
-                      metricData={null}
-                      unit=""
-                      topologyId={topologyId}
-                      colors={colors}
-                      maxCellSize={48}
-                      presentation="summary"
-                      targetNotedQids={targetNotedQids}
-                      forumLinkedQids={forumLinkedQids}
-                      forumLinksByTarget={forumLinksByTarget}
-                      notesByTarget={notesByTarget}
-                      targetNotesByTarget={targetNotesByTarget}
-                      metricKey=""
-                      onQubitClick={setEditingTargetNote}
-                    />
-                  </div>
+            <Card variant="default" padding="md">
+              <button
+                type="button"
+                className="flex w-full items-center gap-3 rounded-lg text-left focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
+                aria-expanded={showTargetSummaries}
+                aria-controls="dashboard-target-summaries"
+                onClick={() => setShowTargetSummaries((visible) => !visible)}
+              >
+                <div className="min-w-0 flex-1">
+                  <h3 className="text-lg font-semibold">Target Summaries</h3>
+                  <p className="mt-0.5 text-sm text-base-content/60">
+                    Pin shared context to individual qubits and couplings.
+                  </p>
                 </div>
-                <div className="flex flex-col gap-2">
-                  <div className={SUMMARY_TOPOLOGY_HEADER_CLASS}>
-                    <div className="flex items-center gap-2">
-                      <h4 className="text-sm font-semibold">Coupling summaries</h4>
+                <div className="hidden flex-wrap justify-end gap-2 sm:flex">
+                  <span className="badge badge-ghost badge-sm">
+                    {targetNotedQids.size} qubit {targetNotedQids.size === 1 ? "note" : "notes"}
+                  </span>
+                  <span className="badge badge-ghost badge-sm">
+                    {targetNotedCouplings.size} coupling{" "}
+                    {targetNotedCouplings.size === 1 ? "note" : "notes"}
+                  </span>
+                </div>
+                <span className="text-xs font-medium text-primary">
+                  {showTargetSummaries ? "Hide" : "Show"}
+                </span>
+                <ChevronDown
+                  className={`h-4 w-4 shrink-0 transition-transform ${showTargetSummaries ? "rotate-180" : ""}`}
+                  aria-hidden="true"
+                />
+              </button>
+
+              {showTargetSummaries && (
+                <div
+                  id="dashboard-target-summaries"
+                  className="mt-5 grid grid-cols-1 items-stretch gap-6 border-t border-base-300 pt-5 xl:grid-cols-2"
+                >
+                  <div className="flex flex-col gap-2">
+                    <div className={SUMMARY_TOPOLOGY_HEADER_CLASS}>
+                      <h4 className="text-sm font-semibold">Qubit summaries</h4>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setCouplingDirection(isReverseCouplingDirection ? "forward" : "reverse")
-                      }
-                      className={`btn btn-sm gap-1.5 ${isReverseCouplingDirection ? "btn-secondary" : "btn-outline"}`}
-                      title={
-                        isReverseCouplingDirection
-                          ? "Showing reverse direction"
-                          : "Showing forward direction"
-                      }
-                    >
-                      <ArrowRightLeft className="h-3.5 w-3.5" />
-                      <span className="text-xs">
-                        {isReverseCouplingDirection ? "Reverse" : "Forward"}
-                      </span>
-                    </button>
+                    <div className={SUMMARY_TOPOLOGY_VIEWPORT_CLASS}>
+                      <DashboardQubitGrid
+                        metricData={null}
+                        unit=""
+                        topologyId={topologyId}
+                        colors={colors}
+                        maxCellSize={48}
+                        presentation="summary"
+                        targetNotedQids={targetNotedQids}
+                        forumLinkedQids={forumLinkedQids}
+                        forumLinksByTarget={forumLinksByTarget}
+                        notesByTarget={notesByTarget}
+                        targetNotesByTarget={targetNotesByTarget}
+                        metricKey=""
+                        onQubitClick={setEditingTargetNote}
+                      />
+                    </div>
                   </div>
-                  <div className={SUMMARY_TOPOLOGY_VIEWPORT_CLASS}>
-                    <DashboardCouplingGrid
-                      metricData={noteCouplingTopologyData}
-                      unit=""
-                      topologyId={topologyId}
-                      colors={colors}
-                      maxCellSize={48}
-                      presentation="summary"
-                      reverseDirection={isReverseCouplingDirection}
-                      targetNotedTargets={targetNotedCouplings}
-                      forumLinkedTargets={forumLinkedCouplings}
-                      forumLinksByTarget={forumLinksByTarget}
-                      notesByTarget={notesByTarget}
-                      targetNotesByTarget={targetNotesByTarget}
-                      metricKey=""
-                      onCouplingClick={setEditingTargetNote}
-                    />
+                  <div className="flex flex-col gap-2">
+                    <div className={SUMMARY_TOPOLOGY_HEADER_CLASS}>
+                      <div className="flex items-center gap-2">
+                        <h4 className="text-sm font-semibold">Coupling summaries</h4>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setCouplingDirection(isReverseCouplingDirection ? "forward" : "reverse")
+                        }
+                        className={`btn btn-sm gap-1.5 ${isReverseCouplingDirection ? "btn-secondary" : "btn-outline"}`}
+                        title={
+                          isReverseCouplingDirection
+                            ? "Showing reverse direction"
+                            : "Showing forward direction"
+                        }
+                      >
+                        <ArrowRightLeft className="h-3.5 w-3.5" />
+                        <span className="text-xs">
+                          {isReverseCouplingDirection ? "Reverse" : "Forward"}
+                        </span>
+                      </button>
+                    </div>
+                    <div className={SUMMARY_TOPOLOGY_VIEWPORT_CLASS}>
+                      <DashboardCouplingGrid
+                        metricData={noteCouplingTopologyData}
+                        unit=""
+                        topologyId={topologyId}
+                        colors={colors}
+                        maxCellSize={48}
+                        presentation="summary"
+                        reverseDirection={isReverseCouplingDirection}
+                        targetNotedTargets={targetNotedCouplings}
+                        forumLinkedTargets={forumLinkedCouplings}
+                        forumLinksByTarget={forumLinksByTarget}
+                        notesByTarget={notesByTarget}
+                        targetNotesByTarget={targetNotesByTarget}
+                        metricKey=""
+                        onCouplingClick={setEditingTargetNote}
+                      />
+                    </div>
                   </div>
                 </div>
-              </div>
+              )}
             </Card>
 
             {/* Summary table — collapsed by default */}

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
 import { ArrowRightLeft, ChevronDown } from "lucide-react";
 
@@ -115,6 +115,30 @@ function scaleData(
     };
   });
   return out;
+}
+
+function EmptyMetricDisclosure({ children }: { children: ReactNode }) {
+  return (
+    <details className="group rounded-lg border border-dashed border-base-300 bg-base-200/40">
+      <summary className="flex cursor-pointer list-none items-center gap-3 px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium">No values in the selected range</p>
+          <p className="text-xs text-base-content/50">
+            Try a wider time range, or open the topology to inspect individual targets.
+          </p>
+        </div>
+        <span className="text-xs font-medium text-primary group-open:hidden">Show topology</span>
+        <span className="hidden text-xs font-medium text-primary group-open:inline">
+          Hide topology
+        </span>
+        <ChevronDown
+          className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
+          aria-hidden="true"
+        />
+      </summary>
+      <div className="border-t border-base-300 p-4">{children}</div>
+    </details>
+  );
 }
 
 export function DashboardPageContent() {
@@ -771,8 +795,8 @@ export function DashboardPageContent() {
                             />
                           </div>
                         </div>
-                        <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 items-start">
-                          <div className="xl:col-span-2 min-w-0">
+                        {cov.current === 0 ? (
+                          <EmptyMetricDisclosure>
                             <DashboardQubitGrid
                               metricData={qubitMetricData[m.key]}
                               unit={m.unit}
@@ -795,16 +819,43 @@ export function DashboardPageContent() {
                                 });
                               }}
                             />
+                          </EmptyMetricDisclosure>
+                        ) : (
+                          <div className="grid grid-cols-1 items-start gap-4 xl:grid-cols-3">
+                            <div className="min-w-0 xl:col-span-2">
+                              <DashboardQubitGrid
+                                metricData={qubitMetricData[m.key]}
+                                unit={m.unit}
+                                topologyId={topologyId}
+                                colors={colors}
+                                notedQids={noted}
+                                targetNotedQids={targetNotedQids}
+                                forumLinkedQids={forumLinkedQids}
+                                forumLinksByTarget={forumLinksByTarget}
+                                crossMetricNotedQids={crossMetricNoted}
+                                notesByTarget={notesByTarget}
+                                targetNotesByTarget={targetNotesByTarget}
+                                metricKey={m.key}
+                                onQubitClick={(qid) => {
+                                  setEditingNote({
+                                    targetId: qid,
+                                    metricKey: m.key,
+                                    metricTitle: m.title,
+                                    metricUnit: m.unit,
+                                  });
+                                }}
+                              />
+                            </div>
+                            <div className="min-w-0 xl:col-span-1">
+                              <DashboardCdfChart
+                                metricData={qubitMetricData[m.key]}
+                                title={m.title}
+                                unit={m.unit}
+                                height={260}
+                              />
+                            </div>
                           </div>
-                          <div className="xl:col-span-1 min-w-0">
-                            <DashboardCdfChart
-                              metricData={qubitMetricData[m.key]}
-                              title={m.title}
-                              unit={m.unit}
-                              height={260}
-                            />
-                          </div>
-                        </div>
+                        )}
                       </div>
                     );
                   })}
@@ -875,8 +926,8 @@ export function DashboardPageContent() {
                             />
                           </div>
                         </div>
-                        <div className="grid grid-cols-1 xl:grid-cols-3 gap-4 items-start">
-                          <div className="xl:col-span-2 min-w-0">
+                        {cov.current === 0 ? (
+                          <EmptyMetricDisclosure>
                             <DashboardCouplingGrid
                               metricData={couplingMetricData[m.key]}
                               unit={m.unit}
@@ -900,16 +951,44 @@ export function DashboardPageContent() {
                                 });
                               }}
                             />
+                          </EmptyMetricDisclosure>
+                        ) : (
+                          <div className="grid grid-cols-1 items-start gap-4 xl:grid-cols-3">
+                            <div className="min-w-0 xl:col-span-2">
+                              <DashboardCouplingGrid
+                                metricData={couplingMetricData[m.key]}
+                                unit={m.unit}
+                                topologyId={topologyId}
+                                colors={colors}
+                                reverseDirection={isReverseCouplingDirection}
+                                notedTargets={noted}
+                                targetNotedTargets={targetNotedCouplings}
+                                forumLinkedTargets={forumLinkedCouplings}
+                                forumLinksByTarget={forumLinksByTarget}
+                                crossMetricNotedTargets={crossMetricNoted}
+                                notesByTarget={notesByTarget}
+                                targetNotesByTarget={targetNotesByTarget}
+                                metricKey={m.key}
+                                onCouplingClick={(couplingId) => {
+                                  setEditingNote({
+                                    targetId: couplingId,
+                                    metricKey: m.key,
+                                    metricTitle: m.title,
+                                    metricUnit: m.unit,
+                                  });
+                                }}
+                              />
+                            </div>
+                            <div className="min-w-0 xl:col-span-1">
+                              <DashboardCdfChart
+                                metricData={couplingMetricData[m.key]}
+                                title={m.title}
+                                unit={m.unit}
+                                height={260}
+                              />
+                            </div>
                           </div>
-                          <div className="xl:col-span-1 min-w-0">
-                            <DashboardCdfChart
-                              metricData={couplingMetricData[m.key]}
-                              title={m.title}
-                              unit={m.unit}
-                              height={260}
-                            />
-                          </div>
-                        </div>
+                        )}
                       </div>
                     );
                   })}

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -491,6 +491,17 @@ export function DashboardPageContent() {
     return [...qubitRows, ...couplingRows];
   }, [qubitMetrics, couplingMetrics, qubitMetricData, couplingMetricData, qubitCount]);
 
+  const metricsWithData = useMemo(
+    () =>
+      summaryRows.filter((row) =>
+        Object.values(row.data ?? {}).some(
+          (metric) => metric.value !== null && metric.value !== undefined,
+        ),
+      ).length,
+    [summaryRows],
+  );
+  const emptyMetricCount = summaryRows.length - metricsWithData;
+
   if (isConfigLoading || isChipsLoading) {
     return <MetricsPageSkeleton />;
   }
@@ -738,15 +749,30 @@ export function DashboardPageContent() {
 
             {/* Summary table — collapsed by default */}
             <Card variant="default" padding="md">
-              <details>
-                <summary className="cursor-pointer list-none flex items-center justify-between">
-                  <div>
+              <details className="group">
+                <summary className="flex cursor-pointer list-none items-center gap-3">
+                  <div className="min-w-0 flex-1">
                     <h3 className="text-lg font-semibold">All Metrics Summary</h3>
                     <p className="text-sm text-base-content/60">
                       Coverage, median, min and max for every metric in the active time range.
                     </p>
                   </div>
-                  <span className="text-xs text-base-content/50">click to expand</span>
+                  <div className="hidden flex-wrap justify-end gap-2 sm:flex">
+                    <span className="badge badge-success badge-sm">
+                      {metricsWithData} with data
+                    </span>
+                    {emptyMetricCount > 0 && (
+                      <span className="badge badge-ghost badge-sm">{emptyMetricCount} empty</span>
+                    )}
+                  </div>
+                  <span className="text-xs font-medium text-primary group-open:hidden">Show</span>
+                  <span className="hidden text-xs font-medium text-primary group-open:inline">
+                    Hide
+                  </span>
+                  <ChevronDown
+                    className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180"
+                    aria-hidden="true"
+                  />
                 </summary>
                 <div className="mt-4">
                   <DashboardSummaryTable rows={summaryRows} />

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -482,71 +482,98 @@ export function DashboardPageContent() {
         </div>
 
         {/* Filters */}
-        <PageFiltersBar>
-          <PageFiltersBar.Group>
-            <PageFiltersBar.Item>
-              <ChipSelector
-                selectedChip={selectedChip}
-                onChipSelect={(chipId) => {
+        <section
+          aria-labelledby="dashboard-data-scope"
+          className="rounded-xl border border-base-300 bg-base-200/45 p-3 sm:p-4"
+        >
+          <h2
+            id="dashboard-data-scope"
+            className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-base-content/55"
+          >
+            Data scope
+          </h2>
+          <div className="flex flex-col gap-4">
+            <PageFiltersBar className="gap-3">
+              <PageFiltersBar.Group className="gap-3">
+                <PageFiltersBar.Item label="Chip">
+                  <ChipSelector
+                    selectedChip={selectedChip}
+                    onChipSelect={(chipId) => {
+                      setSelectedCooldownId(null);
+                      setHasInitializedCooldownSelection(false);
+                      setSelectedChip(chipId);
+                    }}
+                  />
+                </PageFiltersBar.Item>
+                <PageFiltersBar.Item
+                  label="Cooldown"
+                  className="[&:not(:has(.cooldown-selector-control))]:hidden"
+                >
+                  <CooldownSelector
+                    chipId={selectedChip}
+                    selectedCooldownId={selectedCooldownId}
+                    onPick={(cd) => {
+                      setSelectedCooldownId(cd.cooldown_id);
+                      setHasInitializedCooldownSelection(true);
+                      setStartDate(dateToDateTimeLocal(new Date(cd.started_at)));
+                      setEndDate(
+                        dateToDateTimeLocal(cd.ended_at ? new Date(cd.ended_at) : new Date()),
+                      );
+                    }}
+                  />
+                </PageFiltersBar.Item>
+              </PageFiltersBar.Group>
+
+              <PageFiltersBar.Group position="end" className="items-start sm:items-end">
+                <PageFiltersBar.Item label="Value selection">
+                  <div className="space-y-1">
+                    <span className="hidden text-xs font-medium text-base-content/55 sm:block">
+                      Value selection
+                    </span>
+                    <div className="join overflow-hidden rounded-lg">
+                      {(["latest", "best", "average"] as const).map((mode) => (
+                        <button
+                          key={mode}
+                          type="button"
+                          aria-pressed={selectionMode === mode}
+                          className={`join-item btn btn-sm ${
+                            selectionMode === mode ? "btn-primary" : ""
+                          }`}
+                          onClick={() => setSelectionMode(mode)}
+                        >
+                          {mode[0].toUpperCase() + mode.slice(1)}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </PageFiltersBar.Item>
+              </PageFiltersBar.Group>
+            </PageFiltersBar>
+
+            <div className="border-t border-base-300 pt-3">
+              <TimeRangeSelector
+                collapsible
+                startDate={startDate}
+                endDate={endDate}
+                onStartDateChange={(value) => {
                   setSelectedCooldownId(null);
-                  setHasInitializedCooldownSelection(false);
-                  setSelectedChip(chipId);
-                }}
-              />
-            </PageFiltersBar.Item>
-            <PageFiltersBar.Item>
-              <CooldownSelector
-                chipId={selectedChip}
-                selectedCooldownId={selectedCooldownId}
-                onPick={(cd) => {
-                  setSelectedCooldownId(cd.cooldown_id);
                   setHasInitializedCooldownSelection(true);
-                  setStartDate(dateToDateTimeLocal(new Date(cd.started_at)));
-                  setEndDate(dateToDateTimeLocal(cd.ended_at ? new Date(cd.ended_at) : new Date()));
+                  setStartDate(value);
+                }}
+                onEndDateChange={(value) => {
+                  setSelectedCooldownId(null);
+                  setHasInitializedCooldownSelection(true);
+                  setEndDate(value);
+                }}
+                onQuickRange={(range) => {
+                  setSelectedCooldownId(null);
+                  setHasInitializedCooldownSelection(true);
+                  setQuickRange(range);
                 }}
               />
-            </PageFiltersBar.Item>
-          </PageFiltersBar.Group>
-
-          <PageFiltersBar.Group>
-            <PageFiltersBar.Item>
-              <div className="join rounded-lg overflow-hidden">
-                {(["latest", "best", "average"] as const).map((mode) => (
-                  <button
-                    key={mode}
-                    className={`join-item btn btn-sm ${
-                      selectionMode === mode ? "btn-primary" : ""
-                    }`}
-                    onClick={() => setSelectionMode(mode)}
-                  >
-                    {mode[0].toUpperCase() + mode.slice(1)}
-                  </button>
-                ))}
-              </div>
-            </PageFiltersBar.Item>
-          </PageFiltersBar.Group>
-        </PageFiltersBar>
-
-        <TimeRangeSelector
-          collapsible
-          startDate={startDate}
-          endDate={endDate}
-          onStartDateChange={(value) => {
-            setSelectedCooldownId(null);
-            setHasInitializedCooldownSelection(true);
-            setStartDate(value);
-          }}
-          onEndDateChange={(value) => {
-            setSelectedCooldownId(null);
-            setHasInitializedCooldownSelection(true);
-            setEndDate(value);
-          }}
-          onQuickRange={(range) => {
-            setSelectedCooldownId(null);
-            setHasInitializedCooldownSelection(true);
-            setQuickRange(range);
-          }}
-        />
+            </div>
+          </div>
+        </section>
 
         {/* Body */}
         {!selectedChip ? (

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import { ArrowRightLeft, ChevronDown } from "lucide-react";
+import { ArrowRightLeft, ChevronDown, LocateFixed } from "lucide-react";
 
 import { useListChips, useGetChip } from "@/client/chip/chip";
 import { useListCooldowns } from "@/client/cooldown/cooldown";
@@ -430,6 +430,11 @@ export function DashboardPageContent() {
   const [showTargetSummaries, setShowTargetSummaries] = useState(false);
   const isReverseCouplingDirection = couplingDirection === "reverse";
 
+  const jumpToMetric = (metricId: string) => {
+    if (!metricId) return;
+    document.getElementById(metricId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
   const editingLegacyMetricNote =
     editingNote && notesByMetric[editingNote.metricKey]?.[editingNote.targetId]
       ? notesByMetric[editingNote.metricKey][editingNote.targetId]
@@ -730,6 +735,54 @@ export function DashboardPageContent() {
               </details>
             </Card>
 
+            {(qubitMetrics.length > 0 || couplingMetrics.length > 0) && (
+              <nav
+                aria-label="Metric navigation"
+                className="sticky top-16 z-10 flex flex-wrap items-center gap-3 rounded-xl border border-base-300 bg-base-100/95 px-4 py-3 shadow-sm backdrop-blur"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <LocateFixed className="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+                  <span className="text-sm font-semibold">Jump to metric</span>
+                </div>
+                <select
+                  className="select select-bordered select-sm min-w-48 flex-1 sm:max-w-xs"
+                  aria-label="Jump to metric"
+                  defaultValue=""
+                  onChange={(event) => {
+                    jumpToMetric(event.currentTarget.value);
+                    event.currentTarget.value = "";
+                  }}
+                >
+                  <option value="" disabled>
+                    Select a metric…
+                  </option>
+                  {qubitMetrics.length > 0 && (
+                    <optgroup label={`Qubit metrics (${qubitMetrics.length})`}>
+                      {qubitMetrics.map((metric) => (
+                        <option key={metric.key} value={`dashboard-qubit-metric-${metric.key}`}>
+                          {metric.title}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
+                  {couplingMetrics.length > 0 && (
+                    <optgroup label={`Coupling metrics (${couplingMetrics.length})`}>
+                      {couplingMetrics.map((metric) => (
+                        <option key={metric.key} value={`dashboard-coupling-metric-${metric.key}`}>
+                          {metric.title}
+                        </option>
+                      ))}
+                    </optgroup>
+                  )}
+                </select>
+                <div className="ml-auto hidden items-center gap-2 text-xs text-base-content/60 md:flex">
+                  <span>{qubitMetrics.length} qubit</span>
+                  <span aria-hidden="true">·</span>
+                  <span>{couplingMetrics.length} coupling</span>
+                </div>
+              </nav>
+            )}
+
             {/* Qubit metrics grids */}
             {qubitMetrics.length > 0 && (
               <Card
@@ -748,7 +801,11 @@ export function DashboardPageContent() {
                     });
                     const cov = coverageOf(qubitMetricData[m.key], qubitCount);
                     return (
-                      <div key={m.key} className="space-y-2">
+                      <div
+                        key={m.key}
+                        id={`dashboard-qubit-metric-${m.key}`}
+                        className="scroll-mt-32 space-y-2"
+                      >
                         <div className="flex flex-wrap items-center gap-2">
                           <h4 className="text-base font-semibold">{m.title}</h4>
                           <span className="badge badge-outline badge-sm">{m.unit}</span>
@@ -848,7 +905,11 @@ export function DashboardPageContent() {
                       : 0;
                     const cov = coverageOf(couplingMetricData[m.key], couplingTotal);
                     return (
-                      <div key={m.key} className="space-y-2">
+                      <div
+                        key={m.key}
+                        id={`dashboard-coupling-metric-${m.key}`}
+                        className="scroll-mt-32 space-y-2"
+                      >
                         <div className="flex flex-wrap items-center gap-2">
                           <h4 className="text-base font-semibold">{m.title}</h4>
                           <span className="badge badge-outline badge-sm">{m.unit}</span>

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -528,6 +528,7 @@ export function DashboardPageContent() {
         </PageFiltersBar>
 
         <TimeRangeSelector
+          collapsible
           startDate={startDate}
           endDate={endDate}
           onStartDateChange={(value) => {

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import { ArrowRightLeft, ChevronDown, LocateFixed } from "lucide-react";
+import { ArrowRightLeft, ChevronDown } from "lucide-react";
 
 import { useListChips, useGetChip } from "@/client/chip/chip";
 import { useListCooldowns } from "@/client/cooldown/cooldown";
@@ -430,11 +430,6 @@ export function DashboardPageContent() {
   const [showTargetSummaries, setShowTargetSummaries] = useState(false);
   const isReverseCouplingDirection = couplingDirection === "reverse";
 
-  const jumpToMetric = (metricId: string) => {
-    if (!metricId) return;
-    document.getElementById(metricId)?.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
-
   const editingLegacyMetricNote =
     editingNote && notesByMetric[editingNote.metricKey]?.[editingNote.targetId]
       ? notesByMetric[editingNote.metricKey][editingNote.targetId]
@@ -734,54 +729,6 @@ export function DashboardPageContent() {
                 </div>
               </details>
             </Card>
-
-            {(qubitMetrics.length > 0 || couplingMetrics.length > 0) && (
-              <nav
-                aria-label="Metric navigation"
-                className="sticky top-16 z-10 flex flex-wrap items-center gap-3 rounded-xl border border-base-300 bg-base-100/95 px-4 py-3 shadow-sm backdrop-blur"
-              >
-                <div className="flex min-w-0 items-center gap-2">
-                  <LocateFixed className="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
-                  <span className="text-sm font-semibold">Jump to metric</span>
-                </div>
-                <select
-                  className="select select-bordered select-sm min-w-48 flex-1 sm:max-w-xs"
-                  aria-label="Jump to metric"
-                  defaultValue=""
-                  onChange={(event) => {
-                    jumpToMetric(event.currentTarget.value);
-                    event.currentTarget.value = "";
-                  }}
-                >
-                  <option value="" disabled>
-                    Select a metric…
-                  </option>
-                  {qubitMetrics.length > 0 && (
-                    <optgroup label={`Qubit metrics (${qubitMetrics.length})`}>
-                      {qubitMetrics.map((metric) => (
-                        <option key={metric.key} value={`dashboard-qubit-metric-${metric.key}`}>
-                          {metric.title}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                  {couplingMetrics.length > 0 && (
-                    <optgroup label={`Coupling metrics (${couplingMetrics.length})`}>
-                      {couplingMetrics.map((metric) => (
-                        <option key={metric.key} value={`dashboard-coupling-metric-${metric.key}`}>
-                          {metric.title}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                </select>
-                <div className="ml-auto hidden items-center gap-2 text-xs text-base-content/60 md:flex">
-                  <span>{qubitMetrics.length} qubit</span>
-                  <span aria-hidden="true">·</span>
-                  <span>{couplingMetrics.length} coupling</span>
-                </div>
-              </nav>
-            )}
 
             {/* Qubit metrics grids */}
             {qubitMetrics.length > 0 && (

--- a/ui/src/components/features/dashboard/__tests__/DashboardChipNoteCard.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardChipNoteCard.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DashboardChipNoteCard } from "@/components/features/dashboard/DashboardChipNoteCard";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/client/chip/chip", () => ({
+  getGetChipNoteQueryKey: vi.fn(),
+  getGetChipQueryKey: vi.fn(),
+  getListChipsQueryKey: vi.fn(),
+  useDeleteChipNote: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useGetChipNote: () => ({ data: { data: null }, isLoading: false }),
+  useUpsertChipNote: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+vi.mock("@/components/ui/MarkdownEditor", () => ({
+  MarkdownEditor: () => <div data-testid="markdown-editor" />,
+}));
+
+describe("DashboardChipNoteCard", () => {
+  it("keeps an empty note compact until the user chooses to edit", () => {
+    render(<DashboardChipNoteCard chipId="chip-1" />);
+
+    expect(screen.queryByTestId("markdown-editor")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add note" }));
+
+    expect(screen.getByTestId("markdown-editor")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByTestId("markdown-editor")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/features/dashboard/__tests__/DashboardChipNoteCard.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardChipNoteCard.test.tsx
@@ -24,15 +24,15 @@ describe("DashboardChipNoteCard", () => {
   it("keeps an empty note compact until the user chooses to edit", () => {
     render(<DashboardChipNoteCard chipId="chip-1" />);
 
-    expect(screen.queryByTestId("markdown-editor")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Add note" })).toBeInTheDocument();
+    expect(screen.queryByTestId("markdown-editor")).toBeNull();
+    expect(screen.getByRole("button", { name: "Add note" })).not.toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Add note" }));
 
-    expect(screen.getByTestId("markdown-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("markdown-editor")).not.toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(screen.queryByTestId("markdown-editor")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("markdown-editor")).toBeNull();
   });
 });

--- a/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
@@ -349,6 +349,7 @@ describe("DashboardPageContent", () => {
   it("opens the metric history modal for a qubit metric even when the metric value is missing", () => {
     render(<DashboardPageContent />);
 
+    fireEvent.click(screen.getAllByText("Show topology")[0]);
     fireEvent.click(screen.getByRole("button", { name: "Open qubit" }));
 
     expect(screen.getByTestId("metric-note-modal").textContent).toContain("0:t1");
@@ -358,6 +359,7 @@ describe("DashboardPageContent", () => {
   it("opens the metric history modal for a coupling metric even when the metric value is missing", () => {
     render(<DashboardPageContent />);
 
+    fireEvent.click(screen.getAllByText("Show topology")[1]);
     const couplingButtons = screen.getAllByRole("button", { name: "Open coupling" });
     fireEvent.click(couplingButtons[couplingButtons.length - 1]);
 

--- a/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
@@ -364,4 +364,18 @@ describe("DashboardPageContent", () => {
     expect(screen.getByTestId("metric-note-modal").textContent).toContain("0-1:zx90_gate_fidelity");
     expect(screen.queryByTestId("target-note-modal")).toBeNull();
   });
+
+  it("jumps directly to a selected metric", () => {
+    const scrollIntoView = vi.fn();
+    render(<DashboardPageContent />);
+    const couplingMetric = document.getElementById("dashboard-coupling-metric-zx90_gate_fidelity");
+    expect(couplingMetric).not.toBeNull();
+    Object.defineProperty(couplingMetric, "scrollIntoView", { value: scrollIntoView });
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Jump to metric" }), {
+      target: { value: "dashboard-coupling-metric-zx90_gate_fidelity" },
+    });
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+  });
 });

--- a/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
@@ -364,18 +364,4 @@ describe("DashboardPageContent", () => {
     expect(screen.getByTestId("metric-note-modal").textContent).toContain("0-1:zx90_gate_fidelity");
     expect(screen.queryByTestId("target-note-modal")).toBeNull();
   });
-
-  it("jumps directly to a selected metric", () => {
-    const scrollIntoView = vi.fn();
-    render(<DashboardPageContent />);
-    const couplingMetric = document.getElementById("dashboard-coupling-metric-zx90_gate_fidelity");
-    expect(couplingMetric).not.toBeNull();
-    Object.defineProperty(couplingMetric, "scrollIntoView", { value: scrollIntoView });
-
-    fireEvent.change(screen.getByRole("combobox", { name: "Jump to metric" }), {
-      target: { value: "dashboard-coupling-metric-zx90_gate_fidelity" },
-    });
-
-    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
-  });
 });

--- a/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
@@ -329,6 +329,7 @@ describe("DashboardPageContent", () => {
   it("opens the pinned summary modal from the empty qubit topology", () => {
     render(<DashboardPageContent />);
 
+    fireEvent.click(screen.getByRole("button", { name: /Target Summaries/ }));
     fireEvent.click(screen.getAllByRole("button", { name: "Open qubit" })[0]);
 
     expect(screen.getByTestId("target-note-modal").textContent).toContain("0");
@@ -338,6 +339,7 @@ describe("DashboardPageContent", () => {
   it("opens the pinned summary modal from the empty coupling topology", () => {
     render(<DashboardPageContent />);
 
+    fireEvent.click(screen.getByRole("button", { name: /Target Summaries/ }));
     fireEvent.click(screen.getAllByRole("button", { name: "Open coupling" })[0]);
 
     expect(screen.getByTestId("target-note-modal").textContent).toContain("0-1");
@@ -347,7 +349,7 @@ describe("DashboardPageContent", () => {
   it("opens the metric history modal for a qubit metric even when the metric value is missing", () => {
     render(<DashboardPageContent />);
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Open qubit" })[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Open qubit" }));
 
     expect(screen.getByTestId("metric-note-modal").textContent).toContain("0:t1");
     expect(screen.queryByTestId("target-note-modal")).toBeNull();

--- a/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
@@ -366,4 +366,16 @@ describe("DashboardPageContent", () => {
     expect(screen.getByTestId("metric-note-modal").textContent).toContain("0-1:zx90_gate_fidelity");
     expect(screen.queryByTestId("target-note-modal")).toBeNull();
   });
+
+  it("summarizes metric availability before expanding the full table", () => {
+    render(<DashboardPageContent />);
+
+    expect(screen.getByText("0 with data")).toBeTruthy();
+    expect(screen.getByText("2 empty")).toBeTruthy();
+
+    const summary = screen.getByText("All Metrics Summary").closest("summary");
+    expect(summary).not.toBeNull();
+    fireEvent.click(summary!);
+    expect(summary?.parentElement?.hasAttribute("open")).toBe(true);
+  });
 });

--- a/ui/src/components/layout/GlobalCommandPalette.tsx
+++ b/ui/src/components/layout/GlobalCommandPalette.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Search } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { Gauge, Search } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { getNavigationSections } from "@/components/layout/navigation";
@@ -16,12 +16,16 @@ import {
 } from "@/components/ui/Command";
 import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
+import { useMetricsConfig } from "@/hooks/useMetricsConfig";
 
 export function GlobalCommandPalette() {
   const router = useRouter();
+  const pathname = usePathname();
   const { user } = useAuth();
   const { canEdit } = useProject();
   const [open, setOpen] = useState(false);
+  const isDashboard = pathname === "/dashboard";
+  const { qubitMetrics, couplingMetrics } = useMetricsConfig(isDashboard);
   const sections = getNavigationSections({
     canEdit,
     isAdmin: user?.system_role === "admin",
@@ -44,6 +48,13 @@ export function GlobalCommandPalette() {
     router.push(href);
   };
 
+  const jumpToMetric = (metricId: string) => {
+    setOpen(false);
+    window.setTimeout(() => {
+      document.getElementById(metricId)?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 0);
+  };
+
   return (
     <>
       <button
@@ -63,12 +74,42 @@ export function GlobalCommandPalette() {
         open={open}
         onOpenChange={setOpen}
         title="Navigate"
-        description="Search for a page to open."
+        description="Search for a page or dashboard metric to open."
       >
         <Command loop label="QDash navigation">
-          <CommandInput placeholder="Search pages..." />
+          <CommandInput
+            placeholder={isDashboard ? "Search pages and metrics..." : "Search pages..."}
+          />
           <CommandList>
-            <CommandEmpty>No matching pages</CommandEmpty>
+            <CommandEmpty>No matching results</CommandEmpty>
+            {isDashboard && (qubitMetrics.length > 0 || couplingMetrics.length > 0) && (
+              <CommandGroup heading="Dashboard metrics">
+                {qubitMetrics.map((metric) => (
+                  <CommandItem
+                    key={`qubit-${metric.key}`}
+                    value={`${metric.title} qubit metric`}
+                    keywords={[metric.key, "dashboard", "qubit"]}
+                    onSelect={() => jumpToMetric(`dashboard-qubit-metric-${metric.key}`)}
+                  >
+                    <Gauge size={15} className="shrink-0 opacity-60" aria-hidden="true" />
+                    <span>{metric.title}</span>
+                    <span className="ml-auto text-xs text-base-content/40">Qubit</span>
+                  </CommandItem>
+                ))}
+                {couplingMetrics.map((metric) => (
+                  <CommandItem
+                    key={`coupling-${metric.key}`}
+                    value={`${metric.title} coupling metric`}
+                    keywords={[metric.key, "dashboard", "coupling"]}
+                    onSelect={() => jumpToMetric(`dashboard-coupling-metric-${metric.key}`)}
+                  >
+                    <Gauge size={15} className="shrink-0 opacity-60" aria-hidden="true" />
+                    <span>{metric.title}</span>
+                    <span className="ml-auto text-xs text-base-content/40">Coupling</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
             {sections.map((section) => {
               const items = section.items.filter((item) => item.visible !== false);
               if (items.length === 0) return null;

--- a/ui/src/components/layout/__tests__/GlobalCommandPalette.test.tsx
+++ b/ui/src/components/layout/__tests__/GlobalCommandPalette.test.tsx
@@ -1,12 +1,21 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { GlobalCommandPalette } from "@/components/layout/GlobalCommandPalette";
 
 const push = vi.fn();
+const mockPathname = vi.hoisted(() => vi.fn(() => "/inbox"));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
+  usePathname: () => mockPathname(),
+}));
+
+vi.mock("@/hooks/useMetricsConfig", () => ({
+  useMetricsConfig: () => ({
+    qubitMetrics: [{ key: "t1", title: "T1" }],
+    couplingMetrics: [{ key: "zx90_gate_fidelity", title: "ZX90 Gate Fidelity" }],
+  }),
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
@@ -21,6 +30,7 @@ describe("GlobalCommandPalette", () => {
   afterEach(() => {
     cleanup();
     push.mockReset();
+    mockPathname.mockReturnValue("/inbox");
   });
 
   it("opens with the platform shortcut and navigates to a selected page", () => {
@@ -44,5 +54,24 @@ describe("GlobalCommandPalette", () => {
     expect(screen.queryByRole("option", { name: "Workflow" })).toBeNull();
     expect(screen.queryByRole("option", { name: "Admin" })).toBeNull();
     expect(screen.getByRole("option", { name: "Settings" })).toBeTruthy();
+  });
+
+  it("shows dashboard metrics and jumps to the selected metric", async () => {
+    mockPathname.mockReturnValue("/dashboard");
+    const target = document.createElement("div");
+    target.id = "dashboard-coupling-metric-zx90_gate_fidelity";
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(target, "scrollIntoView", { value: scrollIntoView });
+    document.body.appendChild(target);
+
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.click(screen.getByRole("option", { name: /ZX90 Gate Fidelity.*Coupling/ }));
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+    });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    target.remove();
   });
 });

--- a/ui/src/components/selectors/CooldownSelector/index.tsx
+++ b/ui/src/components/selectors/CooldownSelector/index.tsx
@@ -112,14 +112,16 @@ export function CooldownSelector({
   };
 
   return (
-    <Select<CooldownOption>
-      options={options}
-      value={selectedOption}
-      onChange={handleChange}
-      placeholder={placeholder}
-      isClearable={false}
-      className="text-base-content"
-      styles={styles}
-    />
+    <div className="cooldown-selector-control">
+      <Select<CooldownOption>
+        options={options}
+        value={selectedOption}
+        onChange={handleChange}
+        placeholder={placeholder}
+        isClearable={false}
+        className="text-base-content"
+        styles={styles}
+      />
+    </div>
   );
 }

--- a/ui/src/components/ui/TimeRangeSelector.tsx
+++ b/ui/src/components/ui/TimeRangeSelector.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useState } from "react";
 
+import { CalendarRange, ChevronDown } from "lucide-react";
+
 interface TimeRangeSelectorProps {
   startDate: string;
   endDate: string;
   onStartDateChange: (date: string) => void;
   onEndDateChange: (date: string) => void;
   onQuickRange: (days: number) => void;
+  collapsible?: boolean;
 }
 
 export function TimeRangeSelector({
@@ -16,6 +19,7 @@ export function TimeRangeSelector({
   onStartDateChange,
   onEndDateChange,
   onQuickRange,
+  collapsible = false,
 }: TimeRangeSelectorProps) {
   // `startDate` / `endDate` are already datetime-local strings in the display
   // timezone (e.g. "2026-06-21T15:30"), produced by useRangeModeUrlState /
@@ -25,6 +29,7 @@ export function TimeRangeSelector({
   // display timezone, double-applying the offset (+9h for JST). See issue #1107.
   const [localStart, setLocalStart] = useState(startDate);
   const [localEnd, setLocalEnd] = useState(endDate);
+  const [showCustomRange, setShowCustomRange] = useState(!collapsible);
 
   useEffect(() => {
     setLocalStart(startDate);
@@ -36,22 +41,62 @@ export function TimeRangeSelector({
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <span className="text-sm font-medium">Time Range</span>
         <div className="join">
-          <button className="join-item btn btn-sm" onClick={() => onQuickRange(1)}>
+          <button
+            type="button"
+            className="join-item btn btn-sm"
+            onClick={() => {
+              onQuickRange(1);
+              if (collapsible) setShowCustomRange(false);
+            }}
+          >
             1D
           </button>
-          <button className="join-item btn btn-sm" onClick={() => onQuickRange(7)}>
+          <button
+            type="button"
+            className="join-item btn btn-sm"
+            onClick={() => {
+              onQuickRange(7);
+              if (collapsible) setShowCustomRange(false);
+            }}
+          >
             7D
           </button>
-          <button className="join-item btn btn-sm" onClick={() => onQuickRange(30)}>
+          <button
+            type="button"
+            className="join-item btn btn-sm"
+            onClick={() => {
+              onQuickRange(30);
+              if (collapsible) setShowCustomRange(false);
+            }}
+          >
             30D
           </button>
         </div>
+        {collapsible && (
+          <button
+            type="button"
+            className={`btn btn-sm gap-1.5 ${showCustomRange ? "btn-ghost bg-base-200" : "btn-ghost"}`}
+            aria-expanded={showCustomRange}
+            aria-controls="custom-time-range"
+            onClick={() => setShowCustomRange((visible) => !visible)}
+          >
+            <CalendarRange className="h-4 w-4" aria-hidden="true" />
+            Custom
+            <ChevronDown
+              className={`h-3.5 w-3.5 transition-transform ${showCustomRange ? "rotate-180" : ""}`}
+              aria-hidden="true"
+            />
+          </button>
+        )}
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div
+        id="custom-time-range"
+        className={`${showCustomRange ? "grid" : "hidden"} grid-cols-1 gap-4 sm:grid-cols-2`}
+      >
         <div className="form-control w-full">
           <label className="label">
             <span className="label-text">From</span>

--- a/ui/src/components/ui/__tests__/TimeRangeSelector.test.tsx
+++ b/ui/src/components/ui/__tests__/TimeRangeSelector.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TimeRangeSelector } from "@/components/ui/TimeRangeSelector";
+
+const props = {
+  startDate: "2026-08-01T00:00",
+  endDate: "2026-08-08T00:00",
+  onStartDateChange: vi.fn(),
+  onEndDateChange: vi.fn(),
+  onQuickRange: vi.fn(),
+};
+
+afterEach(cleanup);
+
+describe("TimeRangeSelector", () => {
+  it("reveals custom dates on demand when collapsible", () => {
+    render(<TimeRangeSelector {...props} collapsible />);
+
+    expect(document.getElementById("custom-time-range")?.classList.contains("hidden")).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+
+    expect(document.getElementById("custom-time-range")?.classList.contains("grid")).toBe(true);
+    expect(screen.getByRole("button", { name: "Custom" }).getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+  });
+
+  it("keeps custom dates visible by default for existing consumers", () => {
+    render(<TimeRangeSelector {...props} />);
+
+    expect(document.getElementById("custom-time-range")?.classList.contains("grid")).toBe(true);
+  });
+});

--- a/ui/src/hooks/useMetricsConfig.ts
+++ b/ui/src/hooks/useMetricsConfig.ts
@@ -85,9 +85,10 @@ export interface MetricConfig {
  *   - isError: Error state
  *   - error: Error object if failed
  */
-export function useMetricsConfig() {
+export function useMetricsConfig(enabled = true) {
   const { data, isLoading, isError, error } = useGetMetricsConfig({
     query: {
+      enabled,
       staleTime: Infinity, // Config rarely changes, cache indefinitely
       gcTime: Infinity, // Keep in cache forever
     },


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Keeps the Dashboard focused on calibration data by collapsing secondary controls, grouping the active data scope, and shortening navigation through long metric lists.
- UI-only follow-up to #1334 with no API, schema, generated client, or configuration changes.

## Changes
- Shows an `Add note` action instead of opening an empty Markdown editor by default in `DashboardChipNoteCard`.
- Keeps 1D/7D/30D presets visible while moving exact From/To inputs behind an accessible `Custom` disclosure.
- Groups chip, cooldown, value selection, and time range controls in a responsive `Data scope` panel.
- Hides the cooldown filter and label when the selected chip has no cooldown choices.
- Collapses target summary topologies by default so qubit metrics appear sooner, while retaining an accessible disclosure and note counts.
- Adds Dashboard-only qubit and coupling metric commands to the existing `⌘K` navigation palette.
- Supports searching by metric title or key and jumps directly to the selected metric after the palette closes.
- Avoids loading metric configuration from the global palette outside Dashboard.
- Replaces large empty topology/CDF combinations with compact disclosures, while preserving access to individual targets.
- Shows with-data and empty metric counts on the collapsed all-metrics summary.
- Adds focused component tests for the note, time-range, target-summary, empty-metric, availability-summary, and command-palette interactions.

## Verification
- Focused Dashboard and command-palette Vitest tests (13 passing)
- Oxfmt, Oxlint, and TypeScript `--noEmit` checks
- Manual desktop and 390px mobile browser verification for the compact controls
- Manual target-summary collapsed and expanded state verification
- Manual `⌘K` search and navigation across the configured Dashboard metrics
- Manual collapsed and expanded empty-metric verification
- Manual availability count verification with a mixed 7/14 data range
- Betterleaks staged secret scans