### PR TITLE
fix(repo): complete migration with missing artifacts (#1366)

### DIFF
--- a/docs/reference/migration-project-scoped-calibration.md
+++ b/docs/reference/migration-project-scoped-calibration.md
@@ -67,9 +67,14 @@ When two legacy classifier files have the same relative path and different conte
 the latest modification time is retained at the shared destination and the other file is copied
 below `.migration_conflicts/{username}`.
 
-Execution artifacts missing from their expected legacy directories stop an execute migration. After
-reviewing those records and confirming that the files cannot be recovered, an operator can accept
-the missing artifacts explicitly:
+Execution artifacts missing from their expected legacy directories are recorded in the artifact
+migration ledger and emitted as a warning. The report includes the execution ID, status, username,
+stored calibration path, and paths checked so operators can distinguish expected gaps from files
+that need recovery. Missing artifacts do not block the rest of QDash from starting because the
+migration has already moved every artifact it could locate.
+
+After reviewing the warning, an operator can rerun the migration with the following flag to mark
+the missing artifacts as reviewed in the report:
 
 ```bash
 docker compose run --rm calibration-migration \

--- a/src/qdash/dbmodel/migration.py
+++ b/src/qdash/dbmodel/migration.py
@@ -1763,7 +1763,7 @@ if __name__ == "__main__":
     project_calibration_parser.add_argument(
         "--allow-missing-artifacts",
         action="store_true",
-        help="Complete migration despite reviewed legacy execution directories being missing",
+        help="Mark missing legacy execution artifacts as reviewed in the migration report",
     )
 
     args = parser.parse_args()

--- a/src/qdash/dbmodel/project_calibration_migration.py
+++ b/src/qdash/dbmodel/project_calibration_migration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 from datetime import datetime, timedelta, timezone
@@ -10,6 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 from pymongo import ASCENDING, MongoClient, ReturnDocument
 from pymongo.errors import DuplicateKeyError
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pymongo.database import Database
@@ -636,15 +639,17 @@ def migrate_calibration_files(
     base_path: Path,
     dry_run: bool = True,
     allow_missing: bool = False,
-) -> dict[str, int]:
+) -> dict[str, Any]:
     """Copy legacy user artifacts to project-chip paths without deleting sources."""
     _ensure_migration_archive_index(database)
-    stats = {
+    stats: dict[str, Any] = {
         "copied": 0,
         "moved": 0,
         "identical": 0,
         "conflicts": 0,
         "missing": 0,
+        "missing_artifacts": [],
+        "missing_artifacts_reviewed": allow_missing,
         "database_records_updated": 0,
     }
     executions = list(
@@ -657,11 +662,31 @@ def migrate_calibration_files(
         username = execution.get("username")
         if not execution_id or not username:
             stats["missing"] += 1
+            stats["missing_artifacts"].append(
+                {
+                    "execution_id": execution_id,
+                    "username": username,
+                    "status": execution.get("status"),
+                    "calib_data_path": execution.get("calib_data_path"),
+                    "reason": "missing execution_id or username",
+                    "checked_paths": [],
+                }
+            )
             continue
         try:
             date_str, index = execution_id.split("-", 1)
         except ValueError:
             stats["missing"] += 1
+            stats["missing_artifacts"].append(
+                {
+                    "execution_id": execution_id,
+                    "username": username,
+                    "status": execution.get("status"),
+                    "calib_data_path": execution.get("calib_data_path"),
+                    "reason": "invalid execution_id format",
+                    "checked_paths": [],
+                }
+            )
             continue
         legacy_source = base_path / username / date_str / index
         project_chip_path = (
@@ -674,6 +699,16 @@ def migrate_calibration_files(
         source = flat_source if flat_source.is_dir() else legacy_source
         if not source.is_dir():
             stats["missing"] += 1
+            stats["missing_artifacts"].append(
+                {
+                    "execution_id": execution_id,
+                    "username": username,
+                    "status": execution.get("status"),
+                    "calib_data_path": execution.get("calib_data_path"),
+                    "reason": "legacy artifact directory not found",
+                    "checked_paths": [str(flat_source), str(legacy_source)],
+                }
+            )
             continue
         if dry_run:
             if source == flat_source and not target.exists():
@@ -734,11 +769,6 @@ def migrate_calibration_files(
         )
         for key, count in classifier_stats.items():
             stats[key] += count
-    if not dry_run and stats["missing"] and not allow_missing:
-        raise RuntimeError(
-            f"Could not locate legacy artifacts for {stats['missing']} execution(s); "
-            "rerun with --allow-missing-artifacts only after reviewing them"
-        )
     return stats
 
 
@@ -756,7 +786,26 @@ def run_from_environment(*, dry_run: bool, allow_missing_artifacts: bool = False
         database = client[os.getenv("MONGO_DB_NAME", "qdash")]
         stats = migrate_project_scoped_calibration(database, dry_run=dry_run)
         artifact_ledger = database["migration_ledger"]
-        if artifact_ledger.find_one({"migration_id": ARTIFACT_MIGRATION_ID, "status": "completed"}):
+        completed_artifact_migration = artifact_ledger.find_one(
+            {"migration_id": ARTIFACT_MIGRATION_ID, "status": "completed"}
+        )
+        if completed_artifact_migration:
+            recorded_stats = completed_artifact_migration.get("stats", {})
+            if (
+                not dry_run
+                and allow_missing_artifacts
+                and recorded_stats.get("missing")
+                and not recorded_stats.get("missing_artifacts_reviewed")
+            ):
+                artifact_ledger.update_one(
+                    {"migration_id": ARTIFACT_MIGRATION_ID},
+                    {
+                        "$set": {
+                            "stats.missing_artifacts_reviewed": True,
+                            "missing_artifacts_reviewed_at": datetime.now(timezone.utc),
+                        }
+                    },
+                )
             stats["files"] = {"already_completed": True}
             return stats
         stats["files"] = migrate_calibration_files(
@@ -765,6 +814,12 @@ def run_from_environment(*, dry_run: bool, allow_missing_artifacts: bool = False
             dry_run=dry_run,
             allow_missing=allow_missing_artifacts,
         )
+        if stats["files"]["missing"]:
+            logger.warning(
+                "Calibration artifact migration completed with %s missing execution(s): %s",
+                stats["files"]["missing"],
+                stats["files"]["missing_artifacts"],
+            )
         if not dry_run:
             artifact_ledger.update_one(
                 {"migration_id": ARTIFACT_MIGRATION_ID},

--- a/tests/qdash/dbmodel/test_project_calibration_migration.py
+++ b/tests/qdash/dbmodel/test_project_calibration_migration.py
@@ -1,13 +1,17 @@
+import logging
 import os
 from datetime import datetime, timezone
 
 import pytest
 
+import qdash.dbmodel.project_calibration_migration as migration_module
 from qdash.dbmodel.project_calibration_migration import (
+    ARTIFACT_MIGRATION_ID,
     MIGRATION_ID,
     SCOPE_BACKFILL_MIGRATION_ID,
     migrate_calibration_files,
     migrate_project_scoped_calibration,
+    run_from_environment,
 )
 
 
@@ -505,7 +509,7 @@ def test_migration_rejects_ambiguous_calibration_note_chip(init_db) -> None:
         migrate_project_scoped_calibration(init_db, dry_run=False)
 
 
-def test_file_migration_rejects_missing_execution_artifacts(init_db, tmp_path) -> None:
+def test_file_migration_reports_missing_execution_artifacts(init_db, tmp_path) -> None:
     init_db["execution_history"].insert_one(
         {
             "project_id": "proj-1",
@@ -516,5 +520,68 @@ def test_file_migration_rejects_missing_execution_artifacts(init_db, tmp_path) -
         }
     )
 
-    with pytest.raises(RuntimeError, match="allow-missing-artifacts"):
-        migrate_calibration_files(init_db, base_path=tmp_path, dry_run=False)
+    stats = migrate_calibration_files(init_db, base_path=tmp_path, dry_run=False)
+
+    assert stats["missing"] == 1
+    assert stats["missing_artifacts"] == [
+        {
+            "execution_id": "20260102-001",
+            "username": "alice",
+            "status": None,
+            "calib_data_path": str(tmp_path / "alice" / "20260102" / "001"),
+            "reason": "legacy artifact directory not found",
+            "checked_paths": [
+                str(
+                    tmp_path
+                    / "projects"
+                    / "proj-1"
+                    / "chips"
+                    / "chip-1"
+                    / "executions"
+                    / "20260102-001"
+                ),
+                str(tmp_path / "alice" / "20260102" / "001"),
+            ],
+        }
+    ]
+    assert stats["missing_artifacts_reviewed"] is False
+
+
+def test_environment_migration_records_missing_artifacts_and_skips_rerun(
+    init_db, tmp_path, monkeypatch, caplog
+) -> None:
+    init_db["execution_history"].insert_one(
+        {
+            "project_id": "proj-1",
+            "chip_id": "chip-1",
+            "execution_id": "20260102-001",
+            "username": "alice",
+            "status": "failed",
+            "calib_data_path": str(tmp_path / "alice" / "20260102" / "001"),
+        }
+    )
+    monkeypatch.setenv("MONGO_DB_NAME", init_db.name)
+    monkeypatch.setenv("CALIB_DATA_PATH", str(tmp_path))
+    monkeypatch.setattr(migration_module, "MongoClient", lambda *args, **kwargs: init_db.client)
+
+    with caplog.at_level(logging.WARNING):
+        stats = run_from_environment(dry_run=False)
+
+    assert stats["files"]["missing"] == 1
+    assert "20260102-001" in caplog.text
+    ledger = init_db["migration_ledger"].find_one({"migration_id": ARTIFACT_MIGRATION_ID})
+    assert ledger is not None
+    assert ledger["status"] == "completed"
+    assert ledger["stats"]["missing_artifacts"][0]["execution_id"] == "20260102-001"
+
+    reviewed = run_from_environment(dry_run=False, allow_missing_artifacts=True)
+
+    assert reviewed["files"] == {"already_completed": True}
+    reviewed_ledger = init_db["migration_ledger"].find_one({"migration_id": ARTIFACT_MIGRATION_ID})
+    assert reviewed_ledger is not None
+    assert reviewed_ledger["stats"]["missing_artifacts_reviewed"] is True
+    assert "missing_artifacts_reviewed_at" in reviewed_ledger
+
+    repeated = run_from_environment(dry_run=False)
+
+    assert repeated["files"] == {"already_completed": True}


### PR DESCRIPTION
## Ticket

- Closes #1366

## Summary

- Let the project-scoped calibration artifact migration complete after moving all available files, even when some legacy execution directories are missing.
- Persist actionable missing-artifact details in the migration ledger so Docker Compose startup no longer fails repeatedly while operators retain an audit trail.

## Changes

- Record the execution ID, status, username, stored calibration path, reason, and checked paths for each missing artifact.
- Emit a warning containing the missing execution details and write the completed artifact migration ledger entry.
- Preserve the existing `--allow-missing-artifacts` option as an explicit review marker, including for already-completed migrations.
- Add regression coverage for missing-artifact reporting, warning output, ledger completion, review marking, and idempotent reruns.
- Update the project-scoped calibration migration documentation with the non-blocking behavior.

## Verification

- `uv run pytest tests/qdash/dbmodel/test_project_calibration_migration.py -q` (14 passed)
- Focused Ruff lint and format checks
- Focused mypy check
- `git diff --check`