### PR TITLE
fix(workflow): unify HPI duration parameter name

### DIFF
--- a/config/domain/metrics.yaml
+++ b/config/domain/metrics.yaml
@@ -202,8 +202,8 @@ qubit_metrics:
     evaluation:
       mode: none
 
-  hpi_length:
-    title: HPI Length
+  hpi_duration:
+    title: HPI Duration
     unit: ns
     scale: 1
     description: Half-pi pulse duration

--- a/docs/task-knowledge/one-qubit-gate-calibration/CheckHPIPulse/index.md
+++ b/docs/task-knowledge/one-qubit-gate-calibration/CheckHPIPulse/index.md
@@ -51,7 +51,7 @@ Correct cycling pattern over many repetitions with minimal contrast decay.
 
 - qubit_frequency: Loaded from DB
 - hpi_amplitude: Loaded from DB
-- hpi_length: Loaded from DB
+- hpi_duration: Loaded from DB
 - readout_amplitude: Loaded from DB
 - readout_frequency: Loaded from DB
 - readout_length: Readout pulse length (ns)

--- a/docs/task-knowledge/one-qubit-gate-calibration/CreateHPIPulse/index.md
+++ b/docs/task-knowledge/one-qubit-gate-calibration/CreateHPIPulse/index.md
@@ -55,11 +55,11 @@ The π/2 amplitude should be approximately half of the π amplitude; fit quality
 ## Output parameters
 
 - hpi_amplitude: HPI pulse amplitude
-- hpi_length: HPI pulse length (ns)
+- hpi_duration: HPI pulse duration (ns)
 
 ## Run parameters
 
-- hpi_duration: HPI pulse length (ns)
+- hpi_duration: HPI pulse duration (ns)
 - shots: Number of shots for calibration
 - interval: Time interval for calibration (ns)
 

--- a/docs/task-knowledge/td-characterization/CheckRamsey/index.md
+++ b/docs/task-knowledge/td-characterization/CheckRamsey/index.md
@@ -57,7 +57,7 @@ T2* should satisfy T2* ≤ T2_echo. Fringe frequency should match the intended d
 
 - qubit_frequency: Loaded from DB
 - hpi_amplitude: Loaded from DB
-- hpi_length: Loaded from DB
+- hpi_duration: Loaded from DB
 - readout_amplitude: Loaded from DB
 - readout_frequency: Loaded from DB
 - readout_length: Readout pulse length (ns)

--- a/docs/task-knowledge/td-characterization/CheckT1/index.md
+++ b/docs/task-knowledge/td-characterization/CheckT1/index.md
@@ -50,7 +50,7 @@ Exponential fit should have high R²; T1 should be stable across repeated measur
 
 - qubit_frequency: Loaded from DB
 - hpi_amplitude: Loaded from DB
-- hpi_length: Loaded from DB
+- hpi_duration: Loaded from DB
 - readout_amplitude: Loaded from DB
 - readout_frequency: Loaded from DB
 - readout_length: Readout pulse length (ns)

--- a/docs/task-knowledge/td-characterization/CheckT2Echo/index.md
+++ b/docs/task-knowledge/td-characterization/CheckT2Echo/index.md
@@ -53,7 +53,7 @@ T2_echo should satisfy T2_echo ≤ 2\*T1. Compare with T2\* (Ramsey) to quantify
 
 - qubit_frequency: Loaded from DB
 - hpi_amplitude: Loaded from DB
-- hpi_length: Loaded from DB
+- hpi_duration: Loaded from DB
 - readout_amplitude: Loaded from DB
 - readout_frequency: Loaded from DB
 - readout_length: Readout pulse length (ns)

--- a/src/qdash/workflow/calibtasks/fake/__init__.py
+++ b/src/qdash/workflow/calibtasks/fake/__init__.py
@@ -27,7 +27,7 @@ Dependency Graph:
         │
         ├──> CreateHPIPulse (calibrates half-pi pulse)
         │       ├── input: qubit_frequency
-        │       └── output: hpi_amplitude, hpi_length
+        │       └── output: hpi_amplitude, hpi_duration
         │
         ├──> CheckRabi
         │       ├── input: qubit_frequency

--- a/src/qdash/workflow/calibtasks/fake/fake_create_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/fake/fake_create_hpi_pulse.py
@@ -32,7 +32,7 @@ class FakeCreateHPIPulse(FakeTask):
 
     Outputs:
         hpi_amplitude: Half-pi pulse amplitude
-        hpi_length: Half-pi pulse duration (ns)
+        hpi_duration: Half-pi pulse duration (ns)
     """
 
     name: str = "CreateHPIPulse"  # Same name as qubex task for backend-agnostic workflows
@@ -73,7 +73,7 @@ class FakeCreateHPIPulse(FakeTask):
             unit="a.u.",
             description="Half-pi pulse amplitude",
         ),
-        "hpi_length": OutputParameterSpec(
+        "hpi_duration": OutputParameterSpec(
             unit="ns",
             description="Half-pi pulse duration",
         ),
@@ -106,8 +106,8 @@ class FakeCreateHPIPulse(FakeTask):
         hpi_amplitude = base_amplitude + np.random.normal(0, 0.01)
         hpi_amplitude = max(0.15, min(0.45, hpi_amplitude))  # Clamp
 
-        # HPI length is typically fixed but can vary slightly
-        hpi_length = 20 + np.random.randint(-2, 3)  # 18-22 ns
+        # HPI duration is typically fixed but can vary slightly
+        hpi_duration = 20 + np.random.randint(-2, 3)  # 18-22 ns
 
         # Generate fake calibration data (Rabi-like oscillation)
         amplitudes = np.linspace(0.1, 0.5, 21)
@@ -119,7 +119,7 @@ class FakeCreateHPIPulse(FakeTask):
         return RunResult(
             raw_result={
                 "hpi_amplitude": hpi_amplitude,
-                "hpi_length": hpi_length,
+                "hpi_duration": hpi_duration,
                 "amplitudes": amplitudes,
                 "signal": signal,
             },
@@ -135,8 +135,8 @@ class FakeCreateHPIPulse(FakeTask):
         # Set output parameter values
         self.output_parameters["hpi_amplitude"].value = result["hpi_amplitude"]
         self.output_parameters["hpi_amplitude"].error = 0.005
-        self.output_parameters["hpi_length"].value = result["hpi_length"]
-        self.output_parameters["hpi_length"].error = 1.0
+        self.output_parameters["hpi_duration"].value = result["hpi_duration"]
+        self.output_parameters["hpi_duration"].error = 1.0
 
         output_parameters = self.attach_execution_id(execution_id)
 

--- a/src/qdash/workflow/calibtasks/qubex/base.py
+++ b/src/qdash/workflow/calibtasks/qubex/base.py
@@ -152,13 +152,13 @@ class QubexTask(BaseTask):
             role_labels = {"": self.get_qubit_label(backend, qid)}
 
         for prefix, label in role_labels.items():
-            hpi = self._resolved_input_values((f"{prefix}hpi_amplitude", f"{prefix}hpi_length"))
+            hpi = self._resolved_input_values((f"{prefix}hpi_amplitude", f"{prefix}hpi_duration"))
             if hpi is not None:
                 exp.calib_note.update_hpi_param(
                     label,
                     {
                         "target": label,
-                        "duration": hpi[f"{prefix}hpi_length"],
+                        "duration": hpi[f"{prefix}hpi_duration"],
                         "amplitude": hpi[f"{prefix}hpi_amplitude"],
                         "tau": HPI_RAMPTIME,
                     },

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_hpi_pulse.py
@@ -23,7 +23,7 @@ class CheckHPIPulse(QubexTask):
     input_spec: ClassVar[dict[str, InputParameterSpec]] = {
         "qubit_frequency": InputParameterSpec.required_database(),
         "hpi_amplitude": InputParameterSpec.required_database(),
-        "hpi_length": InputParameterSpec.required_database(),
+        "hpi_duration": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_ramsey.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_ramsey.py
@@ -28,7 +28,7 @@ class CheckRamsey(QubexTask):
     input_spec: ClassVar[dict[str, InputParameterSpec]] = {
         "qubit_frequency": InputParameterSpec.required_database(),
         "hpi_amplitude": InputParameterSpec.required_database(),
-        "hpi_length": InputParameterSpec.required_database(),
+        "hpi_duration": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1.py
@@ -28,7 +28,7 @@ class CheckT1(QubexTask):
     input_spec: ClassVar[dict[str, InputParameterSpec]] = {
         "qubit_frequency": InputParameterSpec.required_database(),
         "hpi_amplitude": InputParameterSpec.required_database(),
-        "hpi_length": InputParameterSpec.required_database(),
+        "hpi_duration": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1_average.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t1_average.py
@@ -37,7 +37,7 @@ class CheckT1Average(QubexTask):
     input_spec: ClassVar[dict[str, InputParameterSpec]] = {
         "qubit_frequency": InputParameterSpec.required_database(),
         "hpi_amplitude": InputParameterSpec.required_database(),
-        "hpi_length": InputParameterSpec.required_database(),
+        "hpi_duration": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo.py
@@ -28,7 +28,7 @@ class CheckT2Echo(QubexTask):
     input_spec: ClassVar[dict[str, InputParameterSpec]] = {
         "qubit_frequency": InputParameterSpec.required_database(),
         "hpi_amplitude": InputParameterSpec.required_database(),
-        "hpi_length": InputParameterSpec.required_database(),
+        "hpi_duration": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo_average.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_t2_echo_average.py
@@ -37,7 +37,7 @@ class CheckT2EchoAverage(QubexTask):
     input_spec: ClassVar[dict[str, InputParameterSpec]] = {
         "qubit_frequency": InputParameterSpec.required_database(),
         "hpi_amplitude": InputParameterSpec.required_database(),
-        "hpi_length": InputParameterSpec.required_database(),
+        "hpi_duration": InputParameterSpec.required_database(),
         "readout_amplitude": InputParameterSpec.required_database(),
         "readout_frequency": InputParameterSpec.required_database(),
         "readout_length": InputParameterSpec.database_or_default(

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/create_hpi_pulse.py
@@ -45,7 +45,7 @@ class CreateHPIPulse(QubexTask):
     }
     run_spec: ClassVar[dict[str, RunParameterSpec]] = {
         "hpi_duration": RunParameterSpec(
-            unit="ns", value_type="int", default=HPI_DURATION, description="HPI pulse length"
+            unit="ns", value_type="int", default=HPI_DURATION, description="HPI pulse duration"
         ),
         "shots": RunParameterSpec(
             unit="",
@@ -62,8 +62,8 @@ class CreateHPIPulse(QubexTask):
     }
     output_spec: ClassVar[dict[str, OutputParameterSpec]] = {
         "hpi_amplitude": OutputParameterSpec(unit="", description="HPI pulse amplitude"),
-        "hpi_length": OutputParameterSpec(
-            default=HPI_DURATION, unit="ns", description="HPI pulse length"
+        "hpi_duration": OutputParameterSpec(
+            default=HPI_DURATION, unit="ns", description="HPI pulse duration"
         ),
     }
 

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -317,7 +317,7 @@
       },
       {
         "class_name": "FakeCreateHPIPulse",
-        "description": "Fake task to simulate Half-Pi (HPI) pulse calibration.\n\nThis task depends on qubit_frequency from CheckFineChevron.\nIt simulates calibrating the half-pi pulse parameters.\n\nNote: Uses same name as qubex task for seamless backend switching.\n\nInputs:\n    qubit_frequency: From CheckFineChevron (loaded from DB)\n\nOutputs:\n    hpi_amplitude: Half-pi pulse amplitude\n    hpi_length: Half-pi pulse duration (ns)",
+        "description": "Fake task to simulate Half-Pi (HPI) pulse calibration.\n\nThis task depends on qubit_frequency from CheckFineChevron.\nIt simulates calibrating the half-pi pulse parameters.\n\nNote: Uses same name as qubex task for seamless backend switching.\n\nInputs:\n    qubit_frequency: From CheckFineChevron (loaded from DB)\n\nOutputs:\n    hpi_amplitude: Half-pi pulse amplitude\n    hpi_duration: Half-pi pulse duration (ns)",
         "file_path": "fake_create_hpi_pulse.py",
         "input_parameters": {
           "qubit_frequency": {
@@ -1429,7 +1429,7 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
-          "hpi_length": {
+          "hpi_duration": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -1858,7 +1858,7 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
-          "hpi_length": {
+          "hpi_duration": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2161,7 +2161,7 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
-          "hpi_length": {
+          "hpi_duration": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2226,7 +2226,7 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
-          "hpi_length": {
+          "hpi_duration": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2297,7 +2297,7 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
-          "hpi_length": {
+          "hpi_duration": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2362,7 +2362,7 @@
             "resolution": "database_required",
             "user_override": "allowed"
           },
-          "hpi_length": {
+          "hpi_duration": {
             "default_value": null,
             "resolution": "database_required",
             "user_override": "allowed"
@@ -2991,7 +2991,7 @@
         "name": "CreateHPIPulse",
         "run_parameters": {
           "hpi_duration": {
-            "description": "HPI pulse length",
+            "description": "HPI pulse duration",
             "unit": "ns",
             "value": 32,
             "value_type": "int"

--- a/src/qdash/workflow/templates/fake_backend.py
+++ b/src/qdash/workflow/templates/fake_backend.py
@@ -10,7 +10,7 @@ Backend Switching:
 
 Available Fake Tasks (same names as qubex for seamless switching):
     - CheckFineChevron: Entry point, outputs qubit_frequency, readout_frequency
-    - CreateHPIPulse: Depends on qubit_frequency, outputs hpi_amplitude, hpi_length
+    - CreateHPIPulse: Depends on qubit_frequency, outputs hpi_amplitude, hpi_duration
     - CheckRabi: Depends on qubit_frequency
     - CheckRamsey: Depends on qubit_frequency, hpi_amplitude
     - CheckT1: Depends on qubit_frequency, hpi_amplitude

--- a/tests/qdash/api/services/test_task_file_service.py
+++ b/tests/qdash/api/services/test_task_file_service.py
@@ -240,7 +240,7 @@ def test_list_task_info_includes_database_input_parameter_dependencies() -> None
     assert set(task.input_parameters) == {
         "qubit_frequency",
         "hpi_amplitude",
-        "hpi_length",
+        "hpi_duration",
         "readout_amplitude",
         "readout_frequency",
         "readout_length",

--- a/tests/qdash/workflow/calibtasks/qubex/test_base.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_base.py
@@ -430,7 +430,7 @@ class TestRestoreCalibrationContext:
         task = ConcreteQubexTask()
         task.input_parameters = {
             "hpi_amplitude": ParameterModel(value=0.12),
-            "hpi_length": ParameterModel(value=32),
+            "hpi_duration": ParameterModel(value=32),
         }
         exp = MagicMock()
         exp.get_qubit_label.return_value = "Q00"
@@ -449,9 +449,9 @@ class TestRestoreCalibrationContext:
         task = ConcreteQubexTask()
         task.input_parameters = {
             "control_hpi_amplitude": ParameterModel(value=0.12),
-            "control_hpi_length": ParameterModel(value=32),
+            "control_hpi_duration": ParameterModel(value=32),
             "target_hpi_amplitude": ParameterModel(value=0.13),
-            "target_hpi_length": ParameterModel(value=36),
+            "target_hpi_duration": ParameterModel(value=36),
         }
         exp = MagicMock()
         exp.get_qubit_label.side_effect = lambda qid: f"Q{qid:02d}"
@@ -506,10 +506,10 @@ class TestRestoreCalibrationContext:
         task = ConcreteQubexTask()
         task.input_parameters = {
             "hpi_amplitude": ParameterModel(value=0.12),
-            "hpi_length": ParameterModel(value=None),
+            "hpi_duration": ParameterModel(value=None),
         }
 
-        with pytest.raises(ValueError, match="hpi_length"):
+        with pytest.raises(ValueError, match="hpi_duration"):
             task._restore_qubit_pulse_context(MagicMock(), "0")
 
     def test_replaces_existing_cr_context_with_qdash_values(self, caplog: Any) -> None:

--- a/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_create_hpi_pulse.py
@@ -98,6 +98,12 @@ def test_preprocess_fails_explicitly_when_rabi_inputs_are_missing() -> None:
         task.preprocess(cast("QubexBackend", backend), "1")
 
 
+def test_hpi_duration_is_used_consistently_for_run_and_output_parameters() -> None:
+    assert "hpi_duration" in CreateHPIPulse.run_spec
+    assert "hpi_duration" in CreateHPIPulse.output_spec
+    assert "hpi_length" not in CreateHPIPulse.run_spec
+
+
 def test_restore_rabi_context_rejects_low_quality_database_value() -> None:
     task = _configured_task()
     task.input_parameters["rabi_r2"] = InputParameterModel(value=0.59)


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Standardize the HPI pulse parameter name on `hpi_duration` across workflow tasks, metrics, fake backend metadata, and task knowledge.
- This changes the persisted parameter key from `hpi_length`; existing stored calibration data and external flow configurations using the old key require migration.

## Changes

- Rename CreateHPIPulse output and downstream database inputs to `hpi_duration`.
- Update Qubex pulse-context restoration and fake backend behavior to use the standardized key.
- Update metrics configuration, task knowledge, and affected tests.
- Regenerate the API-facing task catalog.
- Verify 45 focused tests and Ruff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Renamed the HPI pulse parameter from `hpi_length` to `hpi_duration` across calibration tasks, metrics, task catalogs, and documentation.
  * Updated related control and target HPI duration parameter names for consistency.
  * Preserved existing units, defaults, and metadata.

* **Tests**
  * Added regression coverage confirming the new duration naming is used consistently and the previous parameter is no longer exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->