### PR TITLE
refactor(ui): make provenance context-only

### DIFF
--- a/ui/src/components/layout/navigation.ts
+++ b/ui/src/components/layout/navigation.ts
@@ -10,7 +10,6 @@ import {
   Cpu,
   Download,
   Files,
-  GitBranch,
   Inbox,
   LayoutDashboard,
   LayoutGrid,
@@ -59,7 +58,6 @@ export function getNavigationSections({
         { href: "/chip", label: "Chip", icon: Cpu },
         { href: "/analysis", label: "Analysis", icon: BarChart3 },
         { href: "/chat", label: "AI Chat", icon: Bot },
-        { href: "/provenance", label: "Provenance", icon: GitBranch },
       ],
     },
     {


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Remove Provenance from global navigation so it is discovered from the data and execution context where lineage investigation begins.
- The Provenance page and all contextual links remain available; this is a navigation-only change.

## Changes
- Remove the Provenance item from the shared navigation definition used by the sidebar and global command palette.
- Preserve existing contextual links from Dashboard, Metrics, Execution, Chip, and Files.
- Keep the `/provenance` route and functionality unchanged.

## Verification
- `nix develop -c task check`
- 1330 Python tests passed
- 169 UI tests passed
- Confirmed Provenance is absent from both sidebar and command palette