### PR TITLE
Show R2 threshold in error message

### DIFF
--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -429,7 +429,7 @@ class TaskExecutor:
                                     task_name, task_type, qid
                                 )
                             backend_success = False
-                            r2_error_msg = f"{task_name} R² value too low: {r2_value:.4f}"
+                            r2_error_msg = f"{task_name} R² value too low: {r2_value:.4f} (threshold = {task.r2_threshold})"
 
                     if not backend_success and postprocess_result.output_parameters:
                         self.state_manager.clear_output_parameters(task_name, task_type, qid)
@@ -641,7 +641,7 @@ class TaskExecutor:
                                         task_name, task_type, qid
                                     )
                                 backend_success = False
-                                r2_error_msg = f"{task_name} R² value too low: {r2_value:.4f}"
+                                r2_error_msg = f"{task_name} R² value too low: {r2_value:.4f} (threshold = {task.r2_threshold})"
 
                         if not backend_success and postprocess_result.output_parameters:
                             self.state_manager.clear_output_parameters(task_name, task_type, qid)


### PR DESCRIPTION
I was trying to figure out what the R2 threshold was for a failed run. Now I had to go to the prefect logs to find it, I think it's better to show it also in the error message which is what the user sees in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved R² validation error messages by showing both the measured value and the configured threshold for single-task and batch executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->