### PR TITLE
fix(repo): migrate legacy calibration scope and paths

### DIFF
--- a/docs/reference/migration-project-scoped-calibration.md
+++ b/docs/reference/migration-project-scoped-calibration.md
@@ -13,10 +13,14 @@ calibration state.
 `docker compose up` starts the one-shot `calibration-migration` service after MongoDB becomes
 healthy. Other QDash services start only when the migration exits successfully. The migration is
 idempotent and records completion as `project-scoped-calibration-v1` in `migration_ledger`.
-Artifact migration is recorded separately as `project-scoped-calibration-artifacts-v1`, preventing
-legacy files from being reconsidered after shared classifier files receive newer updates.
+Artifact migration is recorded separately as
+`project-scoped-calibration-artifacts-date-layout-v2`, preventing legacy files from being
+reconsidered after shared classifier files receive newer updates.
 The migration lock has a 30-minute lease, so a deployment interrupted by a hard container stop can
 recover automatically on a later deployment.
+An idempotent compound index on migration ID, source collection, source document ID, and migration
+kind keeps archive lookups bounded as `migration_archive` grows. Deployments install this index
+even when the data migration ledger is already complete.
 
 To inspect an installation without changing it, run:
 
@@ -42,14 +46,16 @@ execution ID. The other counter documents are archived in the same way.
 The migration never deletes legacy calibration files. It copies execution artifacts to:
 
 ```text
-calib_data/projects/{project_id}/chips/{chip_id}/executions/{execution_id}/
+calib_data/projects/{project_id}/chips/{chip_id}/executions/{date}/{index}/
 ```
 
 After an execution directory is copied successfully, the migration rewrites its persisted artifact
 references in `execution_history`, `task_result_history`, and `issue_knowledge` to the new project
-path. Every affected document is copied verbatim to `migration_archive` before its paths are
-changed. This keeps historical figures, raw data downloads, and reanalysis available after the
-legacy directories are eventually removed.
+path. Installations that already copied artifacts to `executions/{execution_id}` atomically move
+that intermediate directory into the date layout when the destination does not exist, avoiding a
+second full artifact copy. Every affected database document is copied verbatim to
+`migration_archive` before its paths are changed. This keeps historical figures, raw data
+downloads, and reanalysis available after the legacy directories are eventually removed.
 
 Classifier files are copied to:
 
@@ -71,8 +77,20 @@ docker compose run --rm calibration-migration \
   --execute --allow-missing-artifacts
 ```
 
-Documents missing `project_id` or another required scope field also stop the migration and must be
-corrected before retrying; they are never grouped under an implicit null project.
+For legacy calibration documents missing `project_id`, the migration first resolves the actor by
+`user_id` or `username`. It uses the user's `default_project_id` when available, or a single
+active project membership when no default is stored. The original document is copied to
+`migration_archive` under `project-scoped-calibration-scope-backfill-v1` before the resolved
+project is written.
+
+For legacy calibration notes missing `chip_id`, the migration resolves the chip when
+`project_id + execution_id` identifies execution history for exactly one chip. The note remains
+unresolved if no matching execution exists or multiple chips match.
+
+Documents without a default and with multiple possible active projects, with no resolvable project,
+or with another missing scope field still stop the migration and must be corrected before retrying.
+They are never grouped under an implicit null project, and fields such as `qid`, `recorded_date`,
+and `execution_id` are not inferred.
 
 ## Verification and recovery
 

--- a/docs/user-guide/calibration-data-sharing.md
+++ b/docs/user-guide/calibration-data-sharing.md
@@ -49,7 +49,7 @@ new execution does not overwrite an earlier execution's result or artifact refer
 On a standard deployment, execution artifacts use this layout:
 
 ```text
-calib_data/projects/{project_id}/chips/{chip_id}/executions/{execution_id}/
+calib_data/projects/{project_id}/chips/{chip_id}/executions/{date}/{index}/
 ```
 
 Classifier files are reusable chip state rather than execution output, so they use a shared path:

--- a/src/qdash/dbmodel/project_calibration_migration.py
+++ b/src/qdash/dbmodel/project_calibration_migration.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
     from pymongo.database import Database
 
 MIGRATION_ID = "project-scoped-calibration-v1"
-ARTIFACT_MIGRATION_ID = "project-scoped-calibration-artifacts-v1"
+SCOPE_BACKFILL_MIGRATION_ID = "project-scoped-calibration-scope-backfill-v1"
+ARTIFACT_MIGRATION_ID = "project-scoped-calibration-artifacts-date-layout-v2"
 MIGRATION_LOCK_LEASE = timedelta(minutes=30)
 
 _SHARED_COLLECTIONS: dict[str, tuple[str, ...]] = {
@@ -27,6 +28,19 @@ _SHARED_COLLECTIONS: dict[str, tuple[str, ...]] = {
     "coupling_history": ("project_id", "chip_id", "qid", "recorded_date"),
     "calibration_note": ("project_id", "execution_id", "task_id", "chip_id"),
 }
+
+
+def _ensure_migration_archive_index(database: Database[Any]) -> None:
+    """Install the lookup index used by idempotent migration archive writes."""
+    database["migration_archive"].create_index(
+        [
+            ("migration_id", ASCENDING),
+            ("source_collection", ASCENDING),
+            ("source_id", ASCENDING),
+            ("migration_kind", ASCENDING),
+        ],
+        name="migration_archive_lookup_idx",
+    )
 
 
 def _as_datetime(value: Any) -> datetime | None:
@@ -99,11 +113,107 @@ def _merged_shared_fields(collection_name: str, documents: list[dict[str, Any]])
     return {"note": merged}
 
 
-def _invalid_scope_count(
+def _is_missing_scope_value(value: Any) -> bool:
+    return value is None or value == ""
+
+
+def _resolve_legacy_project_id(database: Database[Any], document: dict[str, Any]) -> str | None:
+    """Resolve a legacy user's project only when the stored ownership is unambiguous."""
+    user_query: dict[str, Any] | None = None
+    if document.get("user_id"):
+        user_query = {"user_id": document["user_id"]}
+    elif document.get("username"):
+        user_query = {"username": document["username"]}
+
+    if user_query is not None:
+        user = database["user"].find_one(user_query, {"default_project_id": 1})
+        if user and not _is_missing_scope_value(user.get("default_project_id")):
+            return str(user["default_project_id"])
+
+    membership_query: dict[str, Any] | None = None
+    if document.get("user_id"):
+        membership_query = {"user_id": document["user_id"], "status": "active"}
+    elif document.get("username"):
+        membership_query = {"username": document["username"], "status": "active"}
+    if membership_query is None:
+        return None
+
+    project_ids = database["project_membership"].distinct("project_id", membership_query)
+    valid_project_ids = [project_id for project_id in project_ids if project_id]
+    return str(valid_project_ids[0]) if len(valid_project_ids) == 1 else None
+
+
+def _resolve_calibration_note_chip_id(
+    database: Database[Any], document: dict[str, Any]
+) -> str | None:
+    """Resolve a legacy note's chip from its uniquely scoped execution."""
+    project_id = document.get("project_id")
+    execution_id = document.get("execution_id")
+    if not project_id or not execution_id:
+        return None
+    chip_ids = database["execution_history"].distinct(
+        "chip_id",
+        {"project_id": project_id, "execution_id": execution_id},
+    )
+    valid_chip_ids = [chip_id for chip_id in chip_ids if chip_id]
+    return str(valid_chip_ids[0]) if len(valid_chip_ids) == 1 else None
+
+
+def _scope_backfill_plan(
     database: Database[Any], collection_name: str, keys: tuple[str, ...]
-) -> int:
+) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], int]:
+    """Plan safe project scope repairs and count documents that remain invalid."""
     invalid_fields = [{"$or": [{key: {"$exists": False}}, {key: None}, {key: ""}]} for key in keys]
-    return database[collection_name].count_documents({"$or": invalid_fields})
+    documents = database[collection_name].find({"$or": invalid_fields})
+    plan: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    unresolved = 0
+    for document in documents:
+        updates: dict[str, Any] = {}
+        if "project_id" in keys and _is_missing_scope_value(document.get("project_id")):
+            project_id = _resolve_legacy_project_id(database, document)
+            if project_id is not None:
+                updates["project_id"] = project_id
+        projected = {**document, **updates}
+        if collection_name == "calibration_note" and _is_missing_scope_value(
+            projected.get("chip_id")
+        ):
+            chip_id = _resolve_calibration_note_chip_id(database, projected)
+            if chip_id is not None:
+                updates["chip_id"] = chip_id
+                projected["chip_id"] = chip_id
+        if any(_is_missing_scope_value(projected.get(key)) for key in keys):
+            unresolved += 1
+        elif updates:
+            plan.append((document, updates))
+    return plan, unresolved
+
+
+def _apply_scope_backfill(
+    database: Database[Any],
+    plans: dict[str, list[tuple[dict[str, Any], dict[str, Any]]]],
+    *,
+    migrated_at: datetime,
+) -> None:
+    archive = database["migration_archive"]
+    for collection_name, collection_plan in plans.items():
+        collection = database[collection_name]
+        for document, updates in collection_plan:
+            archive.update_one(
+                {
+                    "migration_id": SCOPE_BACKFILL_MIGRATION_ID,
+                    "source_collection": collection_name,
+                    "source_id": document["_id"],
+                },
+                {
+                    "$setOnInsert": {
+                        "migrated_at": migrated_at,
+                        "document": document,
+                        "backfilled_fields": updates,
+                    }
+                },
+                upsert=True,
+            )
+            collection.update_one({"_id": document["_id"]}, {"$set": updates})
 
 
 def _duplicates(
@@ -155,6 +265,7 @@ def migrate_project_scoped_calibration(
     Losing documents are copied verbatim to ``migration_archive`` before deletion.
     Re-running the migration is safe; completed migrations return immediately.
     """
+    _ensure_migration_archive_index(database)
     ledger = database["migration_ledger"]
     if ledger.find_one({"migration_id": MIGRATION_ID, "status": "completed"}):
         if not dry_run:
@@ -170,9 +281,12 @@ def migrate_project_scoped_calibration(
     }
     plans: dict[str, list[tuple[dict[str, Any], list[dict[str, Any]]]]] = {}
     invalid_scope: dict[str, int] = {}
+    scope_backfills: dict[str, list[tuple[dict[str, Any], dict[str, Any]]]] = {}
     for collection_name, keys in _SHARED_COLLECTIONS.items():
         collection = database[collection_name]
-        invalid_scope[collection_name] = _invalid_scope_count(database, collection_name, keys)
+        backfill_plan, unresolved = _scope_backfill_plan(database, collection_name, keys)
+        scope_backfills[collection_name] = backfill_plan
+        invalid_scope[collection_name] = unresolved
         plans[collection_name] = []
         archived = 0
         for duplicate in _duplicates(database, collection_name, keys):
@@ -187,10 +301,16 @@ def migrate_project_scoped_calibration(
         }
 
     counter_groups = _duplicates(database, "execution_counter", ("project_id", "date", "chip_id"))
-    invalid_scope["execution_counter"] = _invalid_scope_count(
+    counter_backfills, counter_unresolved = _scope_backfill_plan(
         database, "execution_counter", ("project_id", "date", "chip_id")
     )
+    scope_backfills["execution_counter"] = counter_backfills
+    invalid_scope["execution_counter"] = counter_unresolved
     stats["invalid_scope_documents"] = invalid_scope
+    stats["scope_backfill_documents"] = {
+        collection_name: len(collection_plan)
+        for collection_name, collection_plan in scope_backfills.items()
+    }
     stats["collections"]["execution_counter"] = {
         "duplicate_groups": len(counter_groups),
         "documents_to_archive": sum(group["count"] - 1 for group in counter_groups),
@@ -199,8 +319,18 @@ def migrate_project_scoped_calibration(
         return stats
     invalid_total = sum(invalid_scope.values())
     if invalid_total:
+        unresolved_counts = {
+            collection_name: count for collection_name, count in invalid_scope.items() if count
+        }
+        planned_backfills = {
+            collection_name: len(collection_plan)
+            for collection_name, collection_plan in scope_backfills.items()
+            if collection_plan
+        }
         raise RuntimeError(
-            f"Cannot migrate {invalid_total} calibration document(s) with missing scope fields"
+            f"Cannot migrate {invalid_total} calibration document(s) with missing scope fields; "
+            f"unresolved_by_collection={unresolved_counts}; "
+            f"planned_project_backfills={planned_backfills}"
         )
 
     lock = database["migration_lock"]
@@ -224,6 +354,32 @@ def migrate_project_scoped_calibration(
     archive = database["migration_archive"]
     try:
         migrated_at = datetime.now(timezone.utc)
+        _apply_scope_backfill(database, scope_backfills, migrated_at=migrated_at)
+
+        # Backfilled project IDs can introduce new project-scoped duplicate groups.
+        # Recalculate the consolidation plan against the repaired documents.
+        for collection_name, keys in _SHARED_COLLECTIONS.items():
+            collection = database[collection_name]
+            plans[collection_name] = []
+            archived = 0
+            for duplicate in _duplicates(database, collection_name, keys):
+                documents = list(collection.find({"_id": {"$in": duplicate["ids"]}}))
+                winner = _winner(documents)
+                losers = [doc for doc in documents if doc["_id"] != winner["_id"]]
+                plans[collection_name].append((winner, losers))
+                archived += len(losers)
+            stats["collections"][collection_name] = {
+                "duplicate_groups": len(plans[collection_name]),
+                "documents_to_archive": archived,
+            }
+        counter_groups = _duplicates(
+            database, "execution_counter", ("project_id", "date", "chip_id")
+        )
+        stats["collections"]["execution_counter"] = {
+            "duplicate_groups": len(counter_groups),
+            "documents_to_archive": sum(group["count"] - 1 for group in counter_groups),
+        }
+
         for collection_name, groups in plans.items():
             collection = database[collection_name]
             for winner, losers in groups:
@@ -482,8 +638,10 @@ def migrate_calibration_files(
     allow_missing: bool = False,
 ) -> dict[str, int]:
     """Copy legacy user artifacts to project-chip paths without deleting sources."""
+    _ensure_migration_archive_index(database)
     stats = {
         "copied": 0,
+        "moved": 0,
         "identical": 0,
         "conflicts": 0,
         "missing": 0,
@@ -505,23 +663,23 @@ def migrate_calibration_files(
         except ValueError:
             stats["missing"] += 1
             continue
-        source = base_path / username / date_str / index
-        target = (
-            base_path
-            / "projects"
-            / execution["project_id"]
-            / "chips"
-            / execution["chip_id"]
-            / "executions"
-            / execution_id
+        legacy_source = base_path / username / date_str / index
+        project_chip_path = (
+            base_path / "projects" / execution["project_id"] / "chips" / execution["chip_id"]
         )
+        flat_source = project_chip_path / "executions" / execution_id
+        target = project_chip_path / "executions" / date_str / index
         if execution.get("calib_data_path") == str(target) and target.is_dir():
             continue
+        source = flat_source if flat_source.is_dir() else legacy_source
         if not source.is_dir():
             stats["missing"] += 1
             continue
         if dry_run:
-            stats["copied"] += sum(1 for path in source.rglob("*") if path.is_file())
+            if source == flat_source and not target.exists():
+                stats["moved"] += 1
+            else:
+                stats["copied"] += sum(1 for path in source.rglob("*") if path.is_file())
             stats["database_records_updated"] += _migrate_execution_document_paths(
                 database,
                 execution=execution,
@@ -530,13 +688,18 @@ def migrate_calibration_files(
                 dry_run=True,
             )
             continue
-        copied = _copy_tree_without_overwrite(
-            source,
-            target,
-            target / ".migration_conflicts" / username,
-        )
-        for key, count in copied.items():
-            stats[key] += count
+        if source == flat_source and not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source.rename(target)
+            stats["moved"] += 1
+        else:
+            copied = _copy_tree_without_overwrite(
+                source,
+                target,
+                target / ".migration_conflicts" / username,
+            )
+            for key, count in copied.items():
+                stats[key] += count
         stats["database_records_updated"] += _migrate_execution_document_paths(
             database,
             execution=execution,

--- a/src/qdash/workflow/paths.py
+++ b/src/qdash/workflow/paths.py
@@ -39,7 +39,7 @@ class PathResolver:
     PosixPath('/app/calib_data/alice')
 
     >>> resolver.execution_data_dir("proj-1", "chip-1", "20240101-001")
-    PosixPath('/app/calib_data/projects/proj-1/chips/chip-1/executions/20240101-001')
+    PosixPath('/app/calib_data/projects/proj-1/chips/chip-1/executions/20240101/001')
 
     """
 
@@ -79,7 +79,10 @@ class PathResolver:
 
     def execution_data_dir(self, project_id: str, chip_id: str, execution_id: str) -> Path:
         """Get the immutable artifact directory for an execution."""
-        return self.project_chip_dir(project_id, chip_id) / "executions" / execution_id
+        date_str, separator, index = execution_id.partition("-")
+        if not separator or not date_str or not index:
+            raise ValueError(f"Invalid execution_id: {execution_id!r}")
+        return self.project_chip_dir(project_id, chip_id) / "executions" / date_str / index
 
 
 # Default resolver instance

--- a/tests/qdash/dbmodel/test_project_calibration_migration.py
+++ b/tests/qdash/dbmodel/test_project_calibration_migration.py
@@ -5,6 +5,7 @@ import pytest
 
 from qdash.dbmodel.project_calibration_migration import (
     MIGRATION_ID,
+    SCOPE_BACKFILL_MIGRATION_ID,
     migrate_calibration_files,
     migrate_project_scoped_calibration,
 )
@@ -124,10 +125,13 @@ def test_migration_archives_duplicates_and_installs_project_indexes(init_db) -> 
     assert "project_id_1_chip_id_1_qid_1" in qubits.index_information()
     assert legacy_qubit_index not in qubits.index_information()
     assert "project_id_1_date_1_chip_id_1" in counters.index_information()
+    assert "migration_archive_lookup_idx" in init_db["migration_archive"].index_information()
     ledger = init_db["migration_ledger"].find_one({"migration_id": MIGRATION_ID})
     assert ledger["status"] == "completed"
+    init_db["migration_archive"].drop_index("migration_archive_lookup_idx")
     repeated = migrate_project_scoped_calibration(init_db, dry_run=False)
     assert repeated["already_completed"] is True
+    assert "migration_archive_lookup_idx" in init_db["migration_archive"].index_information()
 
 
 def test_file_migration_copies_legacy_execution_and_classifier(init_db, tmp_path) -> None:
@@ -206,7 +210,8 @@ def test_file_migration_copies_legacy_execution_and_classifier(init_db, tmp_path
     )
 
     target = tmp_path / "projects" / "proj-1" / "chips" / "chip-1"
-    assert (target / "executions" / "20260102-001" / "result.json").read_text() == "result"
+    execution_target = target / "executions" / "20260102" / "001"
+    assert (execution_target / "result.json").read_text() == "result"
     assert (target / "shared" / "classifier" / "model.json").read_text() == "bob-new"
     assert (
         target / "shared" / ".migration_conflicts" / "alice" / "model.json"
@@ -216,21 +221,13 @@ def test_file_migration_copies_legacy_execution_and_classifier(init_db, tmp_path
     assert execution_source.exists()
 
     execution = init_db["execution_history"].find_one({"_id": execution_id})
-    assert execution["calib_data_path"] == str(target / "executions" / "20260102-001")
+    assert execution["calib_data_path"] == str(execution_target)
     task = init_db["task_result_history"].find_one({"_id": task_id})
-    assert task["figure_path"] == [
-        str(target / "executions" / "20260102-001" / "fig" / "result.png")
-    ]
-    assert task["json_figure_path"] == [
-        str(target / "executions" / "20260102-001" / "fig" / "result.json")
-    ]
-    assert task["raw_data_path"] == [
-        str(target / "executions" / "20260102-001" / "raw_data" / "result.nc")
-    ]
+    assert task["figure_path"] == [str(execution_target / "fig" / "result.png")]
+    assert task["json_figure_path"] == [str(execution_target / "fig" / "result.json")]
+    assert task["raw_data_path"] == [str(execution_target / "raw_data" / "result.nc")]
     knowledge = init_db["issue_knowledge"].find_one({"_id": knowledge_id})
-    assert knowledge["figure_paths"] == [
-        str(target / "executions" / "20260102-001" / "fig" / "result.png")
-    ]
+    assert knowledge["figure_paths"] == [str(execution_target / "fig" / "result.png")]
     assert (
         init_db["migration_archive"].count_documents(
             {"migration_id": MIGRATION_ID, "migration_kind": "artifact_path_rewrite"}
@@ -248,6 +245,39 @@ def test_file_migration_copies_legacy_execution_and_classifier(init_db, tmp_path
         )
         == 3
     )
+
+
+def test_file_migration_moves_flat_project_execution_to_date_layout(init_db, tmp_path) -> None:
+    flat_source = (
+        tmp_path / "projects" / "proj-1" / "chips" / "chip-1" / "executions" / "20260102-001"
+    )
+    flat_source.mkdir(parents=True)
+    (flat_source / "result.json").write_text("result")
+    execution_id = (
+        init_db["execution_history"]
+        .insert_one(
+            {
+                "project_id": "proj-1",
+                "chip_id": "chip-1",
+                "execution_id": "20260102-001",
+                "username": "alice",
+                "calib_data_path": str(flat_source),
+            }
+        )
+        .inserted_id
+    )
+
+    stats = migrate_calibration_files(init_db, base_path=tmp_path, dry_run=False)
+
+    date_target = flat_source.parent / "20260102" / "001"
+    assert (date_target / "result.json").read_text() == "result"
+    assert not flat_source.exists()
+    assert init_db["execution_history"].find_one({"_id": execution_id})["calib_data_path"] == str(
+        date_target
+    )
+    assert stats["moved"] == 1
+    assert stats["database_records_updated"] == 1
+    assert "migration_archive_lookup_idx" in init_db["migration_archive"].index_information()
 
 
 def test_migration_reclaims_expired_lock(init_db) -> None:
@@ -280,6 +310,196 @@ def test_migration_rejects_documents_with_missing_project_scope(init_db) -> None
 
     dry_run = migrate_project_scoped_calibration(init_db)
     assert dry_run["invalid_scope_documents"]["qubit"] == 1
+
+    with pytest.raises(RuntimeError, match="missing scope fields"):
+        migrate_project_scoped_calibration(init_db, dry_run=False)
+
+
+def test_migration_backfills_project_scope_from_user_default(init_db) -> None:
+    init_db["user"].insert_one(
+        {
+            "user_id": "user-alice",
+            "username": "alice",
+            "default_project_id": "proj-1",
+        }
+    )
+    qubit_id = (
+        init_db["qubit"]
+        .insert_one(
+            {
+                "chip_id": "chip-1",
+                "qid": "0",
+                "user_id": "user-alice",
+                "username": "alice",
+                "data": {},
+            }
+        )
+        .inserted_id
+    )
+
+    dry_run = migrate_project_scoped_calibration(init_db)
+
+    assert dry_run["scope_backfill_documents"]["qubit"] == 1
+    assert dry_run["invalid_scope_documents"]["qubit"] == 0
+    assert "project_id" not in init_db["qubit"].find_one({"_id": qubit_id})
+
+    migrate_project_scoped_calibration(init_db, dry_run=False)
+
+    assert init_db["qubit"].find_one({"_id": qubit_id})["project_id"] == "proj-1"
+    archived = init_db["migration_archive"].find_one(
+        {
+            "migration_id": SCOPE_BACKFILL_MIGRATION_ID,
+            "source_collection": "qubit",
+            "source_id": qubit_id,
+        }
+    )
+    assert "project_id" not in archived["document"]
+    assert archived["backfilled_fields"] == {"project_id": "proj-1"}
+
+
+def test_migration_backfills_project_scope_from_unique_active_membership(init_db) -> None:
+    init_db["project_membership"].insert_one(
+        {
+            "project_id": "proj-1",
+            "user_id": "user-alice",
+            "username": "alice",
+            "status": "active",
+        }
+    )
+    init_db["execution_counter"].insert_one(
+        {
+            "date": "20260102",
+            "chip_id": "chip-1",
+            "user_id": "user-alice",
+            "username": "alice",
+            "index": 1,
+        }
+    )
+
+    migrate_project_scoped_calibration(init_db, dry_run=False)
+
+    assert init_db["execution_counter"].find_one({})["project_id"] == "proj-1"
+
+
+def test_migration_rejects_ambiguous_project_memberships(init_db) -> None:
+    init_db["project_membership"].insert_many(
+        [
+            {
+                "project_id": project_id,
+                "user_id": "user-alice",
+                "username": "alice",
+                "status": "active",
+            }
+            for project_id in ("proj-1", "proj-2")
+        ]
+    )
+    init_db["qubit"].insert_one(
+        {
+            "chip_id": "chip-1",
+            "qid": "0",
+            "user_id": "user-alice",
+            "username": "alice",
+            "data": {},
+        }
+    )
+
+    dry_run = migrate_project_scoped_calibration(init_db)
+    assert dry_run["scope_backfill_documents"]["qubit"] == 0
+    assert dry_run["invalid_scope_documents"]["qubit"] == 1
+
+    with pytest.raises(RuntimeError, match="missing scope fields"):
+        migrate_project_scoped_calibration(init_db, dry_run=False)
+
+
+def test_migration_does_not_infer_non_project_scope_fields(init_db) -> None:
+    init_db["user"].insert_one(
+        {
+            "user_id": "user-alice",
+            "username": "alice",
+            "default_project_id": "proj-1",
+        }
+    )
+    init_db["qubit"].insert_one(
+        {
+            "chip_id": "chip-1",
+            "user_id": "user-alice",
+            "username": "alice",
+            "data": {},
+        }
+    )
+
+    dry_run = migrate_project_scoped_calibration(init_db)
+    assert dry_run["scope_backfill_documents"]["qubit"] == 0
+    assert dry_run["invalid_scope_documents"]["qubit"] == 1
+
+    with pytest.raises(RuntimeError, match="missing scope fields"):
+        migrate_project_scoped_calibration(init_db, dry_run=False)
+
+
+def test_migration_backfills_calibration_note_chip_from_execution(init_db) -> None:
+    init_db["execution_history"].insert_one(
+        {
+            "project_id": "proj-1",
+            "execution_id": "20260102-001",
+            "chip_id": "chip-1",
+        }
+    )
+    note_id = (
+        init_db["calibration_note"]
+        .insert_one(
+            {
+                "project_id": "proj-1",
+                "execution_id": "20260102-001",
+                "task_id": "task-1",
+                "username": "alice",
+                "note": {},
+            }
+        )
+        .inserted_id
+    )
+
+    dry_run = migrate_project_scoped_calibration(init_db)
+    assert dry_run["scope_backfill_documents"]["calibration_note"] == 1
+    assert dry_run["invalid_scope_documents"]["calibration_note"] == 0
+
+    migrate_project_scoped_calibration(init_db, dry_run=False)
+
+    assert init_db["calibration_note"].find_one({"_id": note_id})["chip_id"] == "chip-1"
+    archived = init_db["migration_archive"].find_one(
+        {
+            "migration_id": SCOPE_BACKFILL_MIGRATION_ID,
+            "source_collection": "calibration_note",
+            "source_id": note_id,
+        }
+    )
+    assert archived["backfilled_fields"] == {"chip_id": "chip-1"}
+
+
+def test_migration_rejects_ambiguous_calibration_note_chip(init_db) -> None:
+    init_db["execution_history"].drop_indexes()
+    init_db["execution_history"].insert_many(
+        [
+            {
+                "project_id": "proj-1",
+                "execution_id": "20260102-001",
+                "chip_id": chip_id,
+            }
+            for chip_id in ("chip-1", "chip-2")
+        ]
+    )
+    init_db["calibration_note"].insert_one(
+        {
+            "project_id": "proj-1",
+            "execution_id": "20260102-001",
+            "task_id": "task-1",
+            "username": "alice",
+            "note": {},
+        }
+    )
+
+    dry_run = migrate_project_scoped_calibration(init_db)
+    assert dry_run["scope_backfill_documents"]["calibration_note"] == 0
+    assert dry_run["invalid_scope_documents"]["calibration_note"] == 1
 
     with pytest.raises(RuntimeError, match="missing scope fields"):
         migrate_project_scoped_calibration(init_db, dry_run=False)

--- a/tests/qdash/workflow/test_paths.py
+++ b/tests/qdash/workflow/test_paths.py
@@ -1,6 +1,8 @@
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 # Import the leaf module without executing qdash.workflow.__init__, which eagerly
 # imports Prefect/Dask and makes this pure path test depend on process discovery.
 _SPEC = importlib.util.spec_from_file_location(
@@ -20,8 +22,15 @@ def test_project_scoped_calibration_paths() -> None:
         "/calib/projects/proj-1/chips/chip-1/shared/classifier"
     )
     assert resolver.execution_data_dir("proj-1", "chip-1", "20240101-001") == Path(
-        "/calib/projects/proj-1/chips/chip-1/executions/20240101-001"
+        "/calib/projects/proj-1/chips/chip-1/executions/20240101/001"
     )
+
+
+def test_execution_data_dir_rejects_malformed_execution_id() -> None:
+    resolver = PathResolver(calib_data_base=Path("/calib"))
+
+    with pytest.raises(ValueError, match="Invalid execution_id"):
+        resolver.execution_data_dir("proj-1", "chip-1", "invalid")
 
 
 def test_legacy_user_data_dir_remains_available_for_migration() -> None:


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Make project-scoped calibration upgrades recover missing legacy scope fields safely and preserve original records in the migration archive.
- Move execution artifacts to the date/index directory layout while retaining compatibility with legacy and intermediate paths; affects database migration and workflow path generation.

## Changes

- Backfill legacy project IDs from user defaults or unambiguous active memberships, and calibration-note chip IDs from uniquely matched execution history.
- Archive documents before scope or artifact-path rewrites and report unresolved records by collection.
- Store execution artifacts under projects/{project_id}/chips/{chip_id}/executions/{date}/{index} and atomically move the intermediate flat layout when possible.
- Add an idempotent migration-archive lookup index to avoid full collection scans during repeated archive writes.
- Add migration, ambiguity, idempotency, archive, and workflow path tests; update calibration sharing and migration documentation.
- No OpenAPI or generated client changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Execution artifacts now use date-and-sequence paths instead of execution IDs.
  - Legacy calibration records can be safely repaired when project and chip scope are unambiguous.
  - Migration archives and lookup indexing improve recovery and traceability.

- **Bug Fixes**
  - Invalid execution IDs now produce clear validation errors.
  - Ambiguous or unresolved legacy records remain blocked rather than receiving incorrect data.
  - Existing artifact references are updated during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->