### PR TITLE
fix(ui): hide the expand figure button in grid cells (#1367)

### DIFF
--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -711,6 +711,7 @@ export function ChipPageContent() {
                                                 path={task.figure_path}
                                                 qid={qid}
                                                 className="w-full h-48 object-contain"
+                                                hideExpandButton
                                               />
                                             </div>
                                           )}

--- a/ui/src/components/features/execution/ExecutionTopologyView.tsx
+++ b/ui/src/components/features/execution/ExecutionTopologyView.tsx
@@ -135,6 +135,7 @@ const TopologyCell = memo(function TopologyCell({
             jsonFigurePath={jsonFigurePath || undefined}
             qid={qid}
             className="w-full h-full object-contain"
+            hideExpandButton
           />
         </div>
       )}
@@ -220,6 +221,7 @@ const CouplingMarker = memo(function CouplingMarker({
             jsonFigurePath={jsonFigurePath || undefined}
             qid={couplingId}
             className="w-full h-full object-contain"
+            hideExpandButton
           />
         </div>
       )}

--- a/ui/src/components/features/execution/__tests__/ExecutionTopologyView.test.tsx
+++ b/ui/src/components/features/execution/__tests__/ExecutionTopologyView.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Task } from "@/schemas";
+
+import { ExecutionTopologyView } from "@/components/features/execution/ExecutionTopologyView";
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderTopologyView(props: React.ComponentProps<typeof ExecutionTopologyView>) {
+  const queryClient = createQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ExecutionTopologyView {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+vi.mock("@/client/chip/chip", () => ({
+  useGetChip: () => ({
+    data: { data: { size: 4, topology_id: "test-topology" } },
+  }),
+}));
+
+vi.mock("@/hooks/useTopologyConfig", () => ({
+  useTopologyConfig: () => ({
+    muxSize: 2,
+    hasMux: false,
+    layoutType: "grid",
+    showMuxBoundaries: false,
+    qubits: {
+      "0": { row: 0, col: 0 },
+      "1": { row: 0, col: 1 },
+    },
+    gridSize: 2,
+  }),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ExecutionTopologyView grid figures", () => {
+  it("renders a one-qubit figure without an expand button", () => {
+    const tasks: Task[] = [
+      {
+        task_id: "task-1",
+        qid: "0",
+        name: "CheckT1",
+        status: "completed",
+        figure_path: ["/path/to/qubit-figure.png"],
+      },
+    ];
+
+    renderTopologyView({
+      chipId: "chip-1",
+      executionId: "exec-1",
+      executionName: "Execution 1",
+      tasks,
+      topologyMode: "1q",
+      filterTaskName: "CheckT1",
+    });
+
+    expect(screen.getByAltText("Result for QID 0")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Expand figure" })).toBeNull();
+  });
+
+  it("renders a coupling figure without an expand button", () => {
+    const tasks: Task[] = [
+      {
+        task_id: "task-2",
+        qid: "0-1",
+        name: "CheckCoupling",
+        status: "completed",
+        figure_path: ["/path/to/coupling-figure.png"],
+      },
+    ];
+
+    renderTopologyView({
+      chipId: "chip-1",
+      executionId: "exec-1",
+      executionName: "Execution 1",
+      tasks,
+      topologyMode: "2q",
+      filterTaskName: "CheckCoupling",
+    });
+
+    expect(screen.getByAltText("Result for QID 0-1")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Expand figure" })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Ticket

close #1367

## Summary

- Hovering a cell in the Execution Detail Task Topology grid popped up an "Expand figure" button. Grid cells are already clickable and open the task detail modal, so the extra control is redundant and covers the figure.
- UI only. No API, schema, or generated client changes, so `task generate` was not needed. `TaskFigure` itself is unchanged, so every detail view and modal keeps its expand button.

### Background

- `TaskFigure` has had a `hideExpandButton` prop since #1055, which replaced the earlier `[&_button]:hidden` CSS approach from #775. `QubitGrid` and `CouplingGrid` were updated then, but the topology grid was not, and it has shown the button since it started using `TaskFigure` in #796.
- Nothing reverted the earlier fix. What changed is #1313, which turned the native `title="Expand"` attribute into a Radix tooltip with `aria-label="Expand figure"`. The button was always there; the instant tooltip just made it obvious.
- Hiding it with CSS is not an option here. `[&_button]:hidden` leaves a focusable button in the DOM, so the control stays reachable by keyboard while being invisible. Not rendering it is also the correct markup: both call sites nest the figure inside an interactive element (`role="button"` in the topology cells, a real `<button>` on the chip page card), and a button must not contain focusable descendants.

## Changes

- `ExecutionTopologyView`: `TopologyCell` and `CouplingMarker` pass `hideExpandButton` to `TaskFigure`, so neither the qubit cells nor the coupling markers render the overlay.
- `ChipPageContent`: the same fix on the Task Results Grid card. The card is a `<button>` wrapping the figure, so this was the same invalid nesting, not just a visual issue.
- Added `execution/__tests__/ExecutionTopologyView.test.tsx`. Each case asserts the figure actually rendered before asserting the expand button is absent, so the test cannot pass by rendering nothing. Covers both 1q cells and 2q coupling markers.

### Out of scope

- Inverting the `TaskFigure` default so the expand button is opt-in. That would prevent the next grid from repeating this, but it means adding a behavior preserving prop to about 25 call sites across 17 detail views, which is a much larger change than this issue calls for. Worth a separate discussion.
- `QubitTaskCard` still shows the button on its 84x64 thumbnail. It is a list card, not a grid cell, and the figure is not nested inside an interactive element, so it was left alone.

## Verification

- `bunx vitest run src/components/features/execution/__tests__/ExecutionTopologyView.test.tsx` passes (2 tests).
- `bun run lint`, `bun run fmt:check`, and `bunx tsc --noEmit` are clean.
- Removing `hideExpandButton` from either call site makes the new test fail with the expand button present, so the guard works.
- Note for reviewers: full suite runs show intermittent 5s timeouts in `chip/__tests__/TaskArtifactDownloads.test.tsx`, the command palette test, and `DashboardTargetNoteModal.test.tsx`. All pass in isolation and reproduce on `develop`, so they are unrelated to this change.
- Note on overlap: #1368 also edits `ExecutionTopologyView.tsx`. The two changes touch different parts of the file, and the new test still holds under that PR's zoom based `showFigures` because the initial scale is 1. Whichever lands second should confirm it after rebase.

