### PR TITLE
fix(workflow): auto-crash zombie flow runs via heartbeat automation (oqtopus-team#1351)

### DIFF
--- a/src/qdash/workflow/setup_automations.py
+++ b/src/qdash/workflow/setup_automations.py
@@ -1,0 +1,85 @@
+"""Setup script to register the zombie-flow detection automation if it is absent.
+
+Follow-up to #1111 / #1350. When an OOM kill takes down the worker process itself
+(not just the flow subprocess), no runner survives to report the crash, so the
+Prefect flow run is never marked terminal and stays ``Running`` forever. This
+registers Prefect's recommended heartbeat-based zombie detection
+(https://docs.prefect.io/v3/advanced/detect-zombie-flows): a Proactive automation
+that flips a stalled run to ``CRASHED`` when its heartbeats stop. Once the run is
+``CRASHED``, the API's reconciliation (#1350) finalizes the execution and releases
+the execution lock.
+
+Run automatically by ``start_worker.py`` on container startup. Idempotent: an
+existing automation with the same name is left untouched, so worker restarts do
+not create duplicates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from prefect.client.orchestration import get_client
+from prefect.events.actions import ChangeFlowRunState
+from prefect.events.schemas.automations import AutomationCore, EventTrigger, Posture
+from prefect.events.schemas.events import ResourceSpecification
+from prefect.states import StateType
+
+if TYPE_CHECKING:
+    from prefect.client.orchestration import PrefectClient
+
+logger = getLogger(__name__)
+
+AUTOMATION_NAME = "Crash zombie flows"
+
+# Flow runs emit a heartbeat every PREFECT_FLOWS_HEARTBEAT_FREQUENCY seconds
+# (default 180). Fire once no heartbeat has arrived for 3x that interval, as the
+# Prefect docs recommend, to avoid false positives from a single missed beat.
+_HEARTBEAT_TIMEOUT_SECONDS = 540
+
+
+def _build_zombie_automation() -> AutomationCore:
+    """Build the AutomationCore for heartbeat-based zombie detection."""
+    return AutomationCore(
+        name=AUTOMATION_NAME,
+        description="Mark flow runs as crashed when their heartbeats stop (zombie detection).",
+        trigger=EventTrigger(
+            after={"prefect.flow-run.heartbeat"},
+            expect={"prefect.flow-run.*"},
+            match=ResourceSpecification({"prefect.resource.id": ["prefect.flow-run.*"]}),
+            for_each={"prefect.resource.id"},
+            posture=Posture.Proactive,
+            threshold=1,
+            within=timedelta(seconds=_HEARTBEAT_TIMEOUT_SECONDS),
+        ),
+        actions=[
+            ChangeFlowRunState(
+                state=StateType.CRASHED,
+                message="Flow run marked as crashed due to missing heartbeats.",
+            )
+        ],
+    )
+
+
+async def _ensure_zombie_automation(client: PrefectClient) -> None:
+    """Create the zombie-detection automation unless one with the same name exists."""
+    existing = await client.read_automations_by_name(AUTOMATION_NAME)
+    if existing:
+        logger.info(f"Automation '{AUTOMATION_NAME}' already exists: {existing[0].id}")
+        return
+
+    logger.info(f"Creating automation '{AUTOMATION_NAME}'...")
+    automation_id = await client.create_automation(_build_zombie_automation())
+    logger.info(f"Automation '{AUTOMATION_NAME}' created: {automation_id}")
+
+
+async def setup_automations() -> None:
+    """Register all required automations against the Prefect server."""
+    async with get_client() as client:
+        await _ensure_zombie_automation(client)
+
+
+if __name__ == "__main__":
+    asyncio.run(setup_automations())

--- a/src/qdash/workflow/setup_automations.py
+++ b/src/qdash/workflow/setup_automations.py
@@ -22,10 +22,10 @@ from logging import getLogger
 from typing import TYPE_CHECKING
 
 from prefect.client.orchestration import get_client
+from prefect.client.schemas.objects import StateType
 from prefect.events.actions import ChangeFlowRunState
 from prefect.events.schemas.automations import AutomationCore, EventTrigger, Posture
 from prefect.events.schemas.events import ResourceSpecification
-from prefect.states import StateType
 
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient

--- a/src/qdash/workflow/start_worker.py
+++ b/src/qdash/workflow/start_worker.py
@@ -26,6 +26,7 @@ if __name__ == "__main__":
     # Run setup scripts then start the worker (all arguments are hardcoded)
     subprocess.run([sys.executable, "setup_work_pool.py"], check=True)
     subprocess.run([sys.executable, "register_system_flows.py"], check=True)
+    subprocess.run([sys.executable, "setup_automations.py"], check=True)
     subprocess.run(
         ["prefect", "worker", "start", "--pool", "user-flows-pool"],  # noqa: S607
         check=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,12 @@ if "prefect" not in sys.modules:
     sys.modules["prefect.deployments"] = MagicMock()
     sys.modules["prefect.exceptions"] = MagicMock()
     sys.modules["prefect.states"] = MagicMock()
+    sys.modules["prefect.client.schemas.objects"] = MagicMock()
+    sys.modules["prefect.events"] = MagicMock()
+    sys.modules["prefect.events.actions"] = MagicMock()
+    sys.modules["prefect.events.schemas"] = MagicMock()
+    sys.modules["prefect.events.schemas.automations"] = MagicMock()
+    sys.modules["prefect.events.schemas.events"] = MagicMock()
 
 import mongomock
 import pytest

--- a/tests/qdash/workflow/test_setup_automations.py
+++ b/tests/qdash/workflow/test_setup_automations.py
@@ -1,0 +1,181 @@
+"""
+Tests for the zombie-flow detection automation setup (#1351).
+"""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from qdash.workflow import setup_automations
+from qdash.workflow.setup_automations import (
+    AUTOMATION_NAME,
+    _build_zombie_automation,
+    _ensure_zombie_automation,
+)
+
+if TYPE_CHECKING:
+    from prefect.client.orchestration import PrefectClient
+
+
+class _Fake:
+    """Records constructor kwargs as attributes for later assertion."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+class FakeAutomationCore(_Fake):
+    """Test stand-in for Prefect's AutomationCore model."""
+
+
+class FakeEventTrigger(_Fake):
+    """Test stand-in for Prefect's EventTrigger model."""
+
+
+class FakeChangeFlowRunState(_Fake):
+    """Test stand-in for Prefect's ChangeFlowRunState action."""
+
+    state: Any
+
+
+class FakeResourceSpecification:
+    """Test stand-in for Prefect's ResourceSpecification root model."""
+
+    def __init__(self, spec: Any) -> None:
+        self.spec = spec
+
+
+class FakePosture:
+    """Test stand-in for Prefect's Posture enum."""
+
+    Proactive = "Proactive"
+    Reactive = "Reactive"
+
+
+class FakeStateType:
+    """Test stand-in for Prefect's StateType enum."""
+
+    CRASHED = "CRASHED"
+
+
+def _patch_automation_types(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Swap the prefect symbols on ``setup_automations`` for recording fakes."""
+    monkeypatch.setattr(setup_automations, "AutomationCore", FakeAutomationCore)
+    monkeypatch.setattr(setup_automations, "EventTrigger", FakeEventTrigger)
+    monkeypatch.setattr(setup_automations, "ChangeFlowRunState", FakeChangeFlowRunState)
+    monkeypatch.setattr(setup_automations, "ResourceSpecification", FakeResourceSpecification)
+    monkeypatch.setattr(setup_automations, "Posture", FakePosture)
+    monkeypatch.setattr(setup_automations, "StateType", FakeStateType)
+
+
+def test_build_zombie_automation_uses_heartbeat_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The trigger fires proactively when flow-run heartbeats stop arriving."""
+    _patch_automation_types(monkeypatch)
+
+    # Fakes are injected via monkeypatch, so treat the return as Any: the static
+    # type is the real prefect union, which does not expose these attributes.
+    automation: Any = _build_zombie_automation()
+    trigger = automation.trigger
+
+    assert automation.name == AUTOMATION_NAME
+    assert trigger.posture == FakePosture.Proactive
+    assert trigger.after == {"prefect.flow-run.heartbeat"}
+    assert trigger.expect == {"prefect.flow-run.*"}
+    assert trigger.for_each == {"prefect.resource.id"}
+    assert trigger.match.spec == {"prefect.resource.id": ["prefect.flow-run.*"]}
+    assert trigger.threshold == 1
+
+
+def test_build_zombie_automation_waits_three_heartbeat_intervals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The window is 3x the 180s heartbeat interval, per the Prefect docs."""
+    _patch_automation_types(monkeypatch)
+
+    trigger: Any = _build_zombie_automation().trigger
+
+    assert trigger.within == timedelta(seconds=3 * 180)
+
+
+def test_build_zombie_automation_crashes_the_flow_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The single action flips the stalled run to CRASHED."""
+    _patch_automation_types(monkeypatch)
+
+    automation: Any = _build_zombie_automation()
+
+    assert len(automation.actions) == 1
+    action = automation.actions[0]
+    assert isinstance(action, FakeChangeFlowRunState)
+    assert action.state == FakeStateType.CRASHED
+
+
+@pytest.mark.asyncio
+async def test_ensure_zombie_automation_creates_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no matching automation, a new one is created."""
+    _patch_automation_types(monkeypatch)
+    client = SimpleNamespace(
+        read_automations_by_name=AsyncMock(return_value=[]),
+        create_automation=AsyncMock(return_value="automation-id"),
+    )
+
+    await _ensure_zombie_automation(cast("PrefectClient", client))
+
+    client.read_automations_by_name.assert_awaited_once_with(AUTOMATION_NAME)
+    client.create_automation.assert_awaited_once()
+    created = client.create_automation.await_args.args[0]
+    assert created.name == AUTOMATION_NAME
+
+
+@pytest.mark.asyncio
+async def test_ensure_zombie_automation_skips_when_present() -> None:
+    """An existing automation with the same name is left untouched (idempotent)."""
+    existing = SimpleNamespace(id="existing-id")
+    client = SimpleNamespace(
+        read_automations_by_name=AsyncMock(return_value=[existing]),
+        create_automation=AsyncMock(),
+    )
+
+    await _ensure_zombie_automation(cast("PrefectClient", client))
+
+    client.read_automations_by_name.assert_awaited_once_with(AUTOMATION_NAME)
+    client.create_automation.assert_not_called()
+
+
+class _FakeClientCtx:
+    """Async-context-manager stand-in for ``get_client()``."""
+
+    def __init__(self, client: object) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> object:
+        return self._client
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_setup_automations_ensures_automation_via_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setup_automations`` opens a client and registers the automation through it."""
+    _patch_automation_types(monkeypatch)
+    client = SimpleNamespace(
+        read_automations_by_name=AsyncMock(return_value=[]),
+        create_automation=AsyncMock(return_value="automation-id"),
+    )
+    monkeypatch.setattr(setup_automations, "get_client", lambda: _FakeClientCtx(client))
+
+    await setup_automations.setup_automations()
+
+    client.read_automations_by_name.assert_awaited_once_with(AUTOMATION_NAME)
+    client.create_automation.assert_awaited_once()


### PR DESCRIPTION
## Ticket

- close #1351 
- relation #1111 
- relation #1350 

## Summary

Follow-up to #1111 / #1350. 

- #1350 finalizes an execution once its Prefect flow run reaches a terminal state, but when an OOM kill takes down the worker process itself, no runner survives to report the crash. The flow run stays `Running` forever, so the reconciliation and the execution is left `running` with the lock held.
- This registers Prefect's recommended heartbeat-based zombie detection on worker startup, so a stalled run is flipped to `CRASHED` once its heartbeats stop. After that, reconciliation finalizes the Mongo execution and releases the lock; the two mechanisms compose. 

### Affected area
- Workflow only (worker startup). 
- No Prefect-side, API, OpenAPI, schema, or generated-client changes, so no regeneration is needed. 
- No flow-run changes either: Prefect ≥ 3.6.22 (we run 3.8.1) emits flow-run heartbeats by default.

Reference: [How to detect and respond to zombie flows — Prefect](https://docs.prefect.io/v3/advanced/detect-zombie-flows)

 ## Notes
- Complements with #1350: this PR adds the Prefect-side `RUNNING` → `CRASHED` transition, and the reconciliation finalizes the Mongo-side record once a run is terminal. The two are independent and compose.
- Mergeable independently: this PR can be merged on its own, and already prevents flow runs from staying `RUNNING` after a worker crash.

## Changes

### Heartbeat-based zombie-detection automation

- `setup_automations.py` (new) idempotently registers a `Crash zombie flows` automation: a Proactive `EventTrigger` that fires when a flow run emits a heartbeat but no follow-up `prefect.flow-run.*` event arrives within the timeout, with a `ChangeFlowRunState` action that sets the run to `CRASHED`.
- It mirrors the read-then-create pattern of `setup_work_pool.py` (`read_automations_by_name` → create only if absent), so worker restarts never create duplicates.
- Timeout is `within = 540s`, i.e. 3× the default 180s heartbeat interval, as the Prefect docs recommend to avoid false positives from a single missed beat.

### Registered on worker startup

- `start_worker.py` runs `setup_automations.py` in its startup sequence, after `setup_work_pool.py` / `register_system_flows.py` and before the worker starts.

## How it works

Server-side state changes do not run flow-level `on_crashed` hooks (there is no process left to run them), but that is fine here: once the run is `CRASHED`, #1350's reconciliation handles the DB side on the next history read.

## Verification

### 1. Startup registration

Confirmed that starting the stack (`task dev-local`) with no automation present automatically registers exactly one via `start_worker.py` → `setup_automations.py`. Registration is idempotent: running it again while the automation already exists is a no-op, so worker restarts never duplicate it.

### 2. Automation crashes the zombie run (this branch)

Reproduced the OOM scenario on this branch alone, which does not include the reconciliation from #1350.
The automation registered by `setup_automations.py` (production setting `within = 540s`) flipped the stalled run to `CRASHED` on its own: deployment run `a832a21d-...`, submitted at 08:17:10 and crashed by the automation ~9 minutes later, matching the 540s timeout:

```
% curl .../events/filter -d '{"filter":{"related":{"id":["prefect.flow-run.a832a21d-..."]}}}'
2026-08-16T08:26:15Z | prefect.automation.action.executed  | prefect.automation.a5e850d6-...
2026-08-16T08:26:15Z | prefect.automation.action.triggered | prefect.automation.a5e850d6-...
2026-08-16T08:17:10Z | prefect.worker.submitted-flow-run   | prefect.worker.process.processworker-...
```

The Prefect flow run is now `CRASHED`. The QDash execution history still shows it `running` at this point, because the Mongo-side finalization lives in #1350 — verified next.

### 3. End-to-end composed with #1350

Combined with the #1350 branch (the reconciliation), the full recovery completes with no manual intervention: after the automation sets `CRASHED`, the reconciliation finalizes the Mongo execution and releases the lock. Using a fast test setting (heartbeat 30s / `within` 90s):

| time (UTC)  | actor               | event                                                            |
| ----------- | ------------------- | ---------------------------------------------------------------- |
| 06:51:33    | flow process        | last heartbeat before OOM                                        |
| ~06:51:3x   | kernel              | OOM kills flow + worker → container restarts (`RestartCount` +1) |
| 06:51–06:53 | —                   | Prefect run stays `RUNNING` (zombie)                             |
| 06:53:05    | **automation**      | heartbeats missing → run set to `CRASHED`                        |
| 06:53:09    | **#1350 reconcile** | execution → `failed` + `end_at`, lock released                   |

Evidence it was the automation (not a runner) that closed the deployment run `95b05d78-...`:

```
state   : CRASHED
message : 'Flow run marked as crashed due to missing heartbeats.'
```

```
% curl .../events/filter -d '{"filter":{"related":{"id":["prefect.flow-run.95b05d78-..."]}}}'
2026-08-16T06:53:05Z | prefect.automation.action.executed | prefect.automation.10426ed6-...
```

After `CRASHED`, #1350's reconciliation finalized the Mongo execution (`failed` + `end_at`) and released the lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of stalled workflow runs that have stopped reporting heartbeats.
  * Stalled runs are now marked as crashed after approximately nine minutes without a heartbeat.
  * Automation setup runs automatically when the workflow worker starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->