### PR TITLE
feat(ui): allow fullscreen on the execution topology grid (#1364)

### DIFF
--- a/ui/src/components/features/chip/CouplingGrid.tsx
+++ b/ui/src/components/features/chip/CouplingGrid.tsx
@@ -29,7 +29,10 @@ import {
 } from "@/components/features/chip/DownloadConfirmModal";
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { CouplingTaskHistoryModal } from "@/components/features/chip/modals/CouplingTaskHistoryModal";
-import { GridFullscreenButton } from "@/components/ui/GridFullscreenButton";
+import {
+  GridFullscreenButton,
+  gridFullscreenPanelClass,
+} from "@/components/ui/GridFullscreenButton";
 import { GridZoomControls } from "@/components/ui/GridZoomControls";
 import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { useCouplingTaskResults } from "@/hooks/useCouplingTaskResults";
@@ -373,7 +376,7 @@ export function CouplingGrid({
   const errorDetail = requestErrorMessage(error);
 
   const containerClass = isFullscreen
-    ? "fixed inset-0 z-[60] flex flex-col h-screen w-screen space-y-2 bg-base-100 p-4 overflow-hidden"
+    ? gridFullscreenPanelClass
     : "flex flex-col h-full space-y-2 max-w-4xl mx-auto w-full mt-8";
 
   if (isLoading)

--- a/ui/src/components/features/chip/CouplingGrid.tsx
+++ b/ui/src/components/features/chip/CouplingGrid.tsx
@@ -129,6 +129,7 @@ function taskRangeLabel(
   return selectedDate;
 }
 
+/** Chip grid of per-coupling results for the selected task and time range. */
 export function CouplingGrid({
   chipId,
   topologyId,

--- a/ui/src/components/features/chip/CouplingGrid.tsx
+++ b/ui/src/components/features/chip/CouplingGrid.tsx
@@ -129,7 +129,6 @@ function taskRangeLabel(
   return selectedDate;
 }
 
-/** Chip grid of per-coupling results for the selected task and time range. */
 export function CouplingGrid({
   chipId,
   topologyId,

--- a/ui/src/components/features/chip/QubitGrid.tsx
+++ b/ui/src/components/features/chip/QubitGrid.tsx
@@ -303,6 +303,7 @@ const GridCell = memo(function GridCell({
   );
 });
 
+/** Chip grid of per-qubit results for the selected task and time range. */
 export function QubitGrid({
   chipId,
   topologyId,

--- a/ui/src/components/features/chip/QubitGrid.tsx
+++ b/ui/src/components/features/chip/QubitGrid.tsx
@@ -19,7 +19,10 @@ import {
 } from "@/components/features/chip/DownloadConfirmModal";
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { TaskHistoryModal } from "@/components/features/chip/modals/TaskHistoryModal";
-import { GridFullscreenButton } from "@/components/ui/GridFullscreenButton";
+import {
+  GridFullscreenButton,
+  gridFullscreenPanelClass,
+} from "@/components/ui/GridFullscreenButton";
 import { GridZoomControls } from "@/components/ui/GridZoomControls";
 import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { useFullscreenPanel } from "@/hooks/useFullscreenPanel";
@@ -509,7 +512,7 @@ export function QubitGrid({
   const errorDetail = requestErrorMessage(taskError);
 
   const containerClass = isFullscreen
-    ? "fixed inset-0 z-[60] flex flex-col h-screen w-screen space-y-2 bg-base-100 p-4 overflow-hidden"
+    ? gridFullscreenPanelClass
     : "flex flex-col h-full space-y-2 max-w-4xl mx-auto w-full mt-8";
 
   if (isLoadingTask)

--- a/ui/src/components/features/chip/QubitGrid.tsx
+++ b/ui/src/components/features/chip/QubitGrid.tsx
@@ -303,7 +303,6 @@ const GridCell = memo(function GridCell({
   );
 });
 
-/** Chip grid of per-qubit results for the selected task and time range. */
 export function QubitGrid({
   chipId,
   topologyId,

--- a/ui/src/components/features/execution/ExecutionClient.tsx
+++ b/ui/src/components/features/execution/ExecutionClient.tsx
@@ -44,6 +44,7 @@ function formatActorLabel(actor?: ActorFields | null) {
   return actor?.user_id || "Unknown";
 }
 
+/** Execution detail page: run summary, cancel control, and the task topology grid. */
 export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailClientProps) {
   const [topologyMode, setTopologyMode] = useState<TopologyMode>("1q");
   const [filterTaskName, setFilterTaskName] = useState<string>("");

--- a/ui/src/components/features/execution/ExecutionClient.tsx
+++ b/ui/src/components/features/execution/ExecutionClient.tsx
@@ -44,7 +44,6 @@ function formatActorLabel(actor?: ActorFields | null) {
   return actor?.user_id || "Unknown";
 }
 
-/** Execution detail page: run summary, cancel control, and the task topology grid. */
 export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailClientProps) {
   const [topologyMode, setTopologyMode] = useState<TopologyMode>("1q");
   const [filterTaskName, setFilterTaskName] = useState<string>("");

--- a/ui/src/components/features/execution/ExecutionClient.tsx
+++ b/ui/src/components/features/execution/ExecutionClient.tsx
@@ -16,9 +16,11 @@ import { useGetExecution, useCancelExecution } from "@/client/execution/executio
 import { CancelExecutionModal } from "@/components/features/execution/CancelExecutionModal";
 import { getCancelErrorMessage } from "@/components/features/execution/getCancelErrorMessage";
 import { ExecutionTopologyView } from "@/components/features/execution/ExecutionTopologyView";
+import { gridFullscreenPanelClass } from "@/components/ui/GridFullscreenButton";
 import { ExecutionDetailPageSkeleton } from "@/components/ui/Skeleton/PageSkeletons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { useToast } from "@/components/ui/Toast";
+import { useFullscreenPanel } from "@/hooks/useFullscreenPanel";
 
 type FilterOption = {
   value: string;
@@ -46,6 +48,7 @@ export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailCl
   const [topologyMode, setTopologyMode] = useState<TopologyMode>("1q");
   const [filterTaskName, setFilterTaskName] = useState<string>("");
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+  const { isFullscreen, toggleFullscreen } = useFullscreenPanel();
 
   const calculateDetailedDuration = (
     start: string | null | undefined,
@@ -162,7 +165,7 @@ export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailCl
       }),
       menu: (provided) => ({
         ...provided,
-        zIndex: 20,
+        zIndex: 40,
       }),
     }),
     [],
@@ -311,8 +314,16 @@ export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailCl
             </div>
           )}
 
-        <div className="bg-base-100 rounded-lg shadow-md p-4 sm:p-6">
-          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 mb-4">
+        <div
+          className={
+            isFullscreen ? gridFullscreenPanelClass : "bg-base-100 rounded-lg shadow-md p-4 sm:p-6"
+          }
+        >
+          <div
+            className={`flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 ${
+              isFullscreen ? "shrink-0" : "mb-4"
+            }`}
+          >
             <div>
               <h2 className="text-lg sm:text-xl font-bold">Task Topology</h2>
               <p className="mt-1 text-xs text-base-content/60">
@@ -345,7 +356,9 @@ export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailCl
           </div>
 
           {/* Filter Controls */}
-          <div className="flex flex-col sm:flex-row gap-2 sm:gap-4 mb-4">
+          <div
+            className={`flex flex-col sm:flex-row gap-2 sm:gap-4 ${isFullscreen ? "shrink-0" : "mb-4"}`}
+          >
             <div className="form-control flex-1 min-w-0">
               <label className="label py-1">
                 <span className="label-text text-xs font-semibold">Task Name</span>
@@ -372,6 +385,8 @@ export function ExecutionDetailClient({ chipId, executionId }: ExecutionDetailCl
             tasks={execution.task || []}
             topologyMode={topologyMode}
             filterTaskName={filterTaskName}
+            isFullscreen={isFullscreen}
+            onToggleFullscreen={toggleFullscreen}
           />
         </div>
       </div>

--- a/ui/src/components/features/execution/ExecutionTopologyView.tsx
+++ b/ui/src/components/features/execution/ExecutionTopologyView.tsx
@@ -239,6 +239,7 @@ const CouplingMarker = memo(function CouplingMarker({
   );
 });
 
+/** Chip topology grid showing the status of one execution's qubit or coupling tasks. */
 export function ExecutionTopologyView({
   chipId,
   executionId,

--- a/ui/src/components/features/execution/ExecutionTopologyView.tsx
+++ b/ui/src/components/features/execution/ExecutionTopologyView.tsx
@@ -239,7 +239,6 @@ const CouplingMarker = memo(function CouplingMarker({
   );
 });
 
-/** Chip topology grid showing the status of one execution's qubit or coupling tasks. */
 export function ExecutionTopologyView({
   chipId,
   executionId,

--- a/ui/src/components/features/execution/ExecutionTopologyView.tsx
+++ b/ui/src/components/features/execution/ExecutionTopologyView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState, memo, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, memo, type KeyboardEvent } from "react";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 import type { Task } from "@/schemas";
@@ -8,6 +8,7 @@ import type { Task } from "@/schemas";
 import { useGetChip } from "@/client/chip/chip";
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { ExecutionTaskDetailModal } from "@/components/features/execution/ExecutionTaskDetailModal";
+import { GridFullscreenButton } from "@/components/ui/GridFullscreenButton";
 import { GridZoomControls } from "@/components/ui/GridZoomControls";
 import { useGridLayout } from "@/hooks/useGridLayout";
 import { useTopologyConfig } from "@/hooks/useTopologyConfig";
@@ -21,6 +22,8 @@ interface ExecutionTopologyViewProps {
   tasks: Task[];
   topologyMode: "1q" | "2q";
   filterTaskName: string;
+  isFullscreen?: boolean;
+  onToggleFullscreen: () => void;
 }
 
 function getStatusColor(status: string | undefined): string {
@@ -243,8 +246,12 @@ export function ExecutionTopologyView({
   tasks,
   topologyMode,
   filterTaskName,
+  isFullscreen,
+  onToggleFullscreen,
 }: ExecutionTopologyViewProps) {
   const [selectedEntityId, setSelectedEntityId] = useState<string | null>(null);
+  const [currentScale, setCurrentScale] = useState(1);
+  const lodTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Get chip data to derive topology_id
   const { data: chipData } = useGetChip(chipId, {
@@ -349,16 +356,31 @@ export function ExecutionTopologyView({
   const { containerRef, cellSize, isMobile, viewportHeight, gap, padding } = useGridLayout({
     cols: gridCols,
     rows: gridRows,
-    reservedHeight: { mobile: 300, desktop: 350 },
-    deps: [oneQTasksByQid, couplingTasksByQid, topologyMode, topologyQubits],
+    reservedHeight: isFullscreen ? { mobile: 200, desktop: 220 } : { mobile: 300, desktop: 350 },
+    deps: [oneQTasksByQid, couplingTasksByQid, topologyMode, topologyQubits, isFullscreen],
   });
 
   const MIN_FIGURE_CELL_SIZE = 60;
   const baseCellSize = Math.max(cellSize, MIN_FIGURE_CELL_SIZE);
 
-  // Fixed LOD thresholds (pan-zoom handles the rest)
-  const showLabels = baseCellSize >= 20;
-  const showFigures = baseCellSize >= 50;
+  const handleTransform = useCallback((_: unknown, state: { scale: number }) => {
+    if (lodTimeoutRef.current) {
+      clearTimeout(lodTimeoutRef.current);
+    }
+    lodTimeoutRef.current = setTimeout(() => {
+      setCurrentScale((prev) => (Math.abs(prev - state.scale) > 0.05 ? state.scale : prev));
+    }, 100);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (lodTimeoutRef.current) clearTimeout(lodTimeoutRef.current);
+    };
+  }, []);
+
+  const effectiveCellSize = baseCellSize * currentScale;
+  const showLabels = effectiveCellSize >= 20;
+  const showFigures = effectiveCellSize >= 50;
 
   const selectedTasks = useMemo(() => {
     if (!selectedEntityId) return null;
@@ -370,16 +392,7 @@ export function ExecutionTopologyView({
   }, [couplingTasksByQid, oneQTasksByQid, selectedEntityId, topologyMode]);
 
   const visibleTaskGroups = topologyMode === "2q" ? couplingTasksByQid : oneQTasksByQid;
-
-  if (Object.keys(visibleTaskGroups).length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-12 text-base-content/50">
-        <p className="text-sm">
-          No {topologyMode === "2q" ? "coupling" : "one-qubit"} tasks to display in topology view
-        </p>
-      </div>
-    );
-  }
+  const hasVisibleTasks = Object.keys(visibleTaskGroups).length > 0;
 
   const gridContent = (
     <div
@@ -532,35 +545,56 @@ export function ExecutionTopologyView({
   );
 
   return (
-    <div className="flex flex-col h-full space-y-2 max-w-4xl mx-auto w-full">
+    <div
+      className={`flex flex-col h-full space-y-2 w-full ${
+        isFullscreen ? "flex-1 min-h-0" : "max-w-4xl mx-auto"
+      }`}
+    >
       <div
         ref={containerRef}
         className="flex-1 relative overflow-hidden flex justify-center bg-base-200/30 border-2 border-dashed border-base-300 rounded-lg"
         style={{ padding: `${Math.max(4, padding / 4)}px` }}
       >
-        <TransformWrapper
-          initialScale={1}
-          minScale={0.3}
-          maxScale={5}
-          wheel={{ step: 0.08 }}
-          pinch={{ step: 5 }}
-          doubleClick={{ mode: "zoomIn", step: 0.7 }}
-          panning={{ velocityDisabled: false }}
-          smooth={false}
-          centerOnInit
-        >
-          <GridZoomControls />
-          <TransformComponent
-            wrapperStyle={{ width: "100%", minHeight: "520px", overflow: "hidden" }}
-            contentStyle={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
+        <GridFullscreenButton isFullscreen={isFullscreen} onToggle={onToggleFullscreen} />
+        {hasVisibleTasks ? (
+          <TransformWrapper
+            initialScale={1}
+            minScale={0.3}
+            maxScale={4}
+            wheel={{ step: 0.08 }}
+            pinch={{ step: 5 }}
+            doubleClick={{ mode: "zoomIn", step: 0.7 }}
+            panning={{ velocityDisabled: true }}
+            smooth={false}
+            limitToBounds={false}
+            centerOnInit
+            onTransform={handleTransform}
           >
-            {gridContent}
-          </TransformComponent>
-        </TransformWrapper>
+            <GridZoomControls isFullscreen={isFullscreen} className="top-12" />
+            <TransformComponent
+              wrapperStyle={{
+                width: "100%",
+                height: isFullscreen ? "100%" : undefined,
+                minHeight: isFullscreen ? undefined : "520px",
+                overflow: "hidden",
+              }}
+              contentStyle={{
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+              }}
+            >
+              {gridContent}
+            </TransformComponent>
+          </TransformWrapper>
+        ) : (
+          <div className="flex flex-col items-center justify-center py-12 text-base-content/50">
+            <p className="text-sm">
+              No {topologyMode === "2q" ? "coupling" : "one-qubit"} tasks to display in topology
+              view
+            </p>
+          </div>
+        )}
       </div>
 
       {selectedEntityId && selectedTasks && (

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -214,7 +214,6 @@ const EmptyCell = memo(function EmptyCell({ muxBgClass }: { muxBgClass: string }
   return <div className={`aspect-square bg-base-300/50 rounded-lg ${muxBgClass}`} />;
 });
 
-/** Chip grid coloring each qubit by the value of a single metric. */
 export function QubitMetricsGrid({
   metricData,
   title,

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -214,6 +214,7 @@ const EmptyCell = memo(function EmptyCell({ muxBgClass }: { muxBgClass: string }
   return <div className={`aspect-square bg-base-300/50 rounded-lg ${muxBgClass}`} />;
 });
 
+/** Chip grid coloring each qubit by the value of a single metric. */
 export function QubitMetricsGrid({
   metricData,
   title,

--- a/ui/src/components/features/metrics/QubitMetricsGrid.tsx
+++ b/ui/src/components/features/metrics/QubitMetricsGrid.tsx
@@ -7,7 +7,10 @@ import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 import { GitBranch, Maximize2, Move } from "lucide-react";
 
-import { GridFullscreenButton } from "@/components/ui/GridFullscreenButton";
+import {
+  GridFullscreenButton,
+  gridFullscreenPanelClass,
+} from "@/components/ui/GridFullscreenButton";
 import { GridZoomControls } from "@/components/ui/GridZoomControls";
 import { RegionZoomToggle } from "@/components/ui/RegionZoomToggle";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
@@ -644,7 +647,7 @@ export function QubitMetricsGrid({
     <div
       className={
         isFullscreen
-          ? "fixed inset-0 z-[60] flex flex-col h-screen w-screen space-y-2 bg-base-100 p-4 overflow-hidden"
+          ? gridFullscreenPanelClass
           : "flex flex-col h-full space-y-2 max-w-4xl mx-auto w-full mt-8"
       }
     >

--- a/ui/src/components/ui/GridFullscreenButton.tsx
+++ b/ui/src/components/ui/GridFullscreenButton.tsx
@@ -12,6 +12,10 @@ interface GridFullscreenButtonProps {
 export const gridControlButtonClass =
   "btn btn-sm btn-square btn-ghost bg-base-100/90 shadow-md hover:bg-base-200";
 
+/** Overlay container for a grid panel expanded to fullscreen. */
+export const gridFullscreenPanelClass =
+  "fixed inset-0 z-[60] flex flex-col h-screen w-screen space-y-2 bg-base-100 p-4 overflow-hidden";
+
 export function GridFullscreenButton({ isFullscreen, onToggle }: GridFullscreenButtonProps) {
   const label = isFullscreen ? "Exit fullscreen" : "Fullscreen";
   return (

--- a/ui/src/components/ui/GridFullscreenButton.tsx
+++ b/ui/src/components/ui/GridFullscreenButton.tsx
@@ -12,11 +12,9 @@ interface GridFullscreenButtonProps {
 export const gridControlButtonClass =
   "btn btn-sm btn-square btn-ghost bg-base-100/90 shadow-md hover:bg-base-200";
 
-/** Overlay container for a grid panel expanded to fullscreen. */
 export const gridFullscreenPanelClass =
   "fixed inset-0 z-[60] flex flex-col h-screen w-screen space-y-2 bg-base-100 p-4 overflow-hidden";
 
-/** Toggle control that expands a grid panel to fullscreen or returns it to the page. */
 export function GridFullscreenButton({ isFullscreen, onToggle }: GridFullscreenButtonProps) {
   const label = isFullscreen ? "Exit fullscreen" : "Fullscreen";
   return (

--- a/ui/src/components/ui/GridFullscreenButton.tsx
+++ b/ui/src/components/ui/GridFullscreenButton.tsx
@@ -16,6 +16,7 @@ export const gridControlButtonClass =
 export const gridFullscreenPanelClass =
   "fixed inset-0 z-[60] flex flex-col h-screen w-screen space-y-2 bg-base-100 p-4 overflow-hidden";
 
+/** Toggle control that expands a grid panel to fullscreen or returns it to the page. */
 export function GridFullscreenButton({ isFullscreen, onToggle }: GridFullscreenButtonProps) {
   const label = isFullscreen ? "Exit fullscreen" : "Fullscreen";
   return (

--- a/ui/src/hooks/__tests__/useFullscreenPanel.test.ts
+++ b/ui/src/hooks/__tests__/useFullscreenPanel.test.ts
@@ -83,6 +83,32 @@ describe("useFullscreenPanel", () => {
     unmount();
   });
 
+  it("keeps the panel open when Escape closes a Radix dialog", () => {
+    const { result, unmount } = renderHook(() => useFullscreenPanel());
+    act(() => result.current.toggleFullscreen());
+
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("data-state", "open");
+    document.body.appendChild(dialog);
+
+    const dismiss = () => dialog.remove();
+    document.addEventListener("keydown", dismiss, { capture: true });
+
+    act(() => {
+      dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    document.removeEventListener("keydown", dismiss, { capture: true });
+
+    expect(dialog.isConnected).toBe(false);
+    expect(result.current.isFullscreen).toBe(true);
+
+    act(() => pressEscape());
+    expect(result.current.isFullscreen).toBe(false);
+
+    unmount();
+  });
+
   it("releases the scroll lock when a fullscreen panel unmounts", () => {
     const { result, unmount } = renderHook(() => useFullscreenPanel());
 

--- a/ui/src/hooks/useFullscreenPanel.ts
+++ b/ui/src/hooks/useFullscreenPanel.ts
@@ -14,6 +14,7 @@ interface UseFullscreenPanelResult {
 const openPanels: Array<() => void> = [];
 let previousOverflow = "";
 
+/** Exit the topmost open panel on Escape, unless a dialog is still open. */
 function handleKeyDown(event: KeyboardEvent) {
   if (event.key !== "Escape") return;
   if (document.querySelector('dialog[open], .modal-open, [role="dialog"][data-state="open"]'))
@@ -21,6 +22,7 @@ function handleKeyDown(event: KeyboardEvent) {
   openPanels[openPanels.length - 1]?.();
 }
 
+/** Register a panel as open and return a function that unregisters it. */
 function openPanel(exit: () => void) {
   if (openPanels.length === 0) {
     previousOverflow = document.body.style.overflow;

--- a/ui/src/hooks/useFullscreenPanel.ts
+++ b/ui/src/hooks/useFullscreenPanel.ts
@@ -14,7 +14,6 @@ interface UseFullscreenPanelResult {
 const openPanels: Array<() => void> = [];
 let previousOverflow = "";
 
-/** Exit the topmost open panel on Escape, unless a dialog is still open. */
 function handleKeyDown(event: KeyboardEvent) {
   if (event.key !== "Escape") return;
   if (document.querySelector('dialog[open], .modal-open, [role="dialog"][data-state="open"]'))
@@ -22,7 +21,6 @@ function handleKeyDown(event: KeyboardEvent) {
   openPanels[openPanels.length - 1]?.();
 }
 
-/** Register a panel as open and return a function that unregisters it. */
 function openPanel(exit: () => void) {
   if (openPanels.length === 0) {
     previousOverflow = document.body.style.overflow;

--- a/ui/src/hooks/useFullscreenPanel.ts
+++ b/ui/src/hooks/useFullscreenPanel.ts
@@ -16,7 +16,8 @@ let previousOverflow = "";
 
 function handleKeyDown(event: KeyboardEvent) {
   if (event.key !== "Escape") return;
-  if (document.querySelector("dialog[open], .modal-open")) return;
+  if (document.querySelector('dialog[open], .modal-open, [role="dialog"][data-state="open"]'))
+    return;
   openPanels[openPanels.length - 1]?.();
 }
 
@@ -24,7 +25,7 @@ function openPanel(exit: () => void) {
   if (openPanels.length === 0) {
     previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
   }
   openPanels.push(exit);
 
@@ -35,7 +36,7 @@ function openPanel(exit: () => void) {
     if (openPanels.length === 0) {
       document.body.style.overflow = previousOverflow;
       previousOverflow = "";
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
     }
   };
 }


### PR DESCRIPTION
## Ticket

close #1364

## Summary

- The Execution Detail grid was the only chip layout without a fullscreen mode. It now expands like the Chip and Metrics grids, and the Qubit/Coupling tabs and the Task Name filter stay usable while expanded.
- UI only. No API, schema, or generated client changes, so `task generate` was not needed. The Escape handling fix in `useFullscreenPanel` also applies to the Chip and Metrics grids, so those pages are worth a look during review.

## Changes

- `ExecutionClient` now owns the fullscreen state and swaps the Task Topology card for a fullscreen overlay. Keeping the state here means the heading, the tabs, and the task filter come along instead of being left behind outside the panel.
- `ExecutionTopologyView` renders `GridFullscreenButton`, reduces the reserved layout height while expanded, and drops the `max-w-4xl` cap. `GridZoomControls` moved to `top-12` so it no longer sits under the new toggle.
- Removed the empty-state early return. Filtering down to zero tasks used to remove the whole panel including the exit control, which left you in a fullscreen view with no visible way out. The message now renders inside the grid frame.
- Level of detail follows the zoom scale. `showFigures` compared against a cell size floored at 60px, so it was always true and the status tile branch was unreachable. Zooming out now draws tiles instead of loading one figure per qubit, which matters on larger chips.
- `useFullscreenPanel` no longer closes the panel and an open dialog on the same Escape press. Radix dialogs are matched by `[role="dialog"][data-state="open"]`, and the listener moved to the capture phase so it runs before Radix removes the dialog from the DOM. The selector change alone was not enough, which the added test covers.
- Extracted `gridFullscreenPanelClass` and reused it in `QubitGrid`, `CouplingGrid`, and `QubitMetricsGrid`. `CouplingMetricsGrid` keeps its own string because it omits `space-y-2`, and changing that would be a visual change unrelated to this PR.
- Aligned the pan and zoom options with the other grids (`limitToBounds={false}`, `maxScale` 4, `velocityDisabled`) and raised the task filter dropdown z-index so it is not painted under the grid controls.

### Out of scope

- Region view for the execution grid.
- Extracting the view-mode state that the four grid components duplicate. Worth doing before Region view lands anywhere else, but larger than this change.

## Verification

- `bun run test:run` (179 tests), `bun run lint`, `bun run fmt:check`, and `bunx tsc --noEmit` all pass.
- Checked in a browser against a 64Q chip: expand and collapse, switching tabs while expanded, the empty state keeping the exit control, opening a task modal on top of the panel, Escape closing only the modal, Escape closing the panel when no modal is open, and figures switching to tiles when zoomed out.
- Note for reviewers: `chip/__tests__/TaskArtifactDownloads.test.tsx` fails intermittently in full suite runs and passes in isolation. It is not related to this change. It reproduces on `develop` as well (one failure, then a clean run), so it is worth a separate issue.
- One known cosmetic issue: the sidebar user avatar renders above the fullscreen overlay. This is existing behavior of the shared overlay and reproduces on the Chip page, so it was left alone here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fullscreen support to execution topology views, including controls, responsive layout, panning, and zooming.
  * Standardized fullscreen presentation across coupling, qubit, and metrics grids.
  * Improved topology readability by adapting labels and content visibility to zoom level.
* **Bug Fixes**
  * Improved Escape-key handling when dialogs close during keyboard event processing.
  * Adjusted fullscreen controls, filtering layout, and menu layering for more reliable interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->