### PR TITLE
chore(repo): upgrade Node.js to 24

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -113,7 +113,7 @@ WORKDIR /workspace/qdash
 # ========================================
 FROM toolchain AS node-env
 
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
     apt-get install -y nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -17,7 +17,7 @@
 | ------------------------------------------- | --------- | ------------------------------------ |
 | [Python](https://www.python.org/downloads/) | 3.11-3.12 | Backend development                  |
 | [Bun](https://bun.sh/)                      | 1.4.0+    | Frontend package manager and runtime |
-| [Node.js](https://nodejs.org/)              | 20+       | Alternative frontend runtime         |
+| [Node.js](https://nodejs.org/)              | 24+       | Alternative frontend runtime         |
 
 ## Getting Started
 
@@ -91,7 +91,7 @@ Install [Nix](https://nixos.org/download/) with flakes enabled, then enter the d
 nix develop
 ```
 
-The shell provides Python 3.11, uv, Bun, Node.js 20, go-task, Docker CLI/Compose, jq, PostgreSQL
+The shell provides Python 3.11, uv, Bun, Node.js 24, go-task, Docker CLI/Compose, jq, PostgreSQL
 client tools, and the secret scanning tools used by the project. It also sets `UV_PYTHON` to the
 Nix-provided Python 3.11 so `uv sync` does not accidentally select Python 3.12 on macOS, where
 some workflow backend dependencies may fail to build. It does not start MongoDB, PostgreSQL,

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
             jq
             lefthook
             lsof
-            nodejs_20
+            nodejs_24
             pkg-config
             postgresql_14
             python311

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -4,7 +4,7 @@ ARG NEXT_PUBLIC_PREFECT_URL
 ARG INTERNAL_API_URL
 ARG NEXT_PUBLIC_COPILOT_ENABLED
 
-FROM oven/bun:1 AS base
+FROM oven/bun:1.4.0 AS base
 WORKDIR /app
 ENV NEXT_TELEMETRY_DISABLED=1
 
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/app/.next/cache \
     bun run next build --turbo
 
 # Standalone output - no need for bun install in runner
-FROM node:20-alpine AS runner
+FROM node:24-alpine AS runner
 ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_ENV
 ARG NEXT_PUBLIC_PREFECT_URL

--- a/ui/package.json
+++ b/ui/package.json
@@ -112,7 +112,7 @@
   },
   "engines": {
     "bun": ">=1.4.0",
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "bun@1.4.0"
 }


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Upgrade QDash development and production environments from end-of-life Node.js 20 to Node.js 24 LTS.
- Keep the published TypeScript client requirement at Node.js 20 to avoid an unrelated breaking compatibility change.

## Changes

- Use Node.js 24 in the devcontainer, Nix development shell, and UI production runner.
- Require Node.js 24 for the UI package and update setup documentation.
- Pin the UI Docker build stage to Bun 1.4.0 for consistency with the repository toolchain.
- Verify 181 UI tests, type checking, lint, formatting, Knip, dependency audit, and the Next.js production build.
- Verify the Node 24 Alpine image and Docker Compose configuration; the full Docker image build was not run because Buildx is unavailable in the local verification environment.