### PR TITLE
feat(workflow): share calibration state by project

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,34 @@ services:
       MONGO_INIT_DATABASE: qubex
     volumes:
       - ${MONGO_DATA_PATH:-./mongo_data/data/db}:/data/db
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mongosh --quiet --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval 'db.adminCommand({ ping: 1 })'",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - custom_net
+  calibration-migration:
+    build:
+      context: .
+      dockerfile: ./src/qdash/api/Dockerfile
+    restart: "no"
+    env_file:
+      - .env
+    depends_on:
+      mongo:
+        condition: service_healthy
+    volumes:
+      - ./src/qdash/dbmodel:/app/qdash/dbmodel
+      - ${CALIB_DATA_PATH:-./calib_data}:/app/calib_data
+    command: python -m qdash.dbmodel.migration project-scoped-calibration --execute
+    environment:
+      - PYTHONPATH=/app
+      - CALIB_DATA_PATH=/app/calib_data
     networks:
       - custom_net
   mongo-express:
@@ -75,7 +103,10 @@ services:
     env_file:
       - .env
     depends_on:
-      - prefect-server
+      prefect-server:
+        condition: service_started
+      calibration-migration:
+        condition: service_completed_successfully
     volumes:
       - ./src/qdash/workflow:/app/qdash/workflow
       - ./src/qdash/analysis:/app/qdash/analysis # Shared spectroscopy analysis (also used by api)
@@ -105,8 +136,12 @@ services:
     env_file:
       - .env
     depends_on:
-      - prefect-server
-      - deployment-service
+      prefect-server:
+        condition: service_started
+      deployment-service:
+        condition: service_started
+      calibration-migration:
+        condition: service_completed_successfully
     volumes:
       - ./src/qdash/workflow:/app/qdash/workflow
       - ./src/qdash/analysis:/app/qdash/analysis # Shared spectroscopy analysis
@@ -165,9 +200,14 @@ services:
           path: ./src/qdash/api
           target: /app/api
     depends_on:
-      - mongo
-      - prefect-server
-      - deployment-service
+      mongo:
+        condition: service_healthy
+      prefect-server:
+        condition: service_started
+      deployment-service:
+        condition: service_started
+      calibration-migration:
+        condition: service_completed_successfully
     environment:
       - PYTHONPATH=/app:/app/qdash:/app/qdash/api:/app/qdash/dbmodel:/app/qdash/datamodel:/app/qdash
       - CALIB_DATA_PATH=/app/calib_data

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,11 +17,12 @@ services:
       test:
         [
           "CMD-SHELL",
-          "mongosh --quiet --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval 'db.adminCommand({ ping: 1 })'",
+          "mongosh --quiet --username \"$$MONGO_INITDB_ROOT_USERNAME\" --password \"$$MONGO_INITDB_ROOT_PASSWORD\" --authenticationDatabase admin --eval 'db.adminCommand({ ping: 1 })'",
         ]
       interval: 5s
       timeout: 5s
       retries: 12
+      start_period: 30s
     networks:
       - custom_net
   calibration-migration:

--- a/docs/development/workflow/engine-architecture.md
+++ b/docs/development/workflow/engine-architecture.md
@@ -67,6 +67,7 @@ from qdash.workflow.engine import CalibOrchestrator, CalibConfig
 
 config = CalibConfig(
     username="alice",
+    project_id="proj-1",
     chip_id="64Qv3",
     qids=["0", "1"],
     execution_id="20240101-001",
@@ -405,4 +406,3 @@ class YourService:
             repo = MongoYourRepository()
         self._repo = repo
 ```
-

--- a/docs/development/workflow/quickstart.md
+++ b/docs/development/workflow/quickstart.md
@@ -29,6 +29,7 @@ from qdash.workflow.engine import CalibOrchestrator, CalibConfig
 # Configure the session
 config = CalibConfig(
     username="alice",
+    project_id="proj-1",
     chip_id="64Qv3",
     qids=["0", "1"],
     execution_id="20240101-001",
@@ -83,6 +84,7 @@ Use the `FakeBackend` for testing without hardware:
 ```python
 config = CalibConfig(
     backend_name="fake",  # Use fake backend
+    project_id="proj-1",
     ...
 )
 ```

--- a/docs/reference/database-indexes.md
+++ b/docs/reference/database-indexes.md
@@ -24,21 +24,21 @@ db.project_membership.create_index([("username", 1), ("status", 1)])
 ### ChipDocument
 
 ```python
-db.chip.create_index([("project_id", 1), ("chip_id", 1), ("username", 1)], unique=True)
+db.chip.create_index([("project_id", 1), ("chip_id", 1)], unique=True)
 db.chip.create_index([("project_id", 1), ("username", 1), ("installed_at", -1)])
 ```
 
 ### QubitDocument
 
 ```python
-db.qubit.create_index([("project_id", 1), ("chip_id", 1), ("qid", 1), ("username", 1)], unique=True)
+db.qubit.create_index([("project_id", 1), ("chip_id", 1), ("qid", 1)], unique=True)
 db.qubit.create_index([("project_id", 1), ("chip_id", 1)])
 ```
 
 ### CouplingDocument
 
 ```python
-db.coupling.create_index([("project_id", 1), ("chip_id", 1), ("qid", 1), ("username", 1)], unique=True)
+db.coupling.create_index([("project_id", 1), ("chip_id", 1), ("qid", 1)], unique=True)
 db.coupling.create_index([("project_id", 1), ("chip_id", 1)])
 ```
 
@@ -102,28 +102,38 @@ db.execution_lock.create_index([("project_id", 1)], unique=True)
 ### ExecutionCounterDocument
 
 ```python
-db.execution_counter.create_index([("project_id", 1), ("date", 1), ("username", 1), ("chip_id", 1)], unique=True)
+db.execution_counter.create_index([("project_id", 1), ("date", 1), ("chip_id", 1)], unique=True)
 ```
 
 ### ChipHistoryDocument
 
 ```python
-db.chip_history.create_index([("project_id", 1), ("chip_id", 1), ("username", 1), ("recorded_date", 1)], unique=True)
+db.chip_history.create_index([("project_id", 1), ("chip_id", 1), ("recorded_date", 1)], unique=True)
 db.chip_history.create_index([("project_id", 1), ("chip_id", 1), ("recorded_date", -1)])
 ```
 
 ### QubitHistoryDocument
 
 ```python
-db.qubit_history.create_index([("project_id", 1), ("chip_id", 1), ("qid", 1), ("username", 1), ("recorded_date", 1)], unique=True)
+db.qubit_history.create_index([("project_id", 1), ("chip_id", 1), ("qid", 1), ("recorded_date", 1)], unique=True)
 db.qubit_history.create_index([("project_id", 1), ("chip_id", 1), ("recorded_date", -1)])
 ```
 
 ### CouplingHistoryDocument
 
 ```python
-db.coupling_history.create_index([("project_id", 1), ("chip_id", 1), ("qid", 1), ("username", 1), ("recorded_date", 1)], unique=True)
+db.coupling_history.create_index([("project_id", 1), ("chip_id", 1), ("qid", 1), ("recorded_date", 1)], unique=True)
 db.coupling_history.create_index([("project_id", 1), ("chip_id", 1), ("recorded_date", -1)])
+```
+
+### CalibrationNoteDocument
+
+```python
+db.calibration_note.create_index(
+    [("project_id", 1), ("execution_id", 1), ("task_id", 1), ("chip_id", 1)],
+    unique=True,
+)
+db.calibration_note.create_index([("project_id", 1), ("chip_id", 1), ("timestamp", 1)])
 ```
 
 ### TaskResultHistoryDocument

--- a/docs/reference/migration-project-scoped-calibration.md
+++ b/docs/reference/migration-project-scoped-calibration.md
@@ -1,0 +1,85 @@
+# Project-scoped calibration migration
+
+QDash now shares current calibration state among all members of a project. The deployment process
+runs this migration automatically before the API, deployment service, and user-flow worker start.
+
+The migration changes the unique ownership of chips, qubits, couplings, calibration notes, their
+daily histories, and execution counters from a project-and-user key to a project-and-chip key.
+`username` and `user_id` remain on documents as actor snapshots; they no longer partition
+calibration state.
+
+## Deployment behavior
+
+`docker compose up` starts the one-shot `calibration-migration` service after MongoDB becomes
+healthy. Other QDash services start only when the migration exits successfully. The migration is
+idempotent and records completion as `project-scoped-calibration-v1` in `migration_ledger`.
+Artifact migration is recorded separately as `project-scoped-calibration-artifacts-v1`, preventing
+legacy files from being reconsidered after shared classifier files receive newer updates.
+The migration lock has a 30-minute lease, so a deployment interrupted by a hard container stop can
+recover automatically on a later deployment.
+
+To inspect an installation without changing it, run:
+
+```bash
+docker compose run --rm calibration-migration \
+  python -m qdash.dbmodel.migration project-scoped-calibration
+```
+
+Normal `task deploy` and `task deploy-local` runs execute the migration automatically with
+`--execute`.
+
+## Duplicate handling
+
+For duplicate current or daily-history documents, QDash retains the latest document as the base.
+Qubit and coupling parameters are merged by parameter name, preferring each parameter's latest
+`calibrated_at` value and falling back to the document update time. Calibration-note mappings are
+merged recursively in document update order. A stable document-ID comparison breaks exact
+timestamp ties. Every losing document is copied verbatim to `migration_archive` before deletion.
+
+Duplicate execution counters keep the largest issued index so a migrated project does not reuse an
+execution ID. The other counter documents are archived in the same way.
+
+The migration never deletes legacy calibration files. It copies execution artifacts to:
+
+```text
+calib_data/projects/{project_id}/chips/{chip_id}/executions/{execution_id}/
+```
+
+After an execution directory is copied successfully, the migration rewrites its persisted artifact
+references in `execution_history`, `task_result_history`, and `issue_knowledge` to the new project
+path. Every affected document is copied verbatim to `migration_archive` before its paths are
+changed. This keeps historical figures, raw data downloads, and reanalysis available after the
+legacy directories are eventually removed.
+
+Classifier files are copied to:
+
+```text
+calib_data/projects/{project_id}/chips/{chip_id}/shared/classifier/
+```
+
+When two legacy classifier files have the same relative path and different content, the file with
+the latest modification time is retained at the shared destination and the other file is copied
+below `.migration_conflicts/{username}`.
+
+Execution artifacts missing from their expected legacy directories stop an execute migration. After
+reviewing those records and confirming that the files cannot be recovered, an operator can accept
+the missing artifacts explicitly:
+
+```bash
+docker compose run --rm calibration-migration \
+  python -m qdash.dbmodel.migration project-scoped-calibration \
+  --execute --allow-missing-artifacts
+```
+
+Documents missing `project_id` or another required scope field also stop the migration and must be
+corrected before retrying; they are never grouped under an implicit null project.
+
+## Verification and recovery
+
+After deployment, verify that `calibration-migration` exited with status zero and that the API and
+worker services started. The legacy `calib_data/{username}` directories remain available for
+rollback. Database documents removed during consolidation remain in `migration_archive`, including
+their original `_id`, source collection, selected winner, and full document content.
+
+Take a MongoDB and calibration-data backup before upgrading a production installation. Restoring
+that backup is the supported full rollback if calibration ownership must return to the prior model.

--- a/docs/user-guide/calibration-data-sharing.md
+++ b/docs/user-guide/calibration-data-sharing.md
@@ -1,0 +1,94 @@
+# Calibration Data Sharing
+
+QDash shares calibration state by project and chip while retaining the user and execution that
+produced each result.
+
+## Data ownership model
+
+Four identifiers describe the scope of calibration data:
+
+| Identifier | Purpose |
+| ---------- | ------- |
+| Project | Collaboration and access boundary |
+| Chip | Hardware whose current calibration state is being maintained |
+| Execution | One calibration run and its results and artifacts |
+| User | Actor recorded for audit and attribution |
+
+The project is the primary isolation boundary. Two projects may use the same chip ID without
+sharing calibration state. Within one project, all members work with the same state for a chip;
+QDash does not maintain a separate copy for each user.
+
+For example, if Alice calibrates qubit `0` on chip `chip-a`, Bob's next execution in the same
+project reads the values saved by Alice. Bob's result becomes the new current state when that task
+is configured to persist its output parameters. Both executions remain in the history with their
+respective users.
+
+## Shared current state
+
+The following data is shared by members of the same project for each chip:
+
+- Chip configuration and topology
+- Current qubit and coupling parameters
+- Parameter history and calibration notes
+- Classifier files used by the calibration backend
+- The execution counter used to allocate execution IDs
+
+This allows one project member to continue calibration from another member's latest result. A user
+must have the appropriate [project role](./projects-and-sharing.md#team-roles-and-permissions) to
+update this state.
+
+The user shown on a record identifies who performed the operation. It is an actor snapshot and
+does not create a user-specific calibration namespace.
+
+## Execution records and artifacts
+
+Each run has its own execution record, task results, figures, and raw data. These records are
+visible to project members but remain associated with the execution that produced them. Starting a
+new execution does not overwrite an earlier execution's result or artifact references.
+
+On a standard deployment, execution artifacts use this layout:
+
+```text
+calib_data/projects/{project_id}/chips/{chip_id}/executions/{execution_id}/
+```
+
+Classifier files are reusable chip state rather than execution output, so they use a shared path:
+
+```text
+calib_data/projects/{project_id}/chips/{chip_id}/shared/classifier/
+```
+
+These are deployment storage paths. Users normally access results through the QDash UI or client
+instead of reading these directories directly.
+
+## What happens during an execution
+
+Quick Run and regular workflow executions use the same ownership model:
+
+1. QDash resolves the project, chip, and target qubits or couplings for the execution.
+2. The workflow loads the chip's current parameters from the selected project.
+3. The backend receives those values and the project's shared classifier files.
+4. Each task stores its result and artifacts under the current execution.
+5. Output parameters update the project's current chip state only when parameter persistence is
+   enabled for that execution and the task output is eligible for an update.
+
+The output-parameter view can therefore show both the previous shared value and the new task
+result. The previous value is the state read before the update, not a value owned by the current
+user.
+
+## Switching projects
+
+The active project determines which chips, current parameters, classifiers, and execution history
+QDash uses. Before starting a calibration, verify the selected project as well as the chip. Moving
+to another project changes the calibration namespace even when a chip with the same ID exists
+there.
+
+Calibration data cannot currently be moved between projects through the user interface. Create the
+chip and establish its calibration state separately when work needs a different access boundary.
+
+## Existing installations
+
+Upgrades migrate legacy user-scoped database records and calibration files into the project and
+chip layout automatically during deployment. Operators should follow the
+[project-scoped calibration migration guide](../reference/migration-project-scoped-calibration.md)
+for backup, verification, duplicate handling, and recovery details.

--- a/docs/user-guide/projects-and-sharing.md
+++ b/docs/user-guide/projects-and-sharing.md
@@ -87,7 +87,12 @@ From the Members tab, owners can:
 
 ## Sharing Calibration Results
 
-Once you have team members in your project, sharing is automatic:
+Once you have team members in your project, sharing is automatic. Current calibration state is
+shared by project and chip, while each result remains associated with the user and execution that
+produced it. See [Calibration Data Sharing](./calibration-data-sharing.md) for the ownership model,
+execution behavior, and artifact layout.
+
+To share calibration results:
 
 1. **Run a calibration** in your project
 2. **All members can view** the results

--- a/src/qdash/api/services/device_topology_service.py
+++ b/src/qdash/api/services/device_topology_service.py
@@ -156,16 +156,12 @@ class DeviceTopologyService:
         drag_hpi_params = latest.note["drag_hpi_params"]
         drag_pi_params = latest.note["drag_pi_params"]
 
-        chip_model = self._chip_repo.get_current_chip(username=latest.username)
+        chip_model = self._chip_repo.find_by_id(project_id=project_id, chip_id=latest.chip_id)
         if chip_model is None:
-            raise ValueError(f"No chip found for user {latest.username}")
+            raise ValueError(f"Chip {latest.chip_id} not found in project {project_id}")
 
-        qubit_models = self._chip_repo.get_all_qubit_models(
-            project_id, chip_model.chip_id, username=chip_model.username
-        )
-        coupling_models = self._chip_repo.get_all_coupling_models(
-            project_id, chip_model.chip_id, username=chip_model.username
-        )
+        qubit_models = self._chip_repo.get_all_qubit_models(project_id, chip_model.chip_id)
+        coupling_models = self._chip_repo.get_all_coupling_models(project_id, chip_model.chip_id)
 
         topology = load_topology(chip_model.topology_id)
         sorted_physical_ids = sorted(request.qubits, key=int)

--- a/src/qdash/dbmodel/calibration_note.py
+++ b/src/qdash/dbmodel/calibration_note.py
@@ -62,7 +62,6 @@ class CalibrationNoteDocument(Document):
                     ("project_id", ASCENDING),
                     ("execution_id", ASCENDING),
                     ("task_id", ASCENDING),
-                    ("username", ASCENDING),
                     ("chip_id", ASCENDING),
                 ],
                 unique=True,
@@ -113,7 +112,6 @@ class CalibrationNoteDocument(Document):
             "project_id": project_id,
             "execution_id": execution_id,
             "task_id": task_id,
-            "username": username,
             "chip_id": chip_id,
         }
 
@@ -123,6 +121,7 @@ class CalibrationNoteDocument(Document):
         update = {
             "$set": {
                 "user_id": user_id,
+                "username": username,
                 "note": note,
                 "timestamp": timestamp,
             },
@@ -131,7 +130,6 @@ class CalibrationNoteDocument(Document):
                 "project_id": project_id,
                 "execution_id": execution_id,
                 "task_id": task_id,
-                "username": username,
                 "chip_id": chip_id,
             },
         }

--- a/src/qdash/dbmodel/chip.py
+++ b/src/qdash/dbmodel/chip.py
@@ -67,7 +67,7 @@ class ChipDocument(Document):
         name = "chip"
         indexes: ClassVar = [
             IndexModel(
-                [("project_id", ASCENDING), ("chip_id", ASCENDING), ("username", ASCENDING)],
+                [("project_id", ASCENDING), ("chip_id", ASCENDING)],
                 unique=True,
             ),
             IndexModel(

--- a/src/qdash/dbmodel/chip_history.py
+++ b/src/qdash/dbmodel/chip_history.py
@@ -57,7 +57,6 @@ class ChipHistoryDocument(Document):
                 [
                     ("project_id", ASCENDING),
                     ("chip_id", ASCENDING),
-                    ("username", ASCENDING),
                     ("recorded_date", ASCENDING),
                 ],
                 unique=True,
@@ -96,7 +95,6 @@ class ChipHistoryDocument(Document):
             {
                 "project_id": project_id,
                 "chip_id": chip_id,
-                "username": username,
                 "recorded_date": yesterday,
             }
         ).run()
@@ -145,7 +143,6 @@ class ChipHistoryDocument(Document):
                 {
                     "project_id": chip_doc.project_id,
                     "chip_id": chip_doc.chip_id,
-                    "username": chip_doc.username,
                     "recorded_date": today,
                 }
             ).run()

--- a/src/qdash/dbmodel/coupling.py
+++ b/src/qdash/dbmodel/coupling.py
@@ -56,7 +56,6 @@ class CouplingDocument(Document):
                     ("project_id", ASCENDING),
                     ("chip_id", ASCENDING),
                     ("qid", ASCENDING),
-                    ("username", ASCENDING),
                 ],
                 unique=True,
             ),
@@ -98,12 +97,13 @@ class CouplingDocument(Document):
         if coupling_doc is None:
             raise ValueError(f"Coupling {qid} not found in chip {chip_id}")
         coupling_doc.user_id = cls._user_id_for_username(username)
+        coupling_doc.username = username
         coupling_doc.data = CouplingDocument.merge_calib_data(coupling_doc.data, output_parameters)
         coupling_doc.system_info.update_time()
         coupling_doc.save()
         # Create history entry for the updated coupling
         coupling_model = CouplingModel(
-            project_id=project_id,
+            project_id=coupling_doc.project_id,
             user_id=coupling_doc.user_id,
             qid=qid,
             chip_id=chip_id,

--- a/src/qdash/dbmodel/coupling.py
+++ b/src/qdash/dbmodel/coupling.py
@@ -82,17 +82,11 @@ class CouplingDocument(Document):
         project_id: str | None,
     ) -> "CouplingDocument":
         """Update the CouplingDocument's calibration data with new values."""
-        query: dict[str, Any] = {"qid": qid, "chip_id": chip_id}
-        if project_id:
-            query["project_id"] = project_id
-            coupling_doc = cls.find_one(query).run()
+        if project_id is not None:
+            query = {"project_id": project_id, "qid": qid, "chip_id": chip_id}
         else:
-            coupling_doc = None
-
-        if coupling_doc is None:
-            coupling_doc = cls.find_one(
-                {"username": username, "qid": qid, "chip_id": chip_id}
-            ).run()
+            query = {"username": username, "qid": qid, "chip_id": chip_id}
+        coupling_doc = cls.find_one(query).run()
 
         if coupling_doc is None:
             raise ValueError(f"Coupling {qid} not found in chip {chip_id}")

--- a/src/qdash/dbmodel/coupling_history.py
+++ b/src/qdash/dbmodel/coupling_history.py
@@ -58,7 +58,6 @@ class CouplingHistoryDocument(Document):
                     ("project_id", ASCENDING),
                     ("chip_id", ASCENDING),
                     ("qid", ASCENDING),
-                    ("username", ASCENDING),
                     ("recorded_date", ASCENDING),
                 ],
                 unique=True,
@@ -105,13 +104,13 @@ class CouplingHistoryDocument(Document):
                 "project_id": coupling.project_id,
                 "chip_id": coupling.chip_id,
                 "qid": coupling.qid,
-                "username": username,
                 "recorded_date": today,
             }
         ).run()
         if existing_history:
             history = existing_history
             history.user_id = user_id
+            history.username = username
             history.data = coupling.data
             history.status = coupling.status
             history.cooldown_id = cooldown_id

--- a/src/qdash/dbmodel/execution_counter.py
+++ b/src/qdash/dbmodel/execution_counter.py
@@ -62,7 +62,7 @@ class ExecutionCounterDocument(Document):
         Args:
         ----
             date: The date to get the next index for
-            username: The username to get the next index for
+            username: The actor username recorded on the counter document
             chip_id: The chip_id to get the next index for
             project_id: The project_id to get the next index for
 

--- a/src/qdash/dbmodel/execution_counter.py
+++ b/src/qdash/dbmodel/execution_counter.py
@@ -30,7 +30,6 @@ class ExecutionCounterDocument(Document):
                 [
                     ("project_id", ASCENDING),
                     ("date", ASCENDING),
-                    ("username", ASCENDING),
                     ("chip_id", ASCENDING),
                 ],
                 unique=True,
@@ -55,10 +54,10 @@ class ExecutionCounterDocument(Document):
         project_id: str,
         user_id: str | None = None,
     ) -> int:
-        """Get the next index for the given date, username and chip_id combination.
+        """Get the next index for a project chip and date.
 
         Uses atomic findAndModify to prevent race conditions in concurrent executions.
-        Index starts from 0 on the first call for a given date/username/chip_id combination.
+        Index starts from 0 on the first call for a project/date/chip combination.
 
         Args:
         ----
@@ -81,9 +80,8 @@ class ExecutionCounterDocument(Document):
         resolved_user_id = user_id or cls._user_id_for_username(username)
         for attempt in range(max_retries):
             # First, try to find existing document
-            doc = cls.find_one(
-                {"project_id": project_id, "date": date, "username": username, "chip_id": chip_id}
-            ).run()
+            counter_key = {"project_id": project_id, "date": date, "chip_id": chip_id}
+            doc = cls.find_one(counter_key).run()
 
             if doc is None:
                 # Try to create initial document with index 0
@@ -106,8 +104,11 @@ class ExecutionCounterDocument(Document):
 
             # Document exists - use atomic increment
             result = cls.get_motor_collection().find_one_and_update(
-                {"project_id": project_id, "date": date, "username": username, "chip_id": chip_id},
-                {"$inc": {"index": 1}, "$set": {"user_id": resolved_user_id}},
+                counter_key,
+                {
+                    "$inc": {"index": 1},
+                    "$set": {"username": username, "user_id": resolved_user_id},
+                },
                 return_document=ReturnDocument.AFTER,
             )
 

--- a/src/qdash/dbmodel/migration.py
+++ b/src/qdash/dbmodel/migration.py
@@ -1751,6 +1751,21 @@ if __name__ == "__main__":
         help="Actually execute the migration (default is dry-run)",
     )
 
+    project_calibration_parser = subparsers.add_parser(
+        "project-scoped-calibration",
+        help="Consolidate user-owned calibration data into project-shared state",
+    )
+    project_calibration_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually execute the migration (default is dry-run)",
+    )
+    project_calibration_parser.add_argument(
+        "--allow-missing-artifacts",
+        action="store_true",
+        help="Complete migration despite reviewed legacy execution directories being missing",
+    )
+
     args = parser.parse_args()
 
     if args.command == "fix-invalid-fidelity":
@@ -1828,6 +1843,14 @@ if __name__ == "__main__":
 
         initialize()
         stats = migrate_forum_status(dry_run=not args.execute)
+        logger.info(f"Migration complete: {stats}")
+    elif args.command == "project-scoped-calibration":
+        from qdash.dbmodel.project_calibration_migration import run_from_environment
+
+        stats = run_from_environment(
+            dry_run=not args.execute,
+            allow_missing_artifacts=args.allow_missing_artifacts,
+        )
         logger.info(f"Migration complete: {stats}")
     else:
         parser.print_help()

--- a/src/qdash/dbmodel/project_calibration_migration.py
+++ b/src/qdash/dbmodel/project_calibration_migration.py
@@ -1,0 +1,609 @@
+"""Pre-start migration from user-owned to project-shared calibration state."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pymongo import ASCENDING, MongoClient, ReturnDocument
+from pymongo.errors import DuplicateKeyError
+
+if TYPE_CHECKING:
+    from pymongo.database import Database
+
+MIGRATION_ID = "project-scoped-calibration-v1"
+ARTIFACT_MIGRATION_ID = "project-scoped-calibration-artifacts-v1"
+MIGRATION_LOCK_LEASE = timedelta(minutes=30)
+
+_SHARED_COLLECTIONS: dict[str, tuple[str, ...]] = {
+    "chip": ("project_id", "chip_id"),
+    "qubit": ("project_id", "chip_id", "qid"),
+    "coupling": ("project_id", "chip_id", "qid"),
+    "chip_history": ("project_id", "chip_id", "recorded_date"),
+    "qubit_history": ("project_id", "chip_id", "qid", "recorded_date"),
+    "coupling_history": ("project_id", "chip_id", "qid", "recorded_date"),
+    "calibration_note": ("project_id", "execution_id", "task_id", "chip_id"),
+}
+
+
+def _as_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    return None
+
+
+def _updated_at(document: dict[str, Any]) -> datetime:
+    return _as_datetime(document.get("system_info", {}).get("updated_at")) or datetime.min.replace(
+        tzinfo=timezone.utc
+    )
+
+
+def _winner(documents: list[dict[str, Any]]) -> dict[str, Any]:
+    """Choose a deterministic current value while preserving losers in the archive."""
+    return max(documents, key=lambda doc: (_updated_at(doc), str(doc["_id"])))
+
+
+def _deep_merge(base: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+    """Merge nested calibration mappings without dropping disjoint values."""
+    result = dict(base)
+    for key, value in update.items():
+        if isinstance(result.get(key), dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _merged_shared_fields(collection_name: str, documents: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge current state without dropping disjoint or newer parameter values."""
+    if collection_name not in {
+        "qubit",
+        "coupling",
+        "qubit_history",
+        "coupling_history",
+        "calibration_note",
+    }:
+        return {}
+    if collection_name != "calibration_note":
+        selected: dict[str, tuple[datetime, str, Any]] = {}
+        for document in documents:
+            data = document.get("data")
+            if not isinstance(data, dict):
+                continue
+            for name, parameter in data.items():
+                calibrated_at = (
+                    _as_datetime(parameter.get("calibrated_at"))
+                    if isinstance(parameter, dict)
+                    else None
+                )
+                key = (calibrated_at or _updated_at(document), str(document["_id"]))
+                current = selected.get(name)
+                if current is None or key > current[:2]:
+                    selected[name] = (*key, parameter)
+        return {"data": {name: selected_value[2] for name, selected_value in selected.items()}}
+
+    merged: dict[str, Any] = {}
+    for document in sorted(documents, key=lambda doc: (_updated_at(doc), str(doc["_id"]))):
+        value = document.get("note")
+        if isinstance(value, dict):
+            merged = _deep_merge(merged, value)
+    return {"note": merged}
+
+
+def _invalid_scope_count(
+    database: Database[Any], collection_name: str, keys: tuple[str, ...]
+) -> int:
+    invalid_fields = [{"$or": [{key: {"$exists": False}}, {key: None}, {key: ""}]} for key in keys]
+    return database[collection_name].count_documents({"$or": invalid_fields})
+
+
+def _duplicates(
+    database: Database[Any], collection_name: str, keys: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    group_id = {key: f"${key}" for key in keys}
+    return list(
+        database[collection_name].aggregate(
+            [
+                {"$group": {"_id": group_id, "ids": {"$push": "$_id"}, "count": {"$sum": 1}}},
+                {"$match": {"count": {"$gt": 1}}},
+            ]
+        )
+    )
+
+
+def _replace_unique_index(
+    database: Database[Any], collection_name: str, keys: tuple[str, ...]
+) -> None:
+    collection = database[collection_name]
+    desired_keys = [(key, ASCENDING) for key in keys]
+    desired_name = "_".join(f"{key}_1" for key in keys)
+    desired_exists = False
+    for name, info in collection.index_information().items():
+        if name == "_id_":
+            continue
+        raw_keys = info.get("key", [])
+        existing_keys = list(raw_keys.items()) if isinstance(raw_keys, dict) else list(raw_keys)
+        if name == desired_name:
+            if existing_keys == desired_keys and info.get("unique") is True:
+                desired_exists = True
+            else:
+                collection.drop_index(name)
+            continue
+        if existing_keys == desired_keys and info.get("unique") is True:
+            collection.drop_index(name)
+        if info.get("unique") and any(key == "username" for key, _ in existing_keys):
+            collection.drop_index(name)
+    if desired_exists:
+        return
+    collection.create_index(desired_keys, unique=True)
+
+
+def migrate_project_scoped_calibration(
+    database: Database[Any], *, dry_run: bool = True
+) -> dict[str, Any]:
+    """Consolidate calibration state by project and install project-scoped indexes.
+
+    Losing documents are copied verbatim to ``migration_archive`` before deletion.
+    Re-running the migration is safe; completed migrations return immediately.
+    """
+    ledger = database["migration_ledger"]
+    if ledger.find_one({"migration_id": MIGRATION_ID, "status": "completed"}):
+        if not dry_run:
+            for collection_name, keys in _SHARED_COLLECTIONS.items():
+                _replace_unique_index(database, collection_name, keys)
+            _replace_unique_index(database, "execution_counter", ("project_id", "date", "chip_id"))
+        return {"migration_id": MIGRATION_ID, "already_completed": True, "collections": {}}
+
+    stats: dict[str, Any] = {
+        "migration_id": MIGRATION_ID,
+        "already_completed": False,
+        "collections": {},
+    }
+    plans: dict[str, list[tuple[dict[str, Any], list[dict[str, Any]]]]] = {}
+    invalid_scope: dict[str, int] = {}
+    for collection_name, keys in _SHARED_COLLECTIONS.items():
+        collection = database[collection_name]
+        invalid_scope[collection_name] = _invalid_scope_count(database, collection_name, keys)
+        plans[collection_name] = []
+        archived = 0
+        for duplicate in _duplicates(database, collection_name, keys):
+            documents = list(collection.find({"_id": {"$in": duplicate["ids"]}}))
+            winner = _winner(documents)
+            losers = [doc for doc in documents if doc["_id"] != winner["_id"]]
+            plans[collection_name].append((winner, losers))
+            archived += len(losers)
+        stats["collections"][collection_name] = {
+            "duplicate_groups": len(plans[collection_name]),
+            "documents_to_archive": archived,
+        }
+
+    counter_groups = _duplicates(database, "execution_counter", ("project_id", "date", "chip_id"))
+    invalid_scope["execution_counter"] = _invalid_scope_count(
+        database, "execution_counter", ("project_id", "date", "chip_id")
+    )
+    stats["invalid_scope_documents"] = invalid_scope
+    stats["collections"]["execution_counter"] = {
+        "duplicate_groups": len(counter_groups),
+        "documents_to_archive": sum(group["count"] - 1 for group in counter_groups),
+    }
+    if dry_run:
+        return stats
+    invalid_total = sum(invalid_scope.values())
+    if invalid_total:
+        raise RuntimeError(
+            f"Cannot migrate {invalid_total} calibration document(s) with missing scope fields"
+        )
+
+    lock = database["migration_lock"]
+    acquired_at = datetime.now(timezone.utc)
+    try:
+        lock.find_one_and_update(
+            {
+                "_id": MIGRATION_ID,
+                "$or": [
+                    {"acquired_at": {"$lt": acquired_at - MIGRATION_LOCK_LEASE}},
+                    {"acquired_at": {"$exists": False}},
+                ],
+            },
+            {"$set": {"acquired_at": acquired_at}},
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+    except DuplicateKeyError as exc:
+        raise RuntimeError(f"Migration {MIGRATION_ID} is already running") from exc
+
+    archive = database["migration_archive"]
+    try:
+        migrated_at = datetime.now(timezone.utc)
+        for collection_name, groups in plans.items():
+            collection = database[collection_name]
+            for winner, losers in groups:
+                documents = [winner, *losers]
+                for loser in losers:
+                    archive.update_one(
+                        {
+                            "migration_id": MIGRATION_ID,
+                            "source_collection": collection_name,
+                            "source_id": loser["_id"],
+                        },
+                        {
+                            "$setOnInsert": {
+                                "migrated_at": migrated_at,
+                                "winner_id": winner["_id"],
+                                "document": loser,
+                            }
+                        },
+                        upsert=True,
+                    )
+                merged_fields = _merged_shared_fields(collection_name, documents)
+                if merged_fields:
+                    collection.update_one({"_id": winner["_id"]}, {"$set": merged_fields})
+                if losers:
+                    collection.delete_many({"_id": {"$in": [doc["_id"] for doc in losers]}})
+            _replace_unique_index(database, collection_name, _SHARED_COLLECTIONS[collection_name])
+
+        counters = database["execution_counter"]
+        for group in counter_groups:
+            documents = list(counters.find({"_id": {"$in": group["ids"]}}))
+            winner = max(documents, key=lambda doc: (int(doc.get("index", 0)), str(doc["_id"])))
+            losers = [doc for doc in documents if doc["_id"] != winner["_id"]]
+            for loser in losers:
+                archive.update_one(
+                    {
+                        "migration_id": MIGRATION_ID,
+                        "source_collection": "execution_counter",
+                        "source_id": loser["_id"],
+                    },
+                    {
+                        "$setOnInsert": {
+                            "migrated_at": migrated_at,
+                            "winner_id": winner["_id"],
+                            "document": loser,
+                        }
+                    },
+                    upsert=True,
+                )
+            counters.delete_many({"_id": {"$in": [doc["_id"] for doc in losers]}})
+        _replace_unique_index(database, "execution_counter", ("project_id", "date", "chip_id"))
+
+        ledger.update_one(
+            {"migration_id": MIGRATION_ID},
+            {"$set": {"status": "completed", "completed_at": migrated_at, "stats": stats}},
+            upsert=True,
+        )
+    finally:
+        lock.delete_one({"_id": MIGRATION_ID})
+    return stats
+
+
+def _copy_tree_without_overwrite(source: Path, target: Path, conflict_root: Path) -> dict[str, int]:
+    stats = {"copied": 0, "identical": 0, "conflicts": 0}
+    if not source.is_dir():
+        return stats
+    for source_file in source.rglob("*"):
+        if not source_file.is_file():
+            continue
+        relative = source_file.relative_to(source)
+        target_file = target / relative
+        if not target_file.exists():
+            target_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_file, target_file)
+            stats["copied"] += 1
+        elif source_file.read_bytes() == target_file.read_bytes():
+            stats["identical"] += 1
+        else:
+            conflict_file = conflict_root / relative
+            conflict_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_file, conflict_file)
+            stats["conflicts"] += 1
+    return stats
+
+
+def _rewrite_artifact_path(value: Any, *, sources: list[Path], target: Path) -> Any:
+    """Rewrite one legacy execution path while leaving unrelated values untouched."""
+    if not isinstance(value, str) or not value:
+        return value
+    candidate = Path(value)
+    for source in sources:
+        try:
+            relative = candidate.relative_to(source)
+        except ValueError:
+            continue
+        return str(target / relative)
+    return value
+
+
+def _archive_path_document(
+    database: Database[Any], *, collection_name: str, document: dict[str, Any]
+) -> None:
+    """Archive a document before changing its persisted artifact paths."""
+    database["migration_archive"].update_one(
+        {
+            "migration_id": MIGRATION_ID,
+            "migration_kind": "artifact_path_rewrite",
+            "source_collection": collection_name,
+            "source_id": document["_id"],
+        },
+        {
+            "$setOnInsert": {
+                "migrated_at": datetime.now(timezone.utc),
+                "document": document,
+            }
+        },
+        upsert=True,
+    )
+
+
+def _migrate_execution_document_paths(
+    database: Database[Any],
+    *,
+    execution: dict[str, Any],
+    source: Path,
+    target: Path,
+    dry_run: bool,
+) -> int:
+    """Rewrite execution, task-result, and derived knowledge artifact paths."""
+    stored_root = execution.get("calib_data_path")
+    sources = [source]
+    if isinstance(stored_root, str) and stored_root:
+        sources.append(Path(stored_root))
+
+    updates: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+    new_root = _rewrite_artifact_path(stored_root, sources=sources, target=target)
+    if new_root != stored_root:
+        updates.append(("execution_history", execution, {"calib_data_path": new_root}))
+
+    task_query = {
+        "project_id": execution["project_id"],
+        "chip_id": execution["chip_id"],
+        "execution_id": execution["execution_id"],
+    }
+    task_documents = list(database["task_result_history"].find(task_query))
+    for task_document in task_documents:
+        task_updates: dict[str, Any] = {}
+        for field in ("figure_path", "json_figure_path", "raw_data_path"):
+            old_paths = task_document.get(field)
+            if not isinstance(old_paths, list):
+                continue
+            new_paths = [
+                _rewrite_artifact_path(path, sources=sources, target=target) for path in old_paths
+            ]
+            if new_paths != old_paths:
+                task_updates[field] = new_paths
+        if task_updates:
+            updates.append(("task_result_history", task_document, task_updates))
+
+        for knowledge in database["issue_knowledge"].find(
+            {"project_id": execution["project_id"], "task_id": task_document.get("task_id")}
+        ):
+            old_paths = knowledge.get("figure_paths")
+            if not isinstance(old_paths, list):
+                continue
+            new_paths = [
+                _rewrite_artifact_path(path, sources=sources, target=target) for path in old_paths
+            ]
+            if new_paths != old_paths:
+                updates.append(("issue_knowledge", knowledge, {"figure_paths": new_paths}))
+
+    if dry_run:
+        return len(updates)
+    for collection_name, document, fields in updates:
+        _archive_path_document(
+            database,
+            collection_name=collection_name,
+            document=document,
+        )
+        database[collection_name].update_one({"_id": document["_id"]}, {"$set": fields})
+    return len(updates)
+
+
+def _migrate_classifier_files(
+    *,
+    sources: dict[str, Path],
+    target: Path,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Select the newest classifier per relative path and preserve all conflicts."""
+    stats = {"copied": 0, "identical": 0, "conflicts": 0}
+    candidates: dict[Path, list[tuple[str, Path]]] = {}
+    for username, source in sources.items():
+        if not source.is_dir():
+            continue
+        for source_file in source.rglob("*"):
+            if source_file.is_file():
+                candidates.setdefault(source_file.relative_to(source), []).append(
+                    (username, source_file)
+                )
+
+    for relative, files in candidates.items():
+        files.sort(key=lambda item: (item[1].stat().st_mtime_ns, item[0]), reverse=True)
+        winner_username, winner_file = files[0]
+        target_file = target / relative
+        if dry_run:
+            stats["copied"] += 1
+            stats["conflicts"] += max(0, len(files) - 1)
+            continue
+
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+        preserve_existing = (
+            target_file.exists() and target_file.stat().st_mtime_ns > winner_file.stat().st_mtime_ns
+        )
+        if not target_file.exists():
+            shutil.copy2(winner_file, target_file)
+            stats["copied"] += 1
+        elif target_file.read_bytes() == winner_file.read_bytes():
+            stats["identical"] += 1
+        elif preserve_existing:
+            conflict_file = target.parent / ".migration_conflicts" / winner_username / relative
+            conflict_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(winner_file, conflict_file)
+            stats["conflicts"] += 1
+        else:
+            previous = target.parent / ".migration_conflicts" / "preexisting" / relative
+            previous.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(target_file, previous)
+            shutil.copy2(winner_file, target_file)
+            stats["copied"] += 1
+            stats["conflicts"] += 1
+
+        for username, source_file in files[1:]:
+            if source_file.read_bytes() == target_file.read_bytes():
+                stats["identical"] += 1
+                continue
+            conflict_file = target.parent / ".migration_conflicts" / username / relative
+            conflict_file.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_file, conflict_file)
+            stats["conflicts"] += 1
+    return stats
+
+
+def migrate_calibration_files(
+    database: Database[Any],
+    *,
+    base_path: Path,
+    dry_run: bool = True,
+    allow_missing: bool = False,
+) -> dict[str, int]:
+    """Copy legacy user artifacts to project-chip paths without deleting sources."""
+    stats = {
+        "copied": 0,
+        "identical": 0,
+        "conflicts": 0,
+        "missing": 0,
+        "database_records_updated": 0,
+    }
+    executions = database["execution_history"].find(
+        {"project_id": {"$exists": True}, "chip_id": {"$exists": True}}
+    )
+    for execution in executions:
+        execution_id = execution.get("execution_id")
+        username = execution.get("username")
+        if not execution_id or not username:
+            stats["missing"] += 1
+            continue
+        try:
+            date_str, index = execution_id.split("-", 1)
+        except ValueError:
+            stats["missing"] += 1
+            continue
+        source = base_path / username / date_str / index
+        target = (
+            base_path
+            / "projects"
+            / execution["project_id"]
+            / "chips"
+            / execution["chip_id"]
+            / "executions"
+            / execution_id
+        )
+        if execution.get("calib_data_path") == str(target) and target.is_dir():
+            continue
+        if not source.is_dir():
+            stats["missing"] += 1
+            continue
+        if dry_run:
+            stats["copied"] += sum(1 for path in source.rglob("*") if path.is_file())
+            stats["database_records_updated"] += _migrate_execution_document_paths(
+                database,
+                execution=execution,
+                source=source,
+                target=target,
+                dry_run=True,
+            )
+            continue
+        copied = _copy_tree_without_overwrite(
+            source,
+            target,
+            target / ".migration_conflicts" / username,
+        )
+        for key, count in copied.items():
+            stats[key] += count
+        stats["database_records_updated"] += _migrate_execution_document_paths(
+            database,
+            execution=execution,
+            source=source,
+            target=target,
+            dry_run=False,
+        )
+
+    for chip in database["chip"].find({"project_id": {"$exists": True}}):
+        usernames = {chip.get("username")}
+        usernames.update(
+            database["execution_history"].distinct(
+                "username",
+                {"project_id": chip["project_id"], "chip_id": chip["chip_id"]},
+            )
+        )
+        target = (
+            base_path
+            / "projects"
+            / chip["project_id"]
+            / "chips"
+            / chip["chip_id"]
+            / "shared"
+            / "classifier"
+        )
+        classifier_stats = _migrate_classifier_files(
+            sources={
+                username: base_path / username / ".classifier" for username in usernames if username
+            },
+            target=target,
+            dry_run=dry_run,
+        )
+        for key, count in classifier_stats.items():
+            stats[key] += count
+    if not dry_run and stats["missing"] and not allow_missing:
+        raise RuntimeError(
+            f"Could not locate legacy artifacts for {stats['missing']} execution(s); "
+            "rerun with --allow-missing-artifacts only after reviewing them"
+        )
+    return stats
+
+
+def run_from_environment(*, dry_run: bool, allow_missing_artifacts: bool = False) -> dict[str, Any]:
+    """Run the migration using the same MongoDB environment as QDash."""
+    host = os.getenv("MONGO_HOST", "mongo")
+    port = 27017 if host == "mongo" else int(os.getenv("MONGO_PORT", "27017"))
+    client: MongoClient[Any] = MongoClient(
+        host,
+        port=port,
+        username=os.getenv("MONGO_INITDB_ROOT_USERNAME"),
+        password=os.getenv("MONGO_INITDB_ROOT_PASSWORD"),
+    )
+    try:
+        database = client[os.getenv("MONGO_DB_NAME", "qdash")]
+        stats = migrate_project_scoped_calibration(database, dry_run=dry_run)
+        artifact_ledger = database["migration_ledger"]
+        if artifact_ledger.find_one({"migration_id": ARTIFACT_MIGRATION_ID, "status": "completed"}):
+            stats["files"] = {"already_completed": True}
+            return stats
+        stats["files"] = migrate_calibration_files(
+            database,
+            base_path=Path(os.getenv("CALIB_DATA_PATH", "/app/calib_data")),
+            dry_run=dry_run,
+            allow_missing=allow_missing_artifacts,
+        )
+        if not dry_run:
+            artifact_ledger.update_one(
+                {"migration_id": ARTIFACT_MIGRATION_ID},
+                {
+                    "$set": {
+                        "status": "completed",
+                        "completed_at": datetime.now(timezone.utc),
+                        "stats": stats["files"],
+                    }
+                },
+                upsert=True,
+            )
+        return stats
+    finally:
+        client.close()

--- a/src/qdash/dbmodel/project_calibration_migration.py
+++ b/src/qdash/dbmodel/project_calibration_migration.py
@@ -382,9 +382,17 @@ def _migrate_execution_document_paths(
         if task_updates:
             updates.append(("task_result_history", task_document, task_updates))
 
-        for knowledge in database["issue_knowledge"].find(
-            {"project_id": execution["project_id"], "task_id": task_document.get("task_id")}
-        ):
+    task_ids = list(
+        dict.fromkeys(
+            task_id for task_document in task_documents if (task_id := task_document.get("task_id"))
+        )
+    )
+    if task_ids:
+        knowledge_query = {
+            "project_id": execution["project_id"],
+            "task_id": {"$in": task_ids},
+        }
+        for knowledge in database["issue_knowledge"].find(knowledge_query):
             old_paths = knowledge.get("figure_paths")
             if not isinstance(old_paths, list):
                 continue
@@ -481,8 +489,10 @@ def migrate_calibration_files(
         "missing": 0,
         "database_records_updated": 0,
     }
-    executions = database["execution_history"].find(
-        {"project_id": {"$exists": True}, "chip_id": {"$exists": True}}
+    executions = list(
+        database["execution_history"].find(
+            {"project_id": {"$exists": True}, "chip_id": {"$exists": True}}
+        )
     )
     for execution in executions:
         execution_id = execution.get("execution_id")

--- a/src/qdash/dbmodel/qubit.py
+++ b/src/qdash/dbmodel/qubit.py
@@ -56,7 +56,6 @@ class QubitDocument(Document):
                     ("project_id", ASCENDING),
                     ("chip_id", ASCENDING),
                     ("qid", ASCENDING),
-                    ("username", ASCENDING),
                 ],
                 unique=True,
             ),
@@ -97,12 +96,13 @@ class QubitDocument(Document):
             raise ValueError(f"Qubit {qid} not found in chip {chip_id}")
         # Merge new calibration data into the existing data
         qubit_doc.user_id = cls._user_id_for_username(username)
+        qubit_doc.username = username
         qubit_doc.data = QubitDocument.merge_calib_data(qubit_doc.data, output_parameters)
         qubit_doc.system_info.update_time()
         qubit_doc.save()
         # Create history entry for the updated qubit
         qubit_model = QubitModel(
-            project_id=project_id,
+            project_id=qubit_doc.project_id,
             user_id=qubit_doc.user_id,
             qid=qid,
             chip_id=chip_id,

--- a/src/qdash/dbmodel/qubit.py
+++ b/src/qdash/dbmodel/qubit.py
@@ -82,15 +82,11 @@ class QubitDocument(Document):
         project_id: str | None,
     ) -> "QubitDocument":
         """Update the QubitDocument's calibration data with new values."""
-        query: dict[str, Any] = {"qid": qid, "chip_id": chip_id}
-        if project_id:
-            query["project_id"] = project_id
-            qubit_doc = cls.find_one(query).run()
+        if project_id is not None:
+            query = {"project_id": project_id, "qid": qid, "chip_id": chip_id}
         else:
-            qubit_doc = None
-
-        if qubit_doc is None:
-            qubit_doc = cls.find_one({"username": username, "qid": qid, "chip_id": chip_id}).run()
+            query = {"username": username, "qid": qid, "chip_id": chip_id}
+        qubit_doc = cls.find_one(query).run()
 
         if qubit_doc is None:
             raise ValueError(f"Qubit {qid} not found in chip {chip_id}")

--- a/src/qdash/dbmodel/qubit_history.py
+++ b/src/qdash/dbmodel/qubit_history.py
@@ -58,7 +58,6 @@ class QubitHistoryDocument(Document):
                     ("project_id", ASCENDING),
                     ("chip_id", ASCENDING),
                     ("qid", ASCENDING),
-                    ("username", ASCENDING),
                     ("recorded_date", ASCENDING),
                 ],
                 unique=True,
@@ -103,13 +102,13 @@ class QubitHistoryDocument(Document):
                 "project_id": qubit.project_id,
                 "chip_id": qubit.chip_id,
                 "qid": qubit.qid,
-                "username": username,
                 "recorded_date": today,
             }
         ).run()
         if existing_history:
             history = existing_history
             history.user_id = user_id
+            history.username = username
             history.data = qubit.data
             history.status = qubit.status
             history.cooldown_id = cooldown_id

--- a/src/qdash/repository/calibration_note.py
+++ b/src/qdash/repository/calibration_note.py
@@ -183,7 +183,6 @@ class MongoCalibrationNoteRepository:
             "project_id": note.project_id,
             "execution_id": note.execution_id,
             "task_id": note.task_id,
-            "username": note.username,
             "chip_id": note.chip_id,
         }
 
@@ -195,6 +194,7 @@ class MongoCalibrationNoteRepository:
         update = {
             "$set": {
                 "user_id": user_id,
+                "username": note.username,
                 "note": note.note,
                 "timestamp": timestamp,
             },
@@ -203,7 +203,6 @@ class MongoCalibrationNoteRepository:
                 "project_id": note.project_id,
                 "execution_id": note.execution_id,
                 "task_id": note.task_id,
-                "username": note.username,
                 "chip_id": note.chip_id,
             },
         }
@@ -257,7 +256,6 @@ class MongoCalibrationNoteRepository:
             "project_id": note.project_id,
             "execution_id": note.execution_id,
             "task_id": note.task_id,
-            "username": note.username,
             "chip_id": note.chip_id,
         }
 
@@ -265,6 +263,7 @@ class MongoCalibrationNoteRepository:
         update = {
             "$set": {
                 "user_id": user_id,
+                "username": note.username,
                 "timestamp": timestamp,
             },
             "$inc": {"version": 1},
@@ -272,7 +271,6 @@ class MongoCalibrationNoteRepository:
                 "project_id": note.project_id,
                 "execution_id": note.execution_id,
                 "task_id": note.task_id,
-                "username": note.username,
                 "chip_id": note.chip_id,
                 "note": note.note,
             },

--- a/src/qdash/repository/chip.py
+++ b/src/qdash/repository/chip.py
@@ -190,11 +190,9 @@ class MongoChipRepository:
             The user performing the update
 
         """
-        ChipDocument.update_chip_data(
-            chip_id=chip_id,
-            calib_data=calib_data,
-            username=username,
-        )
+        # Calibration values live in the project-scoped qubit and coupling
+        # collections. Retain this compatibility hook as an intentional no-op.
+        _ = chip_id, calib_data, username
 
     def _to_model(self, doc: ChipDocument) -> ChipModel:
         """Convert a document to a domain model.
@@ -771,9 +769,10 @@ class MongoChipRepository:
             Map of qubit ID to QubitDocument
 
         """
+        # ``username`` is retained for source compatibility. Calibration state is
+        # shared by all members of the project.
+        _ = username
         query = {"project_id": project_id, "chip_id": chip_id}
-        if username is not None:
-            query["username"] = username
         docs = list(QubitDocument.find(query).run())
         return {doc.qid: doc for doc in docs}
 
@@ -798,9 +797,8 @@ class MongoChipRepository:
             Map of coupling ID to CouplingDocument
 
         """
+        _ = username
         query = {"project_id": project_id, "chip_id": chip_id}
-        if username is not None:
-            query["username"] = username
         docs = list(CouplingDocument.find(query).run())
         return {doc.qid: doc for doc in docs}
 

--- a/src/qdash/repository/chip_history.py
+++ b/src/qdash/repository/chip_history.py
@@ -41,6 +41,9 @@ class MongoChipHistoryRepository:
         chip_id : str, optional
             The specific chip ID to create history for.
             If None, uses the current (most recently installed) chip.
+        project_id : str, optional
+            The owning project ID. When both project_id and chip_id are set,
+            the chip is resolved by project and chip instead of by username.
 
         """
         if project_id is not None and chip_id is not None:

--- a/src/qdash/repository/chip_history.py
+++ b/src/qdash/repository/chip_history.py
@@ -26,7 +26,12 @@ class MongoChipHistoryRepository:
 
     """
 
-    def create_history(self, username: str, chip_id: str | None = None) -> None:
+    def create_history(
+        self,
+        username: str,
+        chip_id: str | None = None,
+        project_id: str | None = None,
+    ) -> None:
         """Create a chip history snapshot.
 
         Parameters
@@ -38,7 +43,9 @@ class MongoChipHistoryRepository:
             If None, uses the current (most recently installed) chip.
 
         """
-        if chip_id is not None:
+        if project_id is not None and chip_id is not None:
+            chip_doc = ChipDocument.find_one({"project_id": project_id, "chip_id": chip_id}).run()
+        elif chip_id is not None:
             chip_doc = ChipDocument.get_chip_by_id(username=username, chip_id=chip_id)
         else:
             try:

--- a/src/qdash/repository/coupling.py
+++ b/src/qdash/repository/coupling.py
@@ -167,15 +167,11 @@ class MongoCouplingCalibrationRepository:
         qid: str,
     ) -> dict[str, Any]:
         """Get the data from the same document resolution path used by updates."""
-        doc = None
-        if project_id:
-            doc = CouplingDocument.find_one(
-                {"project_id": project_id, "chip_id": chip_id, "qid": qid}
-            ).run()
-        if doc is None:
-            doc = CouplingDocument.find_one(
-                {"username": username, "chip_id": chip_id, "qid": qid}
-            ).run()
+        if project_id is not None:
+            query = {"project_id": project_id, "chip_id": chip_id, "qid": qid}
+        else:
+            query = {"username": username, "chip_id": chip_id, "qid": qid}
+        doc = CouplingDocument.find_one(query).run()
         return dict(doc.data) if doc is not None else {}
 
     def _to_model(self, doc: CouplingDocument, project_id: str | None) -> CouplingModel:

--- a/src/qdash/repository/execution_counter.py
+++ b/src/qdash/repository/execution_counter.py
@@ -16,7 +16,7 @@ class MongoExecutionCounterRepository:
     """MongoDB implementation of ExecutionCounterRepository.
 
     This class provides atomic counter generation for execution IDs,
-    scoped by date, username, chip_id, and project_id.
+    scoped by date, chip_id, and project_id. Username records the latest actor.
 
     Example
     -------

--- a/src/qdash/repository/inmemory/calibration_note.py
+++ b/src/qdash/repository/inmemory/calibration_note.py
@@ -46,7 +46,8 @@ class InMemoryCalibrationNoteRepository:
         task_id: str,
     ) -> str:
         """Create a unique key for storage."""
-        return f"{project_id}:{username}:{chip_id}:{execution_id}:{task_id}"
+        _ = username
+        return f"{project_id}:{chip_id}:{execution_id}:{task_id}"
 
     def find_one(
         self,

--- a/src/qdash/repository/inmemory/chip_history.py
+++ b/src/qdash/repository/inmemory/chip_history.py
@@ -23,7 +23,12 @@ class InMemoryChipHistoryRepository:
         """Initialize with empty storage."""
         self._history: list[dict[str, str | None]] = []
 
-    def create_history(self, username: str, chip_id: str | None = None) -> None:
+    def create_history(
+        self,
+        username: str,
+        chip_id: str | None = None,
+        project_id: str | None = None,
+    ) -> None:
         """Create a chip history snapshot.
 
         Parameters
@@ -35,7 +40,7 @@ class InMemoryChipHistoryRepository:
             If None, uses the current (most recently installed) chip.
 
         """
-        self._history.append({"username": username, "chip_id": chip_id})
+        self._history.append({"username": username, "chip_id": chip_id, "project_id": project_id})
 
     def get_all(self) -> list[dict[str, str | None]]:
         """Get all stored history snapshots (test helper).

--- a/src/qdash/repository/inmemory/execution_counter.py
+++ b/src/qdash/repository/inmemory/execution_counter.py
@@ -52,6 +52,10 @@ class InMemoryExecutionCounterRepository:
             The next index (0 on first call, then 1, 2, 3...)
 
         """
+        if project_id is None:
+            msg = "project_id is required to generate an execution index"
+            raise ValueError(msg)
+
         counter_key = f"{date}:{chip_id}:{project_id}"
         current = self._counters.get(counter_key, -1)
         next_index = current + 1

--- a/src/qdash/repository/inmemory/execution_counter.py
+++ b/src/qdash/repository/inmemory/execution_counter.py
@@ -52,7 +52,7 @@ class InMemoryExecutionCounterRepository:
             The next index (0 on first call, then 1, 2, 3...)
 
         """
-        counter_key = f"{date}:{username}:{chip_id}:{project_id}"
+        counter_key = f"{date}:{chip_id}:{project_id}"
         current = self._counters.get(counter_key, -1)
         next_index = current + 1
         self._counters[counter_key] = next_index

--- a/src/qdash/repository/protocols.py
+++ b/src/qdash/repository/protocols.py
@@ -508,7 +508,12 @@ class ChipRepository(Protocol):
 class ChipHistoryRepository(Protocol):
     """Protocol for chip history recording operations."""
 
-    def create_history(self, username: str, chip_id: str | None = None) -> None:
+    def create_history(
+        self,
+        username: str,
+        chip_id: str | None = None,
+        project_id: str | None = None,
+    ) -> None:
         """Create a chip history snapshot.
 
         Parameters
@@ -982,7 +987,7 @@ class ExecutionCounterRepository(Protocol):
     """Protocol for execution counter operations.
 
     This repository provides atomic counter generation for execution IDs.
-    The counter is scoped by date, username, chip_id, and project_id.
+    The counter is scoped by date, chip_id, and project_id.
 
     Example
     -------

--- a/src/qdash/repository/qubit.py
+++ b/src/qdash/repository/qubit.py
@@ -165,15 +165,11 @@ class MongoQubitCalibrationRepository:
         qid: str,
     ) -> dict[str, Any]:
         """Get the data from the same document resolution path used by updates."""
-        doc = None
-        if project_id:
-            doc = QubitDocument.find_one(
-                {"project_id": project_id, "chip_id": chip_id, "qid": qid}
-            ).run()
-        if doc is None:
-            doc = QubitDocument.find_one(
-                {"username": username, "chip_id": chip_id, "qid": qid}
-            ).run()
+        if project_id is not None:
+            query = {"project_id": project_id, "chip_id": chip_id, "qid": qid}
+        else:
+            query = {"username": username, "chip_id": chip_id, "qid": qid}
+        doc = QubitDocument.find_one(query).run()
         return dict(doc.data) if doc is not None else {}
 
     def _to_model(self, doc: QubitDocument, project_id: str | None) -> QubitModel:

--- a/src/qdash/workflow/engine/__init__.py
+++ b/src/qdash/workflow/engine/__init__.py
@@ -64,6 +64,7 @@ Most users should use CalibService. Direct engine usage:
 >>> from qdash.workflow.engine import CalibOrchestrator, CalibConfig
 >>> config = CalibConfig(
 ...     username="alice",
+...     project_id="proj-1",
 ...     chip_id="64Qv3",
 ...     qids=["0", "1"],
 ...     execution_id="20240101-001",

--- a/src/qdash/workflow/engine/config.py
+++ b/src/qdash/workflow/engine/config.py
@@ -56,10 +56,13 @@ class CalibConfig:
 
     def __post_init__(self) -> None:
         """Compute derived paths from execution_id."""
-        date_str, index = self.execution_id.split("-")
+        if not self.project_id:
+            raise ValueError("project_id is required for calibration paths")
         resolver = get_path_resolver()
-        self.classifier_dir = str(resolver.classifier_dir(self.username))
-        self.calib_data_path = str(resolver.execution_data_dir(self.username, date_str, index))
+        self.classifier_dir = str(resolver.classifier_dir(self.project_id, self.chip_id))
+        self.calib_data_path = str(
+            resolver.execution_data_dir(self.project_id, self.chip_id, self.execution_id)
+        )
 
         # Set default tags if not provided
         if self.tags is None:

--- a/src/qdash/workflow/engine/orchestrator.py
+++ b/src/qdash/workflow/engine/orchestrator.py
@@ -41,6 +41,7 @@ class CalibOrchestrator:
         ```python
         config = CalibConfig(
             username="alice",
+            project_id="proj-1",
             chip_id="64Qv3",
             qids=["0", "1"],
             execution_id="20240101-001",

--- a/src/qdash/workflow/engine/orchestrator.py
+++ b/src/qdash/workflow/engine/orchestrator.py
@@ -280,14 +280,19 @@ class CalibOrchestrator:
         # Update chip history
         if update_chip_history:
             try:
+                assert config.project_id is not None
                 chip_repo = MongoChipRepository()
-                chip = chip_repo.get_chip_by_id(username=config.username, chip_id=config.chip_id)
+                chip = chip_repo.find_by_id(project_id=config.project_id, chip_id=config.chip_id)
                 if chip is not None:
                     history_repo = MongoChipHistoryRepository()
-                    history_repo.create_history(username=config.username, chip_id=config.chip_id)
+                    history_repo.create_history(
+                        username=config.username,
+                        chip_id=config.chip_id,
+                        project_id=config.project_id,
+                    )
                 else:
                     logger.warning(
-                        f"Chip '{config.chip_id}' not found for user '{config.username}', "
+                        f"Chip '{config.chip_id}' not found in project '{config.project_id}', "
                         "skipping history update"
                     )
             except Exception as e:

--- a/src/qdash/workflow/engine/orchestrator.py
+++ b/src/qdash/workflow/engine/orchestrator.py
@@ -187,7 +187,7 @@ class CalibOrchestrator:
         """Create the calibration directory structure."""
         config = self.config
         Path(config.calib_data_path).mkdir(parents=True, exist_ok=True)
-        Path(config.classifier_dir).mkdir(exist_ok=True)
+        Path(config.classifier_dir).mkdir(parents=True, exist_ok=True)
         Path(f"{config.calib_data_path}/task").mkdir(exist_ok=True)
         Path(f"{config.calib_data_path}/fig").mkdir(exist_ok=True)
         Path(f"{config.calib_data_path}/calib").mkdir(exist_ok=True)

--- a/src/qdash/workflow/engine/scheduler/cr_scheduler.py
+++ b/src/qdash/workflow/engine/scheduler/cr_scheduler.py
@@ -157,6 +157,7 @@ class CRScheduler:
         chip_id: str,
         wiring_config_path: str | Path | None = None,
         *,
+        project_id: str | None = None,
         chip_repo: ChipRepository | None = None,
     ) -> None:
         """Initialize CR scheduler.
@@ -172,6 +173,7 @@ class CRScheduler:
         """
         self.username = username
         self.chip_id = chip_id
+        self.project_id = project_id
         self.wiring_config_path = wiring_config_path
         self._chip_repo = chip_repo
         self._chip: ChipModel | None = None
@@ -193,9 +195,13 @@ class CRScheduler:
         """Load chip data from database."""
         if self._chip is None:
             chip_repo = self._ensure_chip_repo()
-            chip = chip_repo.get_current_chip(self.username)
+            if self.project_id:
+                chip = chip_repo.find_by_id(self.project_id, self.chip_id)
+            else:
+                chip = chip_repo.get_current_chip(self.username)
             if chip is None:
-                raise ValueError(f"Chip not found for user {self.username}")
+                scope = f"project {self.project_id}" if self.project_id else f"user {self.username}"
+                raise ValueError(f"Chip {self.chip_id} not found for {scope}")
             self._chip = chip
         return self._chip
 

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -500,7 +500,11 @@ class TaskExecutor:
                 self.history_recorder.record_task_result(
                     executed_task, execution_service.to_datamodel()
                 )
-                self.history_recorder.create_chip_history_snapshot(self.username)
+                self.history_recorder.create_chip_history_snapshot(
+                    self.username,
+                    chip_id=execution_service.chip_id,
+                    project_id=execution_service.project_id,
+                )
                 execution_service = self._update_execution(execution_service)
 
         result.calib_data_delta = self.state_manager.calib_data
@@ -696,7 +700,11 @@ class TaskExecutor:
                         executed_task, execution_service.to_datamodel()
                     )
             if execution_service is not None:
-                self.history_recorder.create_chip_history_snapshot(self.username)
+                self.history_recorder.create_chip_history_snapshot(
+                    self.username,
+                    chip_id=execution_service.chip_id,
+                    project_id=execution_service.project_id,
+                )
                 execution_service = self._update_execution(execution_service)
 
         for result in results.values():

--- a/src/qdash/workflow/engine/task/history_recorder.py
+++ b/src/qdash/workflow/engine/task/history_recorder.py
@@ -51,7 +51,12 @@ class ChipRepoProtocol(Protocol):
 class ChipHistoryRepoProtocol(Protocol):
     """Protocol for chip history repository."""
 
-    def create_history(self, username: str) -> None:
+    def create_history(
+        self,
+        username: str,
+        chip_id: str | None = None,
+        project_id: str | None = None,
+    ) -> None:
         """Create chip history."""
         ...
 
@@ -193,7 +198,13 @@ class TaskHistoryRecorder:
             logger.error(f"Failed to update chip data: {e}")
             raise
 
-    def create_chip_history_snapshot(self, username: str) -> None:
+    def create_chip_history_snapshot(
+        self,
+        username: str,
+        *,
+        chip_id: str | None = None,
+        project_id: str | None = None,
+    ) -> None:
         """Create a chip history snapshot.
 
         Parameters
@@ -208,7 +219,11 @@ class TaskHistoryRecorder:
 
         """
         try:
-            self.chip_history_repo.create_history(username)
+            self.chip_history_repo.create_history(
+                username=username,
+                chip_id=chip_id,
+                project_id=project_id,
+            )
         except Exception as e:
             logger.error(f"Failed to create chip history snapshot: {e}")
             # Don't raise - this shouldn't block the workflow
@@ -253,4 +268,8 @@ class TaskHistoryRecorder:
 
         # Create chip history snapshot if requested
         if create_history:
-            self.create_chip_history_snapshot(username)
+            self.create_chip_history_snapshot(
+                username,
+                chip_id=chip_id,
+                project_id=execution_model.project_id,
+            )

--- a/src/qdash/workflow/paths.py
+++ b/src/qdash/workflow/paths.py
@@ -26,11 +26,11 @@ if TYPE_CHECKING:
 
 
 class PathResolver:
-    """Resolves paths for workflow infrastructure.
+    """Resolve project-scoped paths for workflow infrastructure.
 
-    This class provides methods to generate paths for user-specific
-    calibration data, execution directories, and other workflow-related
-    locations.
+    This class provides methods to generate shared project-chip calibration
+    paths and immutable execution artifact directories. ``user_data_dir`` is
+    retained only for legacy migration support.
 
     Examples
     --------
@@ -38,8 +38,8 @@ class PathResolver:
     >>> resolver.user_data_dir("alice")
     PosixPath('/app/calib_data/alice')
 
-    >>> resolver.execution_data_dir("alice", "20240101", "001")
-    PosixPath('/app/calib_data/alice/20240101/001')
+    >>> resolver.execution_data_dir("proj-1", "chip-1", "20240101-001")
+    PosixPath('/app/calib_data/projects/proj-1/chips/chip-1/executions/20240101-001')
 
     """
 
@@ -62,20 +62,24 @@ class PathResolver:
         return self._workflow_dir
 
     # -------------------------------------------------------------------------
-    # User-specific paths
+    # Legacy user-specific paths
     # -------------------------------------------------------------------------
 
     def user_data_dir(self, username: str) -> Path:
         """Get the base directory for a user's calibration data."""
         return self._calib_data_base / username
 
-    def classifier_dir(self, username: str) -> Path:
-        """Get the classifier directory for a user."""
-        return self.user_data_dir(username) / ".classifier"
+    def project_chip_dir(self, project_id: str, chip_id: str) -> Path:
+        """Get the shared calibration directory for a project chip."""
+        return self._calib_data_base / "projects" / project_id / "chips" / chip_id
 
-    def execution_data_dir(self, username: str, date_str: str, index: str) -> Path:
-        """Get the directory for a specific execution's data."""
-        return self.user_data_dir(username) / date_str / index
+    def classifier_dir(self, project_id: str, chip_id: str) -> Path:
+        """Get the shared classifier directory for a project chip."""
+        return self.project_chip_dir(project_id, chip_id) / "shared" / "classifier"
+
+    def execution_data_dir(self, project_id: str, chip_id: str, execution_id: str) -> Path:
+        """Get the immutable artifact directory for an execution."""
+        return self.project_chip_dir(project_id, chip_id) / "executions" / execution_id
 
 
 # Default resolver instance

--- a/src/qdash/workflow/service/agent_candidate_apply_flow.py
+++ b/src/qdash/workflow/service/agent_candidate_apply_flow.py
@@ -87,6 +87,7 @@ def agent_candidate_apply(
                 commit.committed_by,
                 commit.chip_id,
                 commit.execution_id,
+                project_id=project_id,
             )
             base_git_commit = github_integration.pull_config()
             if not base_git_commit:

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -460,6 +460,7 @@ class CalibService:
             username=self.username,
             chip_id=self.chip_id,
             execution_id=self.execution_id,
+            project_id=self.project_id,
         )
 
         # Setup github_push_config if not provided
@@ -1042,13 +1043,17 @@ class CalibService:
             )
 
             chip_repo = MongoChipRepository()
-            chip = chip_repo.get_chip_by_id(username=self.username, chip_id=self.chip_id)
+            chip = chip_repo.find_by_id(project_id=self.project_id, chip_id=self.chip_id)
             if chip is not None:
                 history_repo = MongoChipHistoryRepository()
-                history_repo.create_history(username=self.username, chip_id=self.chip_id)
+                history_repo.create_history(
+                    username=self.username,
+                    chip_id=self.chip_id,
+                    project_id=self.project_id,
+                )
             else:
                 logger.warning(
-                    f"Chip '{self.chip_id}' not found for user '{self.username}', "
+                    f"Chip '{self.chip_id}' not found in project '{self.project_id}', "
                     "skipping history update"
                 )
         except Exception as e:

--- a/src/qdash/workflow/service/github.py
+++ b/src/qdash/workflow/service/github.py
@@ -121,17 +121,25 @@ class GitHubIntegration:
         ```
     """
 
-    def __init__(self, username: str, chip_id: str, execution_id: str) -> None:
+    def __init__(
+        self,
+        username: str,
+        chip_id: str,
+        execution_id: str,
+        project_id: str | None = None,
+    ) -> None:
         """Initialize GitHub integration.
 
         Args:
             username: Username for the calibration session
             chip_id: Target chip ID
             execution_id: Unique execution identifier
+            project_id: Project owning the shared calibration state
         """
         self.username = username
         self.chip_id = chip_id
         self.execution_id = execution_id
+        self.project_id = project_id
         self.logger = get_run_logger()
 
     @staticmethod
@@ -279,11 +287,13 @@ class GitHubIntegration:
         repo = MongoCalibrationNoteRepository()
         latest_note = repo.find_latest_master(
             chip_id=self.chip_id,
-            username=self.username,
+            project_id=self.project_id,
+            username=None if self.project_id else self.username,
         )
 
         if latest_note is None:
-            msg = f"No master calibration note found in MongoDB for user {self.username}"
+            scope = f"project {self.project_id}" if self.project_id else f"user {self.username}"
+            msg = f"No master calibration note found in MongoDB for {scope}"
             raise FileNotFoundError(msg)
 
         master_note = latest_note.note

--- a/src/qdash/workflow/service/github.py
+++ b/src/qdash/workflow/service/github.py
@@ -353,6 +353,7 @@ class GitHubIntegration:
             source_path=source_path,
             target_path=source_path,
             chip_id=self.chip_id,
+            project_id=self.project_id,
         )
 
         commit_message = (

--- a/src/qdash/workflow/service/steps/two_qubit.py
+++ b/src/qdash/workflow/service/steps/two_qubit.py
@@ -94,6 +94,7 @@ class CustomTwoQubit(CalibrationStep):
                 service.username,
                 service.chip_id,
                 wiring_config_path=wiring_config_path,
+                project_id=service.project_id,
             )
             schedule = scheduler.generate(
                 candidate_qubits=candidate_qubits,
@@ -333,6 +334,7 @@ class GenerateCRSchedule(TransformStep):
             service.username,
             service.chip_id,
             wiring_config_path=wiring_config_path,
+            project_id=service.project_id,
         )
         schedule = scheduler.generate(
             candidate_qubits=candidate_qubits,
@@ -415,6 +417,7 @@ class TwoQubitCalibration(CalibrationStep):
                 service.username,
                 service.chip_id,
                 wiring_config_path=wiring_config_path,
+                project_id=service.project_id,
             )
             schedule = scheduler.generate(
                 candidate_qubits=candidate_qubits,

--- a/src/qdash/workflow/service/targets.py
+++ b/src/qdash/workflow/service/targets.py
@@ -47,7 +47,7 @@ class Target(ABC):
         """
 
     @abstractmethod
-    def to_coupling_ids(self, chip_id: str) -> list[str]:
+    def to_coupling_ids(self, chip_id: str, *, project_id: str | None = None) -> list[str]:
         """Convert target to a list of coupling IDs.
 
         Args:
@@ -94,9 +94,12 @@ class MuxTargets(Target):
             all_qids.extend(stage.qids)
         return sorted(set(all_qids))
 
-    def to_coupling_ids(self, chip_id: str) -> list[str]:
+    def to_coupling_ids(self, chip_id: str, *, project_id: str | None = None) -> list[str]:
         """Get coupling IDs for qubits in targeted MUXes."""
         from qdash.workflow.engine import CRScheduler
+
+        if not project_id:
+            raise ValueError("project_id is required to resolve coupling targets")
 
         qids = self.to_qids(chip_id)
         wiring_config_path = str(get_qubex_paths().wiring_yaml(chip_id))
@@ -107,6 +110,7 @@ class MuxTargets(Target):
             username="",  # Not needed for pair generation
             chip_id=chip_id,
             wiring_config_path=wiring_config_path,
+            project_id=project_id,
         )
         schedule = scheduler.generate(candidate_qubits=qids, max_parallel_ops=100)
 
@@ -137,15 +141,19 @@ class QubitTargets(Target):
         """Return the qubit IDs directly."""
         return list(self.qids)
 
-    def to_coupling_ids(self, chip_id: str) -> list[str]:
+    def to_coupling_ids(self, chip_id: str, *, project_id: str | None = None) -> list[str]:
         """Get coupling IDs for the specified qubits."""
         from qdash.workflow.engine import CRScheduler
+
+        if not project_id:
+            raise ValueError("project_id is required to resolve coupling targets")
 
         wiring_config_path = str(get_qubex_paths().wiring_yaml(chip_id))
         scheduler = CRScheduler(
             username="",
             chip_id=chip_id,
             wiring_config_path=wiring_config_path,
+            project_id=project_id,
         )
         schedule = scheduler.generate(candidate_qubits=self.qids, max_parallel_ops=100)
 
@@ -180,7 +188,7 @@ class CouplingTargets(Target):
             qids.add(target)
         return sorted(qids)
 
-    def to_coupling_ids(self, chip_id: str) -> list[str]:
+    def to_coupling_ids(self, chip_id: str, *, project_id: str | None = None) -> list[str]:
         """Return coupling IDs directly."""
         return [f"{c}-{t}" for c, t in self.pairs]
 
@@ -207,9 +215,9 @@ class AllMuxTargets(Target):
             exclude_qids=self.exclude_qids,
         ).to_qids(chip_id)
 
-    def to_coupling_ids(self, chip_id: str) -> list[str]:
+    def to_coupling_ids(self, chip_id: str, *, project_id: str | None = None) -> list[str]:
         """Get all coupling IDs for the chip."""
         return MuxTargets(
             mux_ids=list(range(16)),
             exclude_qids=self.exclude_qids,
-        ).to_coupling_ids(chip_id)
+        ).to_coupling_ids(chip_id, project_id=project_id)

--- a/src/qdash/workflow/worker/flows/push_calib_note/flow.py
+++ b/src/qdash/workflow/worker/flows/push_calib_note/flow.py
@@ -14,6 +14,7 @@ def push_calib_note(
     chip_id: str = "64Qv1",
     commit_message: str = "Update calib_note.json",
     branch: str = "main",
+    project_id: str | None = None,
 ) -> str:
     """Push local calib_note.json to the GitHub repository.
 
@@ -39,10 +40,17 @@ def push_calib_note(
     repo_subpath = f"{chip_id}/calibration/calib_note.json"
 
     repo = MongoCalibrationNoteRepository()
-    latest_note = repo.find_latest_master(chip_id=chip_id, username=username)
+    if project_id is None:
+        from qdash.repository import MongoUserRepository
+
+        project_id = MongoUserRepository().get_default_project_id(username)
+    if project_id is None:
+        raise ValueError(f"Could not resolve project_id for user {username}")
+
+    latest_note = repo.find_latest_master(chip_id=chip_id, project_id=project_id)
 
     if latest_note is None:
-        msg = f"No master calibration note found for user {username}"
+        msg = f"No master calibration note found for project {project_id} and chip {chip_id}"
         raise ValueError(msg)
 
     calib_note = latest_note.note

--- a/src/qdash/workflow/worker/flows/push_props/create_props.py
+++ b/src/qdash/workflow/worker/flows/push_props/create_props.py
@@ -149,21 +149,27 @@ def get_chip_properties(
 
 
 def create_chip_properties(
-    username: str, source_path: str, target_path: str, chip_id: str = "64Qv1"
+    username: str,
+    source_path: str,
+    target_path: str,
+    chip_id: str = "64Qv1",
+    project_id: str | None = None,
 ) -> None:
     """Create and write chip properties to a YAML file."""
     initialize()
     from qdash.repository import MongoChipRepository
+    from qdash.repository.user import MongoUserRepository
 
     chip_repo = MongoChipRepository()
-    chip = chip_repo.get_current_chip(username=username)
+    if project_id is None:
+        project_id = MongoUserRepository().get_default_project_id(username)
+    if project_id is None:
+        raise ValueError(f"Could not resolve project_id for user {username}")
+    chip = chip_repo.find_by_id(project_id=project_id, chip_id=chip_id)
     if chip is None:
-        raise ValueError(f"Chip not found for user {username}")
+        raise ValueError(f"Chip {chip_id} not found in project {project_id}")
 
     # Fetch qubit and coupling models from individual documents (scalable)
-    project_id = chip.project_id
-    if project_id is None:
-        raise ValueError(f"Chip {chip_id} has no project_id")
     qubit_models = chip_repo.get_all_qubit_models(project_id, chip_id)
     coupling_models = chip_repo.get_all_coupling_models(project_id, chip_id)
 

--- a/src/qdash/workflow/worker/flows/push_props/flow.py
+++ b/src/qdash/workflow/worker/flows/push_props/flow.py
@@ -11,6 +11,7 @@ def push_props(
     chip_id: str = "64Qv1",
     commit_message: str = "Update props.yaml",
     branch: str = "main",
+    project_id: str | None = None,
 ) -> str:
     """Push local chip_properties.yaml to the GitHub repository.
 
@@ -31,6 +32,10 @@ def push_props(
     source_path = str(get_qubex_paths().props_yaml(chip_id))
     repo_subpath = f"{chip_id}/params/props.yaml"
     create_chip_properties(
-        username=username, source_path=source_path, target_path=source_path, chip_id=chip_id
+        username=username,
+        source_path=source_path,
+        target_path=source_path,
+        chip_id=chip_id,
+        project_id=project_id,
     )
     return str(push_github(source_path, repo_subpath, commit_message, branch))

--- a/tests/qdash/api/services/test_device_topology_service.py
+++ b/tests/qdash/api/services/test_device_topology_service.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -91,3 +92,30 @@ def test_device_topology_request_accepts_condition_cr_direction() -> None:
     )
 
     assert request.condition.cr_direction == "forward"
+
+
+def test_build_device_topology_resolves_chip_with_project_scope() -> None:
+    chip_repo = MagicMock()
+    chip_repo.find_by_id.return_value = SimpleNamespace(chip_id="chip-1", topology_id="test")
+    chip_repo.get_all_qubit_models.return_value = {}
+    chip_repo.get_all_coupling_models.return_value = {}
+    note_repo = MagicMock()
+    note_repo.find_latest_master_by_project.return_value = SimpleNamespace(
+        chip_id="chip-1",
+        username="alice",
+        note={"cr_params": {}, "drag_hpi_params": {}, "drag_pi_params": {}},
+        timestamp=None,
+    )
+    service = DeviceTopologyService(chip_repo, note_repo)
+    request = DeviceTopologyRequest(qubits=[])
+
+    with (
+        patch("qdash.api.services.device_topology_service.load_topology", return_value=_topology()),
+        patch.object(service, "_build_qubits", return_value=[]),
+        patch.object(service, "_build_couplings", return_value=[]),
+        patch.object(service, "_apply_filters", return_value=([], [])),
+    ):
+        service.build_device_topology("proj-1", request)
+
+    chip_repo.find_by_id.assert_called_once_with(project_id="proj-1", chip_id="chip-1")
+    chip_repo.get_current_chip.assert_not_called()

--- a/tests/qdash/dbmodel/test_project_calibration_migration.py
+++ b/tests/qdash/dbmodel/test_project_calibration_migration.py
@@ -1,0 +1,295 @@
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from qdash.dbmodel.project_calibration_migration import (
+    MIGRATION_ID,
+    migrate_calibration_files,
+    migrate_project_scoped_calibration,
+)
+
+
+def test_migration_archives_duplicates_and_installs_project_indexes(init_db) -> None:
+    qubits = init_db["qubit"]
+    counters = init_db["execution_counter"]
+    notes = init_db["calibration_note"]
+    qubits.drop_indexes()
+    counters.drop_indexes()
+    notes.drop_indexes()
+    older = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    newer = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    qubits.insert_many(
+        [
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "qid": "0",
+                "username": "alice",
+                "data": {
+                    "frequency": {
+                        "value": 5.0,
+                        "calibrated_at": datetime(2026, 1, 3, tzinfo=timezone.utc),
+                    },
+                    "t1": {"value": 100.0},
+                },
+                "system_info": {"created_at": older, "updated_at": older},
+            },
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "qid": "0",
+                "username": "bob",
+                "data": {
+                    "frequency": {
+                        "value": 5.1,
+                        "calibrated_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    }
+                },
+                "system_info": {"created_at": newer, "updated_at": newer},
+            },
+        ]
+    )
+    counters.insert_many(
+        [
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "date": "20260102",
+                "username": "alice",
+                "index": 2,
+            },
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "date": "20260102",
+                "username": "bob",
+                "index": 4,
+            },
+        ]
+    )
+    notes.insert_many(
+        [
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "execution_id": "20260102-001",
+                "task_id": "master",
+                "username": "alice",
+                "note": {"rabi": {"Q0": {"amplitude": 0.1}}},
+                "system_info": {"created_at": older, "updated_at": older},
+            },
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "execution_id": "20260102-001",
+                "task_id": "master",
+                "username": "bob",
+                "note": {"rabi": {"Q1": {"amplitude": 0.2}}},
+                "system_info": {"created_at": newer, "updated_at": newer},
+            },
+        ]
+    )
+
+    dry_run = migrate_project_scoped_calibration(init_db)
+    assert dry_run["collections"]["qubit"]["documents_to_archive"] == 1
+    assert qubits.count_documents({}) == 2
+
+    migrate_project_scoped_calibration(init_db, dry_run=False)
+
+    assert qubits.count_documents({}) == 1
+    assert qubits.find_one({})["username"] == "bob"
+    assert qubits.find_one({})["data"] == {
+        "frequency": {
+            "value": 5.0,
+            "calibrated_at": datetime(2026, 1, 3),
+        },
+        "t1": {"value": 100.0},
+    }
+    assert counters.count_documents({}) == 1
+    assert counters.find_one({})["index"] == 4
+    assert notes.count_documents({}) == 1
+    assert notes.find_one({})["username"] == "bob"
+    assert notes.find_one({})["note"] == {
+        "rabi": {
+            "Q0": {"amplitude": 0.1},
+            "Q1": {"amplitude": 0.2},
+        }
+    }
+    assert init_db["migration_archive"].count_documents({"migration_id": MIGRATION_ID}) == 3
+    assert "project_id_1_chip_id_1_qid_1" in qubits.index_information()
+    assert "project_id_1_date_1_chip_id_1" in counters.index_information()
+    ledger = init_db["migration_ledger"].find_one({"migration_id": MIGRATION_ID})
+    assert ledger["status"] == "completed"
+    repeated = migrate_project_scoped_calibration(init_db, dry_run=False)
+    assert repeated["already_completed"] is True
+
+
+def test_file_migration_copies_legacy_execution_and_classifier(init_db, tmp_path) -> None:
+    execution_source = tmp_path / "alice" / "20260102" / "001"
+    execution_source.mkdir(parents=True)
+    (execution_source / "result.json").write_text("result")
+    classifier_source = tmp_path / "alice" / ".classifier"
+    classifier_source.mkdir(parents=True)
+    alice_classifier = classifier_source / "model.json"
+    alice_classifier.write_text("alice-old")
+    bob_classifier_source = tmp_path / "bob" / ".classifier"
+    bob_classifier_source.mkdir(parents=True)
+    bob_classifier = bob_classifier_source / "model.json"
+    bob_classifier.write_text("bob-new")
+    os.utime(alice_classifier, (1, 1))
+    os.utime(bob_classifier, (2, 2))
+    execution_id = (
+        init_db["execution_history"]
+        .insert_one(
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "execution_id": "20260102-001",
+                "username": "alice",
+                "calib_data_path": str(execution_source),
+            }
+        )
+        .inserted_id
+    )
+    task_id = (
+        init_db["task_result_history"]
+        .insert_one(
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "execution_id": "20260102-001",
+                "task_id": "task-1",
+                "figure_path": [str(execution_source / "fig" / "result.png")],
+                "json_figure_path": [str(execution_source / "fig" / "result.json")],
+                "raw_data_path": [str(execution_source / "raw_data" / "result.nc")],
+            }
+        )
+        .inserted_id
+    )
+    knowledge_id = (
+        init_db["issue_knowledge"]
+        .insert_one(
+            {
+                "project_id": "proj-1",
+                "task_id": "task-1",
+                "figure_paths": [str(execution_source / "fig" / "result.png")],
+            }
+        )
+        .inserted_id
+    )
+    init_db["chip"].insert_one({"project_id": "proj-1", "chip_id": "chip-1", "username": "alice"})
+    init_db["execution_history"].insert_one(
+        {
+            "project_id": "proj-1",
+            "chip_id": "chip-1",
+            "execution_id": "20260103-001",
+            "username": "bob",
+            "calib_data_path": str(tmp_path / "bob" / "20260103" / "001"),
+        }
+    )
+
+    dry_run = migrate_calibration_files(init_db, base_path=tmp_path)
+    assert dry_run["database_records_updated"] == 3
+    assert init_db["execution_history"].find_one({"_id": execution_id})["calib_data_path"] == str(
+        execution_source
+    )
+    assert init_db["migration_archive"].count_documents({}) == 0
+
+    stats = migrate_calibration_files(
+        init_db, base_path=tmp_path, dry_run=False, allow_missing=True
+    )
+
+    target = tmp_path / "projects" / "proj-1" / "chips" / "chip-1"
+    assert (target / "executions" / "20260102-001" / "result.json").read_text() == "result"
+    assert (target / "shared" / "classifier" / "model.json").read_text() == "bob-new"
+    assert (
+        target / "shared" / ".migration_conflicts" / "alice" / "model.json"
+    ).read_text() == "alice-old"
+    assert stats["copied"] == 2
+    assert stats["database_records_updated"] == 3
+    assert execution_source.exists()
+
+    execution = init_db["execution_history"].find_one({"_id": execution_id})
+    assert execution["calib_data_path"] == str(target / "executions" / "20260102-001")
+    task = init_db["task_result_history"].find_one({"_id": task_id})
+    assert task["figure_path"] == [
+        str(target / "executions" / "20260102-001" / "fig" / "result.png")
+    ]
+    assert task["json_figure_path"] == [
+        str(target / "executions" / "20260102-001" / "fig" / "result.json")
+    ]
+    assert task["raw_data_path"] == [
+        str(target / "executions" / "20260102-001" / "raw_data" / "result.nc")
+    ]
+    knowledge = init_db["issue_knowledge"].find_one({"_id": knowledge_id})
+    assert knowledge["figure_paths"] == [
+        str(target / "executions" / "20260102-001" / "fig" / "result.png")
+    ]
+    assert (
+        init_db["migration_archive"].count_documents(
+            {"migration_id": MIGRATION_ID, "migration_kind": "artifact_path_rewrite"}
+        )
+        == 3
+    )
+
+    repeated = migrate_calibration_files(
+        init_db, base_path=tmp_path, dry_run=False, allow_missing=True
+    )
+    assert repeated["database_records_updated"] == 0
+    assert (
+        init_db["migration_archive"].count_documents(
+            {"migration_id": MIGRATION_ID, "migration_kind": "artifact_path_rewrite"}
+        )
+        == 3
+    )
+
+
+def test_migration_reclaims_expired_lock(init_db) -> None:
+    init_db["migration_lock"].insert_one(
+        {
+            "_id": MIGRATION_ID,
+            "acquired_at": datetime(2020, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+
+    migrate_project_scoped_calibration(init_db, dry_run=False)
+
+    assert init_db["migration_lock"].find_one({"_id": MIGRATION_ID}) is None
+
+
+def test_migration_rejects_active_lock(init_db) -> None:
+    init_db["migration_lock"].insert_one(
+        {
+            "_id": MIGRATION_ID,
+            "acquired_at": datetime.now(timezone.utc),
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="already running"):
+        migrate_project_scoped_calibration(init_db, dry_run=False)
+
+
+def test_migration_rejects_documents_with_missing_project_scope(init_db) -> None:
+    init_db["qubit"].insert_one({"chip_id": "chip-1", "qid": "0", "username": "alice", "data": {}})
+
+    dry_run = migrate_project_scoped_calibration(init_db)
+    assert dry_run["invalid_scope_documents"]["qubit"] == 1
+
+    with pytest.raises(RuntimeError, match="missing scope fields"):
+        migrate_project_scoped_calibration(init_db, dry_run=False)
+
+
+def test_file_migration_rejects_missing_execution_artifacts(init_db, tmp_path) -> None:
+    init_db["execution_history"].insert_one(
+        {
+            "project_id": "proj-1",
+            "chip_id": "chip-1",
+            "execution_id": "20260102-001",
+            "username": "alice",
+            "calib_data_path": str(tmp_path / "alice" / "20260102" / "001"),
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="allow-missing-artifacts"):
+        migrate_calibration_files(init_db, base_path=tmp_path, dry_run=False)

--- a/tests/qdash/dbmodel/test_project_calibration_migration.py
+++ b/tests/qdash/dbmodel/test_project_calibration_migration.py
@@ -17,6 +17,10 @@ def test_migration_archives_duplicates_and_installs_project_indexes(init_db) -> 
     qubits.drop_indexes()
     counters.drop_indexes()
     notes.drop_indexes()
+    legacy_qubit_index = qubits.create_index(
+        [("project_id", 1), ("chip_id", 1), ("qid", 1), ("username", 1)],
+        unique=True,
+    )
     older = datetime(2026, 1, 1, tzinfo=timezone.utc)
     newer = datetime(2026, 1, 2, tzinfo=timezone.utc)
     qubits.insert_many(
@@ -118,6 +122,7 @@ def test_migration_archives_duplicates_and_installs_project_indexes(init_db) -> 
     }
     assert init_db["migration_archive"].count_documents({"migration_id": MIGRATION_ID}) == 3
     assert "project_id_1_chip_id_1_qid_1" in qubits.index_information()
+    assert legacy_qubit_index not in qubits.index_information()
     assert "project_id_1_date_1_chip_id_1" in counters.index_information()
     ledger = init_db["migration_ledger"].find_one({"migration_id": MIGRATION_ID})
     assert ledger["status"] == "completed"

--- a/tests/qdash/repository/test_calibration_repository.py
+++ b/tests/qdash/repository/test_calibration_repository.py
@@ -1,6 +1,10 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from qdash.dbmodel.coupling import CouplingDocument
+from qdash.dbmodel.qubit import QubitDocument
 from qdash.repository.coupling import MongoCouplingCalibrationRepository
 from qdash.repository.qubit import MongoQubitCalibrationRepository
 
@@ -11,26 +15,35 @@ def _query_result(value: object) -> MagicMock:
     return result
 
 
-def test_qubit_update_lookup_falls_back_to_legacy_username_document() -> None:
-    legacy_doc = SimpleNamespace(data={"frequency": {"value": 5.0}})
+def test_qubit_update_lookup_does_not_fall_back_outside_project() -> None:
     with patch("qdash.repository.qubit.QubitDocument.find_one") as find_one:
-        find_one.side_effect = [_query_result(None), _query_result(legacy_doc)]
+        find_one.return_value = _query_result(None)
 
         data = MongoQubitCalibrationRepository().get_calibration_data_for_update(
             username="alice", project_id="project-1", chip_id="chip-1", qid="1"
         )
 
+    assert data == {}
+    find_one.assert_called_once_with(
+        {
+            "project_id": "project-1",
+            "chip_id": "chip-1",
+            "qid": "1",
+        }
+    )
+
+
+def test_qubit_update_lookup_uses_legacy_scope_without_project() -> None:
+    legacy_doc = SimpleNamespace(data={"frequency": {"value": 5.0}})
+    with patch("qdash.repository.qubit.QubitDocument.find_one") as find_one:
+        find_one.return_value = _query_result(legacy_doc)
+
+        data = MongoQubitCalibrationRepository().get_calibration_data_for_update(
+            username="alice", project_id=None, chip_id="chip-1", qid="1"
+        )
+
     assert data == {"frequency": {"value": 5.0}}
-    assert find_one.call_args_list[0].args[0] == {
-        "project_id": "project-1",
-        "chip_id": "chip-1",
-        "qid": "1",
-    }
-    assert find_one.call_args_list[1].args[0] == {
-        "username": "alice",
-        "chip_id": "chip-1",
-        "qid": "1",
-    }
+    find_one.assert_called_once_with({"username": "alice", "chip_id": "chip-1", "qid": "1"})
 
 
 def test_coupling_update_lookup_prefers_project_document() -> None:
@@ -44,3 +57,28 @@ def test_coupling_update_lookup_prefers_project_document() -> None:
 
     assert data == {"coupling_strength": {"value": 0.02}}
     find_one.assert_called_once_with({"project_id": "project-1", "chip_id": "chip-1", "qid": "0-1"})
+
+
+@pytest.mark.parametrize(
+    ("document", "qid", "label"),
+    [
+        (QubitDocument, "1", "Qubit"),
+        (CouplingDocument, "0-1", "Coupling"),
+    ],
+)
+def test_document_update_does_not_fall_back_outside_project(
+    document: type[QubitDocument] | type[CouplingDocument], qid: str, label: str
+) -> None:
+    with patch.object(document, "find_one") as find_one:
+        find_one.return_value = _query_result(None)
+
+        with pytest.raises(ValueError, match=label):
+            document.update_calib_data(
+                username="alice",
+                qid=qid,
+                chip_id="chip-1",
+                output_parameters={"frequency": {"value": 5.0}},
+                project_id="project-1",
+            )
+
+    find_one.assert_called_once_with({"project_id": "project-1", "qid": qid, "chip_id": "chip-1"})

--- a/tests/qdash/repository/test_chip_repository.py
+++ b/tests/qdash/repository/test_chip_repository.py
@@ -6,8 +6,7 @@ from qdash.dbmodel.qubit import QubitDocument
 from qdash.repository.chip import MongoChipRepository
 
 
-def test_get_all_qubit_models_filters_by_username(init_db) -> None:
-    """Optional username filter prevents duplicate qids from other users overwriting data."""
+def test_get_all_qubit_models_uses_project_shared_document(init_db) -> None:
     QubitDocument(
         project_id="project-1",
         username="admin",
@@ -16,24 +15,14 @@ def test_get_all_qubit_models_filters_by_username(init_db) -> None:
         data={"readout_fidelity_0": {"value": 0.95}},
         system_info=SystemInfoModel(),
     ).insert()
-    QubitDocument(
-        project_id="project-1",
-        username="other",
-        qid="20",
-        chip_id="64Qv3",
-        data={"seed_only": {"value": 1.0}},
-        system_info=SystemInfoModel(),
-    ).insert()
-
-    result = MongoChipRepository().get_all_qubit_models("project-1", "64Qv3", username="admin")
+    result = MongoChipRepository().get_all_qubit_models("project-1", "64Qv3", username="other")
 
     assert set(result) == {"20"}
     assert result["20"].username == "admin"
     assert "readout_fidelity_0" in result["20"].data
 
 
-def test_get_all_coupling_models_filters_by_username(init_db) -> None:
-    """Optional username filter prevents duplicate coupling ids from other users overwriting data."""
+def test_get_all_coupling_models_uses_project_shared_document(init_db) -> None:
     CouplingDocument(
         project_id="project-1",
         username="admin",
@@ -42,16 +31,7 @@ def test_get_all_coupling_models_filters_by_username(init_db) -> None:
         data={"zx90_gate_fidelity": {"value": 0.91}},
         system_info=SystemInfoModel(),
     ).insert()
-    CouplingDocument(
-        project_id="project-1",
-        username="other",
-        qid="20-21",
-        chip_id="64Qv3",
-        data={"seed_only": {"value": 1.0}},
-        system_info=SystemInfoModel(),
-    ).insert()
-
-    result = MongoChipRepository().get_all_coupling_models("project-1", "64Qv3", username="admin")
+    result = MongoChipRepository().get_all_coupling_models("project-1", "64Qv3", username="other")
 
     assert set(result) == {"20-21"}
     assert result["20-21"].username == "admin"

--- a/tests/qdash/workflow/engine/repository/test_inmemory_impl.py
+++ b/tests/qdash/workflow/engine/repository/test_inmemory_impl.py
@@ -159,6 +159,13 @@ class TestInMemoryExecutionCounterRepository:
         assert index2 == 1
         assert index3 == 2
 
+    def test_get_next_index_requires_project_id(self):
+        """Test in-memory behavior matches the production project requirement."""
+        repo = InMemoryExecutionCounterRepository()
+
+        with pytest.raises(ValueError, match="project_id is required"):
+            repo.get_next_index("20240101", "alice", "chip_1", None)
+
     def test_different_keys_have_separate_counters(self):
         """Test different key combinations have separate counters."""
         repo = InMemoryExecutionCounterRepository()

--- a/tests/qdash/workflow/engine/repository/test_inmemory_impl.py
+++ b/tests/qdash/workflow/engine/repository/test_inmemory_impl.py
@@ -170,9 +170,13 @@ class TestInMemoryExecutionCounterRepository:
         assert index1 == 0
         assert index2 == 0
 
-        # Different users
+        # Different users in the same project/chip share the counter.
         index3 = repo.get_next_index("20240101", "bob", "chip_1", "proj-1")
-        assert index3 == 0
+        assert index3 == 1
+
+        # Different projects have separate counters.
+        index4 = repo.get_next_index("20240101", "bob", "chip_1", "proj-2")
+        assert index4 == 0
 
     def test_clear(self):
         """Test clearing repository."""

--- a/tests/qdash/workflow/engine/repository/test_inmemory_integration.py
+++ b/tests/qdash/workflow/engine/repository/test_inmemory_integration.py
@@ -50,8 +50,8 @@ class TestGenerateExecutionIdWithInMemory:
         assert id2.endswith("-001")
         assert id3.endswith("-002")
 
-    def test_generate_execution_id_different_users_independent(self):
-        """Test that different users have independent counters."""
+    def test_generate_execution_id_different_users_share_project_chip_counter(self):
+        """Project collaborators share one execution counter for a chip."""
         from qdash.workflow.service.calib_service import generate_execution_id
 
         counter_repo = InMemoryExecutionCounterRepository()
@@ -69,9 +69,8 @@ class TestGenerateExecutionIdWithInMemory:
             counter_repo=counter_repo,
         )
 
-        # Both should start at 000
         assert id_alice.endswith("-000")
-        assert id_bob.endswith("-000")
+        assert id_bob.endswith("-001")
 
 
 class TestExecutionLockWithInMemory:

--- a/tests/qdash/workflow/engine/scheduler/test_cr_scheduler.py
+++ b/tests/qdash/workflow/engine/scheduler/test_cr_scheduler.py
@@ -117,6 +117,21 @@ def test_scheduler_default_wiring_path():
     assert scheduler.wiring_config_path is None
 
 
+def test_scheduler_loads_chip_from_project_scope(mock_chip):
+    chip_repo = MagicMock()
+    chip_repo.find_by_id.return_value = mock_chip
+    scheduler = CRScheduler(
+        username="bob",
+        chip_id="test_chip",
+        project_id="proj-1",
+        chip_repo=chip_repo,
+    )
+
+    assert scheduler._load_chip_data() is mock_chip
+    chip_repo.find_by_id.assert_called_once_with("proj-1", "test_chip")
+    chip_repo.get_current_chip.assert_not_called()
+
+
 # MUX conflict detection tests
 def test_build_mux_conflict_map(mock_wiring_config):
     """Test MUX conflict map construction."""

--- a/tests/qdash/workflow/engine/task/test_executor.py
+++ b/tests/qdash/workflow/engine/task/test_executor.py
@@ -247,6 +247,23 @@ class TestTaskExecutorExecuteTask:
         assert result["message"] == "Completed without run result"
         mock_state_manager.update_task_status_to_completed.assert_called_once()
 
+    def test_execute_records_chip_history_in_execution_project(
+        self, executor: TaskExecutor
+    ) -> None:
+        """Test single-task history uses the execution's project and chip scope."""
+        task = MockTask()
+        task.run = MagicMock(return_value=None)  # type: ignore[method-assign]
+        session: Any = MockSession()
+        execution_service = MagicMock(project_id="proj-1", chip_id="chip-1")
+        execution_service.merge_calib_data.return_value = execution_service
+        executor.history_recorder = MagicMock()
+
+        executor.execute(task, session, "0", execution_service)
+
+        executor.history_recorder.create_chip_history_snapshot.assert_called_once_with(
+            "admin", chip_id="chip-1", project_id="proj-1"
+        )
+
     def test_execute_batch_calls_batch_run_once(
         self, executor: TaskExecutor, mock_state_manager: MagicMock
     ) -> None:
@@ -273,6 +290,23 @@ class TestTaskExecutorExecuteTask:
         task.run.assert_not_called()
         assert mock_state_manager.start_task.call_count == 2
         assert mock_state_manager.end_task.call_count == 2
+
+    def test_execute_batch_records_chip_history_in_execution_project(
+        self, executor: TaskExecutor
+    ) -> None:
+        """Test batch history uses the execution's project and chip scope."""
+        task = MockTask()
+        task.batch_run = MagicMock(return_value=None)  # type: ignore[method-assign]
+        session: Any = MockSession()
+        execution_service = MagicMock(project_id="proj-1", chip_id="chip-1")
+        execution_service.merge_calib_data.return_value = execution_service
+        executor.history_recorder = MagicMock()
+
+        executor.execute_batch(task, session, ["0", "4"], execution_service)
+
+        executor.history_recorder.create_chip_history_snapshot.assert_called_once_with(
+            "admin", chip_id="chip-1", project_id="proj-1"
+        )
 
     def test_execute_batch_continues_after_qid_validation_error(
         self, executor: TaskExecutor, mock_state_manager: MagicMock

--- a/tests/qdash/workflow/engine/task/test_history_recorder.py
+++ b/tests/qdash/workflow/engine/task/test_history_recorder.py
@@ -129,7 +129,9 @@ class TestTaskHistoryRecorder:
         """Test create_chip_history_snapshot calls the repository."""
         recorder.create_chip_history_snapshot("test-user")
 
-        mock_repos["chip_history"].create_history.assert_called_once_with("test-user")
+        mock_repos["chip_history"].create_history.assert_called_once_with(
+            username="test-user", chip_id=None, project_id=None
+        )
 
     def test_record_completed_task_calls_all_repos(
         self, recorder, mock_repos, sample_task, sample_execution_model
@@ -148,7 +150,11 @@ class TestTaskHistoryRecorder:
 
         mock_repos["task_result_history"].save.assert_called_once()
         mock_repos["chip"].update_chip_data.assert_called_once()
-        mock_repos["chip_history"].create_history.assert_called_once()
+        mock_repos["chip_history"].create_history.assert_called_once_with(
+            username="test-user",
+            chip_id="test-chip",
+            project_id=sample_execution_model.project_id,
+        )
 
     def test_record_completed_task_skips_history_when_disabled(
         self, recorder, mock_repos, sample_task, sample_execution_model

--- a/tests/qdash/workflow/engine/test_orchestrator_directories.py
+++ b/tests/qdash/workflow/engine/test_orchestrator_directories.py
@@ -1,0 +1,23 @@
+"""Tests for calibration directory creation."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+from qdash.workflow.engine.orchestrator import CalibOrchestrator
+
+
+def test_create_directories_creates_classifier_parents(tmp_path: Path) -> None:
+    """A project's first classifier directory creates the full shared path."""
+    orchestrator = object.__new__(CalibOrchestrator)
+    orchestrator.config = cast(
+        "Any",
+        SimpleNamespace(
+            calib_data_path=str(tmp_path / "executions" / "exec-1"),
+            classifier_dir=str(tmp_path / "shared" / "classifier"),
+        ),
+    )
+
+    orchestrator._create_directories()
+
+    assert (tmp_path / "shared" / "classifier").is_dir()

--- a/tests/qdash/workflow/service/test_targets.py
+++ b/tests/qdash/workflow/service/test_targets.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qdash.workflow.service.targets import MuxTargets, QubitTargets
+
+
+@pytest.mark.parametrize("targets", [MuxTargets([0]), QubitTargets(["0", "1"])])
+def test_database_backed_coupling_targets_require_project_id(targets) -> None:
+    with pytest.raises(ValueError, match="project_id is required"):
+        targets.to_coupling_ids("chip-1")
+
+
+def test_qubit_targets_pass_project_id_to_cr_scheduler() -> None:
+    scheduler = MagicMock()
+    scheduler.generate.return_value.parallel_groups = [[("0", "1")]]
+
+    with patch("qdash.workflow.engine.CRScheduler", return_value=scheduler) as scheduler_cls:
+        result = QubitTargets(["0", "1"]).to_coupling_ids("chip-1", project_id="proj-1")
+
+    assert result == ["0-1"]
+    scheduler_cls.assert_called_once_with(
+        username="",
+        chip_id="chip-1",
+        wiring_config_path="/app/config/qubex-config/chip-1/config/wiring.yaml",
+        project_id="proj-1",
+    )

--- a/tests/qdash/workflow/test_paths.py
+++ b/tests/qdash/workflow/test_paths.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+
+# Import the leaf module without executing qdash.workflow.__init__, which eagerly
+# imports Prefect/Dask and makes this pure path test depend on process discovery.
+_SPEC = importlib.util.spec_from_file_location(
+    "qdash_workflow_paths_for_test",
+    Path(__file__).parents[3] / "src" / "qdash" / "workflow" / "paths.py",
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+PathResolver = _MODULE.PathResolver
+
+
+def test_project_scoped_calibration_paths() -> None:
+    resolver = PathResolver(calib_data_base=Path("/calib"))
+
+    assert resolver.classifier_dir("proj-1", "chip-1") == Path(
+        "/calib/projects/proj-1/chips/chip-1/shared/classifier"
+    )
+    assert resolver.execution_data_dir("proj-1", "chip-1", "20240101-001") == Path(
+        "/calib/projects/proj-1/chips/chip-1/executions/20240101-001"
+    )
+
+
+def test_legacy_user_data_dir_remains_available_for_migration() -> None:
+    resolver = PathResolver(calib_data_base=Path("/calib"))
+
+    assert resolver.user_data_dir("alice") == Path("/calib/alice")

--- a/tests/qdash/workflow/worker/tasks/test_push_github.py
+++ b/tests/qdash/workflow/worker/tasks/test_push_github.py
@@ -2,6 +2,8 @@
 
 import logging
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -249,6 +251,43 @@ class TestGitHubIntegrationPushFilesSync:
         assert result["calib_note"] == "abc12345"
         assert result["all_params"] == {"error": "push failed"}
         sync_local.assert_not_called()
+
+    def test_push_calib_note_reads_latest_note_from_project_across_users(self, tmp_path: Path):
+        """A later actor must publish the project's shared note, not their own stale note."""
+        from qdash.workflow.service.github import GitHubIntegration, GitHubPushConfig
+
+        integration = GitHubIntegration.__new__(GitHubIntegration)
+        integration.username = "bob"
+        integration.chip_id = "chip-1"
+        integration.execution_id = "20260819-001"
+        integration.project_id = "proj-1"
+        integration.logger = MagicMock()
+        note_repo = MagicMock()
+        note_repo.find_latest_master.return_value = SimpleNamespace(note={"actor": "alice"})
+        paths = SimpleNamespace(calib_note_json=lambda _chip_id: tmp_path / "calib_note.json")
+
+        with (
+            patch(
+                "qdash.repository.MongoCalibrationNoteRepository",
+                return_value=note_repo,
+            ),
+            patch("qdash.workflow.service.github.get_qubex_paths", return_value=paths),
+            patch(
+                "qdash.workflow.worker.tasks.push_github.push_github",
+                return_value="abc123",
+            ),
+        ):
+            config = cast(
+                "GitHubPushConfig",
+                SimpleNamespace(commit_message=None, branch="develop"),
+            )
+            result = integration._push_calib_note(config)
+
+        assert result == "abc123"
+        note_repo.find_latest_master.assert_called_once_with(
+            chip_id="chip-1", project_id="proj-1", username=None
+        )
+        assert '"actor": "alice"' in (tmp_path / "calib_note.json").read_text()
 
     def test_does_not_sync_local_repo_when_nothing_changed(self):
         """No-op grouped pushes do not need to reset the local repository."""

--- a/tests/qdash/workflow/worker/tasks/test_push_github.py
+++ b/tests/qdash/workflow/worker/tasks/test_push_github.py
@@ -289,6 +289,43 @@ class TestGitHubIntegrationPushFilesSync:
         )
         assert '"actor": "alice"' in (tmp_path / "calib_note.json").read_text()
 
+    def test_push_props_uses_session_project(self, tmp_path: Path):
+        """Properties must be generated from the session's non-default project."""
+        from qdash.workflow.service.github import GitHubIntegration, GitHubPushConfig
+
+        integration = GitHubIntegration.__new__(GitHubIntegration)
+        integration.username = "bob"
+        integration.chip_id = "chip-1"
+        integration.execution_id = "20260819-001"
+        integration.project_id = "shared-project"
+        integration.logger = MagicMock()
+        paths = SimpleNamespace(props_yaml=lambda _chip_id: tmp_path / "props.yaml")
+
+        with (
+            patch("qdash.workflow.service.github.get_qubex_paths", return_value=paths),
+            patch(
+                "qdash.workflow.worker.flows.push_props.create_props.create_chip_properties"
+            ) as create_properties,
+            patch(
+                "qdash.workflow.worker.tasks.push_github.push_github",
+                return_value="abc123",
+            ),
+        ):
+            config = cast(
+                "GitHubPushConfig",
+                SimpleNamespace(commit_message=None, branch="develop"),
+            )
+            result = integration._push_props(config)
+
+        assert result == "abc123"
+        create_properties.assert_called_once_with(
+            username="bob",
+            source_path=str(tmp_path / "props.yaml"),
+            target_path=str(tmp_path / "props.yaml"),
+            chip_id="chip-1",
+            project_id="shared-project",
+        )
+
     def test_does_not_sync_local_repo_when_nothing_changed(self):
         """No-op grouped pushes do not need to reset the local repository."""
         from qdash.workflow.service.github import GitHubIntegration


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Share current calibration state and classifier artifacts across users in the same project and chip.
- Add an automatic, blocking deployment migration for MongoDB records and legacy calibration files; workflow, API, and infrastructure behavior are affected.

## Changes

- Scope chips, qubits, couplings, histories, notes, and execution counters by project and chip while retaining actor snapshots.
- Store execution artifacts under project/chip/execution paths and classifiers under a shared project/chip path.
- Add dry-run, archival, conflict handling, fail-fast validation, idempotency ledgers, and explicit missing-artifact override support.
- Rewrite persisted execution, figure, JSON figure, raw-data, and issue-knowledge paths after successful file migration.
- Merge duplicate calibration parameters by calibration timestamp and select classifier conflicts by file modification time.
- Propagate project scope through calibration startup, quick runs, GitHub output, device topology, CR scheduling, and compatibility workers.
- Add migration and cross-user regression tests plus deployment and recovery documentation.
- No OpenAPI schema changes or generated client updates are required.

## Verification

- `task check` (1398 Python tests and 178 UI tests passed)
- `docker compose config --quiet`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration data is now shared by project and chip, while execution records remain associated with their creator.
  * Added automatic migration of existing calibration data and artifacts, including duplicate consolidation, archiving, and rollback support.
  * Calibration execution and classifier files now use project- and chip-scoped storage.
  * Execution counters are shared within a project, chip, and date.

* **Bug Fixes**
  * Improved project-scoped chip and calibration lookups.
  * Deployment startup now waits for database health and successful migration completion.

* **Documentation**
  * Added guidance for calibration sharing, migration, indexes, and project-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->