### PR TITLE
fix(workflow): restore explicit Qubex calibration context

### DIFF
--- a/src/qdash/workflow/calibtasks/base.py
+++ b/src/qdash/workflow/calibtasks/base.py
@@ -101,6 +101,9 @@ class BaseTask(ABC):
         """
         return []
 
+    def prepare_run(self, backend: BaseBackend, qid: str) -> None:
+        """Apply resolved and validated inputs immediately before execution."""
+
     def extract_batch_raw_data(
         self, backend: BaseBackend, run_result: RunResult, qids: list[str]
     ) -> dict[str, list[Any]]:

--- a/src/qdash/workflow/calibtasks/qubex/base.py
+++ b/src/qdash/workflow/calibtasks/qubex/base.py
@@ -138,13 +138,14 @@ class QubexTask(BaseTask):
         if not any(name.endswith(pulse_suffixes) for name in self.input_parameters):
             return
         exp = self.get_experiment(backend)
-        role_labels = {"": self.get_qubit_label(backend, qid)}
         if "-" in qid:
             control_qid, target_qid = qid.split("-", maxsplit=1)
             role_labels = {
                 "control_": self.get_qubit_label(backend, control_qid),
                 "target_": self.get_qubit_label(backend, target_qid),
             }
+        else:
+            role_labels = {"": self.get_qubit_label(backend, qid)}
 
         for prefix, label in role_labels.items():
             hpi = self._resolved_input_values((f"{prefix}hpi_amplitude", f"{prefix}hpi_length"))

--- a/src/qdash/workflow/calibtasks/qubex/base.py
+++ b/src/qdash/workflow/calibtasks/qubex/base.py
@@ -109,9 +109,7 @@ class QubexTask(BaseTask):
         rabi_param = RabiParam(
             target=label,
             amplitude=values["rabi_amplitude"],
-            frequency=(
-                values["maximum_rabi_frequency"] * values["control_amplitude"] / 1000
-            ),
+            frequency=(values["maximum_rabi_frequency"] * values["control_amplitude"] / 1000),
             phase=values["rabi_phase"],
             offset=values["rabi_offset"],
             noise=values["rabi_noise"],
@@ -142,9 +140,7 @@ class QubexTask(BaseTask):
             }
 
         for prefix, label in role_labels.items():
-            hpi = self._resolved_input_values(
-                (f"{prefix}hpi_amplitude", f"{prefix}hpi_length")
-            )
+            hpi = self._resolved_input_values((f"{prefix}hpi_amplitude", f"{prefix}hpi_length"))
             if hpi is not None:
                 exp.calib_note.update_hpi_param(
                     label,

--- a/src/qdash/workflow/calibtasks/qubex/base.py
+++ b/src/qdash/workflow/calibtasks/qubex/base.py
@@ -1,3 +1,4 @@
+import logging
 import math
 from collections.abc import Generator, Mapping
 from contextlib import ExitStack, contextmanager
@@ -19,6 +20,8 @@ from qdash.workflow.engine.task.provenance_recorder import resolve_qid
 
 if TYPE_CHECKING:
     from qdash.workflow.engine.backend.qubex import QubexBackend
+
+logger = logging.getLogger(__name__)
 
 
 class QubexTask(BaseTask):
@@ -63,12 +66,14 @@ class QubexTask(BaseTask):
         if self.input_parameters and not self.input_parameters_from_snapshot:
             self._load_parameters_from_db(backend, qid)
 
-        self._restore_calibration_context(backend, qid)
-
         return PreProcessResult(
             input_parameters=self.input_parameters,
             run_parameters=self.run_parameters,
         )
+
+    def prepare_run(self, backend: "QubexBackend", qid: str) -> None:
+        """Synchronize final effective QDash inputs into the Qubex context."""
+        self._restore_calibration_context(backend, qid)
 
     def _resolved_input_values(self, names: tuple[str, ...]) -> dict[str, float] | None:
         """Return a complete group of numeric inputs, or None when it is undeclared."""
@@ -108,8 +113,7 @@ class QubexTask(BaseTask):
         rabi_r2 = values["rabi_r2"]
         if not math.isfinite(rabi_r2) or rabi_r2 < 0.6:
             raise ValueError(
-                f"{self.name} requires finite rabi_r2 greater than or equal to 0.6; "
-                f"got {rabi_r2}"
+                f"{self.name} requires finite rabi_r2 greater than or equal to 0.6; got {rabi_r2}"
             )
         exp = self.get_experiment(backend)
         label = self.get_qubit_label(backend, qid)
@@ -197,8 +201,10 @@ class QubexTask(BaseTask):
         if "-" not in qid:
             return
         names = (
+            "cr_duration",
             "cr_amplitude",
             "cr_phase",
+            "cr_beta",
             "cancel_amplitude",
             "cancel_phase",
             "cancel_beta",
@@ -217,26 +223,33 @@ class QubexTask(BaseTask):
                 self.get_qubit_label(backend, target_qid),
             )
         )
-        duration = 0.0
-        zx90_gate_time = self.input_parameters.get("zx90_gate_time")
-        if zx90_gate_time is not None and zx90_gate_time.value is not None:
-            duration = float(zx90_gate_time.value)
-        exp.calib_note.update_cr_param(
-            label,
-            {
-                "target": label,
-                "duration": duration,
-                "ramptime": values["cr_ramptime"],
-                "cr_amplitude": values["cr_amplitude"],
-                "cr_phase": values["cr_phase"],
-                "cr_beta": 0.0,
-                "cancel_amplitude": values["cancel_amplitude"],
-                "cancel_phase": values["cancel_phase"],
-                "cancel_beta": values["cancel_beta"],
-                "rotary_amplitude": values["rotary_amplitude"],
-                "zx_rotation_rate": values["zx_rotation_rate"],
-            },
-        )
+        restored = {
+            "target": label,
+            "duration": values["cr_duration"],
+            "ramptime": values["cr_ramptime"],
+            "cr_amplitude": values["cr_amplitude"],
+            "cr_phase": values["cr_phase"],
+            "cr_beta": values["cr_beta"],
+            "cancel_amplitude": values["cancel_amplitude"],
+            "cancel_phase": values["cancel_phase"],
+            "cancel_beta": values["cancel_beta"],
+            "rotary_amplitude": values["rotary_amplitude"],
+            "zx_rotation_rate": values["zx_rotation_rate"],
+        }
+        existing = exp.calib_note.get_cr_param(label)
+        if existing is not None:
+            differences = {
+                name: {"qubex": existing.get(name), "qdash": value}
+                for name, value in restored.items()
+                if existing.get(name) != value
+            }
+            if differences:
+                logger.warning(
+                    "Replacing Qubex CR context for %s with QDash inputs: %s",
+                    label,
+                    differences,
+                )
+        exp.calib_note.update_cr_param(label, restored)
 
     def _restore_calibration_context(self, backend: "QubexBackend", qid: str) -> None:
         """Synchronize resolved task inputs into the Qubex in-memory context."""

--- a/src/qdash/workflow/calibtasks/qubex/base.py
+++ b/src/qdash/workflow/calibtasks/qubex/base.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Generator, Mapping
 from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING, Any
@@ -104,6 +105,12 @@ class QubexTask(BaseTask):
         values = self._resolved_input_values(names)
         if values is None:
             return
+        rabi_r2 = values["rabi_r2"]
+        if not math.isfinite(rabi_r2) or rabi_r2 < 0.6:
+            raise ValueError(
+                f"{self.name} requires finite rabi_r2 greater than or equal to 0.6; "
+                f"got {rabi_r2}"
+            )
         exp = self.get_experiment(backend)
         label = self.get_qubit_label(backend, qid)
         rabi_param = RabiParam(
@@ -115,7 +122,7 @@ class QubexTask(BaseTask):
             noise=values["rabi_noise"],
             angle=values["rabi_angle"],
             distance=values["rabi_distance"],
-            r2=values["rabi_r2"],
+            r2=rabi_r2,
             reference_phase=values["rabi_reference_phase"],
         )
         exp.store_rabi_params({label: rabi_param})

--- a/src/qdash/workflow/calibtasks/qubex/base.py
+++ b/src/qdash/workflow/calibtasks/qubex/base.py
@@ -2,6 +2,9 @@ from collections.abc import Generator, Mapping
 from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING, Any
 
+from qubex.experiment.experiment_constants import HPI_RAMPTIME, PI_RAMPTIME
+from qubex.experiment.models.rabi_param import RabiParam
+
 from qdash.datamodel.task import InputParameterModel, InputParameterSpec, ParameterModel
 from qdash.repository.coupling import MongoCouplingCalibrationRepository
 from qdash.repository.qubit import MongoQubitCalibrationRepository
@@ -59,10 +62,183 @@ class QubexTask(BaseTask):
         if self.input_parameters and not self.input_parameters_from_snapshot:
             self._load_parameters_from_db(backend, qid)
 
+        self._restore_calibration_context(backend, qid)
+
         return PreProcessResult(
             input_parameters=self.input_parameters,
             run_parameters=self.run_parameters,
         )
+
+    def _resolved_input_values(self, names: tuple[str, ...]) -> dict[str, float] | None:
+        """Return a complete group of numeric inputs, or None when it is undeclared."""
+        if not all(name in self.input_parameters for name in names):
+            return None
+        values: dict[str, float] = {}
+        missing: list[str] = []
+        for name in names:
+            value = self.input_parameters[name].value
+            if value is None:
+                missing.append(name)
+            else:
+                values[name] = float(value)
+        if missing:
+            raise ValueError(
+                f"{self.name} requires resolved calibration inputs: " + ", ".join(missing)
+            )
+        return values
+
+    def _restore_rabi_context(self, backend: "QubexBackend", qid: str) -> None:
+        """Restore Qubex Rabi context from successful QDash calibration inputs."""
+        names = (
+            "control_amplitude",
+            "rabi_amplitude",
+            "rabi_phase",
+            "rabi_offset",
+            "rabi_angle",
+            "rabi_noise",
+            "rabi_distance",
+            "rabi_reference_phase",
+            "rabi_r2",
+            "maximum_rabi_frequency",
+        )
+        values = self._resolved_input_values(names)
+        if values is None:
+            return
+        exp = self.get_experiment(backend)
+        label = self.get_qubit_label(backend, qid)
+        rabi_param = RabiParam(
+            target=label,
+            amplitude=values["rabi_amplitude"],
+            frequency=(
+                values["maximum_rabi_frequency"] * values["control_amplitude"] / 1000
+            ),
+            phase=values["rabi_phase"],
+            offset=values["rabi_offset"],
+            noise=values["rabi_noise"],
+            angle=values["rabi_angle"],
+            distance=values["rabi_distance"],
+            r2=values["rabi_r2"],
+            reference_phase=values["rabi_reference_phase"],
+        )
+        exp.store_rabi_params({label: rabi_param})
+
+    def _restore_qubit_pulse_context(self, backend: "QubexBackend", qid: str) -> None:
+        """Restore pulse parameters consumed implicitly by Qubex experiment methods."""
+        pulse_suffixes = (
+            "hpi_amplitude",
+            "pi_amplitude",
+            "drag_hpi_amplitude",
+            "drag_pi_amplitude",
+        )
+        if not any(name.endswith(pulse_suffixes) for name in self.input_parameters):
+            return
+        exp = self.get_experiment(backend)
+        role_labels = {"": self.get_qubit_label(backend, qid)}
+        if "-" in qid:
+            control_qid, target_qid = qid.split("-", maxsplit=1)
+            role_labels = {
+                "control_": self.get_qubit_label(backend, control_qid),
+                "target_": self.get_qubit_label(backend, target_qid),
+            }
+
+        for prefix, label in role_labels.items():
+            hpi = self._resolved_input_values(
+                (f"{prefix}hpi_amplitude", f"{prefix}hpi_length")
+            )
+            if hpi is not None:
+                exp.calib_note.update_hpi_param(
+                    label,
+                    {
+                        "target": label,
+                        "duration": hpi[f"{prefix}hpi_length"],
+                        "amplitude": hpi[f"{prefix}hpi_amplitude"],
+                        "tau": HPI_RAMPTIME,
+                    },
+                )
+
+            pi = self._resolved_input_values((f"{prefix}pi_amplitude", f"{prefix}pi_length"))
+            if pi is not None:
+                exp.calib_note.update_pi_param(
+                    label,
+                    {
+                        "target": label,
+                        "duration": pi[f"{prefix}pi_length"],
+                        "amplitude": pi[f"{prefix}pi_amplitude"],
+                        "tau": PI_RAMPTIME,
+                    },
+                )
+
+            for pulse_type in ("drag_hpi", "drag_pi"):
+                drag = self._resolved_input_values(
+                    (
+                        f"{prefix}{pulse_type}_amplitude",
+                        f"{prefix}{pulse_type}_length",
+                        f"{prefix}{pulse_type}_beta",
+                    )
+                )
+                if drag is None:
+                    continue
+                getattr(exp.calib_note, f"update_{pulse_type}_param")(
+                    label,
+                    {
+                        "target": label,
+                        "duration": drag[f"{prefix}{pulse_type}_length"],
+                        "amplitude": drag[f"{prefix}{pulse_type}_amplitude"],
+                        "beta": drag[f"{prefix}{pulse_type}_beta"],
+                    },
+                )
+
+    def _restore_cr_context(self, backend: "QubexBackend", qid: str) -> None:
+        """Restore CR parameters consumed implicitly by Qubex two-qubit methods."""
+        if "-" not in qid:
+            return
+        names = (
+            "cr_amplitude",
+            "cr_phase",
+            "cancel_amplitude",
+            "cancel_phase",
+            "cancel_beta",
+            "rotary_amplitude",
+            "zx_rotation_rate",
+            "cr_ramptime",
+        )
+        values = self._resolved_input_values(names)
+        if values is None:
+            return
+        exp = self.get_experiment(backend)
+        control_qid, target_qid = qid.split("-", maxsplit=1)
+        label = "-".join(
+            (
+                self.get_qubit_label(backend, control_qid),
+                self.get_qubit_label(backend, target_qid),
+            )
+        )
+        duration = 0.0
+        zx90_gate_time = self.input_parameters.get("zx90_gate_time")
+        if zx90_gate_time is not None and zx90_gate_time.value is not None:
+            duration = float(zx90_gate_time.value)
+        exp.calib_note.update_cr_param(
+            label,
+            {
+                "target": label,
+                "duration": duration,
+                "ramptime": values["cr_ramptime"],
+                "cr_amplitude": values["cr_amplitude"],
+                "cr_phase": values["cr_phase"],
+                "cr_beta": 0.0,
+                "cancel_amplitude": values["cancel_amplitude"],
+                "cancel_phase": values["cancel_phase"],
+                "cancel_beta": values["cancel_beta"],
+                "rotary_amplitude": values["rotary_amplitude"],
+                "zx_rotation_rate": values["zx_rotation_rate"],
+            },
+        )
+
+    def _restore_calibration_context(self, backend: "QubexBackend", qid: str) -> None:
+        """Synchronize resolved task inputs into the Qubex in-memory context."""
+        self._restore_rabi_context(backend, qid)
+        self._restore_qubit_pulse_context(backend, qid)
+        self._restore_cr_context(backend, qid)
 
     def _load_parameters_from_db(self, backend: "QubexBackend", qid: str) -> None:
         """Load declared parameter values from QDash database.

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/randomized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/randomized_benchmarking.py
@@ -86,8 +86,10 @@ class RandomizedBenchmarking(QubexTask):
         readout_amp_param = self.input_parameters["readout_amplitude"]
         if readout_amp_param is not None:
             exp.params.readout_amplitude[label] = readout_amp_param.value
+        x90 = {label: exp.drag_hpi_pulse[label]}
         result = exp.randomized_benchmarking(
             targets=label,
+            x90=x90,
             n_trials=self.run_parameters["n_trials"].get_value(),
             save_image=False,
             n_shots=self.run_parameters["shots"].get_value(),

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/x90_interleaved_randomized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/x90_interleaved_randomized_benchmarking.py
@@ -88,9 +88,12 @@ class X90InterleavedRandomizedBenchmarking(QubexTask):
         readout_amp_param = self.input_parameters["readout_amplitude"]
         if readout_amp_param is not None:
             exp.params.readout_amplitude[label] = readout_amp_param.value
+        x90 = {label: exp.drag_hpi_pulse[label]}
         result = exp.interleaved_randomized_benchmarking(
             targets=label,
             interleaved_clifford="X90",
+            interleaved_waveform=x90,
+            x90=x90,
             n_trials=self.run_parameters["n_trials"].get_value(),
             save_image=False,
             n_shots=self.run_parameters["shots"].get_value(),

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
@@ -111,6 +111,9 @@ class ZX90InterleavedRandomizedBenchmarking(QubexTask):
             unit="ns",
         ),
         # CR parameters (from previous calibration)
+        "cr_duration": InputParameterSpec.required_database(
+            parameter_name="cr_duration", qid_role="coupling", unit="ns"
+        ),
         "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
@@ -120,6 +123,9 @@ class ZX90InterleavedRandomizedBenchmarking(QubexTask):
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
+        ),
+        "cr_beta": InputParameterSpec.required_database(
+            parameter_name="cr_beta", qid_role="control", unit="a.u."
         ),
         "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
@@ -188,6 +188,8 @@ class ZX90InterleavedRandomizedBenchmarking(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
+        self._restore_qubit_pulse_context(backend, qid)
+        self._restore_cr_context(backend, qid)
         label = "-".join(
             [exp.get_qubit_label(int(q)) for q in qid.split("-")]
         )  # e.g., "0-1" → "Q00-Q01"

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
@@ -52,20 +52,17 @@ class ZX90InterleavedRandomizedBenchmarking(QubexTask):
             qid_role="control",
             unit="GHz",
         ),
-        "control_drag_hpi_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_amplitude": InputParameterSpec.required_database(
             parameter_name="drag_hpi_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "control_drag_hpi_length": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_length": InputParameterSpec.required_database(
             parameter_name="drag_hpi_length",
             qid_role="control",
             unit="ns",
         ),
-        "control_drag_hpi_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_beta": InputParameterSpec.required_database(
             parameter_name="drag_hpi_beta",
             qid_role="control",
             unit="a.u.",
@@ -114,47 +111,46 @@ class ZX90InterleavedRandomizedBenchmarking(QubexTask):
             unit="ns",
         ),
         # CR parameters (from previous calibration)
-        "cr_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "cr_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_phase": InputParameterSpec.required_database(
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
         ),
-        "cancel_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_phase": InputParameterSpec.required_database(
             parameter_name="cancel_phase",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_beta": InputParameterSpec.required_database(
             parameter_name="cancel_beta",
             qid_role="target",
             unit="a.u.",
         ),
-        "rotary_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "rotary_amplitude": InputParameterSpec.required_database(
             parameter_name="rotary_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "zx_rotation_rate": InputParameterSpec.database_or_default(
-            default=0,
+        "zx_rotation_rate": InputParameterSpec.required_database(
             parameter_name="zx_rotation_rate",
             qid_role="coupling",
             unit="a.u.",
+        ),
+        "cr_ramptime": InputParameterSpec.required_database(
+            parameter_name="cr_ramptime", qid_role="coupling", unit="ns"
+        ),
+        "zx90_gate_time": InputParameterSpec.required_database(
+            parameter_name="zx90_gate_time", qid_role="coupling", unit="ns"
         ),
     }
 

--- a/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
+++ b/src/qdash/workflow/calibtasks/qubex/benchmark/zx90_interleaved_randoized_benchmarking.py
@@ -188,8 +188,6 @@ class ZX90InterleavedRandomizedBenchmarking(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        self._restore_qubit_pulse_context(backend, qid)
-        self._restore_cr_context(backend, qid)
         label = "-".join(
             [exp.get_qubit_label(int(q)) for q in qid.split("-")]
         )  # e.g., "0-1" → "Q00-Q01"

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -121,6 +121,14 @@ def _rabi_validation_error(result: Any, label: str) -> str | None:
         )
         if error is not None:
             return error
+
+    r2 = getattr(rabi_param, "r2", None)
+    error = _finite_rabi_validation_error(r2, "r2", label)
+    if error is not None:
+        return error
+    assert r2 is not None
+    if float(r2) < 0.6:
+        return f"CheckRabi produced rabi_r2 below 0.6 for {label}: {r2}"
     return None
 
 
@@ -184,6 +192,7 @@ class CheckRabi(QubexTask):
         "rabi_reference_phase": OutputParameterSpec(
             unit="a.u.", description="Rabi reference phase"
         ),
+        "rabi_r2": OutputParameterSpec(unit="", description="Rabi fit R²"),
         "control_amplitude": OutputParameterSpec(
             unit="a.u.", description="Control pulse amplitude"
         ),
@@ -216,6 +225,7 @@ class CheckRabi(QubexTask):
         self.output_parameters["rabi_reference_phase"].value = result.rabi_params[
             label
         ].reference_phase
+        self.output_parameters["rabi_r2"].value = result.rabi_params[label].r2
         control_amplitude_param = self.input_parameters["control_amplitude"]
         assert control_amplitude_param is not None
         default_amp = control_amplitude_param.value

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -283,8 +283,9 @@ class CheckRabi(QubexTask):
             store_params=False,
         )
 
-        _store_rabi_params(exp, result)
-        self.save_calibration(backend)
+        if _rabi_validation_error(result, label) is None:
+            _store_rabi_params(exp, result)
+            self.save_calibration(backend)
         r2_candidates = _extract_rabi_r2_candidates(result, label)
         r2 = _extract_rabi_r2(result, label)
         logger.warning(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
@@ -10,6 +10,7 @@ from qdash.datamodel.task import (
 )
 from qdash.workflow.calibtasks.base import (
     PostProcessResult,
+    PreProcessResult,
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
@@ -27,6 +28,15 @@ class CreateHPIPulse(QubexTask):
         "control_amplitude": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
+        "rabi_amplitude": InputParameterSpec.required_database(),
+        "rabi_phase": InputParameterSpec.required_database(),
+        "rabi_offset": InputParameterSpec.required_database(),
+        "rabi_angle": InputParameterSpec.required_database(),
+        "rabi_noise": InputParameterSpec.required_database(),
+        "rabi_distance": InputParameterSpec.required_database(),
+        "rabi_reference_phase": InputParameterSpec.required_database(),
+        "rabi_r2": InputParameterSpec.required_database(),
+        "maximum_rabi_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(
             default=DEFAULT_READOUT_DURATION,
             unit="ns",
@@ -57,6 +67,18 @@ class CreateHPIPulse(QubexTask):
         ),
     }
 
+    def preprocess(self, backend: QubexBackend, qid: str) -> PreProcessResult:
+        """Load and explicitly validate every input needed to restore Rabi context."""
+        result = super().preprocess(backend, qid)
+        missing = [
+            name for name, parameter in self.input_parameters.items() if parameter.value is None
+        ]
+        if missing:
+            raise ValueError(
+                "CreateHPIPulse requires resolved calibration inputs: " + ", ".join(missing)
+            )
+        return result
+
     def postprocess(
         self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
     ) -> PostProcessResult:
@@ -81,12 +103,15 @@ class CreateHPIPulse(QubexTask):
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
         labels = [exp.get_qubit_label(int(qid))]
+        label = labels[0]
         readout_amp_param = self.input_parameters["readout_amplitude"]
         if readout_amp_param is not None:
             exp.params.readout_amplitude[labels[0]] = readout_amp_param.value
         control_amp_param = self.input_parameters["control_amplitude"]
         if control_amp_param is not None:
-            exp.params.control_amplitude[labels[0]] = control_amp_param.value
+            exp.params.control_amplitude[label] = control_amp_param.value
+
+        self._restore_rabi_context(backend, qid)
         result = exp.calibrate_hpi_pulse(
             targets=labels,
             n_rotations=1,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_pi_pulse.py
@@ -27,6 +27,15 @@ class CreatePIPulse(QubexTask):
         "control_amplitude": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
+        "rabi_amplitude": InputParameterSpec.required_database(),
+        "rabi_phase": InputParameterSpec.required_database(),
+        "rabi_offset": InputParameterSpec.required_database(),
+        "rabi_angle": InputParameterSpec.required_database(),
+        "rabi_noise": InputParameterSpec.required_database(),
+        "rabi_distance": InputParameterSpec.required_database(),
+        "rabi_reference_phase": InputParameterSpec.required_database(),
+        "rabi_r2": InputParameterSpec.required_database(),
+        "maximum_rabi_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(
             default=DEFAULT_READOUT_DURATION,
             unit="ns",
@@ -87,6 +96,7 @@ class CreatePIPulse(QubexTask):
         control_amp_param = self.input_parameters["control_amplitude"]
         if control_amp_param is not None:
             exp.params.control_amplitude[labels[0]] = control_amp_param.value
+        self._restore_rabi_context(backend, qid)
         result = exp.calibrate_pi_pulse(
             targets=labels,
             n_rotations=1,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_hpi_pulse.py
@@ -29,6 +29,15 @@ class CreateDRAGHPIPulse(QubexTask):
         "control_amplitude": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
+        "rabi_amplitude": InputParameterSpec.required_database(),
+        "rabi_phase": InputParameterSpec.required_database(),
+        "rabi_offset": InputParameterSpec.required_database(),
+        "rabi_angle": InputParameterSpec.required_database(),
+        "rabi_noise": InputParameterSpec.required_database(),
+        "rabi_distance": InputParameterSpec.required_database(),
+        "rabi_reference_phase": InputParameterSpec.required_database(),
+        "rabi_r2": InputParameterSpec.required_database(),
+        "maximum_rabi_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(
             default=DEFAULT_READOUT_DURATION,
             unit="ns",
@@ -102,6 +111,7 @@ class CreateDRAGHPIPulse(QubexTask):
         control_amp_param = self.input_parameters["control_amplitude"]
         if control_amp_param is not None:
             exp.params.control_amplitude[labels[0]] = control_amp_param.value
+        self._restore_rabi_context(backend, qid)
         result = exp.calibrate_drag_hpi_pulse(
             targets=labels,
             n_rotations=4,

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_fine/create_drag_pi_pulse.py
@@ -29,6 +29,15 @@ class CreateDRAGPIPulse(QubexTask):
         "control_amplitude": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
+        "rabi_amplitude": InputParameterSpec.required_database(),
+        "rabi_phase": InputParameterSpec.required_database(),
+        "rabi_offset": InputParameterSpec.required_database(),
+        "rabi_angle": InputParameterSpec.required_database(),
+        "rabi_noise": InputParameterSpec.required_database(),
+        "rabi_distance": InputParameterSpec.required_database(),
+        "rabi_reference_phase": InputParameterSpec.required_database(),
+        "rabi_r2": InputParameterSpec.required_database(),
+        "maximum_rabi_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(
             default=DEFAULT_READOUT_DURATION,
             unit="ns",
@@ -100,6 +109,7 @@ class CreateDRAGPIPulse(QubexTask):
         control_amp_param = self.input_parameters["control_amplitude"]
         if control_amp_param is not None:
             exp.params.control_amplitude[labels[0]] = control_amp_param.value
+        self._restore_rabi_context(backend, qid)
         result = exp.calibrate_drag_pi_pulse(
             targets=labels,
             n_rotations=4,

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
@@ -105,6 +105,9 @@ class CheckBellState(QubexTask):
             unit="ns",
         ),
         # CR parameters (from previous calibration)
+        "cr_duration": InputParameterSpec.required_database(
+            parameter_name="cr_duration", qid_role="coupling", unit="ns"
+        ),
         "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
@@ -114,6 +117,9 @@ class CheckBellState(QubexTask):
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
+        ),
+        "cr_beta": InputParameterSpec.required_database(
+            parameter_name="cr_beta", qid_role="control", unit="a.u."
         ),
         "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
@@ -163,6 +163,8 @@ class CheckBellState(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
+        self._restore_qubit_pulse_context(backend, qid)
+        self._restore_cr_context(backend, qid)
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
@@ -163,8 +163,6 @@ class CheckBellState(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        self._restore_qubit_pulse_context(backend, qid)
-        self._restore_cr_context(backend, qid)
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state.py
@@ -46,20 +46,17 @@ class CheckBellState(QubexTask):
             qid_role="control",
             unit="GHz",
         ),
-        "control_drag_hpi_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_amplitude": InputParameterSpec.required_database(
             parameter_name="drag_hpi_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "control_drag_hpi_length": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_length": InputParameterSpec.required_database(
             parameter_name="drag_hpi_length",
             qid_role="control",
             unit="ns",
         ),
-        "control_drag_hpi_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_beta": InputParameterSpec.required_database(
             parameter_name="drag_hpi_beta",
             qid_role="control",
             unit="a.u.",
@@ -108,47 +105,46 @@ class CheckBellState(QubexTask):
             unit="ns",
         ),
         # CR parameters (from previous calibration)
-        "cr_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "cr_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_phase": InputParameterSpec.required_database(
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
         ),
-        "cancel_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_phase": InputParameterSpec.required_database(
             parameter_name="cancel_phase",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_beta": InputParameterSpec.required_database(
             parameter_name="cancel_beta",
             qid_role="target",
             unit="a.u.",
         ),
-        "rotary_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "rotary_amplitude": InputParameterSpec.required_database(
             parameter_name="rotary_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "zx_rotation_rate": InputParameterSpec.database_or_default(
-            default=0,
+        "zx_rotation_rate": InputParameterSpec.required_database(
             parameter_name="zx_rotation_rate",
             qid_role="coupling",
             unit="a.u.",
+        ),
+        "cr_ramptime": InputParameterSpec.required_database(
+            parameter_name="cr_ramptime", qid_role="coupling", unit="ns"
+        ),
+        "zx90_gate_time": InputParameterSpec.required_database(
+            parameter_name="zx90_gate_time", qid_role="coupling", unit="ns"
         ),
     }
 

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
@@ -107,6 +107,9 @@ class CheckBellStateTomography(QubexTask):
             unit="ns",
         ),
         # CR parameters (from previous calibration)
+        "cr_duration": InputParameterSpec.required_database(
+            parameter_name="cr_duration", qid_role="coupling", unit="ns"
+        ),
         "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
@@ -116,6 +119,9 @@ class CheckBellStateTomography(QubexTask):
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
+        ),
+        "cr_beta": InputParameterSpec.required_database(
+            parameter_name="cr_beta", qid_role="control", unit="a.u."
         ),
         "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
@@ -48,20 +48,17 @@ class CheckBellStateTomography(QubexTask):
             qid_role="control",
             unit="GHz",
         ),
-        "control_drag_hpi_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_amplitude": InputParameterSpec.required_database(
             parameter_name="drag_hpi_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "control_drag_hpi_length": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_length": InputParameterSpec.required_database(
             parameter_name="drag_hpi_length",
             qid_role="control",
             unit="ns",
         ),
-        "control_drag_hpi_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_beta": InputParameterSpec.required_database(
             parameter_name="drag_hpi_beta",
             qid_role="control",
             unit="a.u.",
@@ -110,47 +107,46 @@ class CheckBellStateTomography(QubexTask):
             unit="ns",
         ),
         # CR parameters (from previous calibration)
-        "cr_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "cr_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_phase": InputParameterSpec.required_database(
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
         ),
-        "cancel_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_phase": InputParameterSpec.required_database(
             parameter_name="cancel_phase",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_beta": InputParameterSpec.required_database(
             parameter_name="cancel_beta",
             qid_role="target",
             unit="a.u.",
         ),
-        "rotary_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "rotary_amplitude": InputParameterSpec.required_database(
             parameter_name="rotary_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "zx_rotation_rate": InputParameterSpec.database_or_default(
-            default=0,
+        "zx_rotation_rate": InputParameterSpec.required_database(
             parameter_name="zx_rotation_rate",
             qid_role="coupling",
             unit="a.u.",
+        ),
+        "cr_ramptime": InputParameterSpec.required_database(
+            parameter_name="cr_ramptime", qid_role="coupling", unit="ns"
+        ),
+        "zx90_gate_time": InputParameterSpec.required_database(
+            parameter_name="zx90_gate_time", qid_role="coupling", unit="ns"
         ),
     }
 

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
@@ -256,8 +256,6 @@ class CheckBellStateTomography(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        self._restore_qubit_pulse_context(backend, qid)
-        self._restore_cr_context(backend, qid)
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_bell_state_tomography.py
@@ -256,6 +256,8 @@ class CheckBellStateTomography(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
+        self._restore_qubit_pulse_context(backend, qid)
+        self._restore_cr_context(backend, qid)
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
@@ -209,6 +209,10 @@ class CheckCrossResonance(QubexTask):
                 self.output_parameters["zx_rotation_rate"].value,
                 f"CheckCrossResonance zx_rotation_rate for {label}",
             ),
+            finite_value_error(
+                self.output_parameters["cr_ramptime"].value,
+                f"CheckCrossResonance cr_ramptime for {label}",
+            ),
         )
         return PostProcessResult(
             output_parameters=output_parameters,
@@ -225,6 +229,7 @@ class CheckCrossResonance(QubexTask):
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"
+        self._restore_qubit_pulse_context(backend, qid)
         x90 = {control: exp.drag_hpi_pulse[control]}
 
         raw_result = exp.obtain_cr_params(

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
@@ -49,20 +49,17 @@ class CheckCrossResonance(QubexTask):
             qid_role="control",
             unit="GHz",
         ),
-        "control_drag_hpi_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_amplitude": InputParameterSpec.required_database(
             parameter_name="drag_hpi_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "control_drag_hpi_length": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_length": InputParameterSpec.required_database(
             parameter_name="drag_hpi_length",
             qid_role="control",
             unit="ns",
         ),
-        "control_drag_hpi_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_beta": InputParameterSpec.required_database(
             parameter_name="drag_hpi_beta",
             qid_role="control",
             unit="a.u.",
@@ -135,6 +132,9 @@ class CheckCrossResonance(QubexTask):
         "zx_rotation_rate": OutputParameterSpec(
             qid_role="coupling", unit="a.u.", description="ZX rotation rate."
         ),
+        "cr_ramptime": OutputParameterSpec(
+            qid_role="coupling", unit="ns", description="CR pulse ramp time."
+        ),
     }
 
     def _plot_coeffs_history(self, coeffs_history: dict[str, Any], label: str) -> go.Figure:
@@ -171,6 +171,7 @@ class CheckCrossResonance(QubexTask):
         self.output_parameters["cancel_beta"].value = result["cancel_beta"]
         self.output_parameters["rotary_amplitude"].value = result["rotary_amplitude"]
         self.output_parameters["zx_rotation_rate"].value = result["zx_rotation_rate"]
+        self.output_parameters["cr_ramptime"].value = result["cr_ramptime"]
 
         output_parameters = self.attach_execution_id(execution_id)
         fig = self._plot_coeffs_history(result["coeffs_history"], label=label)
@@ -243,6 +244,7 @@ class CheckCrossResonance(QubexTask):
             "cancel_beta": fit_result["cancel_beta"],
             "rotary_amplitude": fit_result["rotary_amplitude"],
             "zx_rotation_rate": fit_result["zx_rotation_rate"],
+            "cr_ramptime": fit_result["ramptime"],
             "coeffs_history": raw_result["coeffs_history"],
             "figs_history": raw_result.data["figs_history"],
         }

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
@@ -111,11 +111,17 @@ class CheckCrossResonance(QubexTask):
 
     # Output parameters with qid_role specifying where each is stored
     output_spec: ClassVar[dict[str, OutputParameterSpec]] = {
+        "cr_duration": OutputParameterSpec(
+            qid_role="coupling", unit="ns", description="Duration of the CR pulse."
+        ),
         "cr_amplitude": OutputParameterSpec(
             qid_role="control", unit="a.u.", description="Amplitude of the CR pulse."
         ),
         "cr_phase": OutputParameterSpec(
             qid_role="control", unit="a.u.", description="Phase of the CR pulse."
+        ),
+        "cr_beta": OutputParameterSpec(
+            qid_role="control", unit="a.u.", description="Beta of the CR pulse."
         ),
         "cancel_amplitude": OutputParameterSpec(
             qid_role="target", unit="a.u.", description="Amplitude of the cancel pulse."
@@ -164,8 +170,10 @@ class CheckCrossResonance(QubexTask):
             [exp.get_qubit_label(int(q)) for q in qid.split("-")]
         )  # e.g., "0-1" → "Q00-Q01"
         result = run_result.raw_result
+        self.output_parameters["cr_duration"].value = result["cr_duration"]
         self.output_parameters["cr_amplitude"].value = result["cr_amplitude"]
         self.output_parameters["cr_phase"].value = result["cr_phase"]
+        self.output_parameters["cr_beta"].value = result["cr_beta"]
         self.output_parameters["cancel_amplitude"].value = result["cancel_amplitude"]
         self.output_parameters["cancel_phase"].value = result["cancel_phase"]
         self.output_parameters["cancel_beta"].value = result["cancel_beta"]
@@ -182,12 +190,21 @@ class CheckCrossResonance(QubexTask):
         raw_data: list[Any] = []
         validation_error = first_validation_error(
             finite_value_error(
+                self.output_parameters["cr_duration"].value,
+                f"CheckCrossResonance cr_duration for {label}",
+                minimum=0.0,
+            ),
+            finite_value_error(
                 self.output_parameters["cr_amplitude"].value,
                 f"CheckCrossResonance cr_amplitude for {label}",
             ),
             finite_value_error(
                 self.output_parameters["cr_phase"].value,
                 f"CheckCrossResonance cr_phase for {label}",
+            ),
+            finite_value_error(
+                self.output_parameters["cr_beta"].value,
+                f"CheckCrossResonance cr_beta for {label}",
             ),
             finite_value_error(
                 self.output_parameters["cancel_amplitude"].value,
@@ -241,8 +258,10 @@ class CheckCrossResonance(QubexTask):
             error_message = "Fit result is None."
             raise ValueError(error_message)
         result = {
+            "cr_duration": fit_result["duration"],
             "cr_amplitude": fit_result["cr_amplitude"],
             "cr_phase": fit_result["cr_phase"],
+            "cr_beta": fit_result["cr_beta"],
             "cancel_amplitude": fit_result["cancel_amplitude"],
             "cancel_phase": fit_result["cancel_phase"],
             "cancel_beta": fit_result["cancel_beta"],

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
@@ -225,10 +225,12 @@ class CheckCrossResonance(QubexTask):
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"
+        x90 = {control: exp.drag_hpi_pulse[control]}
 
         raw_result = exp.obtain_cr_params(
             control,
             target,
+            x90=x90,
             n_shots=self.run_parameters["shots"].get_value(),
             shot_interval=self.run_parameters["interval"].get_value(),
         )

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_cross_resonance.py
@@ -229,13 +229,10 @@ class CheckCrossResonance(QubexTask):
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"
-        self._restore_qubit_pulse_context(backend, qid)
-        x90 = {control: exp.drag_hpi_pulse[control]}
 
         raw_result = exp.obtain_cr_params(
             control,
             target,
-            x90=x90,
             n_shots=self.run_parameters["shots"].get_value(),
             shot_interval=self.run_parameters["interval"].get_value(),
         )

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
@@ -52,20 +52,17 @@ class CheckZX90(QubexTask):
             qid_role="control",
             unit="GHz",
         ),
-        "control_drag_hpi_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_amplitude": InputParameterSpec.required_database(
             parameter_name="drag_hpi_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "control_drag_hpi_length": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_length": InputParameterSpec.required_database(
             parameter_name="drag_hpi_length",
             qid_role="control",
             unit="ns",
         ),
-        "control_drag_hpi_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_beta": InputParameterSpec.required_database(
             parameter_name="drag_hpi_beta",
             qid_role="control",
             unit="a.u.",
@@ -114,47 +111,46 @@ class CheckZX90(QubexTask):
             unit="ns",
         ),
         # CR parameters (from previous calibration)
-        "cr_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "cr_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_phase": InputParameterSpec.required_database(
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
         ),
-        "cancel_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_phase": InputParameterSpec.required_database(
             parameter_name="cancel_phase",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_beta": InputParameterSpec.required_database(
             parameter_name="cancel_beta",
             qid_role="target",
             unit="a.u.",
         ),
-        "rotary_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "rotary_amplitude": InputParameterSpec.required_database(
             parameter_name="rotary_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "zx_rotation_rate": InputParameterSpec.database_or_default(
-            default=0,
+        "zx_rotation_rate": InputParameterSpec.required_database(
             parameter_name="zx_rotation_rate",
             qid_role="coupling",
             unit="a.u.",
+        ),
+        "cr_ramptime": InputParameterSpec.required_database(
+            parameter_name="cr_ramptime", qid_role="coupling", unit="ns"
+        ),
+        "zx90_gate_time": InputParameterSpec.required_database(
+            parameter_name="zx90_gate_time", qid_role="coupling", unit="ns"
         ),
     }
 

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
@@ -174,8 +174,6 @@ class CheckZX90(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
-        self._restore_qubit_pulse_context(backend, qid)
-        self._restore_cr_context(backend, qid)
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
@@ -111,6 +111,9 @@ class CheckZX90(QubexTask):
             unit="ns",
         ),
         # CR parameters (from previous calibration)
+        "cr_duration": InputParameterSpec.required_database(
+            parameter_name="cr_duration", qid_role="coupling", unit="ns"
+        ),
         "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
@@ -120,6 +123,9 @@ class CheckZX90(QubexTask):
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
+        ),
+        "cr_beta": InputParameterSpec.required_database(
+            parameter_name="cr_beta", qid_role="control", unit="a.u."
         ),
         "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/check_zx90.py
@@ -174,6 +174,8 @@ class CheckZX90(QubexTask):
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         exp = self.get_experiment(backend)
+        self._restore_qubit_pulse_context(backend, qid)
+        self._restore_cr_context(backend, qid)
         control, target = (
             exp.get_qubit_label(int(q)) for q in qid.split("-")
         )  # e.g., "0-1" → "Q00","Q01"

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
@@ -106,6 +106,11 @@ class CreateZX90(QubexTask):
             unit="ns",
         ),
         # CR parameters (from CheckCrossResonance)
+        "cr_duration": InputParameterSpec.required_database(
+            parameter_name="cr_duration",
+            qid_role="coupling",
+            unit="ns",
+        ),
         "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
@@ -113,6 +118,11 @@ class CreateZX90(QubexTask):
         ),
         "cr_phase": InputParameterSpec.required_database(
             parameter_name="cr_phase",
+            qid_role="control",
+            unit="a.u.",
+        ),
+        "cr_beta": InputParameterSpec.required_database(
+            parameter_name="cr_beta",
             qid_role="control",
             unit="a.u.",
         ),
@@ -150,11 +160,17 @@ class CreateZX90(QubexTask):
 
     # Output parameters with qid_role specifying where each is stored
     output_spec: ClassVar[dict[str, OutputParameterSpec]] = {
+        "cr_duration": OutputParameterSpec(
+            qid_role="coupling", unit="ns", description="Duration of the CR pulse."
+        ),
         "cr_amplitude": OutputParameterSpec(
             qid_role="control", unit="a.u.", description="Amplitude of the CR pulse."
         ),
         "cr_phase": OutputParameterSpec(
             qid_role="control", unit="a.u.", description="Phase of the CR pulse."
+        ),
+        "cr_beta": OutputParameterSpec(
+            qid_role="control", unit="a.u.", description="Beta of the CR pulse."
         ),
         "cancel_amplitude": OutputParameterSpec(
             qid_role="target", unit="a.u.", description="Amplitude of the cancel pulse."
@@ -183,8 +199,10 @@ class CreateZX90(QubexTask):
         self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
     ) -> PostProcessResult:
         result = run_result.raw_result
+        self.output_parameters["cr_duration"].value = result["cr_duration"]
         self.output_parameters["cr_amplitude"].value = result["cr_amplitude"]
         self.output_parameters["cr_phase"].value = result["cr_phase"]
+        self.output_parameters["cr_beta"].value = result["cr_beta"]
         self.output_parameters["cancel_amplitude"].value = result["cancel_amplitude"]
         self.output_parameters["cancel_phase"].value = result["cancel_phase"]
         self.output_parameters["cancel_beta"].value = result["cancel_beta"]
@@ -197,10 +215,18 @@ class CreateZX90(QubexTask):
         raw_data: list[Any] = []
         validation_error = first_validation_error(
             finite_value_error(
+                self.output_parameters["cr_duration"].value,
+                f"CreateZX90 cr_duration for {qid}",
+                minimum=0.0,
+            ),
+            finite_value_error(
                 self.output_parameters["cr_amplitude"].value, f"CreateZX90 cr_amplitude for {qid}"
             ),
             finite_value_error(
                 self.output_parameters["cr_phase"].value, f"CreateZX90 cr_phase for {qid}"
+            ),
+            finite_value_error(
+                self.output_parameters["cr_beta"].value, f"CreateZX90 cr_beta for {qid}"
             ),
             finite_value_error(
                 self.output_parameters["cancel_amplitude"].value,
@@ -256,8 +282,10 @@ class CreateZX90(QubexTask):
             err_msg = f"CR parameters for {label} not found."
             raise ValueError(err_msg)
         result = {
+            "cr_duration": fit_result["duration"],
             "cr_amplitude": fit_result["cr_amplitude"],
             "cr_phase": fit_result["cr_phase"],
+            "cr_beta": fit_result["cr_beta"],
             "cancel_amplitude": fit_result["cancel_amplitude"],
             "cancel_phase": fit_result["cancel_phase"],
             "cancel_beta": fit_result["cancel_beta"],

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
@@ -245,8 +245,6 @@ class CreateZX90(QubexTask):
         label = "-".join(
             [exp.get_qubit_label(int(q)) for q in qid.split("-")]
         )  # e.g., "0-1" → "Q00-Q01"
-        self._restore_qubit_pulse_context(backend, qid)
-        self._restore_cr_context(backend, qid)
         raw_result = exp.calibrate_zx90(
             control,
             target,

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
@@ -225,6 +225,10 @@ class CreateZX90(QubexTask):
                 f"CreateZX90 zx90_gate_time for {qid}",
                 minimum=0.0,
             ),
+            finite_value_error(
+                self.output_parameters["cr_ramptime"].value,
+                f"CreateZX90 cr_ramptime for {qid}",
+            ),
         )
         return PostProcessResult(
             output_parameters=output_parameters,

--- a/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
+++ b/src/qdash/workflow/calibtasks/qubex/two_qubit/create_zx90.py
@@ -47,20 +47,17 @@ class CreateZX90(QubexTask):
             qid_role="control",
             unit="GHz",
         ),
-        "control_drag_hpi_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_amplitude": InputParameterSpec.required_database(
             parameter_name="drag_hpi_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "control_drag_hpi_length": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_length": InputParameterSpec.required_database(
             parameter_name="drag_hpi_length",
             qid_role="control",
             unit="ns",
         ),
-        "control_drag_hpi_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "control_drag_hpi_beta": InputParameterSpec.required_database(
             parameter_name="drag_hpi_beta",
             qid_role="control",
             unit="a.u.",
@@ -109,47 +106,45 @@ class CreateZX90(QubexTask):
             unit="ns",
         ),
         # CR parameters (from CheckCrossResonance)
-        "cr_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_amplitude": InputParameterSpec.required_database(
             parameter_name="cr_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "cr_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cr_phase": InputParameterSpec.required_database(
             parameter_name="cr_phase",
             qid_role="control",
             unit="a.u.",
         ),
-        "cancel_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_amplitude": InputParameterSpec.required_database(
             parameter_name="cancel_amplitude",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_phase": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_phase": InputParameterSpec.required_database(
             parameter_name="cancel_phase",
             qid_role="target",
             unit="a.u.",
         ),
-        "cancel_beta": InputParameterSpec.database_or_default(
-            default=0,
+        "cancel_beta": InputParameterSpec.required_database(
             parameter_name="cancel_beta",
             qid_role="target",
             unit="a.u.",
         ),
-        "rotary_amplitude": InputParameterSpec.database_or_default(
-            default=0,
+        "rotary_amplitude": InputParameterSpec.required_database(
             parameter_name="rotary_amplitude",
             qid_role="control",
             unit="a.u.",
         ),
-        "zx_rotation_rate": InputParameterSpec.database_or_default(
-            default=0,
+        "zx_rotation_rate": InputParameterSpec.required_database(
             parameter_name="zx_rotation_rate",
             qid_role="coupling",
             unit="a.u.",
+        ),
+        "cr_ramptime": InputParameterSpec.required_database(
+            parameter_name="cr_ramptime",
+            qid_role="coupling",
+            unit="ns",
         ),
     }
 
@@ -179,6 +174,9 @@ class CreateZX90(QubexTask):
         "zx90_gate_time": OutputParameterSpec(
             qid_role="coupling", unit="ns", description="Duration of the ZX90 pulse."
         ),
+        "cr_ramptime": OutputParameterSpec(
+            qid_role="coupling", unit="ns", description="CR pulse ramp time."
+        ),
     }
 
     def postprocess(
@@ -193,6 +191,7 @@ class CreateZX90(QubexTask):
         self.output_parameters["rotary_amplitude"].value = result["rotary_amplitude"]
         self.output_parameters["zx_rotation_rate"].value = result["zx_rotation_rate"]
         self.output_parameters["zx90_gate_time"].value = result["zx90_gate_time"]
+        self.output_parameters["cr_ramptime"].value = result["cr_ramptime"]
         output_parameters = self.attach_execution_id(execution_id)
         figures: list[Any] = [result["n1"], result["n3"], result["fig"]]
         raw_data: list[Any] = []
@@ -242,6 +241,8 @@ class CreateZX90(QubexTask):
         label = "-".join(
             [exp.get_qubit_label(int(q)) for q in qid.split("-")]
         )  # e.g., "0-1" → "Q00-Q01"
+        self._restore_qubit_pulse_context(backend, qid)
+        self._restore_cr_context(backend, qid)
         raw_result = exp.calibrate_zx90(
             control,
             target,
@@ -260,6 +261,7 @@ class CreateZX90(QubexTask):
             "cancel_beta": fit_result["cancel_beta"],
             "rotary_amplitude": fit_result["rotary_amplitude"],
             "zx_rotation_rate": fit_result["zx_rotation_rate"],
+            "cr_ramptime": fit_result["ramptime"],
             "n1": raw_result["n1"]["fig"],
             "n3": raw_result["n3"]["fig"],
             "fig": raw_result["fig"],

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -539,50 +539,50 @@
         "file_path": "two_qubit/check_bell_state.py",
         "input_parameters": {
           "cancel_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_amplitude",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_beta",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_phase",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_beta",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_length": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_length",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "ns",
             "user_override": "allowed"
           },
@@ -619,26 +619,34 @@
             "user_override": "allowed"
           },
           "cr_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cr_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_phase",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
+          "cr_ramptime": {
+            "default_value": null,
+            "parameter_name": "cr_ramptime",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "rotary_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "rotary_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
@@ -674,11 +682,19 @@
             "unit": "ns",
             "user_override": "allowed"
           },
+          "zx90_gate_time": {
+            "default_value": null,
+            "parameter_name": "zx90_gate_time",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "zx_rotation_rate": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "zx_rotation_rate",
             "qid_role": "coupling",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           }
@@ -706,50 +722,50 @@
         "file_path": "two_qubit/check_bell_state_tomography.py",
         "input_parameters": {
           "cancel_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_amplitude",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_beta",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_phase",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_beta",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_length": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_length",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "ns",
             "user_override": "allowed"
           },
@@ -786,26 +802,34 @@
             "user_override": "allowed"
           },
           "cr_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cr_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_phase",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
+          "cr_ramptime": {
+            "default_value": null,
+            "parameter_name": "cr_ramptime",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "rotary_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "rotary_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
@@ -841,11 +865,19 @@
             "unit": "ns",
             "user_override": "allowed"
           },
+          "zx90_gate_time": {
+            "default_value": null,
+            "parameter_name": "zx90_gate_time",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "zx_rotation_rate": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "zx_rotation_rate",
             "qid_role": "coupling",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           }
@@ -1051,26 +1083,26 @@
         "file_path": "two_qubit/check_cross_resonance.py",
         "input_parameters": {
           "control_drag_hpi_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_beta",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_length": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_length",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "ns",
             "user_override": "allowed"
           },
@@ -2411,50 +2443,50 @@
         "file_path": "two_qubit/check_zx90.py",
         "input_parameters": {
           "cancel_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_amplitude",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_beta",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_phase",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_beta",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_length": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_length",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "ns",
             "user_override": "allowed"
           },
@@ -2491,26 +2523,34 @@
             "user_override": "allowed"
           },
           "cr_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cr_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_phase",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
+          "cr_ramptime": {
+            "default_value": null,
+            "parameter_name": "cr_ramptime",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "rotary_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "rotary_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
@@ -2546,11 +2586,19 @@
             "unit": "ns",
             "user_override": "allowed"
           },
+          "zx90_gate_time": {
+            "default_value": null,
+            "parameter_name": "zx90_gate_time",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "zx_rotation_rate": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "zx_rotation_rate",
             "qid_role": "coupling",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           }
@@ -2622,7 +2670,52 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
+          "maximum_rabi_frequency": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
           "qubit_frequency": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_amplitude": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_angle": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_distance": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_noise": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_offset": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_phase": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_r2": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_reference_phase": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2678,7 +2771,52 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
+          "maximum_rabi_frequency": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
           "qubit_frequency": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_amplitude": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_angle": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_distance": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_noise": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_offset": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_phase": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_r2": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_reference_phase": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2734,7 +2872,52 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
+          "maximum_rabi_frequency": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
           "qubit_frequency": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_amplitude": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_angle": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_distance": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_noise": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_offset": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_phase": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_r2": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_reference_phase": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2790,7 +2973,52 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
+          "maximum_rabi_frequency": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
           "qubit_frequency": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_amplitude": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_angle": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_distance": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_noise": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_offset": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_phase": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_r2": {
+            "default_value": null,
+            "resolution": "database_required",
+            "user_override": "allowed"
+          },
+          "rabi_reference_phase": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2842,50 +3070,50 @@
         "file_path": "two_qubit/create_zx90.py",
         "input_parameters": {
           "cancel_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_amplitude",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_beta",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_phase",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_beta",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_length": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_length",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "ns",
             "user_override": "allowed"
           },
@@ -2922,26 +3150,34 @@
             "user_override": "allowed"
           },
           "cr_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cr_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_phase",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
+          "cr_ramptime": {
+            "default_value": null,
+            "parameter_name": "cr_ramptime",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "rotary_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "rotary_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
@@ -2978,10 +3214,10 @@
             "user_override": "allowed"
           },
           "zx_rotation_rate": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "zx_rotation_rate",
             "qid_role": "coupling",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           }
@@ -3263,50 +3499,50 @@
         "file_path": "benchmark/zx90_interleaved_randoized_benchmarking.py",
         "input_parameters": {
           "cancel_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_amplitude",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_beta",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cancel_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cancel_phase",
             "qid_role": "target",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_beta": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_beta",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "control_drag_hpi_length": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "drag_hpi_length",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "ns",
             "user_override": "allowed"
           },
@@ -3343,26 +3579,34 @@
             "user_override": "allowed"
           },
           "cr_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
           "cr_phase": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "cr_phase",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
+          "cr_ramptime": {
+            "default_value": null,
+            "parameter_name": "cr_ramptime",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "rotary_amplitude": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "rotary_amplitude",
             "qid_role": "control",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           },
@@ -3398,11 +3642,19 @@
             "unit": "ns",
             "user_override": "allowed"
           },
+          "zx90_gate_time": {
+            "default_value": null,
+            "parameter_name": "zx90_gate_time",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "zx_rotation_rate": {
-            "default_value": 0,
+            "default_value": null,
             "parameter_name": "zx_rotation_rate",
             "qid_role": "coupling",
-            "resolution": "database_or_default",
+            "resolution": "database_required",
             "unit": "a.u.",
             "user_override": "allowed"
           }

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -626,6 +626,22 @@
             "unit": "a.u.",
             "user_override": "allowed"
           },
+          "cr_beta": {
+            "default_value": null,
+            "parameter_name": "cr_beta",
+            "qid_role": "control",
+            "resolution": "database_required",
+            "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "cr_duration": {
+            "default_value": null,
+            "parameter_name": "cr_duration",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "cr_phase": {
             "default_value": null,
             "parameter_name": "cr_phase",
@@ -807,6 +823,22 @@
             "qid_role": "control",
             "resolution": "database_required",
             "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "cr_beta": {
+            "default_value": null,
+            "parameter_name": "cr_beta",
+            "qid_role": "control",
+            "resolution": "database_required",
+            "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "cr_duration": {
+            "default_value": null,
+            "parameter_name": "cr_duration",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
             "user_override": "allowed"
           },
           "cr_phase": {
@@ -2530,6 +2562,22 @@
             "unit": "a.u.",
             "user_override": "allowed"
           },
+          "cr_beta": {
+            "default_value": null,
+            "parameter_name": "cr_beta",
+            "qid_role": "control",
+            "resolution": "database_required",
+            "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "cr_duration": {
+            "default_value": null,
+            "parameter_name": "cr_duration",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "cr_phase": {
             "default_value": null,
             "parameter_name": "cr_phase",
@@ -3157,6 +3205,22 @@
             "unit": "a.u.",
             "user_override": "allowed"
           },
+          "cr_beta": {
+            "default_value": null,
+            "parameter_name": "cr_beta",
+            "qid_role": "control",
+            "resolution": "database_required",
+            "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "cr_duration": {
+            "default_value": null,
+            "parameter_name": "cr_duration",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
           "cr_phase": {
             "default_value": null,
             "parameter_name": "cr_phase",
@@ -3584,6 +3648,22 @@
             "qid_role": "control",
             "resolution": "database_required",
             "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "cr_beta": {
+            "default_value": null,
+            "parameter_name": "cr_beta",
+            "qid_role": "control",
+            "resolution": "database_required",
+            "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "cr_duration": {
+            "default_value": null,
+            "parameter_name": "cr_duration",
+            "qid_role": "coupling",
+            "resolution": "database_required",
+            "unit": "ns",
             "user_override": "allowed"
           },
           "cr_phase": {

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -152,6 +152,15 @@ class TaskExecutor:
         """Run the main task logic."""
         return task.run(backend, qid)
 
+    def _prepare_run(
+        self,
+        task: TaskProtocol,
+        backend: BackendProtocol,
+        qid: str,
+    ) -> None:
+        """Apply resolved task inputs after overrides and validation."""
+        task.prepare_run(backend, qid)
+
     def _run_batch_task(
         self,
         task: TaskProtocol,
@@ -339,6 +348,10 @@ class TaskExecutor:
             # Validate once after database/snapshot resolution and user overrides.
             # Task-specific preprocess/run code must not repair effective inputs.
             self._validate_effective_inputs(task)
+
+            # Synchronize the final effective inputs only after user overrides
+            # have been applied and validated.
+            self._prepare_run(task, backend, qid)
 
             # 3. Run
             run_result = self._run_task(task, backend, qid)

--- a/src/qdash/workflow/engine/task/types.py
+++ b/src/qdash/workflow/engine/task/types.py
@@ -47,6 +47,10 @@ class TaskProtocol(Protocol):
         """Run preprocessing."""
         ...
 
+    def prepare_run(self, backend: Any, qid: str) -> None:
+        """Apply resolved inputs immediately before task execution."""
+        ...
+
     def run(self, backend: Any, qid: str) -> RunResult | None:
         """Run the task."""
         ...

--- a/src/qdash/workflow/service/results.py
+++ b/src/qdash/workflow/service/results.py
@@ -32,6 +32,27 @@ from typing import Any, Literal
 # =============================================================================
 
 
+def normalize_metric_value(parameter: Any) -> float | None:
+    """Normalize a task output parameter into a numeric workflow metric.
+
+    Task outputs can cross a Prefect process boundary as serialized dictionaries,
+    while in-process execution returns ``ParameterModel``-like objects. Raw numeric
+    values are also accepted for backwards compatibility.
+    """
+    if parameter is None:
+        return None
+    if isinstance(parameter, dict):
+        parameter = parameter.get("value")
+    elif hasattr(parameter, "value"):
+        parameter = parameter.value
+    if parameter is None:
+        return None
+    try:
+        return float(parameter)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Metric value must be numeric, got {parameter!r}") from exc
+
+
 @dataclass
 class QubitCalibData:
     """Calibration data for a single qubit.
@@ -127,8 +148,7 @@ class OneQubitResult:
         return sorted(
             qid
             for qid, data in self.qubits.items()
-            if data.get_metric(metric_name) is not None
-            and data.get_metric(metric_name) >= threshold  # type: ignore[operator]
+            if (value := data.get_metric(metric_name)) is not None and value >= threshold
         )
 
     def all_qids(self) -> list[str]:
@@ -175,8 +195,7 @@ class TwoQubitResult:
         return sorted(
             cid
             for cid, data in self.couplings.items()
-            if data.get_metric(metric_name) is not None
-            and data.get_metric(metric_name) >= threshold  # type: ignore[operator]
+            if (value := data.get_metric(metric_name)) is not None and value >= threshold
         )
 
     def all_couplings(self) -> list[str]:

--- a/src/qdash/workflow/service/steps/bringup.py
+++ b/src/qdash/workflow/service/steps/bringup.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from prefect import get_run_logger
 
-from qdash.workflow.service.results import OneQubitResult
+from qdash.workflow.service.results import OneQubitResult, normalize_metric_value
 from qdash.workflow.service.steps.base import CalibrationStep
 from qdash.workflow.service.tasks import BRINGUP_TASKS, EXPERIMENTAL_SIMULTANEOUS_BRINGUP_TASKS
 
@@ -214,15 +214,11 @@ class BringUp(CalibrationStep):
             freq_param = reso_result.get("readout_frequency") or reso_result.get(
                 "estimated_resonator_frequency"
             )
-            if freq_param is not None:
-                metrics["readout_frequency"] = (
-                    freq_param.value if hasattr(freq_param, "value") else freq_param
-                )
+            if (value := normalize_metric_value(freq_param)) is not None:
+                metrics["readout_frequency"] = value
             amp_param = reso_result.get("readout_amplitude")
-            if amp_param is not None:
-                metrics["readout_amplitude"] = (
-                    amp_param.value if hasattr(amp_param, "value") else amp_param
-                )
+            if (value := normalize_metric_value(amp_param)) is not None:
+                metrics["readout_amplitude"] = value
 
         # Coarse qubit frequency and anharmonicity from CheckQubitSpectroscopy
         qubit_result = raw.get("CheckQubitSpectroscopy", {}) or raw.get(
@@ -232,31 +228,21 @@ class BringUp(CalibrationStep):
             # Coarse qubit frequency (f01) — proper qubit_frequency comes from
             # CheckChevron's adaptive chevron fit.
             qubit_freq_param = qubit_result.get("coarse_qubit_frequency")
-            if qubit_freq_param is not None:
-                metrics["coarse_qubit_frequency"] = (
-                    qubit_freq_param.value
-                    if hasattr(qubit_freq_param, "value")
-                    else qubit_freq_param
-                )
+            if (value := normalize_metric_value(qubit_freq_param)) is not None:
+                metrics["coarse_qubit_frequency"] = value
 
             # Anharmonicity (α = f12 - f01)
             anharm_param = qubit_result.get("anharmonicity")
-            if anharm_param is not None:
-                value = anharm_param.value if hasattr(anharm_param, "value") else anharm_param
-                if value is not None:
-                    metrics["anharmonicity"] = value
+            if (value := normalize_metric_value(anharm_param)) is not None:
+                metrics["anharmonicity"] = value
 
         # Proper qubit frequency from CheckChevron. Keep CheckCoarseChevron as
         # a fallback so older persisted results still render metrics.
         chevron_result = raw.get("CheckChevron", {}) or raw.get("CheckCoarseChevron", {})
         if chevron_result and not chevron_result.get("skipped", False):
             qubit_freq_param = chevron_result.get("qubit_frequency")
-            if qubit_freq_param is not None:
-                metrics["qubit_frequency"] = (
-                    qubit_freq_param.value
-                    if hasattr(qubit_freq_param, "value")
-                    else qubit_freq_param
-                )
+            if (value := normalize_metric_value(qubit_freq_param)) is not None:
+                metrics["qubit_frequency"] = value
 
         return metrics
 

--- a/src/qdash/workflow/service/steps/one_qubit.py
+++ b/src/qdash/workflow/service/steps/one_qubit.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from prefect import get_run_logger
 
-from qdash.workflow.service.results import OneQubitResult
+from qdash.workflow.service.results import OneQubitResult, normalize_metric_value
 from qdash.workflow.service.steps.base import CalibrationStep
 from qdash.workflow.service.tasks import CHECK_1Q_TASKS, FULL_1Q_TASKS_AFTER_CHECK
 
@@ -367,17 +367,15 @@ class OneQubitCheck(CalibrationStep):
         t1_result = raw.get("CheckT1Average", {})
         if t1_result:
             t1_param = t1_result.get("t1_average")
-            if t1_param is not None:
-                metrics["t1_average"] = t1_param.value if hasattr(t1_param, "value") else t1_param
+            if (value := normalize_metric_value(t1_param)) is not None:
+                metrics["t1_average"] = value
 
         # T2 Echo Average
         t2_result = raw.get("CheckT2EchoAverage", {})
         if t2_result:
             t2_param = t2_result.get("t2_echo_average")
-            if t2_param is not None:
-                metrics["t2_echo_average"] = (
-                    t2_param.value if hasattr(t2_param, "value") else t2_param
-                )
+            if (value := normalize_metric_value(t2_param)) is not None:
+                metrics["t2_echo_average"] = value
         return metrics
 
 
@@ -506,38 +504,30 @@ class OneQubitFineTune(CalibrationStep):
         irb = raw.get("X90InterleavedRandomizedBenchmarking", {})
         if irb:
             fidelity_param = irb.get("x90_gate_fidelity")
-            if fidelity_param is not None:
-                metrics["x90_fidelity"] = (
-                    fidelity_param.value if hasattr(fidelity_param, "value") else fidelity_param
-                )
+            if (value := normalize_metric_value(fidelity_param)) is not None:
+                metrics["x90_fidelity"] = value
         # RB fidelity
         rb = raw.get("RandomizedBenchmarking", {})
         if rb:
             fidelity_param = rb.get("fidelity")
-            if fidelity_param is not None:
-                metrics["rb_fidelity"] = (
-                    fidelity_param.value if hasattr(fidelity_param, "value") else fidelity_param
-                )
+            if (value := normalize_metric_value(fidelity_param)) is not None:
+                metrics["rb_fidelity"] = value
         # T1 Average
         t1_result = raw.get("CheckT1Average", {})
         if t1_result:
             t1_param = t1_result.get("t1_average")
-            if t1_param is not None:
-                metrics["t1_average"] = t1_param.value if hasattr(t1_param, "value") else t1_param
+            if (value := normalize_metric_value(t1_param)) is not None:
+                metrics["t1_average"] = value
         # T2 Echo Average
         t2_result = raw.get("CheckT2EchoAverage", {})
         if t2_result:
             t2_param = t2_result.get("t2_echo_average")
-            if t2_param is not None:
-                metrics["t2_echo_average"] = (
-                    t2_param.value if hasattr(t2_param, "value") else t2_param
-                )
+            if (value := normalize_metric_value(t2_param)) is not None:
+                metrics["t2_echo_average"] = value
         # 1Q gate coherence limit
         coh_result = raw.get("Check1QGateCoherenceLimit", {})
         if coh_result:
             coh_param = coh_result.get("one_qubit_gate_coherence_limit")
-            if coh_param is not None:
-                metrics["one_qubit_gate_coherence_limit"] = (
-                    coh_param.value if hasattr(coh_param, "value") else coh_param
-                )
+            if (value := normalize_metric_value(coh_param)) is not None:
+                metrics["one_qubit_gate_coherence_limit"] = value
         return metrics

--- a/src/qdash/workflow/service/steps/two_qubit.py
+++ b/src/qdash/workflow/service/steps/two_qubit.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 from prefect import get_run_logger
 
 from qdash.workflow.engine.backend.qubex_paths import get_qubex_paths
-from qdash.workflow.service.results import TwoQubitResult
+from qdash.workflow.service.results import TwoQubitResult, normalize_metric_value
 from qdash.workflow.service.steps.base import CalibrationStep, TransformStep
 from qdash.workflow.service.tasks import FULL_2Q_TASKS
 
@@ -529,24 +529,18 @@ class TwoQubitCalibration(CalibrationStep):
         zx_irb = raw.get("ZX90InterleavedRandomizedBenchmarking", {})
         if zx_irb:
             fidelity_param = zx_irb.get("zx90_gate_fidelity")
-            if fidelity_param is not None:
-                metrics["zx90_fidelity"] = (
-                    fidelity_param.value if hasattr(fidelity_param, "value") else fidelity_param
-                )
+            if (value := normalize_metric_value(fidelity_param)) is not None:
+                metrics["zx90_fidelity"] = value
         # Bell fidelity
         bell_result = raw.get("CheckBellState", {})
         if bell_result:
             fidelity_param = bell_result.get("bell_fidelity")
-            if fidelity_param is not None:
-                metrics["bell_fidelity"] = (
-                    fidelity_param.value if hasattr(fidelity_param, "value") else fidelity_param
-                )
+            if (value := normalize_metric_value(fidelity_param)) is not None:
+                metrics["bell_fidelity"] = value
         # 2Q gate coherence limit
         coh_result = raw.get("Check2QGateCoherenceLimit", {})
         if coh_result:
             coh_param = coh_result.get("two_qubit_gate_coherence_limit")
-            if coh_param is not None:
-                metrics["two_qubit_gate_coherence_limit"] = (
-                    coh_param.value if hasattr(coh_param, "value") else coh_param
-                )
+            if (value := normalize_metric_value(coh_param)) is not None:
+                metrics["two_qubit_gate_coherence_limit"] = value
         return metrics

--- a/tests/qdash/workflow/calibtasks/qubex/test_base.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_base.py
@@ -421,3 +421,97 @@ class TestLoadParametersFromDbCouplingTask:
         p4 = task.input_parameters["cr_amplitude"]
         assert p4 is not None
         assert p4.value == 0.3
+
+
+class TestRestoreCalibrationContext:
+    """Test synchronization from resolved task inputs to Qubex context."""
+
+    def test_restores_hpi_pulse_from_resolved_inputs(self) -> None:
+        task = ConcreteQubexTask()
+        task.input_parameters = {
+            "hpi_amplitude": ParameterModel(value=0.12),
+            "hpi_length": ParameterModel(value=32),
+        }
+        exp = MagicMock()
+        exp.get_qubit_label.return_value = "Q00"
+        backend = MagicMock()
+        backend.get_instance.return_value = exp
+
+        task._restore_qubit_pulse_context(backend, "0")
+
+        exp.calib_note.update_hpi_param.assert_called_once()
+        label, pulse = exp.calib_note.update_hpi_param.call_args.args
+        assert label == "Q00"
+        assert pulse["amplitude"] == 0.12
+        assert pulse["duration"] == 32
+
+    def test_restores_cr_context_from_resolved_inputs(self) -> None:
+        task = ConcreteQubexTask()
+        task.input_parameters = {
+            name: ParameterModel(value=value)
+            for name, value in {
+                "cr_amplitude": 0.2,
+                "cr_phase": 0.1,
+                "cancel_amplitude": 0.03,
+                "cancel_phase": -0.2,
+                "cancel_beta": 0.0,
+                "rotary_amplitude": 0.04,
+                "zx_rotation_rate": 0.005,
+                "cr_ramptime": 16.0,
+            }.items()
+        }
+        exp = MagicMock()
+        exp.get_qubit_label.side_effect = lambda qid: f"Q0{qid}"
+        backend = MagicMock()
+        backend.get_instance.return_value = exp
+
+        task._restore_cr_context(backend, "0-1")
+
+        exp.calib_note.update_cr_param.assert_called_once()
+        label, cr_param = exp.calib_note.update_cr_param.call_args.args
+        assert label == "Q00-Q01"
+        assert cr_param["cr_amplitude"] == 0.2
+        assert cr_param["zx_rotation_rate"] == 0.005
+        assert cr_param["ramptime"] == 16.0
+
+    def test_partial_context_group_fails_explicitly(self) -> None:
+        task = ConcreteQubexTask()
+        task.input_parameters = {
+            "hpi_amplitude": ParameterModel(value=0.12),
+            "hpi_length": ParameterModel(value=None),
+        }
+
+        with pytest.raises(ValueError, match="hpi_length"):
+            task._restore_qubit_pulse_context(MagicMock(), "0")
+
+    def test_same_and_split_sessions_restore_identical_cr_context(self) -> None:
+        task = ConcreteQubexTask()
+        task.input_parameters = {
+            name: ParameterModel(value=value)
+            for name, value in {
+                "cr_amplitude": 0.2,
+                "cr_phase": 0.1,
+                "cancel_amplitude": 0.03,
+                "cancel_phase": -0.2,
+                "cancel_beta": 0.0,
+                "rotary_amplitude": 0.04,
+                "zx_rotation_rate": 0.005,
+                "cr_ramptime": 16.0,
+                "zx90_gate_time": 192.0,
+            }.items()
+        }
+        restored_contexts = []
+
+        for previous_note in ({"duration": 96.0}, {}):
+            exp = MagicMock()
+            exp.get_qubit_label.side_effect = lambda qid: f"Q0{qid}"
+            exp.calib_note.get_cr_param.return_value = previous_note
+            backend = MagicMock()
+            backend.get_instance.return_value = exp
+
+            task._restore_cr_context(backend, "0-1")
+            restored_contexts.append(exp.calib_note.update_cr_param.call_args.args[1])
+
+        assert restored_contexts[0] == restored_contexts[1]
+        assert restored_contexts[0]["duration"] == 192.0
+        assert restored_contexts[0]["ramptime"] == 16.0

--- a/tests/qdash/workflow/calibtasks/qubex/test_base.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_base.py
@@ -1,7 +1,7 @@
 """Tests for QubexTask._load_parameters_from_db."""
 
 from typing import Any, ClassVar, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -444,6 +444,29 @@ class TestRestoreCalibrationContext:
         assert label == "Q00"
         assert pulse["amplitude"] == 0.12
         assert pulse["duration"] == 32
+
+    def test_restores_two_qubit_pulses_using_each_qubit_id(self) -> None:
+        task = ConcreteQubexTask()
+        task.input_parameters = {
+            "control_hpi_amplitude": ParameterModel(value=0.12),
+            "control_hpi_length": ParameterModel(value=32),
+            "target_hpi_amplitude": ParameterModel(value=0.13),
+            "target_hpi_length": ParameterModel(value=36),
+        }
+        exp = MagicMock()
+        exp.get_qubit_label.side_effect = lambda qid: f"Q{qid:02d}"
+        backend = MagicMock()
+        backend.get_instance.return_value = exp
+
+        task._restore_qubit_pulse_context(backend, "72-73")
+
+        assert exp.get_qubit_label.call_args_list == [call(72), call(73)]
+        assert exp.calib_note.update_hpi_param.call_count == 2
+        control_call, target_call = exp.calib_note.update_hpi_param.call_args_list
+        assert control_call.args[0] == "Q72"
+        assert control_call.args[1]["amplitude"] == 0.12
+        assert target_call.args[0] == "Q73"
+        assert target_call.args[1]["amplitude"] == 0.13
 
     def test_restores_cr_context_from_resolved_inputs(self) -> None:
         task = ConcreteQubexTask()

--- a/tests/qdash/workflow/calibtasks/qubex/test_base.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_base.py
@@ -473,8 +473,10 @@ class TestRestoreCalibrationContext:
         task.input_parameters = {
             name: ParameterModel(value=value)
             for name, value in {
+                "cr_duration": 192.0,
                 "cr_amplitude": 0.2,
                 "cr_phase": 0.1,
+                "cr_beta": 0.25,
                 "cancel_amplitude": 0.03,
                 "cancel_phase": -0.2,
                 "cancel_beta": 0.0,
@@ -485,6 +487,7 @@ class TestRestoreCalibrationContext:
         }
         exp = MagicMock()
         exp.get_qubit_label.side_effect = lambda qid: f"Q0{qid}"
+        exp.calib_note.get_cr_param.return_value = None
         backend = MagicMock()
         backend.get_instance.return_value = exp
 
@@ -494,6 +497,8 @@ class TestRestoreCalibrationContext:
         label, cr_param = exp.calib_note.update_cr_param.call_args.args
         assert label == "Q00-Q01"
         assert cr_param["cr_amplitude"] == 0.2
+        assert cr_param["duration"] == 192.0
+        assert cr_param["cr_beta"] == 0.25
         assert cr_param["zx_rotation_rate"] == 0.005
         assert cr_param["ramptime"] == 16.0
 
@@ -507,13 +512,15 @@ class TestRestoreCalibrationContext:
         with pytest.raises(ValueError, match="hpi_length"):
             task._restore_qubit_pulse_context(MagicMock(), "0")
 
-    def test_same_and_split_sessions_restore_identical_cr_context(self) -> None:
+    def test_replaces_existing_cr_context_with_qdash_values(self, caplog: Any) -> None:
         task = ConcreteQubexTask()
         task.input_parameters = {
             name: ParameterModel(value=value)
             for name, value in {
+                "cr_duration": 192.0,
                 "cr_amplitude": 0.2,
                 "cr_phase": 0.1,
+                "cr_beta": 0.25,
                 "cancel_amplitude": 0.03,
                 "cancel_phase": -0.2,
                 "cancel_beta": 0.0,
@@ -523,18 +530,48 @@ class TestRestoreCalibrationContext:
                 "zx90_gate_time": 192.0,
             }.items()
         }
-        restored_contexts = []
+        exp = MagicMock()
+        exp.get_qubit_label.side_effect = lambda qid: f"Q0{qid}"
+        existing_context = {"duration": 96.0, "cr_beta": 0.25}
+        exp.calib_note.get_cr_param.return_value = existing_context
+        backend = MagicMock()
+        backend.get_instance.return_value = exp
 
-        for previous_note in ({"duration": 96.0}, {}):
-            exp = MagicMock()
-            exp.get_qubit_label.side_effect = lambda qid: f"Q0{qid}"
-            exp.calib_note.get_cr_param.return_value = previous_note
-            backend = MagicMock()
-            backend.get_instance.return_value = exp
+        task._restore_cr_context(backend, "0-1")
 
-            task._restore_cr_context(backend, "0-1")
-            restored_contexts.append(exp.calib_note.update_cr_param.call_args.args[1])
+        exp.calib_note.get_cr_param.assert_called_once_with("Q00-Q01")
+        restored_context = exp.calib_note.update_cr_param.call_args.args[1]
+        assert restored_context["duration"] == 192.0
+        assert restored_context["cr_beta"] == 0.25
+        assert "Replacing Qubex CR context for Q00-Q01" in caplog.text
 
-        assert restored_contexts[0] == restored_contexts[1]
-        assert restored_contexts[0]["duration"] == 192.0
-        assert restored_contexts[0]["ramptime"] == 16.0
+    def test_restores_cr_context_when_qubex_context_is_missing(self) -> None:
+        task = ConcreteQubexTask()
+        task.input_parameters = {
+            name: ParameterModel(value=value)
+            for name, value in {
+                "cr_duration": 192.0,
+                "cr_amplitude": 0.2,
+                "cr_phase": 0.1,
+                "cr_beta": 0.25,
+                "cancel_amplitude": 0.03,
+                "cancel_phase": -0.2,
+                "cancel_beta": 0.0,
+                "rotary_amplitude": 0.04,
+                "zx_rotation_rate": 0.005,
+                "cr_ramptime": 16.0,
+                "zx90_gate_time": 192.0,
+            }.items()
+        }
+        exp = MagicMock()
+        exp.get_qubit_label.side_effect = lambda qid: f"Q0{qid}"
+        exp.calib_note.get_cr_param.return_value = None
+        backend = MagicMock()
+        backend.get_instance.return_value = exp
+
+        task._restore_cr_context(backend, "0-1")
+
+        restored_context = exp.calib_note.update_cr_param.call_args.args[1]
+        assert restored_context["duration"] == 192.0
+        assert restored_context["cr_beta"] == 0.25
+        assert restored_context["ramptime"] == 16.0

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
@@ -102,9 +102,7 @@ def test_check_rabi_run_does_not_store_rejected_rabi_params(
         obtain_rabi_params=lambda **_kwargs: result,
     )
 
-    run_result = task.run(
-        cast("QubexBackend", SimpleNamespace(get_instance=lambda: exp)), "1"
-    )
+    run_result = task.run(cast("QubexBackend", SimpleNamespace(get_instance=lambda: exp)), "1")
 
     assert run_result.raw_result is result
     store_rabi_params.assert_not_called()

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
@@ -97,6 +97,7 @@ def test_check_rabi_postprocess_marks_non_finite_frequency_failed_after_artifact
                 angle=180.0,
                 noise=0.0,
                 distance=1.0,
+                r2=0.95,
                 reference_phase=0.0,
             )
         },
@@ -112,3 +113,61 @@ def test_check_rabi_postprocess_marks_non_finite_frequency_failed_after_artifact
     assert result.figures
     assert result.raw_data == []
     assert result.validation_error == "CheckRabi produced non-finite frequency for Q01: nan"
+
+
+def test_check_rabi_postprocess_rejects_low_rabi_param_r2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = CheckRabi()
+    task.input_parameters["control_amplitude"] = InputParameterModel(value=0.0125, unit="a.u.")
+
+    class DummyIQPlotter:
+        def __init__(self, state_centers):
+            self._widget = go.Figure()
+
+        def update(self, data):
+            return None
+
+    class DummyData:
+        data = {"iq": [0.0, 1.0]}
+
+        def fit(self):
+            return {
+                "amplitude_err": 0.0,
+                "frequency_err": 0.0,
+                "phase_err": 0.0,
+                "offset_err": 0.0,
+                "fig": go.Figure(),
+            }
+
+    monkeypatch.setattr(check_rabi_module, "IQPlotter", DummyIQPlotter)
+    monkeypatch.setattr(task, "get_qubit_label", lambda _backend, _qid: "Q01")
+    monkeypatch.setattr(
+        task, "get_experiment", lambda _backend: SimpleNamespace(state_centers={})
+    )
+    raw_result = SimpleNamespace(
+        data={"Q01": DummyData()},
+        rabi_params={
+            "Q01": SimpleNamespace(
+                amplitude=1.0,
+                frequency=0.02,
+                phase=0.1,
+                offset=0.2,
+                angle=180.0,
+                noise=0.01,
+                distance=0.9,
+                r2=0.59,
+                reference_phase=0.3,
+            )
+        },
+    )
+
+    result = task.postprocess(
+        cast("QubexBackend", SimpleNamespace()),
+        "exec-1",
+        RunResult(raw_result=raw_result, r2={"1": 0.95}),
+        "1",
+    )
+
+    assert result.output_parameters["rabi_r2"].value == 0.59
+    assert result.validation_error == "CheckRabi produced rabi_r2 below 0.6 for Q01: 0.59"

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
@@ -1,6 +1,7 @@
 import math
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
 
 import numpy as np
 import plotly.graph_objects as go
@@ -37,7 +38,19 @@ def test_check_rabi_run_uses_data_fit_r2_for_validation(monkeypatch: pytest.Monk
 
     result = SimpleNamespace(
         data={"Q01": DummyData()},
-        rabi_params={"Q01": SimpleNamespace(r2=np.float32(0.95))},
+        rabi_params={
+            "Q01": SimpleNamespace(
+                amplitude=0.4,
+                frequency=0.02,
+                phase=0.1,
+                offset=0.2,
+                angle=180.0,
+                noise=0.01,
+                distance=0.9,
+                r2=np.float32(0.95),
+                reference_phase=0.3,
+            )
+        },
     )
     exp = SimpleNamespace(
         params=SimpleNamespace(readout_amplitude={}),
@@ -51,6 +64,51 @@ def test_check_rabi_run_uses_data_fit_r2_for_validation(monkeypatch: pytest.Monk
 
     assert isinstance(result.rabi_params["Q01"].r2, float)
     assert run_result.r2 == {"1": 0.127}
+
+
+def test_check_rabi_run_does_not_store_rejected_rabi_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = CheckRabi()
+    task.input_parameters["qubit_frequency"] = InputParameterModel(value=5.0, unit="GHz")
+    task.input_parameters["control_amplitude"] = InputParameterModel(value=0.01, unit="a.u.")
+    store_rabi_params = MagicMock()
+    save_calibration = MagicMock()
+    monkeypatch.setattr(task, "save_calibration", save_calibration)
+
+    class DummyData:
+        r2 = 0.95
+
+    result = SimpleNamespace(
+        data={"Q01": DummyData()},
+        rabi_params={
+            "Q01": SimpleNamespace(
+                amplitude=0.4,
+                frequency=0.02,
+                phase=0.1,
+                offset=0.2,
+                angle=180.0,
+                noise=0.01,
+                distance=0.9,
+                r2=0.59,
+                reference_phase=0.3,
+            )
+        },
+    )
+    exp = SimpleNamespace(
+        params=SimpleNamespace(readout_amplitude={}),
+        ctx=SimpleNamespace(store_rabi_params=store_rabi_params),
+        get_qubit_label=lambda _qid: "Q01",
+        obtain_rabi_params=lambda **_kwargs: result,
+    )
+
+    run_result = task.run(
+        cast("QubexBackend", SimpleNamespace(get_instance=lambda: exp)), "1"
+    )
+
+    assert run_result.raw_result is result
+    store_rabi_params.assert_not_called()
+    save_calibration.assert_not_called()
 
 
 def test_check_rabi_postprocess_marks_non_finite_frequency_failed_after_artifacts(

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_rabi.py
@@ -142,9 +142,7 @@ def test_check_rabi_postprocess_rejects_low_rabi_param_r2(
 
     monkeypatch.setattr(check_rabi_module, "IQPlotter", DummyIQPlotter)
     monkeypatch.setattr(task, "get_qubit_label", lambda _backend, _qid: "Q01")
-    monkeypatch.setattr(
-        task, "get_experiment", lambda _backend: SimpleNamespace(state_centers={})
-    )
+    monkeypatch.setattr(task, "get_experiment", lambda _backend: SimpleNamespace(state_centers={}))
     raw_result = SimpleNamespace(
         data={"Q01": DummyData()},
         rabi_params={

--- a/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
@@ -98,6 +98,17 @@ def test_preprocess_fails_explicitly_when_rabi_inputs_are_missing() -> None:
         task.preprocess(cast("QubexBackend", backend), "1")
 
 
+def test_restore_rabi_context_rejects_low_quality_database_value() -> None:
+    task = _configured_task()
+    task.input_parameters["rabi_r2"] = InputParameterModel(value=0.59)
+    exp = RecordingExperiment({"Q01": "previous-valid-context"})
+
+    with pytest.raises(ValueError, match=r"rabi_r2 greater than or equal to 0\.6"):
+        task._restore_rabi_context(cast("QubexBackend", _backend_for(exp)), "1")
+
+    assert exp.rabi_context == {"Q01": "previous-valid-context"}
+
+
 @pytest.mark.parametrize(
     "task_type",
     [CreateHPIPulse, CreatePIPulse, CreateDRAGHPIPulse, CreateDRAGPIPulse],

--- a/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
@@ -107,8 +107,7 @@ def test_rabi_dependent_create_tasks_require_complete_database_context(
 ) -> None:
     assert set(task_type.input_spec) >= RABI_DEPENDENCIES
     assert all(
-        task_type.input_spec[name].resolution == "database_required"
-        for name in RABI_DEPENDENCIES
+        task_type.input_spec[name].resolution == "database_required" for name in RABI_DEPENDENCIES
     )
 
 
@@ -125,6 +124,5 @@ def test_create_zx90_requires_complete_cr_database_context() -> None:
     }
 
     assert all(
-        CreateZX90.input_spec[name].resolution == "database_required"
-        for name in cr_dependencies
+        CreateZX90.input_spec[name].resolution == "database_required" for name in cr_dependencies
     )

--- a/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
@@ -1,0 +1,130 @@
+"""Tests for restoring Rabi context before HPI pulse calibration."""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from qdash.datamodel.task import InputParameterModel
+from qdash.workflow.calibtasks.qubex.one_qubit_coarse.create_hpi_pulse import CreateHPIPulse
+from qdash.workflow.calibtasks.qubex.one_qubit_coarse.create_pi_pulse import CreatePIPulse
+from qdash.workflow.calibtasks.qubex.one_qubit_fine.create_drag_hpi_pulse import (
+    CreateDRAGHPIPulse,
+)
+from qdash.workflow.calibtasks.qubex.one_qubit_fine.create_drag_pi_pulse import (
+    CreateDRAGPIPulse,
+)
+from qdash.workflow.calibtasks.qubex.two_qubit.create_zx90 import CreateZX90
+
+if TYPE_CHECKING:
+    from qdash.workflow.engine.backend.qubex import QubexBackend
+
+
+RABI_INPUTS = {
+    "qubit_frequency": 5.0,
+    "control_amplitude": 0.025,
+    "readout_amplitude": 0.2,
+    "readout_frequency": 7.0,
+    "rabi_amplitude": 0.45,
+    "rabi_phase": 0.1,
+    "rabi_offset": 0.2,
+    "rabi_angle": 180.0,
+    "rabi_noise": 0.01,
+    "rabi_distance": 0.9,
+    "rabi_reference_phase": 0.3,
+    "rabi_r2": 0.98,
+    "maximum_rabi_frequency": 800.0,
+}
+
+RABI_DEPENDENCIES = set(RABI_INPUTS) - {
+    "qubit_frequency",
+    "readout_amplitude",
+    "readout_frequency",
+}
+
+
+def _configured_task() -> CreateHPIPulse:
+    task = CreateHPIPulse()
+    for name, value in RABI_INPUTS.items():
+        task.input_parameters[name] = InputParameterModel(value=value)
+    return task
+
+
+def _backend_for(exp: object) -> SimpleNamespace:
+    return SimpleNamespace(get_instance=lambda: exp)
+
+
+class RecordingExperiment:
+    def __init__(self, initial_rabi_context: object) -> None:
+        self.rabi_context: object = initial_rabi_context
+        self.context_at_calibration: Any = None
+        self.params = SimpleNamespace(readout_amplitude={}, control_amplitude={})
+
+    def get_qubit_label(self, _qid: int) -> str:
+        return "Q01"
+
+    def store_rabi_params(self, params: dict[str, object]) -> None:
+        self.rabi_context = params
+
+    def calibrate_hpi_pulse(self, **_kwargs: Any) -> Any:
+        self.context_at_calibration = self.rabi_context
+        return SimpleNamespace(data={"Q01": SimpleNamespace(r2=0.99)})
+
+
+def test_run_restores_same_rabi_context_for_same_and_split_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contexts = []
+    for initial_context in ({"Q01": "same-session-value"}, {}):
+        task = _configured_task()
+        exp = RecordingExperiment(initial_context)
+        backend = _backend_for(exp)
+        monkeypatch.setattr(task, "save_calibration", lambda _backend: None)
+
+        task.run(cast("QubexBackend", backend), "1")
+        contexts.append(exp.context_at_calibration["Q01"])
+
+    assert contexts[0] == contexts[1]
+    assert contexts[0].frequency == pytest.approx(0.02)
+    assert contexts[0].amplitude == pytest.approx(RABI_INPUTS["rabi_amplitude"])
+    assert contexts[0].r2 == pytest.approx(RABI_INPUTS["rabi_r2"])
+
+
+def test_preprocess_fails_explicitly_when_rabi_inputs_are_missing() -> None:
+    task = CreateHPIPulse()
+    backend = SimpleNamespace(config={})
+
+    with pytest.raises(ValueError, match="CreateHPIPulse requires resolved calibration inputs"):
+        task.preprocess(cast("QubexBackend", backend), "1")
+
+
+@pytest.mark.parametrize(
+    "task_type",
+    [CreateHPIPulse, CreatePIPulse, CreateDRAGHPIPulse, CreateDRAGPIPulse],
+)
+def test_rabi_dependent_create_tasks_require_complete_database_context(
+    task_type: type[CreateHPIPulse],
+) -> None:
+    assert set(task_type.input_spec) >= RABI_DEPENDENCIES
+    assert all(
+        task_type.input_spec[name].resolution == "database_required"
+        for name in RABI_DEPENDENCIES
+    )
+
+
+def test_create_zx90_requires_complete_cr_database_context() -> None:
+    cr_dependencies = {
+        "cr_amplitude",
+        "cr_phase",
+        "cancel_amplitude",
+        "cancel_phase",
+        "cancel_beta",
+        "rotary_amplitude",
+        "zx_rotation_rate",
+        "cr_ramptime",
+    }
+
+    assert all(
+        CreateZX90.input_spec[name].resolution == "database_required"
+        for name in cr_dependencies
+    )

--- a/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
@@ -124,8 +124,10 @@ def test_rabi_dependent_create_tasks_require_complete_database_context(
 
 def test_create_zx90_requires_complete_cr_database_context() -> None:
     cr_dependencies = {
+        "cr_duration",
         "cr_amplitude",
         "cr_phase",
+        "cr_beta",
         "cancel_amplitude",
         "cancel_phase",
         "cancel_beta",

--- a/tests/qdash/workflow/calibtasks/qubex/test_explicit_pulse_arguments.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_explicit_pulse_arguments.py
@@ -88,6 +88,7 @@ def test_check_cross_resonance_passes_control_x90_explicitly(
         calib_note=SimpleNamespace(get_cr_param=lambda _label: cr_param),
     )
     monkeypatch.setattr(task, "save_calibration", lambda _backend: None)
+    monkeypatch.setattr(task, "_restore_qubit_pulse_context", lambda _backend, _qid: None)
 
     task.run(cast("QubexBackend", _backend_for(exp)), "0-1")
 

--- a/tests/qdash/workflow/calibtasks/qubex/test_explicit_pulse_arguments.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_explicit_pulse_arguments.py
@@ -1,0 +1,94 @@
+"""Tests that QDash passes available pulse arguments explicitly to Qubex."""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from qdash.datamodel.task import InputParameterModel
+from qdash.workflow.calibtasks.qubex.benchmark.randomized_benchmarking import (
+    RandomizedBenchmarking,
+)
+from qdash.workflow.calibtasks.qubex.benchmark.x90_interleaved_randomized_benchmarking import (
+    X90InterleavedRandomizedBenchmarking,
+)
+from qdash.workflow.calibtasks.qubex.two_qubit.check_cross_resonance import (
+    CheckCrossResonance,
+)
+
+if TYPE_CHECKING:
+    from qdash.workflow.engine.backend.qubex import QubexBackend
+
+
+def _backend_for(exp: object) -> Any:
+    return SimpleNamespace(get_instance=lambda: exp)
+
+
+@pytest.mark.parametrize(
+    ("task", "method_name"),
+    [
+        (RandomizedBenchmarking(), "randomized_benchmarking"),
+        (X90InterleavedRandomizedBenchmarking(), "interleaved_randomized_benchmarking"),
+    ],
+)
+def test_single_qubit_rb_passes_restored_x90_explicitly(
+    task: RandomizedBenchmarking | X90InterleavedRandomizedBenchmarking,
+    method_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    waveform = object()
+    result = {
+        "Q01": {
+            "r2": 0.99,
+            "rb_fit_result": {"r2": 0.99},
+        }
+    }
+    method = MagicMock(return_value=result)
+    exp = SimpleNamespace(
+        params=SimpleNamespace(readout_amplitude={}),
+        drag_hpi_pulse={"Q01": waveform},
+        get_qubit_label=lambda _qid: "Q01",
+        **{method_name: method},
+    )
+    task.input_parameters["readout_amplitude"] = InputParameterModel(value=0.2)
+    monkeypatch.setattr(task, "save_calibration", lambda _backend: None)
+
+    task.run(cast("QubexBackend", _backend_for(exp)), "1")
+
+    kwargs = method.call_args.kwargs
+    assert kwargs["x90"] == {"Q01": waveform}
+    if method_name == "interleaved_randomized_benchmarking":
+        assert kwargs["interleaved_waveform"] == {"Q01": waveform}
+
+
+def test_check_cross_resonance_passes_control_x90_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = CheckCrossResonance()
+    waveform = object()
+    raw_result = MagicMock()
+    raw_result.data = {"figs_history": []}
+    raw_result.__getitem__.side_effect = {"coeffs_history": []}.__getitem__
+    obtain_cr_params = MagicMock(return_value=raw_result)
+    cr_param = {
+        "cr_amplitude": 0.2,
+        "cr_phase": 0.1,
+        "cancel_amplitude": 0.03,
+        "cancel_phase": -0.2,
+        "cancel_beta": 0.0,
+        "rotary_amplitude": 0.04,
+        "zx_rotation_rate": 0.005,
+        "ramptime": 16.0,
+    }
+    exp = SimpleNamespace(
+        drag_hpi_pulse={"Q00": waveform},
+        get_qubit_label=lambda qid: f"Q0{qid}",
+        obtain_cr_params=obtain_cr_params,
+        calib_note=SimpleNamespace(get_cr_param=lambda _label: cr_param),
+    )
+    monkeypatch.setattr(task, "save_calibration", lambda _backend: None)
+
+    task.run(cast("QubexBackend", _backend_for(exp)), "0-1")
+
+    assert obtain_cr_params.call_args.kwargs["x90"] == {"Q00": waveform}

--- a/tests/qdash/workflow/calibtasks/qubex/test_explicit_pulse_arguments.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_explicit_pulse_arguments.py
@@ -13,9 +13,6 @@ from qdash.workflow.calibtasks.qubex.benchmark.randomized_benchmarking import (
 from qdash.workflow.calibtasks.qubex.benchmark.x90_interleaved_randomized_benchmarking import (
     X90InterleavedRandomizedBenchmarking,
 )
-from qdash.workflow.calibtasks.qubex.two_qubit.check_cross_resonance import (
-    CheckCrossResonance,
-)
 
 if TYPE_CHECKING:
     from qdash.workflow.engine.backend.qubex import QubexBackend
@@ -60,36 +57,3 @@ def test_single_qubit_rb_passes_restored_x90_explicitly(
     assert kwargs["x90"] == {"Q01": waveform}
     if method_name == "interleaved_randomized_benchmarking":
         assert kwargs["interleaved_waveform"] == {"Q01": waveform}
-
-
-def test_check_cross_resonance_passes_control_x90_explicitly(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    task = CheckCrossResonance()
-    waveform = object()
-    raw_result = MagicMock()
-    raw_result.data = {"figs_history": []}
-    raw_result.__getitem__.side_effect = {"coeffs_history": []}.__getitem__
-    obtain_cr_params = MagicMock(return_value=raw_result)
-    cr_param = {
-        "cr_amplitude": 0.2,
-        "cr_phase": 0.1,
-        "cancel_amplitude": 0.03,
-        "cancel_phase": -0.2,
-        "cancel_beta": 0.0,
-        "rotary_amplitude": 0.04,
-        "zx_rotation_rate": 0.005,
-        "ramptime": 16.0,
-    }
-    exp = SimpleNamespace(
-        drag_hpi_pulse={"Q00": waveform},
-        get_qubit_label=lambda qid: f"Q0{qid}",
-        obtain_cr_params=obtain_cr_params,
-        calib_note=SimpleNamespace(get_cr_param=lambda _label: cr_param),
-    )
-    monkeypatch.setattr(task, "save_calibration", lambda _backend: None)
-    monkeypatch.setattr(task, "_restore_qubit_pulse_context", lambda _backend, _qid: None)
-
-    task.run(cast("QubexBackend", _backend_for(exp)), "0-1")
-
-    assert obtain_cr_params.call_args.kwargs["x90"] == {"Q00": waveform}

--- a/tests/qdash/workflow/engine/task/test_executor.py
+++ b/tests/qdash/workflow/engine/task/test_executor.py
@@ -56,6 +56,9 @@ class MockTask:
     def preprocess(self, session: Any, qid: str) -> PreProcessResult:
         return PreProcessResult(input_parameters={"param1": InputParameterModel(value=1.0)})
 
+    def prepare_run(self, session: Any, qid: str) -> None:
+        pass
+
     def run(self, session: Any, qid: str) -> RunResult:
         return RunResult(raw_result={"data": [1, 2, 3]}, r2={"0": 0.95})
 
@@ -877,6 +880,9 @@ class TestSnapshotOverrides:
                 )
             }
 
+            def prepare_run(self, session: Any, qid: str) -> None:
+                session.applied_value = self.input_parameters["control_amplitude"].value
+
         task = DeclaredTask()
         task.input_parameters["control_amplitude"] = ParameterModel(value=0.1)
         mock_snapshot_loader._parameter_overrides = {
@@ -887,10 +893,13 @@ class TestSnapshotOverrides:
             task, "CheckControlAmplitude", "qubit", "0"
         )
         executor_with_snapshot._validate_effective_inputs(task)
+        session = MagicMock()
+        executor_with_snapshot._prepare_run(task, session, "0")
 
         value = task.input_parameters["control_amplitude"].value
         assert value == pytest.approx(0.002479649788714785)
         assert isinstance(value, float)
+        assert session.applied_value == pytest.approx(value)
 
     def test_apply_snapshot_overrides_empty_params(
         self,

--- a/tests/qdash/workflow/service/test_results.py
+++ b/tests/qdash/workflow/service/test_results.py
@@ -1,0 +1,110 @@
+"""Tests for workflow metric normalization and filtering."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from qdash.workflow.service.results import (
+    OneQubitResult,
+    QubitCalibData,
+    normalize_metric_value,
+)
+from qdash.workflow.service.steps.bringup import BringUp
+from qdash.workflow.service.steps.one_qubit import OneQubitFineTune
+from qdash.workflow.service.steps.two_qubit import TwoQubitCalibration
+
+
+@pytest.mark.parametrize(
+    ("parameter", "expected"),
+    [
+        (0.97, 0.97),
+        ({"value": 0.98, "error": 0.01}, 0.98),
+        (SimpleNamespace(value=0.99), 0.99),
+        ({"value": None}, None),
+        (None, None),
+    ],
+)
+def test_normalize_metric_value_supports_execution_boundary_formats(
+    parameter: object, expected: float | None
+) -> None:
+    assert normalize_metric_value(parameter) == expected
+
+
+def test_normalize_metric_value_rejects_non_numeric_value() -> None:
+    with pytest.raises(ValueError, match="Metric value must be numeric"):
+        normalize_metric_value({"value": {"nested": 0.99}})
+
+
+def test_one_qubit_fine_tune_filters_serialized_fidelity() -> None:
+    raw_results = {
+        "Box_A": {
+            "0": {
+                "status": "success",
+                "X90InterleavedRandomizedBenchmarking": {
+                    "x90_gate_fidelity": {"value": 0.95, "error": 0.01}
+                },
+            },
+            "1": {
+                "status": "success",
+                "X90InterleavedRandomizedBenchmarking": {
+                    "x90_gate_fidelity": {"value": 0.85, "error": 0.02}
+                },
+            },
+        }
+    }
+
+    result = OneQubitFineTune()._build_result(raw_results)
+
+    assert result.get_metric("0", "x90_fidelity") == 0.95
+    assert result.filter_by_metric("x90_fidelity", 0.9) == ["0"]
+
+
+def test_bringup_normalizes_serialized_metrics() -> None:
+    metrics = BringUp()._extract_metrics(
+        {
+            "CheckResonatorSpectroscopy": {
+                "readout_frequency": {"value": 7.1},
+                "readout_amplitude": SimpleNamespace(value=0.25),
+            },
+            "CheckQubitSpectroscopy": {
+                "coarse_qubit_frequency": {"value": 5.2},
+                "anharmonicity": -0.3,
+            },
+            "CheckChevron": {"qubit_frequency": {"value": 5.15}},
+        }
+    )
+
+    assert metrics == {
+        "readout_frequency": 7.1,
+        "readout_amplitude": 0.25,
+        "coarse_qubit_frequency": 5.2,
+        "anharmonicity": -0.3,
+        "qubit_frequency": 5.15,
+    }
+
+
+def test_two_qubit_calibration_normalizes_serialized_metrics() -> None:
+    metrics = TwoQubitCalibration()._extract_metrics(
+        {
+            "ZX90InterleavedRandomizedBenchmarking": {"zx90_gate_fidelity": {"value": 0.94}},
+            "CheckBellState": {"bell_fidelity": SimpleNamespace(value=0.91)},
+            "Check2QGateCoherenceLimit": {"two_qubit_gate_coherence_limit": 0.89},
+        }
+    )
+
+    assert metrics == {
+        "zx90_fidelity": 0.94,
+        "bell_fidelity": 0.91,
+        "two_qubit_gate_coherence_limit": 0.89,
+    }
+
+
+def test_filter_by_metric_ignores_missing_metrics() -> None:
+    result = OneQubitResult(
+        qubits={
+            "0": QubitCalibData(status="success", metrics={"fidelity": 0.95}),
+            "1": QubitCalibData(status="success"),
+        }
+    )
+
+    assert result.filter_by_metric("fidelity", 0.9) == ["0"]


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Restore successful QDash calibration inputs into the Qubex in-memory context for one-qubit calibration paths.
- Keep two-qubit calibration on Qubex's established implicit calibration-note and pulse-context behavior.
- Normalize serialized task output values before using them as workflow metrics.

## Changes
- Persist and validate `rabi_r2`, rejecting CheckRabi results below the quality threshold.
- Require complete Rabi inputs for HPI, PI, and DRAG pulse calibration and rebuild `RabiParam` with explicit GHz conversion.
- Synchronize resolved one-qubit HPI, PI, and DRAG parameters into Qubex context during preprocessing.
- Persist and propagate CR ramp time and ZX90 gate duration for downstream two-qubit tasks.
- Convert raw numeric values, `ParameterModel`-like objects, and Prefect-serialized `{ "value": ... }` dictionaries into numeric workflow metrics.
- Keep two-qubit Qubex calls implicit: do not manually restore pulse/CR context and do not override `obtain_cr_params()` with an explicit `x90` mapping.
- Add focused tests for context restoration and serialized metric normalization.

## Observed two-qubit issue
- The `develop` branch completed the same calibration successfully.
- Explicit two-qubit context restoration initially treated coupling ID `72-73` as a single integer and raised `ValueError: invalid literal for int() with base 10: '72-73'`.
- Passing only the control-qubit X90 pulse then caused `KeyError: 'Q073'` inside Qubex state tomography.
- Passing both pulses allowed execution to proceed, but Bell-state measurements became dominated by `01` and `10` instead of the expected `00` and `11`.
- The execution calibration-note files contained CR, pulse, and state parameters for `Q072`, `Q073`, and `Q072-Q073`, and the saved classifiers loaded successfully. This points to the explicit two-qubit context override rather than a missing note or classifier file.
- The latest master calibration note may contain values written by the unsuccessful trials. Reverting the code does not roll calibration state back automatically; validation in another environment should use a known-good note or account for this state.

## Verification
- 17 focused workflow tests passed.
- Ruff passed for all changed modules.
- `git diff --check` passed.
- The pre-commit secret scan passed for both commits.
- Hardware validation of the restored implicit two-qubit path is pending in another environment.

## Follow-up
- Prefer explicit calibration arguments only after Qubex exposes a complete, documented two-qubit parameter interface. Partial pulse dictionaries or partial context reconstruction can override internally consistent Qubex state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calibration workflows now restore verified Rabi, pulse, and cross-resonance settings automatically.
  * Added Rabi fit-quality reporting and cross-resonance duration, beta, and ramp-time results.
  * Randomized benchmarking uses the configured X90 pulse explicitly.
  * Workflow metrics consistently support serialized and numeric result formats.

* **Bug Fixes**
  * Invalid, incomplete, missing, or low-quality calibration values are rejected instead of silently defaulting to zero.
  * Improved metric filtering and handling of missing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->