### PR TITLE
feat(ui): add task-oriented home page

### DIFF
--- a/docs/development/ui/architecture.md
+++ b/docs/development/ui/architecture.md
@@ -31,7 +31,8 @@ src/app/
 │   │   ├── page.tsx            # /forum
 │   │   └── [postId]/page.tsx   # /forum/:postId
 │   ├── import/page.tsx         # /import
-│   ├── inbox/page.tsx          # /inbox (default landing page)
+│   ├── home/page.tsx           # /home (default landing page)
+│   ├── inbox/page.tsx          # /inbox
 │   ├── issue-knowledge/
 │   │   ├── page.tsx            # /issue-knowledge
 │   │   └── [knowledgeId]/page.tsx # /issue-knowledge/:knowledgeId
@@ -58,7 +59,7 @@ src/app/
 ├── api/                        # Next.js route handlers and proxy endpoints
 ├── globals.css                 # Global styles
 ├── layout.tsx                  # Root layout
-├── page.tsx                    # / (redirects to /inbox)
+├── page.tsx                    # / (redirects to /home)
 └── providers.tsx               # Provider composition
 ```
 
@@ -68,8 +69,8 @@ Route groups (parenthesized folders) organize routes without affecting URLs:
 
 ```tsx
 // (auth) group - requires authentication
-// File: src/app/(auth)/inbox/page.tsx
-// URL: /inbox (not /auth/inbox)
+// File: src/app/(auth)/home/page.tsx
+// URL: /home (not /auth/home)
 
 // (public) group - no authentication required
 // File: src/app/(public)/login/page.tsx

--- a/docs/development/ui/guidelines.md
+++ b/docs/development/ui/guidelines.md
@@ -47,7 +47,8 @@ ui/
 │   │   │   ├── chip/           # Chip management
 │   │   │   ├── execution/      # Execution monitoring
 │   │   │   ├── files/          # File management
-│   │   │   ├── inbox/          # Inbox (default landing page)
+│   │   │   ├── home/           # Home (default landing page)
+│   │   │   ├── inbox/          # Notification inbox
 │   │   │   ├── issues/         # Issue tracking
 │   │   │   ├── metrics/        # Metrics dashboard
 │   │   │   ├── provenance/     # Data provenance
@@ -60,7 +61,7 @@ ui/
 │   │   ├── api/                # API route handlers (SSE streaming)
 │   │   ├── globals.css         # Global styles
 │   │   ├── layout.tsx          # Root layout
-│   │   ├── page.tsx            # Root page (redirects to /inbox)
+│   │   ├── page.tsx            # Root page (redirects to /home)
 │   │   └── providers.tsx       # Provider composition
 │   ├── client/                 # Auto-generated API client (DO NOT EDIT)
 │   ├── components/             # Reusable components

--- a/docs/development/ui/testing.md
+++ b/docs/development/ui/testing.md
@@ -236,7 +236,7 @@ task dev-local
 
 Verify the following per page during manual testing:
 
-- **Authentication** — login, redirect to `/inbox`, protected routes redirect to `/login`, logout clears session
+- **Authentication** — login, redirect to `/home`, protected routes redirect to `/login`, logout clears session
 - **Metrics** (`/metrics`) — page loads, chip selector, visualizations, time range
 - **Chip** (`/chip`) — list loads, details page, qubit grid, task results
 - **Execution** (`/execution`) — list loads, details, real-time updates

--- a/docs/user-guide/application-tour.md
+++ b/docs/user-guide/application-tour.md
@@ -19,7 +19,7 @@ See [Projects and Sharing](./projects-and-sharing.md) for membership and role de
 
 | Page | Purpose |
 | --- | --- |
-| **Inbox** | Review mentions, replies, and system notifications. |
+| **Home** | Start common work and review active executions, failed tasks, and recent notifications. |
 | **Dashboard** | Scan all configured chip metrics, coverage, distributions, and scoped notes. |
 | **Metrics** | Inspect one metric across qubits or couplings and compare its history. |
 | **Chip** | Browse calibration tasks and the latest results on the chip topology. |
@@ -47,6 +47,7 @@ permission. See [Running Calibrations](./running-calibrations.md) for the end-to
 
 | Page | Purpose |
 | --- | --- |
+| **Inbox** | Review mentions, replies, and system notifications. |
 | **Issues** | Track and discuss a problem attached to a task result. |
 | **Forum** | Hold project-wide discussions that are not tied to one result. |
 | **Knowledge** | Reuse curated cases derived from resolved issues. |

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "ui",
   "version": "0.0.0",
   "private": true,
-  "homepage": "/inbox",
+  "homepage": "/home",
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build --turbo",

--- a/ui/src/app/(auth)/home/page.tsx
+++ b/ui/src/app/(auth)/home/page.tsx
@@ -1,0 +1,5 @@
+import { HomePageContent } from "@/components/features/home/HomePageContent";
+
+export default function HomePage() {
+  return <HomePageContent />;
+}

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function Home() {
-  redirect("/inbox");
+  redirect("/home");
 }

--- a/ui/src/components/features/home/HomePageContent.tsx
+++ b/ui/src/components/features/home/HomePageContent.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import Link from "next/link";
+import {
+  AlertCircle,
+  ArrowRight,
+  CheckCircle2,
+  ClipboardList,
+  Gauge,
+  MessageSquare,
+  Play,
+  Workflow,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { useGetExecutionLockStatus } from "@/client/execution/execution";
+import { useListTaskResults } from "@/client/task-result/task-result";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { PageContainer } from "@/components/ui/PageContainer";
+import { PageHeader } from "@/components/ui/PageHeader";
+import { useProject } from "@/contexts/ProjectContext";
+import { useNotificationActions, useNotifications } from "@/hooks/useNotifications";
+import { formatRelativeTime } from "@/lib/utils/datetime";
+import type { NotificationResponse } from "@/schemas";
+
+const ACTIVE_STATUSES = new Set(["scheduled", "pending", "running"]);
+
+interface SectionHeadingProps {
+  title: string;
+  description: string;
+  href?: string;
+  linkLabel?: string;
+}
+
+interface QuickActionsProps {
+  canEdit: boolean;
+}
+
+interface QuickAction {
+  href: string;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+function SectionHeading({ title, description, href, linkLabel }: SectionHeadingProps) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <p className="mt-0.5 text-sm text-base-content/60">{description}</p>
+      </div>
+      {href && linkLabel && (
+        <Link href={href} className="btn btn-ghost btn-sm shrink-0 gap-1">
+          {linkLabel}
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function QuickActions({ canEdit }: QuickActionsProps) {
+  const actions: QuickAction[] = [
+    ...(canEdit
+      ? [
+          {
+            href: "/tasks",
+            label: "Run a task",
+            description: "Start a calibration task",
+            icon: Play,
+          },
+          {
+            href: "/workflow",
+            label: "Open workflows",
+            description: "Create or run a workflow",
+            icon: Workflow,
+          },
+        ]
+      : []),
+    {
+      href: "/dashboard",
+      label: "View dashboard",
+      description: "Check overall chip health",
+      icon: Gauge,
+    },
+    {
+      href: "/task-results",
+      label: "Find task results",
+      description: "Investigate recent outcomes",
+      icon: ClipboardList,
+    },
+  ];
+
+  return (
+    <section aria-labelledby="quick-actions-heading">
+      <h2 id="quick-actions-heading" className="mb-3 text-sm font-semibold text-base-content/60">
+        Quick actions
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {actions.map(({ href, label, description, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            className="card card-interactive border border-base-300 bg-base-100 shadow-sm"
+          >
+            <div className="card-body flex-row items-center gap-3 p-4">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Icon className="h-5 w-5" />
+              </span>
+              <span className="min-w-0">
+                <span className="block font-semibold">{label}</span>
+                <span className="block text-xs text-base-content/55">{description}</span>
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RecentNotifications() {
+  const { data, isLoading, error } = useNotifications(false);
+  const { markRead } = useNotificationActions();
+  const notifications = (data?.data.notifications ?? []).slice(0, 5);
+
+  const handleOpen = (notification: NotificationResponse) => {
+    if (notification.read_at == null) {
+      markRead.mutate({ notificationId: notification.id });
+    }
+  };
+
+  return (
+    <section className="card bg-base-200 shadow-lg">
+      <div className="card-body gap-4 p-5">
+        <SectionHeading
+          title="Recent notifications"
+          description="Mentions and replies from your project"
+          href="/inbox"
+          linkLabel="View inbox"
+        />
+        {isLoading ? (
+          <div className="flex justify-center py-10">
+            <span className="loading loading-spinner loading-md" />
+          </div>
+        ) : error ? (
+          <div className="alert alert-error py-3 text-sm">Failed to load notifications.</div>
+        ) : notifications.length === 0 ? (
+          <EmptyState
+            title="You are all caught up"
+            description="New mentions and replies will appear here."
+            emoji="check"
+            size="sm"
+            className="rounded-lg bg-base-100/60 px-4"
+          />
+        ) : (
+          <div className="divide-y divide-base-300">
+            {notifications.map((notification) => (
+              <Link
+                key={notification.id}
+                href={notification.target_url}
+                onClick={() => handleOpen(notification)}
+                className="flex gap-3 py-3 first:pt-0 last:pb-0 hover:text-primary"
+              >
+                <span
+                  className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
+                    notification.read_at == null
+                      ? "bg-primary text-primary-content"
+                      : "bg-base-200 text-base-content/55"
+                  }`}
+                >
+                  <MessageSquare className="h-4 w-4" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="line-clamp-1 block text-sm font-medium">
+                    {notification.title}
+                  </span>
+                  {notification.excerpt && (
+                    <span className="mt-0.5 line-clamp-1 block text-xs text-base-content/55">
+                      {notification.excerpt}
+                    </span>
+                  )}
+                  <span className="mt-1 block text-xs text-base-content/50">
+                    {notification.actor_username} · {formatRelativeTime(notification.created_at)}
+                  </span>
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export function HomePageContent() {
+  const { canEdit } = useProject();
+  const { data: lockResponse, isLoading: lockLoading } = useGetExecutionLockStatus({
+    query: { refetchInterval: 5000, refetchIntervalInBackground: true },
+  });
+  const {
+    data: failedResponse,
+    isLoading: failedLoading,
+    error: failedError,
+  } = useListTaskResults(
+    { status: "failed", limit: 5 },
+    { query: { staleTime: 15_000, refetchInterval: 60_000 } },
+  );
+
+  const lock = lockResponse?.data;
+  const isRunning = Boolean(lock?.lock && lock.status && ACTIVE_STATUSES.has(lock.status));
+  const executionHref =
+    lock?.chip_id && lock.execution_id
+      ? `/execution/${encodeURIComponent(lock.chip_id)}/${encodeURIComponent(lock.execution_id)}`
+      : "/execution";
+  const failedResults = failedResponse?.data.items ?? [];
+
+  return (
+    <PageContainer maxWidth>
+      <PageHeader title="Home" description="Start work and review what needs your attention" />
+
+      <div className="space-y-6">
+        <QuickActions canEdit={canEdit} />
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">
+          <div className="space-y-6">
+            <section className="card bg-base-200 shadow-lg">
+              <div className="card-body gap-4 p-5">
+                <SectionHeading
+                  title="Current execution"
+                  description="The calibration currently running in this project"
+                  href="/execution"
+                  linkLabel="All executions"
+                />
+                {lockLoading ? (
+                  <div className="skeleton h-24 w-full" />
+                ) : isRunning ? (
+                  <Link
+                    href={executionHref}
+                    className="flex items-center gap-4 rounded-lg border border-info/30 bg-info/10 p-4 transition-colors hover:bg-info/15"
+                  >
+                    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-info text-info-content">
+                      <span className="loading loading-spinner loading-sm" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-semibold">
+                        {lock?.name || "Calibration execution"}
+                      </span>
+                      <span className="mt-1 flex flex-wrap gap-x-3 text-xs text-base-content/60">
+                        <span className="capitalize">{lock?.status}</span>
+                        {lock?.chip_id && <span>Chip {lock.chip_id}</span>}
+                      </span>
+                    </span>
+                    <ArrowRight className="h-5 w-5 shrink-0" />
+                  </Link>
+                ) : (
+                  <div className="flex items-center gap-3 rounded-lg bg-base-100/60 p-4">
+                    <CheckCircle2 className="h-6 w-6 shrink-0 text-success" />
+                    <div>
+                      <p className="font-medium">No calibration is running</p>
+                      <p className="text-sm text-base-content/55">
+                        This project is ready for the next run.
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </section>
+
+            <section className="card bg-base-200 shadow-lg">
+              <div className="card-body gap-4 p-5">
+                <SectionHeading
+                  title="Needs attention"
+                  description="Recent failed task results to investigate"
+                  href="/task-results?status=failed"
+                  linkLabel="View failures"
+                />
+                {failedLoading ? (
+                  <div className="space-y-2">
+                    <div className="skeleton h-16 w-full" />
+                    <div className="skeleton h-16 w-full" />
+                  </div>
+                ) : failedError ? (
+                  <div className="alert alert-error py-3 text-sm">Failed to load task results.</div>
+                ) : failedResults.length === 0 ? (
+                  <div className="flex items-center gap-3 rounded-lg bg-base-100/60 p-4">
+                    <CheckCircle2 className="h-6 w-6 shrink-0 text-success" />
+                    <div>
+                      <p className="font-medium">No failed task results</p>
+                      <p className="text-sm text-base-content/55">
+                        There is nothing waiting for investigation.
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="divide-y divide-base-300">
+                    {failedResults.map((result) => (
+                      <Link
+                        key={result.task_id}
+                        href={`/task-results/${encodeURIComponent(result.task_id)}`}
+                        className="flex items-center gap-3 py-3 first:pt-0 last:pb-0 hover:text-error"
+                      >
+                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-error/10 text-error">
+                          <AlertCircle className="h-5 w-5" />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-semibold">
+                            {result.task_name}
+                          </span>
+                          <span className="mt-0.5 block truncate text-xs text-base-content/55">
+                            {result.qid} · {result.chip_id}
+                            {result.message ? ` · ${result.message}` : ""}
+                          </span>
+                        </span>
+                        {result.start_at && (
+                          <span className="hidden shrink-0 text-xs text-base-content/50 sm:block">
+                            {formatRelativeTime(result.start_at)}
+                          </span>
+                        )}
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </section>
+          </div>
+
+          <RecentNotifications />
+        </div>
+      </div>
+    </PageContainer>
+  );
+}

--- a/ui/src/components/features/home/__tests__/HomePageContent.test.tsx
+++ b/ui/src/components/features/home/__tests__/HomePageContent.test.tsx
@@ -1,0 +1,120 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HomePageContent } from "@/components/features/home/HomePageContent";
+
+const mockExecutionLock = vi.hoisted(() => vi.fn());
+const mockTaskResults = vi.hoisted(() => vi.fn());
+const mockNotifications = vi.hoisted(() => vi.fn());
+
+vi.mock("@/client/execution/execution", () => ({
+  useGetExecutionLockStatus: mockExecutionLock,
+}));
+
+vi.mock("@/client/task-result/task-result", () => ({
+  useListTaskResults: mockTaskResults,
+}));
+
+vi.mock("@/contexts/ProjectContext", () => ({
+  useProject: () => ({ canEdit: true }),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useNotifications: mockNotifications,
+  useNotificationActions: () => ({ markRead: { mutate: vi.fn() } }),
+}));
+
+describe("HomePageContent", () => {
+  beforeEach(() => {
+    mockExecutionLock.mockReturnValue({
+      data: {
+        data: {
+          lock: true,
+          execution_id: "execution-1",
+          chip_id: "chip-1",
+          name: "Daily calibration",
+          status: "running",
+        },
+      },
+      isLoading: false,
+    });
+    mockTaskResults.mockReturnValue({
+      data: {
+        data: {
+          items: [
+            {
+              task_id: "task-1",
+              task_name: "CheckRabi",
+              qid: "Q0",
+              chip_id: "chip-1",
+              status: "failed",
+              execution_id: "execution-1",
+              message: "Fit failed",
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+    mockNotifications.mockReturnValue({
+      data: {
+        data: {
+          notifications: [
+            {
+              id: "notification-1",
+              kind: "forum_reply",
+              title: "A new reply",
+              excerpt: "Please review this result",
+              actor_username: "alice",
+              created_at: new Date().toISOString(),
+              target_url: "/forum/post-1",
+              read_at: null,
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("summarizes active work and items that need attention", () => {
+    render(<HomePageContent />);
+
+    expect(screen.getByRole("heading", { name: "Home" })).toBeTruthy();
+    expect(screen.getByText("Daily calibration")).toBeTruthy();
+    expect(screen.getByText("CheckRabi")).toBeTruthy();
+    expect(screen.getByText("A new reply")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Run a task/ }).getAttribute("href")).toBe("/tasks");
+    expect(screen.getByRole("link", { name: /View inbox/ }).getAttribute("href")).toBe("/inbox");
+  });
+
+  it("shows calm empty states when no work is waiting", () => {
+    mockExecutionLock.mockReturnValue({
+      data: { data: { lock: false } },
+      isLoading: false,
+    });
+    mockTaskResults.mockReturnValue({
+      data: { data: { items: [] } },
+      isLoading: false,
+      error: null,
+    });
+    mockNotifications.mockReturnValue({
+      data: { data: { notifications: [] } },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<HomePageContent />);
+
+    expect(screen.getByText("No calibration is running")).toBeTruthy();
+    expect(screen.getByText("No failed task results")).toBeTruthy();
+    expect(screen.getByText("You are all caught up")).toBeTruthy();
+  });
+});

--- a/ui/src/components/layout/navigation.ts
+++ b/ui/src/components/layout/navigation.ts
@@ -10,6 +10,7 @@ import {
   Cpu,
   Database,
   Files,
+  House,
   Inbox,
   LayoutDashboard,
   LayoutGrid,
@@ -52,7 +53,7 @@ export function getNavigationSections({
     {
       label: "Overview",
       items: [
-        { href: "/inbox", label: "Inbox", icon: Inbox, badge: unreadNotifications },
+        { href: "/home", label: "Home", icon: House },
         { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
         { href: "/metrics", label: "Metrics", icon: LayoutGrid },
         { href: "/chip", label: "Chip", icon: Cpu },
@@ -71,7 +72,12 @@ export function getNavigationSections({
           visible: canEdit,
         },
         { href: "/execution", label: "Execution", icon: Zap },
-        { href: "/task-results", label: "Task Results", icon: ClipboardList, match: "prefix" },
+        {
+          href: "/task-results",
+          label: "Task Results",
+          icon: ClipboardList,
+          match: "prefix",
+        },
         { href: "/tasks", label: "Tasks", icon: ListTodo, visible: canEdit },
         { href: "/cryo", label: "Cryo", icon: Snowflake },
         { href: "/import", label: "Calibration DB", icon: Database },
@@ -80,17 +86,49 @@ export function getNavigationSections({
     {
       label: "Collaborate",
       items: [
+        {
+          href: "/inbox",
+          label: "Inbox",
+          icon: Inbox,
+          badge: unreadNotifications,
+        },
         { href: "/issues", label: "Issues", icon: CircleDot, match: "prefix" },
-        { href: "/forum", label: "Forum", icon: MessagesSquare, match: "prefix" },
-        { href: "/issue-knowledge", label: "Knowledge", icon: Brain, match: "prefix" },
-        { href: "/ai-reviews", label: "AI Reviews", icon: ClipboardCheck, match: "prefix" },
-        { href: "/task-knowledge", label: "Task Knowledge", icon: BookMarked, match: "prefix" },
+        {
+          href: "/forum",
+          label: "Forum",
+          icon: MessagesSquare,
+          match: "prefix",
+        },
+        {
+          href: "/issue-knowledge",
+          label: "Knowledge",
+          icon: Brain,
+          match: "prefix",
+        },
+        {
+          href: "/ai-reviews",
+          label: "AI Reviews",
+          icon: ClipboardCheck,
+          match: "prefix",
+        },
+        {
+          href: "/task-knowledge",
+          label: "Task Knowledge",
+          icon: BookMarked,
+          match: "prefix",
+        },
       ],
     },
     {
       label: "Manage",
       items: [
-        { href: "/files", label: "Files", icon: Files, match: "prefix", visible: canEdit },
+        {
+          href: "/files",
+          label: "Files",
+          icon: Files,
+          match: "prefix",
+          visible: canEdit,
+        },
         { href: "/settings", label: "Settings", icon: Settings },
         { href: "/admin", label: "Admin", icon: ShieldCheck, visible: isAdmin },
       ],


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add a dedicated Home page that surfaces active calibration work, failed task results, recent notifications, and common actions.
- Make Home the default landing page while keeping Inbox as the full notification view; UI-only change with no API or configuration compatibility impact.

## Changes
- Add `HomePageContent` with permission-aware quick actions, current execution status, recent failures, and notification summaries.
- Add the authenticated `/home` route and redirect `/` to it.
- Move Inbox to the Collaborate navigation section while preserving its unread badge.
- Add Home page tests and update UI architecture, testing, and application tour documentation.
- No OpenAPI, schema, or generated client changes.

## Verification
- `bun run lint`
- `bunx tsc --noEmit`
- `bun run test:run src/components/features/home/__tests__/HomePageContent.test.tsx src/components/layout/__tests__/GlobalCommandPalette.test.tsx`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Home page with quick actions, recent notifications, execution status, and failed task results.
  * Added navigation links for Home and Inbox in their updated sections.
  * The default landing page now opens at `/home`.

* **Documentation**
  * Updated architecture, development, testing, and user-guide documentation to reflect the new Home landing page and navigation.

* **Tests**
  * Added coverage for Home page activity, notifications, navigation, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->