### PR TITLE
feat(ui): improve dashboard metric summaries

### DIFF
--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -452,6 +452,8 @@ export function DashboardPageContent() {
   const [editingTargetNote, setEditingTargetNote] = useState<string | null>(null);
   const [couplingDirection, setCouplingDirection] = useState<"forward" | "reverse">("forward");
   const [showTargetSummaries, setShowTargetSummaries] = useState(false);
+  const [showEmptyQubitMetrics, setShowEmptyQubitMetrics] = useState(false);
+  const [showEmptyCouplingMetrics, setShowEmptyCouplingMetrics] = useState(false);
   const isReverseCouplingDirection = couplingDirection === "reverse";
 
   const editingLegacyMetricNote =
@@ -501,6 +503,13 @@ export function DashboardPageContent() {
     [summaryRows],
   );
   const emptyMetricCount = summaryRows.length - metricsWithData;
+  const emptyQubitMetricCount = qubitMetrics.filter(
+    (metric) => coverageOf(qubitMetricData[metric.key], qubitCount).current === 0,
+  ).length;
+  const emptyCouplingMetricCount = couplingMetrics.filter((metric) => {
+    const metricData = couplingMetricData[metric.key];
+    return coverageOf(metricData, metricData ? Object.keys(metricData).length : 0).current === 0;
+  }).length;
 
   if (isConfigLoading || isChipsLoading) {
     return <MetricsPageSkeleton />;
@@ -788,6 +797,31 @@ export function DashboardPageContent() {
                 title="Qubit Metrics"
                 description="Click any qubit to update its pinned summary while inspecting the selected metric."
               >
+                {emptyQubitMetricCount > 0 && (
+                  <button
+                    type="button"
+                    className="mb-5 flex w-full items-center justify-between gap-3 rounded-lg border border-dashed border-base-300 bg-base-200/40 px-4 py-3 text-left transition-colors hover:bg-base-200/70"
+                    aria-expanded={showEmptyQubitMetrics}
+                    onClick={() => setShowEmptyQubitMetrics((visible) => !visible)}
+                  >
+                    <span>
+                      <span className="block text-sm font-medium">
+                        {emptyQubitMetricCount} qubit{" "}
+                        {emptyQubitMetricCount === 1 ? "metric" : "metrics"} without data
+                      </span>
+                      <span className="block text-xs text-base-content/50">
+                        Hidden to keep this dashboard focused on available results.
+                      </span>
+                    </span>
+                    <span className="flex shrink-0 items-center gap-1.5 text-xs font-medium text-primary">
+                      {showEmptyQubitMetrics ? "Hide" : "Show"}
+                      <ChevronDown
+                        className={`h-4 w-4 transition-transform ${showEmptyQubitMetrics ? "rotate-180" : ""}`}
+                        aria-hidden="true"
+                      />
+                    </span>
+                  </button>
+                )}
                 <div className="space-y-8">
                   {qubitMetrics.map((m) => {
                     const noted = new Set(Object.keys(notesByMetric[m.key] ?? {}));
@@ -797,6 +831,7 @@ export function DashboardPageContent() {
                       if (!noted.has(targetId)) crossMetricNoted.add(targetId);
                     });
                     const cov = coverageOf(qubitMetricData[m.key], qubitCount);
+                    if (cov.current === 0 && !showEmptyQubitMetrics) return null;
                     return (
                       <div
                         key={m.key}
@@ -897,6 +932,31 @@ export function DashboardPageContent() {
                 title="Coupling Metrics"
                 description="Click any coupling to update its pinned summary while inspecting the selected metric."
               >
+                {emptyCouplingMetricCount > 0 && (
+                  <button
+                    type="button"
+                    className="mb-4 flex w-full items-center justify-between gap-3 rounded-lg border border-dashed border-base-300 bg-base-200/40 px-4 py-3 text-left transition-colors hover:bg-base-200/70"
+                    aria-expanded={showEmptyCouplingMetrics}
+                    onClick={() => setShowEmptyCouplingMetrics((visible) => !visible)}
+                  >
+                    <span>
+                      <span className="block text-sm font-medium">
+                        {emptyCouplingMetricCount} coupling{" "}
+                        {emptyCouplingMetricCount === 1 ? "metric" : "metrics"} without data
+                      </span>
+                      <span className="block text-xs text-base-content/50">
+                        Hidden to keep this dashboard focused on available results.
+                      </span>
+                    </span>
+                    <span className="flex shrink-0 items-center gap-1.5 text-xs font-medium text-primary">
+                      {showEmptyCouplingMetrics ? "Hide" : "Show"}
+                      <ChevronDown
+                        className={`h-4 w-4 transition-transform ${showEmptyCouplingMetrics ? "rotate-180" : ""}`}
+                        aria-hidden="true"
+                      />
+                    </span>
+                  </button>
+                )}
                 <div className="mb-4 flex justify-end">
                   <button
                     type="button"
@@ -928,6 +988,7 @@ export function DashboardPageContent() {
                       ? Object.keys(couplingMetricData[m.key] ?? {}).length
                       : 0;
                     const cov = coverageOf(couplingMetricData[m.key], couplingTotal);
+                    if (cov.current === 0 && !showEmptyCouplingMetrics) return null;
                     return (
                       <div
                         key={m.key}

--- a/ui/src/components/features/dashboard/DashboardSummaryTable.tsx
+++ b/ui/src/components/features/dashboard/DashboardSummaryTable.tsx
@@ -24,14 +24,16 @@ interface SummaryRow {
   title: string;
   unit: string;
   type: "Qubit" | "Coupling";
-  coverage: string;
+  valueCount: number;
+  total: number;
+  coveragePct: number;
   median: string;
   min: string;
   max: string;
 }
 
 function fmt(value: number | null): string {
-  if (value === null) return "N/A";
+  if (value === null) return "—";
   const abs = Math.abs(value);
   if (abs >= 100) return value.toFixed(2);
   if (abs >= 10) return value.toFixed(3);
@@ -47,7 +49,12 @@ export function DashboardSummaryTable({ rows }: DashboardSummaryTableProps) {
           .map((v) => v.value)
           .filter((v): v is number => v !== null && v !== undefined);
         const sorted = [...values].sort((a, b) => a - b);
-        const median = sorted.length ? sorted[Math.floor(sorted.length / 2)] : null;
+        const middle = Math.floor(sorted.length / 2);
+        const median = sorted.length
+          ? sorted.length % 2 === 0
+            ? (sorted[middle - 1] + sorted[middle]) / 2
+            : sorted[middle]
+          : null;
         const min = values.length ? Math.min(...values) : null;
         const max = values.length ? Math.max(...values) : null;
         const total = r.expectedTotal || values.length;
@@ -57,7 +64,9 @@ export function DashboardSummaryTable({ rows }: DashboardSummaryTableProps) {
           title: r.title,
           unit: r.unit,
           type: r.type,
-          coverage: `${coverage.toFixed(1)}% (${values.length}/${total})`,
+          valueCount: values.length,
+          total,
+          coveragePct: coverage,
           median: fmt(median),
           min: fmt(min),
           max: fmt(max),
@@ -67,10 +76,13 @@ export function DashboardSummaryTable({ rows }: DashboardSummaryTableProps) {
   );
 
   return (
-    <div className="overflow-x-auto">
-      <table className="table table-zebra table-sm">
+    <div className="overflow-x-auto rounded-lg border border-base-300">
+      <table className="table table-sm">
+        <caption className="sr-only">
+          Metric coverage and distribution statistics for the selected data scope
+        </caption>
         <thead>
-          <tr>
+          <tr className="bg-base-200/70 text-xs uppercase tracking-wide text-base-content/60">
             <th>Metric</th>
             <th>Type</th>
             <th>Unit</th>
@@ -82,7 +94,7 @@ export function DashboardSummaryTable({ rows }: DashboardSummaryTableProps) {
         </thead>
         <tbody>
           {summaries.map((row) => (
-            <tr key={`${row.type}-${row.key}`}>
+            <tr key={`${row.type}-${row.key}`} className="hover:bg-base-200/45">
               <td className="font-medium">{row.title}</td>
               <td>
                 <span
@@ -94,10 +106,22 @@ export function DashboardSummaryTable({ rows }: DashboardSummaryTableProps) {
                 </span>
               </td>
               <td className="text-base-content/70">{row.unit}</td>
-              <td className="tabular-nums">{row.coverage}</td>
-              <td className="tabular-nums">{row.median}</td>
-              <td className="tabular-nums">{row.min}</td>
-              <td className="tabular-nums">{row.max}</td>
+              <td className="min-w-40">
+                <div className="flex items-center gap-2">
+                  <progress
+                    className="progress progress-primary h-1.5 w-20"
+                    value={row.coveragePct}
+                    max="100"
+                    aria-label={`${row.title} coverage`}
+                  />
+                  <span className="whitespace-nowrap text-xs tabular-nums">
+                    {row.coveragePct.toFixed(1)}% ({row.valueCount}/{row.total})
+                  </span>
+                </div>
+              </td>
+              <td className="font-medium tabular-nums">{row.median}</td>
+              <td className="tabular-nums text-base-content/70">{row.min}</td>
+              <td className="tabular-nums text-base-content/70">{row.max}</td>
             </tr>
           ))}
         </tbody>

--- a/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardPageContent.test.tsx
@@ -317,6 +317,7 @@ describe("DashboardPageContent", () => {
     ]);
 
     render(<DashboardPageContent />);
+    fireEvent.click(screen.getByRole("button", { name: /Target Summaries/ }));
 
     expect(screen.getAllByTestId("qubit-forum-label").map((item) => item.textContent)).toContain(
       "anomaly",
@@ -349,6 +350,7 @@ describe("DashboardPageContent", () => {
   it("opens the metric history modal for a qubit metric even when the metric value is missing", () => {
     render(<DashboardPageContent />);
 
+    fireEvent.click(screen.getByRole("button", { name: /1 qubit metric without data/ }));
     fireEvent.click(screen.getAllByText("Show topology")[0]);
     fireEvent.click(screen.getByRole("button", { name: "Open qubit" }));
 
@@ -359,7 +361,8 @@ describe("DashboardPageContent", () => {
   it("opens the metric history modal for a coupling metric even when the metric value is missing", () => {
     render(<DashboardPageContent />);
 
-    fireEvent.click(screen.getAllByText("Show topology")[1]);
+    fireEvent.click(screen.getByRole("button", { name: /1 coupling metric without data/ }));
+    fireEvent.click(screen.getByText("Show topology"));
     const couplingButtons = screen.getAllByRole("button", { name: "Open coupling" });
     fireEvent.click(couplingButtons[couplingButtons.length - 1]);
 
@@ -377,5 +380,15 @@ describe("DashboardPageContent", () => {
     expect(summary).not.toBeNull();
     fireEvent.click(summary!);
     expect(summary?.parentElement?.hasAttribute("open")).toBe(true);
+  });
+
+  it("keeps empty metrics grouped until requested", () => {
+    render(<DashboardPageContent />);
+
+    expect(screen.queryByText("No values in the selected range")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /1 qubit metric without data/ }));
+
+    expect(screen.getByText("No values in the selected range")).toBeTruthy();
   });
 });

--- a/ui/src/components/features/dashboard/__tests__/DashboardSummaryTable.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardSummaryTable.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DashboardSummaryTable } from "@/components/features/dashboard/DashboardSummaryTable";
+
+describe("DashboardSummaryTable", () => {
+  it("shows coverage and calculates the median for an even number of values", () => {
+    render(
+      <DashboardSummaryTable
+        rows={[
+          {
+            key: "t1",
+            title: "T1",
+            unit: "us",
+            type: "Qubit",
+            expectedTotal: 4,
+            data: {
+              "0": { value: 1 },
+              "1": { value: 3 },
+              "2": { value: null },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("50.0% (2/4)")).toBeTruthy();
+    expect(screen.getByText("2.0000")).toBeTruthy();
+    expect(screen.getByRole("progressbar", { name: "T1 coverage" }).getAttribute("value")).toBe(
+      "50",
+    );
+  });
+
+  it("uses a dash for unavailable distribution values", () => {
+    render(
+      <DashboardSummaryTable
+        rows={[
+          {
+            key: "fidelity",
+            title: "Gate Fidelity",
+            unit: "",
+            type: "Coupling",
+            expectedTotal: 2,
+            data: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("0.0% (0/2)")).toBeTruthy();
+    expect(screen.getAllByText("—")).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Improve Dashboard metric scanning by prioritizing available results and making coverage easier to compare.
- UI-only change with no API, schema, configuration, or generated-client impact.

## Changes
- Group empty qubit and coupling metrics behind explicit expandable controls in `DashboardPageContent`.
- Add visual coverage indicators and clearer unavailable-value formatting to `DashboardSummaryTable`.
- Correct median calculation for even-sized metric sets.
- Add Dashboard tests for empty-metric grouping, coverage, and summary statistics.

## Verification
- Dashboard tests: 14 passed.
- Full Python suite: 1330 passed.
- Full UI suite: 163 passed.
- TypeScript typecheck, lint, and format checks passed.
- `task check` reaches Knip and then reports the pre-existing unused file `ui/src/components/ui/LoadingSpinner/index.tsx`, which is outside this PR.