### PR TITLE
docs(workflow): clarify bring-up parameter defaults

### DIFF
--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
@@ -47,7 +47,7 @@ class CheckQubitSpectroscopy(QubexTask):
             default=None,
             description=(
                 "Frequency range as [start, stop, step] in GHz. Leave blank to use "
-                "the connected control box default. Examples: low band "
+                "the connected control box's qubex default: low band "
                 "[3.0, 5.75, 0.005], high band [6.5, 9.75, 0.005]."
             ),
         ),

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
@@ -67,7 +67,7 @@ class CheckResonatorSpectroscopy(QubexTask):
             default=None,
             description=(
                 "Frequency range as [start, stop, step] in GHz. Leave blank to use "
-                "the connected readout box default. Examples: low band "
+                "the connected readout box's qubex default: low band "
                 "[5.75, 6.75, 0.002], high band [9.75, 10.75, 0.002]."
             ),
         ),
@@ -89,7 +89,8 @@ class CheckResonatorSpectroscopy(QubexTask):
             default=[3, 0, 2, 1],
             description=(
                 "Qubit offsets in increasing resonator-frequency order. "
-                "Must contain each offset from 0 to 3 exactly once."
+                "The default is [3, 0, 2, 1]. Must contain each offset from 0 to 3 "
+                "exactly once."
             ),
         ),
     }

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -1472,7 +1472,7 @@
         "name": "CheckQubitSpectroscopy",
         "run_parameters": {
           "frequency_range": {
-            "description": "Frequency range as [start, stop, step] in GHz. Leave blank to use the connected control box default. Examples: low band [3.0, 5.75, 0.005], high band [6.5, 9.75, 0.005].",
+            "description": "Frequency range as [start, stop, step] in GHz. Leave blank to use the connected control box's qubex default: low band [3.0, 5.75, 0.005], high band [6.5, 9.75, 0.005].",
             "unit": "GHz",
             "value": null,
             "value_type": "np.arange"
@@ -1631,7 +1631,7 @@
         "name": "CheckResonatorSpectroscopy",
         "run_parameters": {
           "frequency_range": {
-            "description": "Frequency range as [start, stop, step] in GHz. Leave blank to use the connected readout box default. Examples: low band [5.75, 6.75, 0.002], high band [9.75, 10.75, 0.002].",
+            "description": "Frequency range as [start, stop, step] in GHz. Leave blank to use the connected readout box's qubex default: low band [5.75, 6.75, 0.002], high band [9.75, 10.75, 0.002].",
             "unit": "GHz",
             "value": null,
             "value_type": "np.arange"
@@ -1647,7 +1647,7 @@
             "value_type": "np.arange"
           },
           "resonator_assignment_order": {
-            "description": "Qubit offsets in increasing resonator-frequency order. Must contain each offset from 0 to 3 exactly once.",
+            "description": "Qubit offsets in increasing resonator-frequency order. The default is [3, 0, 2, 1]. Must contain each offset from 0 to 3 exactly once.",
             "unit": "",
             "value": [
               3,

--- a/src/qdash/workflow/templates/bringup.py
+++ b/src/qdash/workflow/templates/bringup.py
@@ -80,8 +80,13 @@ def bringup(
     default_run_parameters: dict[str, Any] = {
         "interval": {"value": 150 * 1024, "value_type": "int"},
         # resonator_assignment_order lists the four qid offsets within each MUX
-        # in increasing resonator-frequency order. For 16Q, the order is
-        # mux[0] < mux[3] < mux[1] < mux[2], so use [0, 3, 1, 2].
+        # in increasing resonator-frequency order. The default is [3, 0, 2, 1].
+        # For 16Q, override it with [0, 3, 1, 2] because the order is
+        # mux[0] < mux[3] < mux[1] < mux[2].
+        #
+        # CheckResonatorSpectroscopy uses the connected readout box's qubex default:
+        # low band [5.75, 6.75, 0.002] GHz or high band [9.75, 10.75, 0.002] GHz.
+        # Leave frequency_range unset to use that default, or uncomment to override it.
         # "CheckResonatorSpectroscopy": {
         #     "resonator_assignment_order": {
         #         "value": [0, 3, 1, 2],
@@ -92,6 +97,9 @@ def bringup(
         #         "value_type": "np.arange",
         #     },
         # },
+        # CheckQubitSpectroscopy uses the connected control box's qubex default:
+        # low band [3.0, 5.75, 0.005] GHz or high band [6.5, 9.75, 0.005] GHz.
+        # Leave frequency_range unset to use that default, or uncomment to override it.
         # "CheckQubitSpectroscopy": {
         #     "frequency_range": {
         #         "value": [3.0, 5.75, 0.005],


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Clarify the qubex frequency-range and resonator-assignment defaults used by bring-up calibration.
- Documentation-only workflow and Tasks page metadata changes; no API, compatibility, or configuration behavior changes.

## Changes
- Document the readout and control box frequency ranges beside their corresponding bring-up task overrides.
- Document the default resonator assignment order and distinguish the 16Q override.
- Regenerate the task catalog metadata shown on the Tasks page.