### PR TITLE
fix(ui): render forum previews with BlockNote

### DIFF
--- a/ui/src/components/features/forum/ForumBlockEditor.tsx
+++ b/ui/src/components/features/forum/ForumBlockEditor.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Image from "next/image";
-import { useEffect, useState, type MutableRefObject, type ReactNode } from "react";
+import { useEffect, useState, type MutableRefObject } from "react";
 
 import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
@@ -60,141 +59,21 @@ interface ForumBlockEditorProps {
   editable?: boolean;
 }
 
-type ForumBlock = Record<string, unknown> & {
-  type?: string;
-  props?: Record<string, unknown>;
-  content?: unknown;
-  children?: ForumBlock[];
-};
-
-type ForumInlineContent = {
-  type?: string;
-  text?: unknown;
-  href?: unknown;
-  content?: unknown;
-};
-
-function safeLinkHref(href: unknown): string | null {
-  if (typeof href !== "string") return null;
-  const value = href.trim();
-  if (value.startsWith("/") || value.startsWith("#") || /^(https?:|mailto:)/i.test(value)) {
-    return value;
-  }
-  return null;
-}
-
-function renderInlineContent(content: unknown): ReactNode {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .map((item, index) => {
-      if (typeof item === "string") return item;
-      if (!item || typeof item !== "object") return "";
-
-      const inline = item as ForumInlineContent;
-      if (inline.type === "link") {
-        const children = renderInlineContent(inline.content);
-        const href = safeLinkHref(inline.href);
-        if (!href) return children;
-        return (
-          <a
-            key={index}
-            href={href}
-            className="break-words text-primary underline underline-offset-2 hover:text-primary/80"
-          >
-            {children}
-          </a>
-        );
-      }
-
-      return typeof inline.text === "string" ? inline.text : "";
-    })
-    .filter((item) => item !== "");
-}
-
-function renderViewerBlock(block: ForumBlock, index: number) {
-  const props = block.props ?? {};
-  const content = renderInlineContent(block.content);
-  const children = Array.isArray(block.children) ? block.children : [];
-
-  if (block.type === "image") {
-    const url = typeof props.url === "string" ? props.url : "";
-    const caption = typeof props.caption === "string" ? props.caption : "";
-    const width = typeof props.previewWidth === "number" ? props.previewWidth : undefined;
-    if (!url) return null;
-    return (
-      <figure key={String(block.id ?? index)} className="my-3">
-        <Image
-          src={url}
-          alt={typeof props.name === "string" ? props.name : caption}
-          width={width ?? 800}
-          height={450}
-          unoptimized
-          style={
-            width
-              ? { width, maxWidth: "100%", height: "auto" }
-              : { maxWidth: "100%", height: "auto" }
-          }
-          className="rounded border border-base-300"
-        />
-        {caption && (
-          <figcaption className="mt-1 text-xs text-base-content/50">{caption}</figcaption>
-        )}
-      </figure>
-    );
-  }
-
-  const key = String(block.id ?? index);
-  if (block.type === "heading") {
-    const level = props.level === 1 || props.level === 2 || props.level === 3 ? props.level : 3;
-    const className = level === 1 ? "text-xl" : level === 2 ? "text-lg" : "text-base";
-    return (
-      <h3 key={key} className={`my-2 font-semibold ${className}`}>
-        {content}
-      </h3>
-    );
-  }
-  if (block.type === "bulletListItem") {
-    return (
-      <li key={key} className="ml-5 list-disc">
-        {content}
-      </li>
-    );
-  }
-  if (block.type === "numberedListItem") {
-    return (
-      <li key={key} className="ml-5 list-decimal">
-        {content}
-      </li>
-    );
-  }
-  if (block.type === "quote") {
-    return (
-      <blockquote key={key} className="my-2 border-l-2 border-base-300 pl-3 text-base-content/70">
-        {content}
-      </blockquote>
-    );
-  }
-  if (block.type === "codeBlock") {
-    return (
-      <pre key={key} className="my-2 overflow-x-auto rounded bg-base-200 p-3 text-xs">
-        <code>{content}</code>
-      </pre>
-    );
-  }
-
-  return (
-    <div key={key} className="my-1">
-      {content && <p>{content}</p>}
-      {children.length > 0 && <div className="ml-4">{children.map(renderViewerBlock)}</div>}
-    </div>
-  );
-}
-
 export function ForumBlockViewer({ blocks }: { blocks: Record<string, unknown>[] }) {
+  const colorScheme = useThemeScheme();
+  const editor = useCreateBlockNote(
+    {
+      // Use the same full schema as the editor so tables and other rich blocks
+      // render consistently in forum previews.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialContent: blocks.length > 0 ? (blocks as any) : undefined,
+    },
+    [blocks],
+  );
+
   return (
-    <div className="text-sm leading-6 text-base-content/80">
-      {(blocks as ForumBlock[]).map(renderViewerBlock)}
+    <div className="forum-blocknote wiring-blocknote">
+      <BlockNoteView editor={editor} editable={false} theme={colorScheme} />
     </div>
   );
 }

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -8,7 +8,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeft,
   CalendarDays,
-  Check,
   MessageSquare,
   Pencil,
   Crosshair,
@@ -25,7 +24,6 @@ import {
   getGetForumPostQueryKey,
   getGetForumPostRepliesQueryKey,
   getListForumPostsQueryKey,
-  useCloseForumPost,
   useCreateForumPost,
   useDeleteForumPost,
   useGetForumPost,
@@ -135,7 +133,6 @@ function PostBody({
   canEdit: canEditOverride,
   onEdit,
   onDelete,
-  postAction = "delete",
   editing,
   editContent,
   editInitialBlocks,
@@ -153,7 +150,6 @@ function PostBody({
   canEdit?: boolean;
   onEdit: () => void;
   onDelete?: () => void;
-  postAction?: "delete" | "close";
   editing: boolean;
   /** Current markdown projection — used only to gate the Save button. */
   editContent: string;
@@ -169,8 +165,6 @@ function PostBody({
 }) {
   const canEdit = canEditOverride ?? currentUsername === post.username;
   const isAi = post.is_ai_reply || post.username === "qdash";
-  const ActionIcon = postAction === "close" ? Check : Trash2;
-  const actionTitle = postAction === "close" ? "Close thread" : "Delete";
 
   return (
     <div
@@ -195,7 +189,7 @@ function PostBody({
             <span className="text-xs italic text-base-content/30">(edited)</span>
           )}
         </div>
-        {canEdit && !editing && !isAi && onDelete && (
+        {canEdit && !editing && !isAi && (
           <div className="flex items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
@@ -210,21 +204,21 @@ function PostBody({
               </TooltipTrigger>
               <TooltipContent>Edit</TooltipContent>
             </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  className={`btn btn-ghost btn-sm btn-square text-base-content/40 ${
-                    postAction === "close" ? "hover:text-primary" : "hover:text-error"
-                  }`}
-                  onClick={onDelete}
-                  aria-label={actionTitle}
-                >
-                  <ActionIcon className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>{actionTitle}</TooltipContent>
-            </Tooltip>
+            {onDelete && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-sm btn-square text-base-content/40 hover:text-error"
+                    onClick={onDelete}
+                    aria-label="Delete"
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>Delete</TooltipContent>
+              </Tooltip>
+            )}
           </div>
         )}
       </div>
@@ -378,7 +372,6 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   const createMutation = useCreateForumPost();
   const updateMutation = useUpdateForumPost();
   const deleteMutation = useDeleteForumPost();
-  const closeMutation = useCloseForumPost();
   const {
     isGenerating,
     statusMessage: aiStatus,
@@ -739,12 +732,6 @@ export function ForumDetailPage({ postId }: { postId: string }) {
             currentUsername={currentUsername}
             canEdit={canManage}
             onEdit={handleStartEditRoot}
-            onDelete={
-              isTerminal
-                ? undefined
-                : () => closeMutation.mutate({ postId }, { onSuccess: invalidateThread })
-            }
-            postAction="close"
             editing={editingRoot}
             editContent={editRootContent}
             editInitialBlocks={editRootBlocks}

--- a/ui/src/components/features/forum/__tests__/ForumBlockEditor.test.tsx
+++ b/ui/src/components/features/forum/__tests__/ForumBlockEditor.test.tsx
@@ -54,4 +54,55 @@ describe("ForumBlockViewer", () => {
     expect(screen.getByText("unsafe link")).toBeTruthy();
     expect(screen.queryByRole("link")).toBeNull();
   });
+
+  it("renders BlockNote tables in read-only previews", () => {
+    render(
+      <ForumBlockViewer
+        blocks={[
+          {
+            id: "table-1",
+            type: "table",
+            props: { textColor: "default" },
+            content: {
+              type: "tableContent",
+              columnWidths: [120, 120],
+              rows: [
+                {
+                  cells: [
+                    {
+                      type: "tableCell",
+                      props: {
+                        backgroundColor: "default",
+                        textColor: "default",
+                        textAlignment: "left",
+                        colspan: 1,
+                        rowspan: 1,
+                      },
+                      content: [{ type: "text", text: "Qubit", styles: {} }],
+                    },
+                    {
+                      type: "tableCell",
+                      props: {
+                        backgroundColor: "default",
+                        textColor: "default",
+                        textAlignment: "left",
+                        colspan: 1,
+                        rowspan: 1,
+                      },
+                      content: [{ type: "text", text: "Frequency", styles: {} }],
+                    },
+                  ],
+                },
+              ],
+            },
+            children: [],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("table")).toBeTruthy();
+    expect(screen.getByText("Qubit")).toBeTruthy();
+    expect(screen.getByText("Frequency")).toBeTruthy();
+  });
 });

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -8,3 +8,17 @@ class ResizeObserverMock implements ResizeObserver {
 
 globalThis.ResizeObserver = ResizeObserverMock;
 HTMLElement.prototype.scrollIntoView = () => undefined;
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Render forum post previews with BlockNote's read-only view so rich blocks such as tables remain visible.
- Simplify the forum thread header by keeping status changes in the sidebar and removing the duplicate Close thread action. This affects the forum UI only; there are no API, schema, configuration, or generated-client changes.

## Changes

- Replace the custom ForumBlockViewer renderer with a read-only BlockNoteView using the full default block schema.
- Preserve link safety behavior and add regression coverage for BlockNote tables.
- Remove the root post's top Close thread action while retaining Edit and reply Delete actions.
- Add a matchMedia test polyfill required by the Mantine-backed BlockNote view.

## Verification

- bun run test:run src/components/features/forum/__tests__/ForumBlockEditor.test.tsx
- bunx oxlint src/components/features/forum/ForumDetailPage.tsx src/components/features/forum/ForumBlockEditor.tsx src/components/features/forum/__tests__/ForumBlockEditor.test.tsx vitest.setup.ts
- bunx oxfmt --check src/components/features/forum/ForumDetailPage.tsx src/components/features/forum/ForumBlockEditor.tsx src/components/features/forum/__tests__/ForumBlockEditor.test.tsx vitest.setup.ts
- bunx tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved forum content previews with consistent read-only rendering, including support for tables and color schemes.
  - Removed the forum-post close action from the detail view.

- **Bug Fixes**
  - Forum block previews now correctly display structured content and table cell text.

- **Tests**
  - Added coverage for rendering tables in read-only forum previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->