### PR TITLE
feat(ui): add guided chip setup tour

### DIFF
--- a/docs/user-guide/application-tour.md
+++ b/docs/user-guide/application-tour.md
@@ -29,6 +29,11 @@ See [Projects and Sharing](./projects-and-sharing.md) for membership and role de
 Use **Dashboard** for broad health checks, **Metrics** for a parameter-focused investigation, and
 **Chip** when the calibration task or physical target is the starting point.
 
+When a project has no chips, Home highlights the **Setup tour** for project editors. After a chip
+exists, the tour remains available as a compact Home action for replay. It opens the Chip page,
+points to the creation action, and explains the chip ID and topology fields without creating data
+until the form is submitted.
+
 ## Operate
 
 | Page | Purpose |

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -24,6 +24,7 @@
         "dagre": "^0.8.5",
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
+        "driver.js": "^1.8.0",
         "lucide-react": "^1.26.0",
         "mermaid": "^11.16.1",
         "next": "^16.2.11",
@@ -967,6 +968,8 @@
     "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "dompurify": ["dompurify@3.4.14", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg=="],
+
+    "driver.js": ["driver.js@1.8.0", "", {}, "sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -37,6 +37,7 @@
     "dagre": "^0.8.5",
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
+    "driver.js": "^1.8.0",
     "lucide-react": "^1.26.0",
     "mermaid": "^11.16.1",
     "next": "^16.2.11",

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -1549,3 +1549,47 @@ html[data-theme="dark"],
 .animate-fade-in-up {
   animation: fadeInUp 0.3s ease-out;
 }
+
+/* Driver.js product tours, themed to match DaisyUI. */
+.driver-popover.qdash-tour-popover {
+  max-width: 22rem;
+  border: 1px solid var(--color-base-300);
+  border-radius: 1rem;
+  background: var(--color-base-100);
+  color: var(--color-base-content);
+  box-shadow: 0 20px 25px -5px color-mix(in oklch, var(--color-base-content) 14%, transparent);
+}
+
+.driver-popover.qdash-tour-popover .driver-popover-title {
+  color: var(--color-base-content);
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.driver-popover.qdash-tour-popover .driver-popover-description,
+.driver-popover.qdash-tour-popover .driver-popover-progress-text {
+  color: color-mix(in oklch, var(--color-base-content) 65%, transparent);
+  font-family: inherit;
+}
+
+.driver-popover.qdash-tour-popover button {
+  border: 1px solid var(--color-base-300);
+  border-radius: 0.5rem;
+  background: var(--color-base-200);
+  color: var(--color-base-content);
+  font-family: inherit;
+  text-shadow: none;
+}
+
+.driver-popover.qdash-tour-popover .driver-popover-next-btn {
+  border-color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-primary-content);
+}
+
+.driver-popover.qdash-tour-popover .driver-popover-close-btn {
+  border: 0;
+  background: transparent;
+  color: var(--color-base-content);
+}

--- a/ui/src/components/features/chip/ChipCreationTour.tsx
+++ b/ui/src/components/features/chip/ChipCreationTour.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { driver } from "driver.js";
+import type { Config, DriveStep } from "driver.js";
+import "driver.js/dist/driver.css";
+
+interface ChipCreationTourProps {
+  active: boolean;
+  completed: boolean;
+  restartKey: number;
+  onDismiss: () => void;
+}
+
+const POPOVER_CLASS = "qdash-tour-popover";
+
+export function getChipCreationTourSteps(): DriveStep[] {
+  return [
+    {
+      popover: {
+        title: "Create your first chip",
+        description:
+          "A chip identifies the device whose calibration data and task results QDash will track.",
+      },
+    },
+    {
+      element: '[data-tour="create-chip"]',
+      advanceOnClick: true,
+      popover: {
+        title: "Open the chip form",
+        description: "Select Create Chip to enter the device ID and topology.",
+        side: "bottom",
+        align: "end",
+        showButtons: ["previous", "close"],
+      },
+    },
+    {
+      element: "#chip-id-input",
+      waitForElement: 3000,
+      popover: {
+        title: "Name the chip",
+        description: "Enter a unique ID used to identify this device across QDash.",
+        side: "right",
+        align: "start",
+      },
+    },
+    {
+      element: "#topology-select",
+      waitForElement: 3000,
+      popover: {
+        title: "Choose a topology",
+        description: "Select the template that matches the chip layout and number of qubits.",
+        side: "right",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="submit-chip"]',
+      waitForElement: 3000,
+      popover: {
+        title: "Create the chip",
+        description: "Review the values, then select Create Chip to finish.",
+        side: "top",
+        align: "end",
+        showButtons: ["previous", "close"],
+      },
+    },
+  ];
+}
+
+function getTourConfig(onDismiss: () => void): Config {
+  return {
+    animate: true,
+    smoothScroll: true,
+    allowClose: true,
+    allowScroll: true,
+    disableActiveInteraction: false,
+    showProgress: true,
+    progressText: "{{current}} of {{total}}",
+    nextBtnText: "Next",
+    prevBtnText: "Back",
+    doneBtnText: "Done",
+    popoverClass: POPOVER_CLASS,
+    stagePadding: 6,
+    stageRadius: 10,
+    onCloseClick: (_element, _step, { driver: tour }) => {
+      tour.destroy();
+      onDismiss();
+    },
+  };
+}
+
+export function ChipCreationTour({
+  active,
+  completed,
+  restartKey,
+  onDismiss,
+}: ChipCreationTourProps) {
+  useEffect(() => {
+    if (!active) return;
+
+    const tour = driver(getTourConfig(onDismiss));
+
+    if (completed) {
+      tour.setSteps([
+        {
+          popover: {
+            title: "Chip created",
+            description: "Your chip is ready. You can now select it and begin calibration work.",
+            doneBtnText: "Finish",
+            onDoneClick: (_element, _step, { driver: completedTour }) => {
+              completedTour.destroy();
+              onDismiss();
+            },
+          },
+        },
+      ]);
+      tour.drive();
+      return () => tour.destroy();
+    }
+
+    tour.setSteps(getChipCreationTourSteps());
+    tour.drive(restartKey > 0 ? 1 : 0);
+
+    return () => tour.destroy();
+  }, [active, completed, onDismiss, restartKey]);
+
+  return null;
+}

--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import React, { useState, useEffect, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
 
 import { keepPreviousData } from "@tanstack/react-query";
-import { Bot } from "lucide-react";
+import { Bot, Plus } from "lucide-react";
 
 import { dateToDateTimeLocal, formatDateTime, toIsoSeconds } from "@/lib/utils/datetime";
 
 import { CouplingGrid } from "./CouplingGrid";
 import { QubitGrid } from "./QubitGrid";
 import { ChipManageModal } from "./ChipManageModal";
+import { ChipCreationTour } from "./ChipCreationTour";
 import { getAiReviewBadgeState, type AiReviewBadgeState } from "./aiReviewBadge";
 import { CreateChipModal } from "./modals/CreateChipModal";
 
@@ -51,7 +52,9 @@ function dateKeyToRange(dateKey: string): { start: string; end: string } {
 
 export function ChipPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { canEdit } = useProject();
+  const tutorialActive = canEdit && searchParams.get("tutorial") === "create-chip";
   // URL state management
   const {
     selectedChip,
@@ -131,6 +134,36 @@ export function ChipPageContent() {
   const [selectedTaskInfo, setSelectedTaskInfo] = useState<SelectedTaskInfo | null>(null);
   const [isCreateChipModalOpen, setIsCreateChipModalOpen] = useState(false);
   const [isManageChipModalOpen, setIsManageChipModalOpen] = useState(false);
+  const [tutorialCompleted, setTutorialCompleted] = useState(false);
+  const [tutorialRestartKey, setTutorialRestartKey] = useState(0);
+  const tutorialJustCompleted = useRef(false);
+
+  useEffect(() => {
+    if (tutorialActive) {
+      setTutorialCompleted(false);
+      setTutorialRestartKey(0);
+    }
+  }, [tutorialActive]);
+
+  const finishTutorial = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("tutorial");
+    const query = params.toString();
+    router.replace(query ? `/chip?${query}` : "/chip", { scroll: false });
+  }, [router, searchParams]);
+
+  const openCreateChipModal = () => {
+    setIsCreateChipModalOpen(true);
+  };
+
+  const closeCreateChipModal = () => {
+    setIsCreateChipModalOpen(false);
+    if (tutorialJustCompleted.current) {
+      tutorialJustCompleted.current = false;
+    } else if (tutorialActive) {
+      setTutorialRestartKey((current) => current + 1);
+    }
+  };
 
   // Track previous date to distinguish modal navigation from external navigation
   const [previousDate, setPreviousDate] = useState(selectedDate);
@@ -417,22 +450,10 @@ export function ChipPageContent() {
                   )}
                   <button
                     className="btn btn-primary btn-sm w-fit"
-                    onClick={() => setIsCreateChipModalOpen(true)}
+                    onClick={openCreateChipModal}
+                    data-tour="create-chip"
                   >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="h-5 w-5"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 4v16m8-8H4"
-                      />
-                    </svg>
+                    <Plus size={20} />
                     Create Chip
                   </button>
                 </div>
@@ -766,12 +787,25 @@ export function ChipPageContent() {
       {/* Create Chip Modal */}
       <CreateChipModal
         isOpen={isCreateChipModalOpen}
-        onClose={() => setIsCreateChipModalOpen(false)}
+        onClose={closeCreateChipModal}
         onSuccess={(chipId) => {
           // Automatically select the newly created chip
           setSelectedChip(chipId);
+          if (tutorialActive) {
+            tutorialJustCompleted.current = true;
+            setTutorialCompleted(true);
+          }
         }}
       />
+
+      {tutorialActive && (
+        <ChipCreationTour
+          active
+          completed={tutorialCompleted}
+          restartKey={tutorialRestartKey}
+          onDismiss={finishTutorial}
+        />
+      )}
 
       {/* Manage Chip Modal */}
       {isManageChipModalOpen && selectedChip && (

--- a/ui/src/components/features/chip/__tests__/ChipCreationTour.test.tsx
+++ b/ui/src/components/features/chip/__tests__/ChipCreationTour.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ChipCreationTour,
+  getChipCreationTourSteps,
+} from "@/components/features/chip/ChipCreationTour";
+
+const mocks = vi.hoisted(() => ({
+  driver: vi.fn(),
+  drive: vi.fn(),
+  destroy: vi.fn(),
+  setSteps: vi.fn(),
+}));
+
+vi.mock("driver.js", () => ({ driver: mocks.driver }));
+
+describe("ChipCreationTour", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("targets the chip action and creation form in order", () => {
+    const steps = getChipCreationTourSteps();
+
+    expect(steps).toHaveLength(5);
+    expect(steps[1].element).toBe('[data-tour="create-chip"]');
+    expect(steps[1].advanceOnClick).toBe(true);
+    expect(steps[2].element).toBe("#chip-id-input");
+    expect(steps[3].element).toBe("#topology-select");
+    expect(steps[4].element).toBe('[data-tour="submit-chip"]');
+  });
+
+  it("starts from the beginning and restarts at the create action", () => {
+    mocks.driver.mockReturnValue({
+      drive: mocks.drive,
+      destroy: mocks.destroy,
+      setSteps: mocks.setSteps,
+    });
+    const onDismiss = vi.fn();
+    const { rerender } = render(
+      <ChipCreationTour active completed={false} restartKey={0} onDismiss={onDismiss} />,
+    );
+
+    expect(mocks.drive).toHaveBeenLastCalledWith(0);
+
+    rerender(<ChipCreationTour active completed={false} restartKey={1} onDismiss={onDismiss} />);
+    expect(mocks.drive).toHaveBeenLastCalledWith(1);
+  });
+
+  it("shows a completion popover after creation", () => {
+    mocks.driver.mockReturnValue({
+      drive: mocks.drive,
+      destroy: mocks.destroy,
+      setSteps: mocks.setSteps,
+    });
+
+    render(<ChipCreationTour active completed restartKey={0} onDismiss={vi.fn()} />);
+
+    expect(mocks.setSteps).toHaveBeenCalledWith([
+      expect.objectContaining({
+        popover: expect.objectContaining({ title: "Chip created", doneBtnText: "Finish" }),
+      }),
+    ]);
+    expect(mocks.drive).toHaveBeenCalledWith();
+  });
+});

--- a/ui/src/components/features/chip/modals/CreateChipModal.tsx
+++ b/ui/src/components/features/chip/modals/CreateChipModal.tsx
@@ -245,6 +245,7 @@ export function CreateChipModal({ isOpen, onClose, onSuccess }: CreateChipModalP
               type="submit"
               className="btn btn-primary"
               disabled={createChipMutation.isPending}
+              data-tour="submit-chip"
             >
               {createChipMutation.isPending ? (
                 <>

--- a/ui/src/components/features/home/HomePageContent.tsx
+++ b/ui/src/components/features/home/HomePageContent.tsx
@@ -6,7 +6,9 @@ import {
   ArrowRight,
   CheckCircle2,
   ClipboardList,
+  Cpu,
   Gauge,
+  GraduationCap,
   MessageSquare,
   Play,
   Workflow,
@@ -14,6 +16,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 
 import { useGetExecutionLockStatus } from "@/client/execution/execution";
+import { useListChips } from "@/client/chip/chip";
 import { useListTaskResults } from "@/client/task-result/task-result";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { PageContainer } from "@/components/ui/PageContainer";
@@ -196,6 +199,11 @@ function RecentNotifications() {
 
 export function HomePageContent() {
   const { canEdit } = useProject();
+  const {
+    data: chipsResponse,
+    isLoading: chipsLoading,
+    error: chipsError,
+  } = useListChips({ query: { staleTime: 30_000 } });
   const { data: lockResponse, isLoading: lockLoading } = useGetExecutionLockStatus({
     query: { refetchInterval: 5000, refetchIntervalInBackground: true },
   });
@@ -215,12 +223,49 @@ export function HomePageContent() {
       ? `/execution/${encodeURIComponent(lock.chip_id)}/${encodeURIComponent(lock.execution_id)}`
       : "/execution";
   const failedResults = failedResponse?.data.items ?? [];
+  const hasChips = (chipsResponse?.data.chips.length ?? 0) > 0;
+  const showGettingStarted = canEdit && !chipsLoading && !chipsError && !hasChips;
+  const showHeaderTour = canEdit && !chipsLoading && (hasChips || Boolean(chipsError));
 
   return (
     <PageContainer maxWidth>
-      <PageHeader title="Home" description="Start work and review what needs your attention" />
+      <PageHeader
+        title="Home"
+        description="Start work and review what needs your attention"
+        actions={
+          showHeaderTour && (
+            <Link href="/chip?tutorial=create-chip" className="btn btn-ghost btn-sm gap-2">
+              <GraduationCap size={18} />
+              Setup tour
+            </Link>
+          )
+        }
+      />
 
       <div className="space-y-6">
+        {showGettingStarted && (
+          <section className="flex flex-col gap-4 rounded-xl border border-primary/25 bg-primary/5 p-4 sm:flex-row sm:items-center sm:justify-between sm:p-5">
+            <div className="flex items-start gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Cpu size={20} />
+              </span>
+              <div>
+                <h2 className="font-semibold">Create your first chip</h2>
+                <p className="mt-1 text-sm text-base-content/60">
+                  Set up the device QDash will use for calibration tasks and results.
+                </p>
+              </div>
+            </div>
+            <Link
+              href="/chip?tutorial=create-chip"
+              className="btn btn-primary btn-sm shrink-0 gap-2 sm:self-center"
+            >
+              <GraduationCap size={18} />
+              Start setup tour
+            </Link>
+          </section>
+        )}
+
         <QuickActions canEdit={canEdit} />
 
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">

--- a/ui/src/components/features/home/__tests__/HomePageContent.test.tsx
+++ b/ui/src/components/features/home/__tests__/HomePageContent.test.tsx
@@ -4,11 +4,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomePageContent } from "@/components/features/home/HomePageContent";
 
 const mockExecutionLock = vi.hoisted(() => vi.fn());
+const mockChips = vi.hoisted(() => vi.fn());
 const mockTaskResults = vi.hoisted(() => vi.fn());
 const mockNotifications = vi.hoisted(() => vi.fn());
 
 vi.mock("@/client/execution/execution", () => ({
   useGetExecutionLockStatus: mockExecutionLock,
+}));
+
+vi.mock("@/client/chip/chip", () => ({
+  useListChips: mockChips,
 }));
 
 vi.mock("@/client/task-result/task-result", () => ({
@@ -26,6 +31,11 @@ vi.mock("@/hooks/useNotifications", () => ({
 
 describe("HomePageContent", () => {
   beforeEach(() => {
+    mockChips.mockReturnValue({
+      data: { data: { chips: [{ chip_id: "chip-1" }] } },
+      isLoading: false,
+      error: null,
+    });
     mockExecutionLock.mockReturnValue({
       data: {
         data: {
@@ -93,6 +103,9 @@ describe("HomePageContent", () => {
     expect(screen.getByText("A new reply")).toBeTruthy();
     expect(screen.getByRole("link", { name: /Run a task/ }).getAttribute("href")).toBe("/tasks");
     expect(screen.getByRole("link", { name: /View inbox/ }).getAttribute("href")).toBe("/inbox");
+    expect(screen.getByRole("link", { name: "Setup tour" }).getAttribute("href")).toBe(
+      "/chip?tutorial=create-chip",
+    );
   });
 
   it("shows calm empty states when no work is waiting", () => {
@@ -116,5 +129,21 @@ describe("HomePageContent", () => {
     expect(screen.getByText("No calibration is running")).toBeTruthy();
     expect(screen.getByText("No failed task results")).toBeTruthy();
     expect(screen.getByText("You are all caught up")).toBeTruthy();
+  });
+
+  it("prominently offers setup when the project has no chips", () => {
+    mockChips.mockReturnValue({
+      data: { data: { chips: [] } },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<HomePageContent />);
+
+    expect(screen.getByRole("heading", { name: "Create your first chip" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Start setup tour" }).getAttribute("href")).toBe(
+      "/chip?tutorial=create-chip",
+    );
+    expect(screen.queryByRole("link", { name: "Setup tour" })).toBeNull();
   });
 });


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add a replayable Setup tour that guides project editors through creating a chip.
- Highlight onboarding prominently when a project has no chips and keep a compact replay action afterward; UI-only change with no API or configuration compatibility impact.

## Changes
- Add a Driver.js-powered `ChipCreationTour` that spotlights the Create Chip action, chip ID, topology, and submit controls.
- Continue the tour across the existing create dialog, handle cancellation and successful completion, and preserve replay state in the URL.
- Add a conditional Getting started callout to `HomePageContent` and retain a compact Setup tour action for configured projects.
- Theme Driver.js popovers with DaisyUI semantic colors and document the onboarding behavior.
- Add tour step and Home visibility tests.
- No OpenAPI, schema, or generated client changes.

## Verification
- `bun run lint`
- `bunx tsc --noEmit`
- `bun run test:run src/components/features/home/__tests__/HomePageContent.test.tsx src/components/features/chip/__tests__/ChipCreationTour.test.tsx src/components/features/chip/modals/CreateChipModal.test.tsx`
- `bun run build`