### PR TITLE
feat(ui): improve cryogenic operations overview

### DIFF
--- a/ui/src/components/features/cryo/CooldownTimeline.tsx
+++ b/ui/src/components/features/cryo/CooldownTimeline.tsx
@@ -21,6 +21,7 @@ const ROW_HEIGHT = 30;
 const BAR_HEIGHT = 22;
 const TOP_PADDING = 10;
 const ROW_PIXEL_GAP = 8;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const CHIP_STYLES = [
   {
@@ -84,6 +85,27 @@ function formatChipSummary(chipIds: string[]): string {
   if (chipIds.length === 0) return "No chips";
   if (chipIds.length <= 2) return chipIds.join(", ");
   return `${chipIds.slice(0, 2).join(", ")} +${chipIds.length - 2}`;
+}
+
+function buildTicks(lo: number, span: number, range: number, firstStartedAt: number) {
+  if (range < DAY_MS) {
+    return [
+      {
+        pct: 0,
+        label: formatDateTime(new Date(firstStartedAt).toISOString(), "MMM d, HH:mm"),
+      },
+      { pct: 100, label: "Now" },
+    ];
+  }
+
+  const tickCount = range < 14 * DAY_MS ? Math.min(6, Math.floor(range / DAY_MS) + 1) : 6;
+  const fractions = Array.from({ length: tickCount }, (_, index) => index / (tickCount - 1));
+  const pattern = range < 180 * DAY_MS ? "MMM d" : "yyyy MMM";
+
+  return fractions.map((fraction) => ({
+    pct: fraction * 100,
+    label: formatDateTime(new Date(lo + span * fraction).toISOString(), pattern),
+  }));
 }
 
 /**
@@ -155,14 +177,7 @@ export function CooldownTimeline({ cooldowns, selectedId, onSelect }: CooldownTi
     // may be packed slightly tighter or looser than ideal but never overlap.
     const { bars, rowCount } = layoutBars(cooldowns, lo, span, 720, now);
 
-    const ticks = [0, 0.2, 0.4, 0.6, 0.8, 1].map((f) => {
-      const t = lo + span * f;
-      const date = new Date(t);
-      return {
-        pct: f * 100,
-        label: formatDateTime(date.toISOString(), "yyyy MMM"),
-      };
-    });
+    const ticks = buildTicks(lo, span, range, tMin);
 
     const chipLegend = Array.from(new Set(cooldowns.flatMap((c) => c.chip_ids))).sort();
 
@@ -234,7 +249,9 @@ export function CooldownTimeline({ cooldowns, selectedId, onSelect }: CooldownTi
         {ticks.map((t) => (
           <span
             key={t.pct}
-            className="absolute -translate-x-1/2 text-[10px] text-base-content/50"
+            className={`absolute text-[10px] text-base-content/50 ${
+              t.pct === 0 ? "" : t.pct === 100 ? "-translate-x-full" : "-translate-x-1/2"
+            }`}
             style={{ left: `${t.pct}%` }}
           >
             {t.label}

--- a/ui/src/components/features/cryo/CryoPageContent.tsx
+++ b/ui/src/components/features/cryo/CryoPageContent.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 
-import { Plus, X } from "lucide-react";
+import { AlertCircle, CircleDot, Cpu, Plus, Refrigerator, RotateCcw, X } from "lucide-react";
 
 import { useListChips } from "@/client/chip/chip";
 import {
@@ -25,13 +25,23 @@ import { CryostatCard } from "./CryostatCard";
 
 export function CryoPageContent() {
   const queryClient = useQueryClient();
-  const { data: cryostatsData, isLoading: cryostatsLoading } = useListCryostats();
-  const { data: cooldownsData, isLoading: cooldownsLoading } = useListCooldowns();
+  const {
+    data: cryostatsData,
+    isLoading: cryostatsLoading,
+    isError: cryostatsError,
+    refetch: refetchCryostats,
+  } = useListCryostats();
+  const {
+    data: cooldownsData,
+    isLoading: cooldownsLoading,
+    isError: cooldownsError,
+    refetch: refetchCooldowns,
+  } = useListCooldowns();
   const { data: chipsData } = useListChips();
 
-  const cryostats = cryostatsData?.data?.cryostats ?? [];
+  const cryostats = useMemo(() => cryostatsData?.data?.cryostats ?? [], [cryostatsData]);
   const cooldowns = useMemo(() => cooldownsData?.data?.cooldowns ?? [], [cooldownsData]);
-  const chips = chipsData?.data?.chips ?? [];
+  const chips = useMemo(() => chipsData?.data?.chips ?? [], [chipsData]);
 
   const cooldownsByCryo = useMemo(() => {
     const map: Record<string, typeof cooldowns> = {};
@@ -51,7 +61,22 @@ export function CryoPageContent() {
   const [newCooldownFor, setNewCooldownFor] = useState<string | null>(null);
 
   const isLoading = cryostatsLoading || cooldownsLoading;
+  const isError = cryostatsError || cooldownsError;
   const showNewCryostatHeaderBtn = cryostats.length > 0;
+
+  const overview = useMemo(() => {
+    const activeCooldowns = cooldowns.filter((cooldown) => !cooldown.ended_at);
+    return {
+      activeCooldowns: activeCooldowns.length,
+      loadedChips: new Set(activeCooldowns.flatMap((cooldown) => cooldown.chip_ids)).size,
+      attentionCryostats: cryostats.filter((cryo) => cryo.status !== "active").length,
+    };
+  }, [cooldowns, cryostats]);
+
+  const retry = () => {
+    void refetchCryostats();
+    void refetchCooldowns();
+  };
 
   return (
     <PageContainer>
@@ -75,6 +100,21 @@ export function CryoPageContent() {
 
         {isLoading ? (
           <CryoLoadingSkeleton />
+        ) : isError ? (
+          <div className="alert alert-error" role="alert">
+            <AlertCircle className="h-5 w-5" aria-hidden="true" />
+            <div className="min-w-0 flex-1">
+              <div className="font-semibold">Failed to load cryogenic operations</div>
+              <div className="text-sm opacity-80">
+                Cryostats or cool-down history could not be retrieved. Existing data has not been
+                changed.
+              </div>
+            </div>
+            <button type="button" className="btn btn-sm btn-ghost gap-1" onClick={retry}>
+              <RotateCcw className="h-4 w-4" aria-hidden="true" />
+              Retry
+            </button>
+          </div>
         ) : cryostats.length === 0 ? (
           <EmptyState
             title="No cryostats yet"
@@ -92,17 +132,25 @@ export function CryoPageContent() {
             }
           />
         ) : (
-          <div className="divide-y divide-base-300">
-            {cryostats.map((cryo) => (
-              <CryostatCard
-                key={cryo.cryo_id}
-                cryo={cryo}
-                cooldowns={cooldownsByCryo[cryo.cryo_id] ?? []}
-                allChips={chips.map((c) => c.chip_id)}
-                onChange={invalidate}
-                onCreateCooldown={() => setNewCooldownFor(cryo.cryo_id)}
-              />
-            ))}
+          <div className="space-y-6">
+            <CryoOverview
+              cryostats={cryostats.length}
+              activeCooldowns={overview.activeCooldowns}
+              loadedChips={overview.loadedChips}
+              attentionCryostats={overview.attentionCryostats}
+            />
+            <div className="divide-y divide-base-300">
+              {cryostats.map((cryo) => (
+                <CryostatCard
+                  key={cryo.cryo_id}
+                  cryo={cryo}
+                  cooldowns={cooldownsByCryo[cryo.cryo_id] ?? []}
+                  allChips={chips.map((c) => c.chip_id)}
+                  onChange={invalidate}
+                  onCreateCooldown={() => setNewCooldownFor(cryo.cryo_id)}
+                />
+              ))}
+            </div>
           </div>
         )}
       </div>
@@ -118,6 +166,56 @@ export function CryoPageContent() {
         />
       )}
     </PageContainer>
+  );
+}
+
+function CryoOverview({
+  cryostats,
+  activeCooldowns,
+  loadedChips,
+  attentionCryostats,
+}: {
+  cryostats: number;
+  activeCooldowns: number;
+  loadedChips: number;
+  attentionCryostats: number;
+}) {
+  const items = [
+    { label: "Cryostats", value: cryostats, icon: Refrigerator },
+    { label: "Cooling now", value: activeCooldowns, icon: CircleDot, active: true },
+    { label: "Chips loaded", value: loadedChips, icon: Cpu },
+    {
+      label: "Need attention",
+      value: attentionCryostats,
+      icon: AlertCircle,
+      warning: attentionCryostats > 0,
+    },
+  ];
+
+  return (
+    <section
+      aria-label="Cryogenic operations overview"
+      className="grid grid-cols-2 lg:grid-cols-4 gap-2"
+    >
+      {items.map(({ label, value, icon: Icon, active, warning }) => (
+        <div key={label} className="rounded-xl border border-base-300 bg-base-100 px-3 py-3">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-base-content/60">{label}</span>
+            <Icon
+              className={`h-4 w-4 ${
+                warning
+                  ? "text-warning"
+                  : active && value > 0
+                    ? "text-success"
+                    : "text-base-content/35"
+              }`}
+              aria-hidden="true"
+            />
+          </div>
+          <div className="mt-1 text-xl font-semibold tabular-nums">{value}</div>
+        </div>
+      ))}
+    </section>
   );
 }
 


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Make the Cryo page easier to scan by surfacing current cryogenic operations before detailed cool-down history.
- UI-only change with no API, schema, configuration, or generated-client changes.

## Changes
- Add overview metrics for cryostats, active cool-downs, loaded chips, and cryostats needing attention in `CryoPageContent`.
- Distinguish loading, empty, and API failure states with a retry action.
- Use adaptive timeline labels so short cool-down periods show a meaningful start time and `Now` instead of repeated month labels.
- Verify the populated state with an active cool-down and assigned chip.

## Verification
- `nix develop -c task check`
- 1330 Python tests passed
- 169 UI tests passed