### PR TITLE
feat(ui): improve task definition navigation

### DIFF
--- a/ui/src/components/features/tasks/TasksPageContent.tsx
+++ b/ui/src/components/features/tasks/TasksPageContent.tsx
@@ -5,7 +5,18 @@ import { useRouter } from "next/navigation";
 import { useState, useEffect, useMemo } from "react";
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Braces, Copy, FileCode2, ListTree, PanelLeft, Pencil, Plus, Save } from "lucide-react";
+import {
+  Braces,
+  Copy,
+  FileCode2,
+  ListTree,
+  PanelLeft,
+  Pencil,
+  Plus,
+  Save,
+  Search,
+  X,
+} from "lucide-react";
 import { useToast } from "@/components/ui/Toast";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
@@ -54,6 +65,7 @@ export function TasksPageContent() {
   } | null>(null);
   const [isEditorLocked, setIsEditorLocked] = useState(true);
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
+  const [taskSearch, setTaskSearch] = useState("");
 
   // Fetch settings (including default backend)
   const { data: settingsData } = useQuery({
@@ -191,6 +203,31 @@ export function TasksPageContent() {
     selectFile(path);
   };
 
+  useEffect(() => {
+    if (!selectedBackend) return;
+    window.dispatchEvent(
+      new CustomEvent("qdash:task-backend-change", {
+        detail: { backend: selectedBackend },
+      }),
+    );
+  }, [selectedBackend]);
+
+  useEffect(() => {
+    const handleOpenTaskSource = (event: Event) => {
+      const detail = (event as CustomEvent<{ filePath?: string; backend?: string }>).detail;
+      if (!detail?.filePath || detail.backend !== selectedBackend) return;
+      if (hasUnsavedChanges) {
+        setPendingNavigation({ type: "file", value: detail.filePath });
+        return;
+      }
+      setSelectedFile(`${selectedBackend}/${detail.filePath}`);
+      setHasUnsavedChanges(false);
+      setIsEditorLocked(true);
+    };
+    window.addEventListener("qdash:open-task-source", handleOpenTaskSource);
+    return () => window.removeEventListener("qdash:open-task-source", handleOpenTaskSource);
+  }, [selectedBackend, hasUnsavedChanges]);
+
   const handleTaskClick = (task: TaskInfo) => {
     // Open the file containing this task
     handleFileSelect(task.file_path);
@@ -230,10 +267,21 @@ export function TasksPageContent() {
     setHasUnsavedChanges(true);
   };
 
+  const filteredTasks = useMemo(() => {
+    const tasks = taskListData?.tasks ?? [];
+    const query = taskSearch.trim().toLowerCase();
+    if (!query) return tasks;
+    return tasks.filter(
+      (task) =>
+        task.name.toLowerCase().includes(query) ||
+        task.task_type?.toLowerCase().includes(query) ||
+        task.file_path.toLowerCase().includes(query),
+    );
+  }, [taskListData?.tasks, taskSearch]);
+
   // Group tasks by task_type
   const groupedTasks = useMemo(() => {
-    if (!taskListData?.tasks) return {};
-    return taskListData.tasks.reduce((acc: Record<string, TaskInfo[]>, task: TaskInfo) => {
+    return filteredTasks.reduce((acc: Record<string, TaskInfo[]>, task: TaskInfo) => {
       const type = task.task_type || "other";
       if (!acc[type]) {
         acc[type] = [];
@@ -241,7 +289,7 @@ export function TasksPageContent() {
       acc[type].push(task);
       return acc;
     }, {});
-  }, [taskListData]);
+  }, [filteredTasks]);
 
   const renderTaskList = () => {
     if (isTaskListLoading) {
@@ -253,7 +301,18 @@ export function TasksPageContent() {
     }
 
     if (!taskListData?.tasks || taskListData.tasks.length === 0) {
-      return <div className="text-xs text-base-content/50 px-3 py-2">No tasks found</div>;
+      return (
+        <div className="px-3 py-6 text-center text-xs text-base-content/50">No tasks found</div>
+      );
+    }
+
+    if (filteredTasks.length === 0) {
+      return (
+        <div className="px-4 py-8 text-center">
+          <p className="text-sm font-medium">No matching tasks</p>
+          <p className="mt-1 text-xs text-base-content/50">Try another name, type, or file path.</p>
+        </div>
+      );
     }
 
     return (
@@ -267,22 +326,21 @@ export function TasksPageContent() {
             </summary>
             <div className="space-y-0.5">
               {tasks.map((task: TaskInfo) => (
-                <div
-                  key={`${task.file_path}-${task.name}`}
-                  className="group/item flex items-center justify-between px-3 py-1 hover:bg-base-200 cursor-pointer"
-                  onClick={() => handleTaskClick(task)}
-                >
-                  <div className="flex items-center gap-2 min-w-0 flex-1">
+                <div key={`${task.file_path}-${task.name}`} className="group/item flex px-2">
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded px-1 py-1 text-left hover:bg-base-200"
+                    onClick={() => handleTaskClick(task)}
+                    aria-label={`Open source for ${task.name}`}
+                  >
                     <Braces className="text-purple-400 flex-shrink-0" size={14} />
                     <span className="text-sm text-base-content/80 truncate">{task.name}</span>
-                  </div>
+                  </button>
                   <button
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleCopyTaskName(task.name);
-                    }}
-                    className="opacity-0 group-hover/item:opacity-100 p-1 hover:bg-base-300 rounded transition-opacity"
-                    title="Copy task name"
+                    type="button"
+                    onClick={() => handleCopyTaskName(task.name)}
+                    className="opacity-0 group-hover/item:opacity-100 group-focus-within/item:opacity-100 p-1 hover:bg-base-300 rounded transition-opacity"
+                    aria-label={`Copy ${task.name} task name`}
                   >
                     <Copy className="text-base-content/50 hover:text-base-content" size={14} />
                   </button>
@@ -324,7 +382,9 @@ export function TasksPageContent() {
         <div className="flex flex-col sm:flex-row sm:items-center justify-between px-2 sm:px-4 py-2 bg-base-200 border-b border-base-300 gap-2">
           <div className="flex items-center gap-2 sm:gap-4 min-w-0">
             <div className="flex items-center gap-1 sm:gap-2 min-w-0 overflow-hidden">
-              <span className="text-sm font-medium flex-shrink-0 hidden sm:inline">Task Files</span>
+              <span className="text-sm font-medium flex-shrink-0 hidden sm:inline">
+                Task Definitions
+              </span>
               {selectedBackend && (
                 <>
                   <span className="text-base-content/50 hidden sm:inline">/</span>
@@ -391,8 +451,14 @@ export function TasksPageContent() {
               className={`${isSidebarVisible ? "w-48 sm:w-64" : "w-0"} flex flex-col transition-all duration-200 overflow-hidden`}
             >
               {/* Tab buttons */}
-              <div className="flex border-b border-base-300">
+              <div
+                className="flex border-b border-base-300"
+                role="tablist"
+                aria-label="Task browser"
+              >
                 <button
+                  role="tab"
+                  aria-selected={viewMode === "files"}
                   onClick={() => setViewMode("files")}
                   className={`flex-1 px-3 py-2 text-xs font-medium flex items-center justify-center gap-1 transition-colors whitespace-nowrap ${
                     viewMode === "files"
@@ -404,6 +470,8 @@ export function TasksPageContent() {
                   Files
                 </button>
                 <button
+                  role="tab"
+                  aria-selected={viewMode === "tasks"}
                   onClick={() => setViewMode("tasks")}
                   className={`flex-1 px-3 py-2 text-xs font-medium flex items-center justify-center gap-1 transition-colors whitespace-nowrap ${
                     viewMode === "tasks"
@@ -450,13 +518,37 @@ export function TasksPageContent() {
                   </>
                 ) : (
                   <>
-                    <h2 className="text-xs font-bold text-base-content/60 mb-1 px-3 tracking-wider">
-                      TASK LIST
-                    </h2>
-                    <div className="text-xs text-base-content/50 px-3 mb-2">
-                      Click to view source, copy button for Flow Editor
+                    <div className="px-3 pb-2">
+                      <div className="mb-2 flex items-center justify-between gap-2">
+                        <h2 className="text-xs font-bold tracking-wider text-base-content/60">
+                          TASKS
+                        </h2>
+                        <span className="text-xs text-base-content/45">
+                          {filteredTasks.length}/{taskListData?.tasks.length ?? 0}
+                        </span>
+                      </div>
+                      <label className="input input-sm input-bordered flex w-full items-center gap-2 bg-base-100">
+                        <Search className="h-3.5 w-3.5 shrink-0 text-base-content/40" />
+                        <input
+                          value={taskSearch}
+                          onChange={(event) => setTaskSearch(event.target.value)}
+                          className="min-w-0 grow text-sm"
+                          placeholder="Search tasks"
+                          aria-label="Search tasks"
+                        />
+                        {taskSearch && (
+                          <button
+                            type="button"
+                            className="btn btn-ghost btn-xs btn-square"
+                            onClick={() => setTaskSearch("")}
+                            aria-label="Clear task search"
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </label>
                     </div>
-                    {renderTaskList()}
+                    <div className="min-h-0 flex-1 overflow-y-auto">{renderTaskList()}</div>
                   </>
                 )}
               </div>
@@ -526,7 +618,7 @@ export function TasksPageContent() {
                 <div className="text-center">
                   <FileCode2 className="mx-auto mb-4 text-blue-400/50" size={64} />
                   <p className="text-lg mb-2">No file selected</p>
-                  <p className="text-sm">Select a Python file from the tree to view or edit</p>
+                  <p className="text-sm">Select a task or Python file from the sidebar</p>
                 </div>
               </div>
             )}

--- a/ui/src/components/layout/GlobalCommandPalette.tsx
+++ b/ui/src/components/layout/GlobalCommandPalette.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Gauge, Search } from "lucide-react";
+import { Braces, Gauge, Search } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
+import { useGetTaskFileSettings, useListTaskInfo } from "@/client/task-file/task-file";
 import { getNavigationSections } from "@/components/layout/navigation";
 import {
   Command,
@@ -26,8 +27,20 @@ export function GlobalCommandPalette() {
   const [open, setOpen] = useState(false);
   const isDashboard = pathname === "/dashboard";
   const isMetrics = pathname === "/metrics";
+  const isTasks = pathname === "/tasks";
   const hasMetricCommands = isDashboard || isMetrics;
   const { qubitMetrics, couplingMetrics } = useMetricsConfig(hasMetricCommands);
+  const { data: taskFileSettings } = useGetTaskFileSettings({
+    query: { enabled: isTasks, staleTime: 60_000 },
+  });
+  const defaultTaskBackend = taskFileSettings?.data?.default_backend ?? "";
+  const [activeTaskBackend, setActiveTaskBackend] = useState("");
+  const taskBackend = activeTaskBackend || defaultTaskBackend;
+  const { data: taskInfoData } = useListTaskInfo(
+    { backend: taskBackend || "__none__" },
+    { query: { enabled: isTasks && !!taskBackend, staleTime: 60_000 } },
+  );
+  const taskCommands = taskInfoData?.data?.tasks ?? [];
   const sections = getNavigationSections({
     canEdit,
     isAdmin: user?.system_role === "admin",
@@ -43,6 +56,15 @@ export function GlobalCommandPalette() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  useEffect(() => {
+    const handleBackendChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ backend?: string }>).detail;
+      if (detail?.backend) setActiveTaskBackend(detail.backend);
+    };
+    window.addEventListener("qdash:task-backend-change", handleBackendChange);
+    return () => window.removeEventListener("qdash:task-backend-change", handleBackendChange);
   }, []);
 
   const navigate = (href: string) => {
@@ -75,6 +97,13 @@ export function GlobalCommandPalette() {
     jumpToMetric(`dashboard-${metricType}-metric-${metricKey}`);
   };
 
+  const selectTask = (filePath: string) => {
+    setOpen(false);
+    window.dispatchEvent(
+      new CustomEvent("qdash:open-task-source", { detail: { filePath, backend: taskBackend } }),
+    );
+  };
+
   return (
     <>
       <button
@@ -94,14 +123,38 @@ export function GlobalCommandPalette() {
         open={open}
         onOpenChange={setOpen}
         title="Navigate"
-        description="Search for a page or metric to open."
+        description="Search for a page or page-specific item to open."
       >
         <Command loop label="QDash navigation">
           <CommandInput
-            placeholder={hasMetricCommands ? "Search pages and metrics..." : "Search pages..."}
+            placeholder={
+              hasMetricCommands
+                ? "Search pages and metrics..."
+                : isTasks
+                  ? "Search pages and tasks..."
+                  : "Search pages..."
+            }
           />
           <CommandList>
             <CommandEmpty>No matching results</CommandEmpty>
+            {isTasks && taskCommands.length > 0 && (
+              <CommandGroup heading="Switch task source">
+                {taskCommands.map((task) => (
+                  <CommandItem
+                    key={`${task.file_path}-${task.name}`}
+                    value={`${task.name} task source`}
+                    keywords={[task.task_type ?? "", task.file_path, taskBackend]}
+                    onSelect={() => selectTask(task.file_path)}
+                  >
+                    <Braces size={15} className="shrink-0 opacity-60" aria-hidden="true" />
+                    <span>{task.name}</span>
+                    <span className="ml-auto text-xs text-base-content/40">
+                      {task.task_type || "Other"}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
             {hasMetricCommands && (qubitMetrics.length > 0 || couplingMetrics.length > 0) && (
               <CommandGroup heading={isMetrics ? "Switch metric" : "Dashboard metrics"}>
                 {qubitMetrics.map((metric) => (

--- a/ui/src/components/layout/__tests__/GlobalCommandPalette.test.tsx
+++ b/ui/src/components/layout/__tests__/GlobalCommandPalette.test.tsx
@@ -18,6 +18,23 @@ vi.mock("@/hooks/useMetricsConfig", () => ({
   }),
 }));
 
+vi.mock("@/client/task-file/task-file", () => ({
+  useGetTaskFileSettings: () => ({ data: { data: { default_backend: "qubex" } } }),
+  useListTaskInfo: () => ({
+    data: {
+      data: {
+        tasks: [
+          {
+            name: "CheckRabi",
+            task_type: "qubit",
+            file_path: "one_qubit/check_rabi.py",
+          },
+        ],
+      },
+    },
+  }),
+}));
+
 vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => ({ user: { system_role: "user" } }),
 }));
@@ -87,5 +104,23 @@ describe("GlobalCommandPalette", () => {
       "/metrics?project=project-1&chip=chip-1&type=coupling&metric=zx90_gate_fidelity",
     );
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens task source commands on the tasks page", () => {
+    mockPathname.mockReturnValue("/tasks");
+    const onOpenTask = vi.fn();
+    window.addEventListener("qdash:open-task-source", onOpenTask);
+
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.click(screen.getByRole("option", { name: /CheckRabi.*qubit/i }));
+
+    expect(onOpenTask).toHaveBeenCalledTimes(1);
+    expect((onOpenTask.mock.calls[0][0] as CustomEvent).detail).toEqual({
+      filePath: "one_qubit/check_rabi.py",
+      backend: "qubex",
+    });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    window.removeEventListener("qdash:open-task-source", onOpenTask);
   });
 });


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Make task definitions easier to find and open from the Tasks page.
- UI-only change with no API, schema, configuration, or generated-client impact.

## Changes
- Add task search by name, type, and file path to `TasksPageContent`.
- Show filtered and total task counts with clear empty-search feedback.
- Keep long task lists independently scrollable and clarify the empty editor guidance.
- Separate source-opening and copy-name actions with improved keyboard and screen-reader semantics.
- Add task source switching to the global command palette on the Tasks page.
- Keep command-palette task candidates synchronized with the selected backend.
- Preserve unsaved-change confirmation when a command opens another task source.
- Extend `GlobalCommandPalette` tests for task source commands.

## Verification
- `task check`
- Python: 1330 tests passed
- UI: 169 tests passed
- TypeScript, lint, format, dependency audit, and leak scan passed
- Verified task filtering and task-source selection with local task data