### PR TITLE
fix(repo): prevent tests from sending Slack notifications

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,13 +54,16 @@ pytest.mark.asyncio_default_fixture_loop_scope = "function"  # type: ignore[attr
 os.environ["ENV"] = "test"
 os.environ.setdefault("CLIENT_URL", "http://localhost:3000")
 os.environ.setdefault("PREFECT_API_URL", "http://localhost:4200/api")
-os.environ.setdefault("SLACK_BOT_TOKEN", "test-token")
-os.environ.setdefault("SLACK_CHANNEL_ID", "test-channel")
+# Never inherit real Slack credentials or enable outbound notifications in tests.
+os.environ["SLACK_BOT_TOKEN"] = "test-token"  # noqa: S105
+os.environ["SLACK_CHANNEL_ID"] = "test-channel"
+os.environ["SLACK_FORUM_NOTIFICATION"] = "false"
+os.environ["SLACK_FORUM_CHANNEL_ID"] = ""
 os.environ.setdefault("POSTGRES_DATA_PATH", "/tmp/postgres")
 os.environ.setdefault("MONGO_DATA_PATH", "/tmp/mongo")
 os.environ.setdefault("CALIB_DATA_PATH", "/tmp/calib")
 os.environ.setdefault("QPU_DATA_PATH", "/tmp/qpu")
-os.environ.setdefault("SLACK_APP_TOKEN", "test-app-token")
+os.environ["SLACK_APP_TOKEN"] = "test-app-token"  # noqa: S105
 os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
 
 


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Prevent test runs from inheriting real Slack credentials and sending forum notifications.
- This only affects the test environment; production Slack notification behavior is unchanged.

## Changes

- Override Slack bot and app tokens with dummy values during pytest initialization.
- Force forum Slack notifications off and clear the forum channel in tests.
- Keep mocked Slack notification unit coverage intact.

## Verification

- `uv run pytest tests/qdash/test_config.py tests/qdash/api/services/test_slack_notification_service.py -q` (30 passed)
- `task check`: lint, formatting, and mypy passed; pytest collection stopped on 19 workflow tests because `psutil.NoSuchProcess(pid=551)` was raised by the container environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to use consistent Slack credentials and notification settings.
  * Disabled forum notifications and cleared the forum channel during tests.
  * Preserved existing test data-path defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->