### PR TITLE
fix(workflow): support qubit spectroscopy power ranges

### DIFF
--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
@@ -51,6 +51,15 @@ class CheckQubitSpectroscopy(QubexTask):
                 "[3.0, 5.75, 0.005], high band [6.5, 9.75, 0.005]."
             ),
         ),
+        "power_range": RunParameterSpec(
+            unit="dB",
+            value_type="np.arange",
+            default=None,
+            description=(
+                "Power range as [start, stop, step] in dB. Leave blank to use "
+                "qubex's default [-60, 0, 5] dB. The stop value is exclusive."
+            ),
+        ),
         "readout_amplitude": RunParameterSpec(
             unit="a.u.",
             value_type="float",
@@ -269,6 +278,7 @@ class CheckQubitSpectroscopy(QubexTask):
             result = exp.qubit_spectroscopy(
                 label,
                 frequency_range=self._frequency_range(),
+                power_range=self.run_parameters["power_range"].get_value(),
                 readout_amplitude=self._get_readout_amplitude_value(),
                 readout_frequency=readout_freq_param.value,
             )
@@ -292,6 +302,7 @@ class CheckQubitSpectroscopy(QubexTask):
             result = exp.qubit_spectroscopy(
                 label,
                 frequency_range=frequency_range,
+                power_range=self.run_parameters["power_range"].get_value(),
                 readout_amplitude=readout_amplitude,
             )
             results[label] = result

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_resonator_spectroscopy.py
@@ -75,7 +75,10 @@ class CheckResonatorSpectroscopy(QubexTask):
             unit="dB",
             value_type="np.arange",
             default=(-60, 5, 5),
-            description="Power range for resonator spectroscopy",
+            description=(
+                "Power range as [start, stop, step] in dB. The qubex default is "
+                "[-60, 5, 5] dB. The stop value is exclusive."
+            ),
         ),
         "shots": RunParameterSpec(
             unit="a.u.",

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -1477,6 +1477,12 @@
             "value": null,
             "value_type": "np.arange"
           },
+          "power_range": {
+            "description": "Power range as [start, stop, step] in dB. Leave blank to use qubex's default [-60, 0, 5] dB. The stop value is exclusive.",
+            "unit": "dB",
+            "value": null,
+            "value_type": "np.arange"
+          },
           "readout_amplitude": {
             "description": "Readout amplitude used during the qubit spectroscopy sweep",
             "unit": "a.u.",
@@ -1637,7 +1643,7 @@
             "value_type": "np.arange"
           },
           "power_range": {
-            "description": "Power range for resonator spectroscopy",
+            "description": "Power range as [start, stop, step] in dB. The qubex default is [-60, 5, 5] dB. The stop value is exclusive.",
             "unit": "dB",
             "value": [
               -60,

--- a/src/qdash/workflow/templates/bringup.py
+++ b/src/qdash/workflow/templates/bringup.py
@@ -86,7 +86,8 @@ def bringup(
         #
         # CheckResonatorSpectroscopy uses the connected readout box's qubex default:
         # low band [5.75, 6.75, 0.002] GHz or high band [9.75, 10.75, 0.002] GHz.
-        # Leave frequency_range unset to use that default, or uncomment to override it.
+        # Its qubex default power range is [-60, 5, 5] dB (stop is exclusive).
+        # Leave each range unset to use its default, or uncomment to override it.
         # "CheckResonatorSpectroscopy": {
         #     "resonator_assignment_order": {
         #         "value": [0, 3, 1, 2],
@@ -99,15 +100,19 @@ def bringup(
         # },
         # CheckQubitSpectroscopy uses the connected control box's qubex default:
         # low band [3.0, 5.75, 0.005] GHz or high band [6.5, 9.75, 0.005] GHz.
+        # Its qubex default power range is [-60, 0, 5] dB (stop is exclusive).
         # Leave frequency_range unset to use that default, or uncomment to override it.
         # "CheckQubitSpectroscopy": {
         #     "frequency_range": {
         #         "value": [3.0, 5.75, 0.005],
         #         "value_type": "np.arange",
         #     },
+        #     "power_range": {
+        #         "value": [-60, 0, 10],
+        #         "value_type": "np.arange",
+        #     },
         # },
     }
-
     steps = [
         ConfigureAll(),
         BringUp(mode=mode, tasks=BRINGUP_TASKS),

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
@@ -1,4 +1,5 @@
 import copy
+from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, patch
@@ -128,7 +129,32 @@ def test_frequency_range_is_resolved_from_control_box_when_unset(monkeypatch) ->
 
 
 def test_run_parameters_only_expose_measurement_settings() -> None:
-    assert set(CheckQubitSpectroscopy.run_spec) == {"frequency_range", "readout_amplitude"}
+    assert set(CheckQubitSpectroscopy.run_spec) == {
+        "frequency_range",
+        "power_range",
+        "readout_amplitude",
+    }
+
+
+def test_power_range_is_forwarded_to_qubex(monkeypatch) -> None:
+    task = CheckQubitSpectroscopy()
+    task.run_parameters = copy.deepcopy(task.run_parameters)
+    task.run_parameters["power_range"].value = (-40.0, -19.0, 10.0)
+    task.input_parameters["readout_frequency"].value = 6.0
+    backend = cast("QubexBackend", object())
+    exp = MagicMock()
+    monkeypatch.setattr(task, "get_experiment", lambda _backend: exp)
+    monkeypatch.setattr(task, "get_qubit_label", lambda _backend, _qid: "Q00")
+    monkeypatch.setattr(task, "save_calibration", lambda _backend: None)
+    monkeypatch.setattr(
+        task, "_modified_qubit_readout_frequencies", lambda *args, **kwargs: nullcontext()
+    )
+
+    task.run(backend, "0")
+
+    assert list(exp.qubit_spectroscopy.call_args.kwargs["power_range"]) == pytest.approx(
+        [-40.0, -30.0, -20.0]
+    )
 
 
 def test_frequency_range_can_be_overridden_per_task() -> None:


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Allow `CheckQubitSpectroscopy` power sweeps to be configured through the existing per-task run-parameter mechanism.
- Keep the workflow contract compatible while documenting the qubex defaults for both qubit and resonator spectroscopy.

## Changes

- Add the `power_range` run parameter to `CheckQubitSpectroscopy` using `[start, stop, step]` (`numpy.arange`) semantics.
- Forward the resolved power range in individual and batch qubit spectroscopy runs.
- Document the qubex power defaults and exclusive stop behavior in task metadata and the bring-up template.
- Regenerate the task catalog and add coverage for forwarding custom power ranges.
- Verify with Ruff, 32 focused workflow tests, and the task catalog consistency check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional power-range setting for qubit spectroscopy.
  * Users can customize the dB sweep; when omitted, the standard Qubex range is used.
* **Documentation**
  * Clarified default power ranges and exclusive stop values for resonator and qubit spectroscopy.
  * Added an example showing how to override the qubit spectroscopy power range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->