### PR TITLE
fix(ui): preserve array parameters in task execution

### DIFF
--- a/src/qdash/api/routers/task.py
+++ b/src/qdash/api/routers/task.py
@@ -48,8 +48,10 @@ def _matches_parameter_type(value: object, value_type: object) -> bool:
         )
     if value_type == "bool":
         return isinstance(value, bool)
-    if value_type in {"np.linspace", "np.logspace", "np.arange", "range"}:
+    if value_type == "list":
         return isinstance(value, list)
+    if value_type in {"np.linspace", "np.logspace", "np.arange", "range"}:
+        return isinstance(value, list) and len(value) == 3
     if value_type in {"str", "string"}:
         return isinstance(value, str)
     return True

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
@@ -88,9 +88,10 @@ class CheckResonatorSpectroscopy(QubexTask):
             value_type="list",
             default=[3, 0, 2, 1],
             description=(
-                "Qubit offsets in increasing resonator-frequency order. "
-                "The default is [3, 0, 2, 1]. Must contain each offset from 0 to 3 "
-                "exactly once."
+                "Qubit offsets within each MUX in increasing resonator-frequency order. "
+                "Enter a JSON array containing each offset from 0 to 3 exactly once. "
+                "The default is [3, 0, 2, 1]. For 16Q, use [0, 3, 1, 2] when the "
+                "frequency order is mux[0] < mux[3] < mux[1] < mux[2]."
             ),
         ),
     }

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -1647,7 +1647,7 @@
             "value_type": "np.arange"
           },
           "resonator_assignment_order": {
-            "description": "Qubit offsets in increasing resonator-frequency order. The default is [3, 0, 2, 1]. Must contain each offset from 0 to 3 exactly once.",
+            "description": "Qubit offsets within each MUX in increasing resonator-frequency order. Enter a JSON array containing each offset from 0 to 3 exactly once. The default is [3, 0, 2, 1]. For 16Q, use [0, 3, 1, 2] when the frequency order is mux[0] < mux[3] < mux[1] < mux[2].",
             "unit": "",
             "value": [
               3,

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -883,8 +883,27 @@ class TaskExecutor:
             for key, new_value in run_overrides.items():
                 param = task.run_parameters.get(key)
                 if isinstance(param, RunParameterModel):
-                    param.value = new_value
-                    logger.info("User override applied: run.%s = %s", key, new_value)
+                    converted_value = new_value
+                    if param.value_type == "list":
+                        if not isinstance(new_value, (list, tuple)):
+                            raise ValueError(
+                                f"Run parameter {key!r} must be a JSON array, got {new_value!r}"
+                            )
+                        converted_value = list(new_value)
+                    elif param.value_type in {
+                        "np.linspace",
+                        "np.logspace",
+                        "np.arange",
+                        "range",
+                    }:
+                        if not isinstance(new_value, (list, tuple)) or len(new_value) != 3:
+                            raise ValueError(
+                                f"Run parameter {key!r} must be a 3-value JSON array, "
+                                f"got {new_value!r}"
+                            )
+                        converted_value = tuple(new_value)
+                    logger.info("User override applied: run.%s = %s", key, converted_value)
+                    param.value = converted_value
             run_params_dict = {k: v.model_dump() for k, v in task.run_parameters.items()}
             self.state_manager.put_run_parameters(task_name, run_params_dict, task_type, qid)
 

--- a/tests/qdash/api/routers/test_task.py
+++ b/tests/qdash/api/routers/test_task.py
@@ -35,7 +35,11 @@ def _task_info() -> TaskInfo:
             "qubit_frequency": {"user_override": "allowed", "value_type": "float"},
             "readout_duration": {"user_override": "forbidden", "value_type": "float"},
         },
-        run_parameters={"shots": {"value_type": "int"}},
+        run_parameters={
+            "shots": {"value_type": "int"},
+            "frequency_range": {"value_type": "np.arange"},
+            "resonator_assignment_order": {"value_type": "list"},
+        },
     )
 
 
@@ -128,6 +132,24 @@ async def test_quick_run_task_resolves_and_validates_default_backend(
                 run_parameter_overrides={"shots": 100.5},
             ),
             "invalid parameter types: input.qubit_frequency must be float, run.shots must be int",
+        ),
+        (
+            QuickRunTaskRequest(
+                chip_id="chip-1",
+                qid="0",
+                backend_name="fake",
+                run_parameter_overrides={"resonator_assignment_order": "[3, 0, 2, 1]"},
+            ),
+            "invalid parameter types: run.resonator_assignment_order must be list",
+        ),
+        (
+            QuickRunTaskRequest(
+                chip_id="chip-1",
+                qid="0",
+                backend_name="fake",
+                run_parameter_overrides={"frequency_range": [5.75, 6.75]},
+            ),
+            "invalid parameter types: run.frequency_range must be np.arange",
         ),
     ],
 )

--- a/tests/qdash/workflow/engine/task/test_executor.py
+++ b/tests/qdash/workflow/engine/task/test_executor.py
@@ -924,6 +924,39 @@ class TestSnapshotOverrides:
         assert isinstance(value, float)
         assert session.applied_value == pytest.approx(value)
 
+    def test_user_run_override_preserves_list_value(
+        self,
+        executor_with_snapshot: TaskExecutor,
+        mock_snapshot_loader: MagicMock,
+    ) -> None:
+        task = MockTask()
+        task.run_parameters["resonator_assignment_order"] = RunParameterModel(
+            value=[3, 0, 2, 1], value_type="list"
+        )
+        mock_snapshot_loader._parameter_overrides = {
+            "run": {"resonator_assignment_order": [0, 3, 1, 2]}
+        }
+
+        executor_with_snapshot._apply_user_overrides_only(task, "Task", "qubit", "0")
+
+        assert task.run_parameters["resonator_assignment_order"].value == [0, 3, 1, 2]
+
+    def test_user_run_override_rejects_string_for_array_type(
+        self,
+        executor_with_snapshot: TaskExecutor,
+        mock_snapshot_loader: MagicMock,
+    ) -> None:
+        task = MockTask()
+        task.run_parameters["frequency_range"] = RunParameterModel(
+            value=(5.75, 6.75, 0.002), value_type="np.arange"
+        )
+        mock_snapshot_loader._parameter_overrides = {
+            "run": {"frequency_range": "[5.75, 6.75, 0.002]"}
+        }
+
+        with pytest.raises(ValueError, match="must be a 3-value JSON array"):
+            executor_with_snapshot._apply_user_overrides_only(task, "Task", "qubit", "0")
+
     def test_apply_snapshot_overrides_empty_params(
         self,
         executor_with_snapshot: TaskExecutor,

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -41,6 +41,7 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
 import { formatDateTime, formatRelativeTime } from "@/lib/utils/datetime";
+import { formatTaskParameter, parseTaskParameter } from "@/lib/utils/task-parameters";
 import { useToast } from "@/components/ui/Toast";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/Dialog";
 
@@ -59,9 +60,16 @@ function formatActorLabel(actor?: ActorFields | null) {
 /** Extract the display value from a parameter entry (may be a dict with `value` key or a plain value). */
 function extractParamValue(entry: unknown): string {
   if (entry != null && typeof entry === "object" && "value" in (entry as Record<string, unknown>)) {
-    return String((entry as Record<string, unknown>).value ?? "");
+    return formatTaskParameter((entry as Record<string, unknown>).value);
   }
-  return String(entry ?? "");
+  return formatTaskParameter(entry);
+}
+
+function extractParamValueType(entry: unknown): unknown {
+  if (entry != null && typeof entry === "object" && "value_type" in entry) {
+    return (entry as Record<string, unknown>).value_type;
+  }
+  return undefined;
 }
 
 /** Extract the unit from a parameter entry. */
@@ -82,24 +90,16 @@ function buildFormValues(params: Record<string, unknown> | undefined): Record<st
   return result;
 }
 
-/** Parse a string back to a number if possible, otherwise keep as string. */
-function parseValue(val: string): string | number | boolean {
-  if (val === "true") return true;
-  if (val === "false") return false;
-  const num = Number(val);
-  if (val.trim() !== "" && !isNaN(num)) return num;
-  return val;
-}
-
 /** Compute changed overrides by comparing current form values to originals. */
 function computeOverrides(
+  parameters: Record<string, unknown>,
   original: Record<string, string>,
   current: Record<string, string>,
-): Record<string, string | number | boolean> {
-  const overrides: Record<string, string | number | boolean> = {};
+): Record<string, unknown> {
+  const overrides: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(current)) {
     if (val !== original[key]) {
-      overrides[key] = parseValue(val);
+      overrides[key] = parseTaskParameter(val, extractParamValueType(parameters[key]));
     }
   }
   return overrides;
@@ -395,8 +395,14 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
     setReExecCountBefore(taskResult.re_executions?.length ?? 0);
     try {
       // Build parameter_overrides only with changed values
-      const runOverrides = computeOverrides(originalRunValues, runParamValues);
-      const inputOverrides = computeOverrides(originalInputValues, inputParamValues);
+      const runParameters = taskResult.run_parameters as Record<string, unknown> | undefined;
+      const inputParameters = taskResult.input_parameters as Record<string, unknown> | undefined;
+      const runOverrides = computeOverrides(runParameters ?? {}, originalRunValues, runParamValues);
+      const inputOverrides = computeOverrides(
+        inputParameters ?? {},
+        originalInputValues,
+        inputParamValues,
+      );
       const hasOverrides =
         Object.keys(runOverrides).length > 0 || Object.keys(inputOverrides).length > 0;
 

--- a/ui/src/components/features/tasks/TaskWorkbench.tsx
+++ b/ui/src/components/features/tasks/TaskWorkbench.tsx
@@ -14,6 +14,7 @@ import { TaskFigure } from "@/components/charts/TaskFigure";
 import { ParametersTable } from "@/components/features/metrics/ParametersTable";
 import { useToast } from "@/components/ui/Toast";
 import { AXIOS_INSTANCE } from "@/lib/api/custom-instance";
+import { formatTaskParameter, parseTaskParameter } from "@/lib/utils/task-parameters";
 
 interface TaskWorkbenchProps {
   task: TaskInfo;
@@ -26,29 +27,6 @@ function badgeClass(status?: string | null) {
   if (status === "cancelled") return "badge-neutral";
   if (status === "running") return "badge-info";
   return "badge-warning";
-}
-
-export function parseTaskParameter(raw: string, valueType: unknown) {
-  const normalized = raw.trim();
-  if (valueType === "int") {
-    const value = Number(normalized);
-    if (!Number.isInteger(value)) throw new Error(`Expected an integer, got "${raw}"`);
-    return value;
-  }
-  if (valueType === "float") {
-    const value = Number(normalized);
-    if (!Number.isFinite(value)) throw new Error(`Expected a finite number, got "${raw}"`);
-    return value;
-  }
-  if (["np.linspace", "np.logspace", "np.arange", "range"].includes(String(valueType))) {
-    return JSON.parse(normalized);
-  }
-  if (valueType === "bool") {
-    if (normalized.toLowerCase() === "true") return true;
-    if (normalized.toLowerCase() === "false") return false;
-    throw new Error(`Expected true or false, got "${raw}"`);
-  }
-  return raw;
 }
 
 export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
@@ -97,11 +75,7 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
       Object.fromEntries(
         Object.entries(task.run_parameters ?? {}).map(([name, parameter]) => [
           name,
-          parameter.value === null || parameter.value === undefined
-            ? ""
-            : Array.isArray(parameter.value)
-              ? JSON.stringify(parameter.value)
-              : String(parameter.value),
+          formatTaskParameter(parameter.value),
         ]),
       ),
     );

--- a/ui/src/components/features/tasks/__tests__/TaskWorkbench.test.ts
+++ b/ui/src/components/features/tasks/__tests__/TaskWorkbench.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { parseTaskParameter } from "../TaskWorkbench";
+import { formatTaskParameter, parseTaskParameter } from "@/lib/utils/task-parameters";
 
 describe("parseTaskParameter", () => {
+  it("formats stored arrays as editable JSON", () => {
+    expect(formatTaskParameter([3, 0, 2, 1])).toBe("[3,0,2,1]");
+  });
+
   it("parses complete numeric values", () => {
     expect(parseTaskParameter("42", "int")).toBe(42);
     expect(parseTaskParameter(" 1.25 ", "float")).toBe(1.25);
@@ -22,5 +26,14 @@ describe("parseTaskParameter", () => {
 
   it("parses array-shaped run parameter JSON", () => {
     expect(parseTaskParameter("[0, 1, 2]", "np.linspace")).toEqual([0, 1, 2]);
+    expect(parseTaskParameter("[-60, 5, 5]", "np.arange")).toEqual([-60, 5, 5]);
+    expect(parseTaskParameter("[3, 0, 2, 1]", "list")).toEqual([3, 0, 2, 1]);
+  });
+
+  it("rejects invalid array-shaped parameters", () => {
+    expect(() => parseTaskParameter('"not a list"', "list")).toThrow("Expected a JSON array");
+    expect(() => parseTaskParameter("[5.75, 6.75]", "np.arange")).toThrow(
+      "Expected exactly 3 array values",
+    );
   });
 });

--- a/ui/src/lib/utils/task-parameters.ts
+++ b/ui/src/lib/utils/task-parameters.ts
@@ -1,0 +1,39 @@
+const RANGE_VALUE_TYPES = new Set(["np.linspace", "np.logspace", "np.arange", "range"]);
+
+export function formatTaskParameter(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  return Array.isArray(value) ? JSON.stringify(value) : String(value);
+}
+
+export function parseTaskParameter(raw: string, valueType: unknown): unknown {
+  const normalized = raw.trim();
+  if (valueType === "int") {
+    const value = Number(normalized);
+    if (!Number.isInteger(value)) throw new Error(`Expected an integer, got "${raw}"`);
+    return value;
+  }
+  if (valueType === "float") {
+    const value = Number(normalized);
+    if (!Number.isFinite(value)) throw new Error(`Expected a finite number, got "${raw}"`);
+    return value;
+  }
+  if (valueType === "list" || RANGE_VALUE_TYPES.has(String(valueType))) {
+    const value: unknown = JSON.parse(normalized);
+    if (!Array.isArray(value)) throw new Error(`Expected a JSON array, got "${raw}"`);
+    if (valueType !== "list" && value.length !== 3) {
+      throw new Error(`Expected exactly 3 array values for ${String(valueType)}`);
+    }
+    return value;
+  }
+  if (valueType === "bool") {
+    if (normalized.toLowerCase() === "true") return true;
+    if (normalized.toLowerCase() === "false") return false;
+    throw new Error(`Expected true or false, got "${raw}"`);
+  }
+  if (valueType === "str" || valueType === "string") return raw;
+
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  const numericValue = Number(normalized);
+  return normalized !== "" && Number.isFinite(numericValue) ? numericValue : raw;
+}


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Preserve list and range-shaped task parameters when executing tasks from the Tasks page or re-executing from Task Result details.
- Align UI, API, and workflow validation so malformed array overrides fail before measurement code runs. No API schema or generated client changes are required.

## Changes

- Add shared task-parameter formatting and parsing for Tasks and Task Result re-execution forms.
- Parse list values as JSON arrays and require three values for np.arange, np.linspace, np.logspace, and range parameters.
- Validate quick-run array overrides at the API boundary and re-execution overrides in the workflow executor.
- Expand CheckResonatorSpectroscopy guidance with the 16Q resonator assignment example and regenerate the task catalog.
- Add UI, API router, and workflow executor regression tests.

## Verification

- UI unit tests: 6 passed.
- API and workflow focused tests: 57 passed; snapshot and executor suite: 74 passed.
- UI lint and formatting, Ruff, task catalog check, and git diff check passed.
- Full TypeScript no-emit check remains blocked by pre-existing missing driver.js declarations in ChipCreationTour.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task parameter values now display consistently and preserve their original types when edited and re-run.
  * Run-parameter overrides support validated lists, numeric ranges, booleans, and numeric values.
* **Bug Fixes**
  * Invalid parameter formats and incorrectly sized range arrays are rejected with validation errors.
  * List-based range parameters now require exactly three values.
* **Documentation**
  * Clarified resonator assignment ordering requirements, including a 16Q example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->