### PR TITLE
feat(ui): show dependent tasks in the execution topology modal (#1365)

### DIFF
--- a/ui/src/components/features/execution/ExecutionTaskDetailModal.tsx
+++ b/ui/src/components/features/execution/ExecutionTaskDetailModal.tsx
@@ -27,6 +27,7 @@ interface ExecutionTaskDetailModalProps {
   executionName?: string;
   qid: string;
   tasks: Task[];
+  initialTaskIndex?: number;
   onClose: () => void;
 }
 
@@ -60,9 +61,10 @@ export function ExecutionTaskDetailModal({
   executionName,
   qid,
   tasks,
+  initialTaskIndex = 0,
   onClose,
 }: ExecutionTaskDetailModalProps) {
-  const [selectedTaskIndex, setSelectedTaskIndex] = useState(0);
+  const [selectedTaskIndex, setSelectedTaskIndex] = useState(initialTaskIndex);
   const [mobileTab, setMobileTab] = useState<ExecutionHistoryMobileTab>("tasks");
   const { openMiniChat } = useAnalysisChatContext();
 

--- a/ui/src/components/features/execution/ExecutionTopologyView.tsx
+++ b/ui/src/components/features/execution/ExecutionTopologyView.tsx
@@ -8,6 +8,12 @@ import type { Task } from "@/schemas";
 import { useGetChip } from "@/client/chip/chip";
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { ExecutionTaskDetailModal } from "@/components/features/execution/ExecutionTaskDetailModal";
+import {
+  filterTaskGroupsByName,
+  groupTasksByEntity,
+  resolveInitialTaskIndex,
+  selectTaskNeighborhood,
+} from "@/components/features/execution/executionTopologyTasks";
 import { GridZoomControls } from "@/components/ui/GridZoomControls";
 import { useGridLayout } from "@/hooks/useGridLayout";
 import { useTopologyConfig } from "@/hooks/useTopologyConfig";
@@ -40,20 +46,6 @@ function aggregateStatus(tasks: Task[]): string {
   if (tasks.some((t) => t.status === "running")) return "running";
   if (tasks.every((t) => t.status === "completed")) return "completed";
   return "pending";
-}
-
-function normalizeQid(qid: string): string {
-  const numericQid = Number.parseInt(qid.replace(/\D/g, ""), 10);
-  return Number.isNaN(numericQid) ? qid : String(numericQid);
-}
-
-function compareQid(first: string, second: string): number {
-  const firstNumber = Number(first);
-  const secondNumber = Number(second);
-  if (!Number.isNaN(firstNumber) && !Number.isNaN(secondNumber)) {
-    return firstNumber - secondNumber;
-  }
-  return first.localeCompare(second);
 }
 
 const EmptyCell = memo(function EmptyCell({ muxBgClass }: { muxBgClass: string }) {
@@ -293,33 +285,17 @@ export function ExecutionTopologyView({
     [hasMux, muxSize, gridSize, layoutType],
   );
 
-  // Group one-qubit tasks by qid. If filterTaskName is set, only include matching tasks.
-  const oneQTasksByQid = useMemo(() => {
-    const map: Record<string, Task[]> = {};
-    for (const task of tasks) {
-      if (!task.qid) continue;
-      if (task.qid.includes("-")) continue;
-      if (!filterTaskName || task.name !== filterTaskName) continue;
-      const qid = normalizeQid(task.qid);
-      if (!map[qid]) map[qid] = [];
-      map[qid].push(task);
-    }
-    return map;
-  }, [tasks, filterTaskName]);
+  const allTasksByEntity = useMemo(() => groupTasksByEntity(tasks), [tasks]);
 
-  const couplingTasksByQid = useMemo(() => {
-    const map: Record<string, Task[]> = {};
-    for (const task of tasks) {
-      if (!task.qid || !task.qid.includes("-")) continue;
-      if (!filterTaskName || task.name !== filterTaskName) continue;
-      const [first, second] = task.qid.split("-");
-      if (!first || !second) continue;
-      const normalizedQid = [normalizeQid(first), normalizeQid(second)].sort(compareQid).join("-");
-      if (!map[normalizedQid]) map[normalizedQid] = [];
-      map[normalizedQid].push(task);
-    }
-    return map;
-  }, [tasks, filterTaskName]);
+  const oneQTasksByQid = useMemo(
+    () => filterTaskGroupsByName(allTasksByEntity.oneQubit, filterTaskName),
+    [allTasksByEntity, filterTaskName],
+  );
+
+  const couplingTasksByQid = useMemo(
+    () => filterTaskGroupsByName(allTasksByEntity.coupling, filterTaskName),
+    [allTasksByEntity, filterTaskName],
+  );
 
   // Build grid positions for all qids
   const gridPositions = useMemo(() => {
@@ -364,10 +340,16 @@ export function ExecutionTopologyView({
     if (!selectedEntityId) return null;
     const entityTasks =
       topologyMode === "2q"
-        ? couplingTasksByQid[selectedEntityId]
-        : oneQTasksByQid[selectedEntityId];
-    return entityTasks ?? [];
-  }, [couplingTasksByQid, oneQTasksByQid, selectedEntityId, topologyMode]);
+        ? allTasksByEntity.coupling[selectedEntityId]
+        : allTasksByEntity.oneQubit[selectedEntityId];
+    if (!entityTasks) return [];
+    return selectTaskNeighborhood(entityTasks, filterTaskName);
+  }, [allTasksByEntity, selectedEntityId, topologyMode, filterTaskName]);
+
+  const initialTaskIndex = useMemo(
+    () => (selectedTasks ? resolveInitialTaskIndex(selectedTasks, filterTaskName) : 0),
+    [selectedTasks, filterTaskName],
+  );
 
   const visibleTaskGroups = topologyMode === "2q" ? couplingTasksByQid : oneQTasksByQid;
 
@@ -565,8 +547,10 @@ export function ExecutionTopologyView({
 
       {selectedEntityId && selectedTasks && (
         <ExecutionTaskDetailModal
+          key={selectedEntityId}
           isOpen={!!selectedEntityId}
           tasks={selectedTasks}
+          initialTaskIndex={initialTaskIndex}
           qid={selectedEntityId}
           chipId={chipId}
           executionId={executionId}

--- a/ui/src/components/features/execution/__tests__/executionTopologyTasks.test.ts
+++ b/ui/src/components/features/execution/__tests__/executionTopologyTasks.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import type { Task } from "@/schemas";
+
+import {
+  filterTaskGroupsByName,
+  groupTasksByEntity,
+  resolveInitialTaskIndex,
+  selectTaskNeighborhood,
+} from "@/components/features/execution/executionTopologyTasks";
+
+function task(name: string, qid: string): Task {
+  return { name, qid, task_id: `${name}-${qid}` };
+}
+
+function chain(names: string[], qid = "0"): Task[] {
+  return names.map((name, index) => ({
+    ...task(name, qid),
+    upstream_id: index === 0 ? "" : `${names[index - 1]}-${qid}`,
+  }));
+}
+
+const tasks: Task[] = [
+  task("CheckStatus", "Q00"),
+  task("CheckRabi", "Q00"),
+  task("CreateHPIPulse", "Q00"),
+  task("CheckRabi", "1"),
+  task("CheckCrossResonance", "2-1"),
+  task("CheckStatus", "1-2"),
+];
+
+describe("groupTasksByEntity", () => {
+  it("keeps every task of a qubit in execution order", () => {
+    const { oneQubit } = groupTasksByEntity(tasks);
+
+    expect(oneQubit["0"].map((entry) => entry.name)).toEqual([
+      "CheckStatus",
+      "CheckRabi",
+      "CreateHPIPulse",
+    ]);
+    expect(oneQubit["1"].map((entry) => entry.name)).toEqual(["CheckRabi"]);
+  });
+
+  it("normalizes coupling ids so both directions share one group", () => {
+    const { coupling } = groupTasksByEntity(tasks);
+
+    expect(Object.keys(coupling)).toEqual(["1-2"]);
+    expect(coupling["1-2"].map((entry) => entry.name)).toEqual([
+      "CheckCrossResonance",
+      "CheckStatus",
+    ]);
+  });
+});
+
+describe("filterTaskGroupsByName", () => {
+  it("keeps only the entities that ran the selected task", () => {
+    const { oneQubit } = groupTasksByEntity(tasks);
+    const filtered = filterTaskGroupsByName(oneQubit, "CreateHPIPulse");
+
+    expect(Object.keys(filtered)).toEqual(["0"]);
+    expect(filtered["0"]).toHaveLength(1);
+  });
+
+  it("returns nothing when no task is selected", () => {
+    const { oneQubit } = groupTasksByEntity(tasks);
+
+    expect(filterTaskGroupsByName(oneQubit, "")).toEqual({});
+  });
+});
+
+describe("selectTaskNeighborhood", () => {
+  const linked = chain(["CheckFineChevron", "CheckRabi", "CreateHPIPulse", "CheckT1"]);
+
+  it("keeps the upstream and downstream tasks of the selected one", () => {
+    expect(selectTaskNeighborhood(linked, "CheckRabi").map((entry) => entry.name)).toEqual([
+      "CheckFineChevron",
+      "CheckRabi",
+      "CreateHPIPulse",
+    ]);
+  });
+
+  it("drops tasks that are more than one dependency away", () => {
+    expect(selectTaskNeighborhood(linked, "CheckFineChevron").map((entry) => entry.name)).toEqual([
+      "CheckFineChevron",
+      "CheckRabi",
+    ]);
+    expect(selectTaskNeighborhood(linked, "CheckT1").map((entry) => entry.name)).toEqual([
+      "CreateHPIPulse",
+      "CheckT1",
+    ]);
+  });
+
+  it("keeps every branch that depends on the selected task", () => {
+    const branched: Task[] = [
+      { ...task("CheckRabi", "0"), upstream_id: "" },
+      { ...task("CreateHPIPulse", "0"), upstream_id: "CheckRabi-0" },
+      { ...task("CheckT1", "0"), upstream_id: "CheckRabi-0" },
+    ];
+
+    expect(selectTaskNeighborhood(branched, "CheckRabi")).toHaveLength(3);
+    expect(selectTaskNeighborhood(branched, "CreateHPIPulse").map((entry) => entry.name)).toEqual([
+      "CheckRabi",
+      "CreateHPIPulse",
+    ]);
+  });
+
+  it("falls back to the adjacent tasks when the execution has no upstream links", () => {
+    const { oneQubit } = groupTasksByEntity(tasks);
+
+    expect(selectTaskNeighborhood(oneQubit["0"], "CheckRabi").map((entry) => entry.name)).toEqual([
+      "CheckStatus",
+      "CheckRabi",
+      "CreateHPIPulse",
+    ]);
+  });
+
+  it("returns the whole group when the task is missing or unset", () => {
+    expect(selectTaskNeighborhood(linked, "CheckT2Echo")).toHaveLength(linked.length);
+    expect(selectTaskNeighborhood(linked, "")).toHaveLength(linked.length);
+  });
+});
+
+describe("resolveInitialTaskIndex", () => {
+  it("points at the task selected in the filter", () => {
+    const { oneQubit } = groupTasksByEntity(tasks);
+
+    expect(resolveInitialTaskIndex(oneQubit["0"], "CheckRabi")).toBe(1);
+  });
+
+  it("falls back to the first task when the name is absent", () => {
+    const { oneQubit } = groupTasksByEntity(tasks);
+
+    expect(resolveInitialTaskIndex(oneQubit["0"], "CheckT1")).toBe(0);
+    expect(resolveInitialTaskIndex(oneQubit["0"], "")).toBe(0);
+  });
+});

--- a/ui/src/components/features/execution/__tests__/executionTopologyTasks.test.ts
+++ b/ui/src/components/features/execution/__tests__/executionTopologyTasks.test.ts
@@ -114,6 +114,21 @@ describe("selectTaskNeighborhood", () => {
     ]);
   });
 
+  it("falls back per task when only part of the group is linked", () => {
+    const partiallyLinked: Task[] = [
+      { ...task("CheckFineChevron", "0"), upstream_id: "" },
+      { ...task("CheckRabi", "0"), upstream_id: "CheckFineChevron-0" },
+      { ...task("CheckT1", "0"), upstream_id: "" },
+      { ...task("CheckT2Echo", "0"), upstream_id: "" },
+    ];
+
+    expect(selectTaskNeighborhood(partiallyLinked, "CheckT1").map((entry) => entry.name)).toEqual([
+      "CheckRabi",
+      "CheckT1",
+      "CheckT2Echo",
+    ]);
+  });
+
   it("returns the whole group when the task is missing or unset", () => {
     expect(selectTaskNeighborhood(linked, "CheckT2Echo")).toHaveLength(linked.length);
     expect(selectTaskNeighborhood(linked, "")).toHaveLength(linked.length);

--- a/ui/src/components/features/execution/executionTopologyTasks.ts
+++ b/ui/src/components/features/execution/executionTopologyTasks.ts
@@ -1,0 +1,115 @@
+import type { Task } from "@/schemas";
+
+export type TaskGroups = Record<string, Task[]>;
+
+export interface GroupedExecutionTasks {
+  oneQubit: TaskGroups;
+  coupling: TaskGroups;
+}
+
+function normalizeQid(qid: string): string {
+  const numericQid = Number.parseInt(qid.replace(/\D/g, ""), 10);
+  return Number.isNaN(numericQid) ? qid : String(numericQid);
+}
+
+function compareQid(first: string, second: string): number {
+  const firstNumber = Number(first);
+  const secondNumber = Number(second);
+  if (!Number.isNaN(firstNumber) && !Number.isNaN(secondNumber)) {
+    return firstNumber - secondNumber;
+  }
+  return first.localeCompare(second);
+}
+
+/**
+ * Groups execution tasks by the entity the topology grid draws: a qubit for
+ * one-qubit tasks, a normalized `low-high` id for coupling tasks. Task order
+ * inside a group is the execution order the API returns.
+ */
+export function groupTasksByEntity(tasks: Task[]): GroupedExecutionTasks {
+  const oneQubit: TaskGroups = {};
+  const coupling: TaskGroups = {};
+
+  for (const task of tasks) {
+    if (!task.qid) continue;
+    if (task.qid.includes("-")) {
+      const [first, second] = task.qid.split("-");
+      if (!first || !second) continue;
+      const couplingId = [normalizeQid(first), normalizeQid(second)].sort(compareQid).join("-");
+      (coupling[couplingId] ??= []).push(task);
+    } else {
+      const qid = normalizeQid(task.qid);
+      (oneQubit[qid] ??= []).push(task);
+    }
+  }
+
+  return { oneQubit, coupling };
+}
+
+/**
+ * Keeps only the entities that ran `taskName`, and only those task runs. This is
+ * what the grid renders, so an empty `taskName` yields no entities.
+ */
+export function filterTaskGroupsByName(groups: TaskGroups, taskName: string): TaskGroups {
+  if (!taskName) return {};
+  const filtered: TaskGroups = {};
+  for (const [entityId, entityTasks] of Object.entries(groups)) {
+    const matched = entityTasks.filter((task) => task.name === taskName);
+    if (matched.length > 0) filtered[entityId] = matched;
+  }
+  return filtered;
+}
+
+/**
+ * Narrows one entity's tasks to the selected task plus the tasks directly linked
+ * to it: its upstream task and every task declaring it as upstream.
+ *
+ * Executions recorded without `upstream_id` links fall back to the neighbours in
+ * execution order, so the selected task is never shown on its own.
+ */
+export function selectTaskNeighborhood(entityTasks: Task[], taskName: string): Task[] {
+  if (!taskName) return entityTasks;
+
+  const selectedIndexes = entityTasks.reduce<number[]>((indexes, task, index) => {
+    if (task.name === taskName) indexes.push(index);
+    return indexes;
+  }, []);
+  if (selectedIndexes.length === 0) return entityTasks;
+
+  const indexByTaskId = new Map<string, number>();
+  entityTasks.forEach((task, index) => {
+    if (task.task_id) indexByTaskId.set(task.task_id, index);
+  });
+  const hasUpstreamLinks = entityTasks.some(
+    (task) => task.upstream_id && indexByTaskId.has(task.upstream_id),
+  );
+
+  const kept = new Set<number>(selectedIndexes);
+  for (const selectedIndex of selectedIndexes) {
+    const selected = entityTasks[selectedIndex];
+    if (hasUpstreamLinks) {
+      const upstreamIndex = selected.upstream_id
+        ? indexByTaskId.get(selected.upstream_id)
+        : undefined;
+      if (upstreamIndex !== undefined) kept.add(upstreamIndex);
+      entityTasks.forEach((task, index) => {
+        if (task.upstream_id && task.upstream_id === selected.task_id) kept.add(index);
+      });
+    } else {
+      if (selectedIndex > 0) kept.add(selectedIndex - 1);
+      if (selectedIndex < entityTasks.length - 1) kept.add(selectedIndex + 1);
+    }
+  }
+
+  return entityTasks.filter((_, index) => kept.has(index));
+}
+
+/**
+ * Position of the task selected in the filter, used as the detail modal's
+ * initial selection. Falls back to the first task when the name is not present.
+ */
+export function resolveInitialTaskIndex(tasks: Task[], taskName: string): number {
+  if (!taskName) return 0;
+  const index = tasks.findIndex((task) => task.name === taskName);
+  return index >= 0 ? index : 0;
+}

--- a/ui/src/components/features/execution/executionTopologyTasks.ts
+++ b/ui/src/components/features/execution/executionTopologyTasks.ts
@@ -64,7 +64,7 @@ export function filterTaskGroupsByName(groups: TaskGroups, taskName: string): Ta
  * Narrows one entity's tasks to the selected task plus the tasks directly linked
  * to it: its upstream task and every task declaring it as upstream.
  *
- * Executions recorded without `upstream_id` links fall back to the neighbours in
+ * A task with no link recorded on either side falls back to its neighbours in
  * execution order, so the selected task is never shown on its own.
  */
 export function selectTaskNeighborhood(entityTasks: Task[], taskName: string): Task[] {
@@ -80,25 +80,25 @@ export function selectTaskNeighborhood(entityTasks: Task[], taskName: string): T
   entityTasks.forEach((task, index) => {
     if (task.task_id) indexByTaskId.set(task.task_id, index);
   });
-  const hasUpstreamLinks = entityTasks.some(
-    (task) => task.upstream_id && indexByTaskId.has(task.upstream_id),
-  );
-
   const kept = new Set<number>(selectedIndexes);
   for (const selectedIndex of selectedIndexes) {
     const selected = entityTasks[selectedIndex];
-    if (hasUpstreamLinks) {
-      const upstreamIndex = selected.upstream_id
-        ? indexByTaskId.get(selected.upstream_id)
-        : undefined;
-      if (upstreamIndex !== undefined) kept.add(upstreamIndex);
-      entityTasks.forEach((task, index) => {
-        if (task.upstream_id && task.upstream_id === selected.task_id) kept.add(index);
-      });
-    } else {
+    const upstreamIndex = selected.upstream_id
+      ? indexByTaskId.get(selected.upstream_id)
+      : undefined;
+    const downstreamIndexes = entityTasks.reduce<number[]>((indexes, task, index) => {
+      if (selected.task_id && task.upstream_id === selected.task_id) indexes.push(index);
+      return indexes;
+    }, []);
+
+    if (upstreamIndex === undefined && downstreamIndexes.length === 0) {
       if (selectedIndex > 0) kept.add(selectedIndex - 1);
       if (selectedIndex < entityTasks.length - 1) kept.add(selectedIndex + 1);
+      continue;
     }
+
+    if (upstreamIndex !== undefined) kept.add(upstreamIndex);
+    for (const downstreamIndex of downstreamIndexes) kept.add(downstreamIndex);
   }
 
   return entityTasks.filter((_, index) => kept.has(index));


### PR DESCRIPTION
## Ticket

close #1365

## Summary

- Opening a qubit from the Task Topology grid listed only the task picked in the Task Name filter, so there was no way to see what ran before or after it. The modal now also lists the tasks directly linked to that task.
- UI only, scoped to the Execution Detail page. No API, schema, or generated client changes, so `task generate` was not needed. The Chip and Metrics pages share `ExecutionHistoryModalContent` but not `ExecutionTaskDetailModal`, so they are unaffected.

## Changes

- `ExecutionTopologyView` groups every task of the execution per grid entity once, then applies the Task Name filter only to what the grid draws. The grid keeps showing a single task per qubit or coupling, as before.
- `ExecutionTaskDetailModal` now receives the selected task together with its upstream task and every task that declares it as upstream. With a CheckFineChevron, CheckRabi, CreateHPIPulse chain, filtering on CheckRabi lists all three, while filtering on CheckFineChevron lists only CheckFineChevron and CheckRabi.
- The filtered task is preselected through the new `initialTaskIndex` prop, so the modal opens on the task that was clicked instead of the first task of the chain. The modal is keyed by entity id, so the selection resets when a different qubit is opened.
- Executions recorded without `upstream_id` links fall back to the neighbors in execution order. Most existing task history has an empty `upstream_id`, and without this fallback those executions would keep showing a single row.
- Added `executionTopologyTasks.ts` for the grouping and neighbor helpers. `normalizeQid` and `compareQid` moved there with the grouping code they support. Unit tests cover the linked chain, branching downstream tasks, the fallback, and the case where the filtered name is absent.

### Out of scope

- Coupling (2q) mode was not exercised end to end. The code path is shared with the qubit mode, but the local database holds no coupling task history to check against.
- Highlighting the dependency chain in the grid itself.

## Verification

- `bun run test:run`, `bun run lint`, `bun run fmt:check`, `bun run knip`, and `bunx tsc --noEmit` pass.
- Checked in a browser against a locally seeded execution whose tasks form a CheckFineChevron, CheckRabi, CreateHPIPulse chain. Each filter value shows the selected task with its direct neighbors only, and the modal opens on the filtered task. Also checked an existing execution with no `upstream_id` links, where three of its five tasks appear.
- Note for reviewers: `chip/__tests__/TaskArtifactDownloads.test.tsx` and `dashboard/__tests__/DashboardTargetNoteModal.test.tsx` fail intermittently in full suite runs and pass in isolation. The first also fails on a clean `develop`, so neither is related to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Execution topology views now organize and filter tasks more consistently by entity, name, and dependency neighborhood.
  * Task detail modals can open directly to the relevant task when selected from the topology.
  * Added fallback selection using execution order when dependency links are unavailable.

* **Bug Fixes**
  * Improved task grouping and coupling identification for more accurate topology details.

* **Tests**
  * Added coverage for task grouping, filtering, neighborhood selection, fallback behavior, and initial task selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->