### PR TITLE
fix: allow editors to manage forum metadata

### DIFF
--- a/src/qdash/api/routers/forum.py
+++ b/src/qdash/api/routers/forum.py
@@ -429,7 +429,7 @@ def update_forum_post(
     ctx: Annotated[ProjectContext, Depends(get_project_context)],
     service: Annotated[ForumService, Depends(get_forum_service)],
 ) -> ForumPostResponse:
-    """Update a forum post. Only the author or project owner can edit."""
+    """Update a forum post, or update root-thread metadata as a project editor."""
     # Distinguish "content_blocks omitted" (leave unchanged) from "explicitly []"
     # (clear); the default_factory makes both look like [] on the model otherwise.
     content_blocks = body.content_blocks if "content_blocks" in body.model_fields_set else None

--- a/src/qdash/api/services/forum_service.py
+++ b/src/qdash/api/services/forum_service.py
@@ -931,9 +931,23 @@ class ForumService:
         if doc is None:
             raise HTTPException(status_code=404, detail="Forum post not found")
         user_id = self._user_id_for_username(username)
-        if not self._is_author(doc, user_id=user_id) and role != ProjectRole.OWNER:
+        can_edit_content = self._is_author(doc, user_id=user_id) or role == ProjectRole.OWNER
+        can_edit_metadata = doc.parent_id is None and role == ProjectRole.EDITOR
+        content_blocks_changed = content_blocks is not None and content_blocks != doc.content_blocks
+        content_changed = content != doc.content
+        title_changed = title is not None and title != doc.title
+        if not can_edit_content and not (
+            can_edit_metadata
+            and not content_changed
+            and not content_blocks_changed
+            and not title_changed
+        ):
             raise HTTPException(
-                status_code=403, detail="Only the author or project owner can edit this post"
+                status_code=403,
+                detail=(
+                    "Only the author or project owner can edit post content; "
+                    "project editors can edit thread metadata"
+                ),
             )
 
         status_changed = False

--- a/tests/qdash/api/routers/test_forum.py
+++ b/tests/qdash/api/routers/test_forum.py
@@ -540,6 +540,47 @@ def test_author_can_update_forum_thread_category(test_client, init_db):
     assert fetched.json()["category"] == "coupling"
 
 
+def test_editor_can_update_forum_thread_metadata(test_client, init_db):
+    """Project editors can manage metadata on a thread created by another user."""
+    _create_user("owner", "owner_token", ProjectRole.OWNER)
+    _create_user("editor", "editor_token", ProjectRole.EDITOR)
+    _create_project()
+
+    root = _create_post(test_client, _headers("owner_token"))
+    root_id = root.json()["id"]
+    response = test_client.patch(
+        f"/forum/posts/{root_id}",
+        headers=_headers("editor_token"),
+        json={
+            "category": "coupling",
+            "content": root.json()["content"],
+            "labels": ["anomaly"],
+            "status": "investigating",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["category"] == "coupling"
+    assert response.json()["labels"] == ["anomaly"]
+    assert response.json()["status"] == "investigating"
+
+
+def test_editor_cannot_update_another_users_forum_content(test_client, init_db):
+    """Metadata moderation does not grant editors permission to rewrite post content."""
+    _create_user("owner", "owner_token", ProjectRole.OWNER)
+    _create_user("editor", "editor_token", ProjectRole.EDITOR)
+    _create_project()
+
+    root = _create_post(test_client, _headers("owner_token"))
+    response = test_client.patch(
+        f"/forum/posts/{root.json()['id']}",
+        headers=_headers("editor_token"),
+        json={"content": "Rewritten by editor", "status": "investigating"},
+    )
+
+    assert response.status_code == 403
+
+
 def test_update_forum_thread_rejects_unknown_category(test_client, init_db):
     """Updating to a non-existent category is rejected and leaves the thread unchanged."""
     _create_user("owner", "owner_token", ProjectRole.OWNER)

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -264,7 +264,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { isOwner, projectId } = useProject();
+  const { canEdit, isOwner, projectId } = useProject();
   const { uploadImage } = useImageUpload("forum");
   const currentUsername = user?.username;
   const [replyText, setReplyText] = useState("");
@@ -544,7 +544,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
     assigneeUsername?: string | null;
     status?: ForumPostResponse["status"];
   }) => {
-    if (!post || !canManage) return;
+    if (!post || !canManageMetadata) return;
     const response = await updateMutation.mutateAsync({
       postId: post.id,
       data: {
@@ -641,7 +641,8 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   const category = getForumCategory(post.category, categories);
   const CategoryIcon = category.icon;
   const targetContext = linkedTargetContext;
-  const canManage = isOwner || currentUsername === post.username;
+  const canManageContent = isOwner || currentUsername === post.username;
+  const canManageMetadata = canEdit || currentUsername === post.username;
   const statusDef = getForumStatus(post.status);
   const StatusIcon = statusDef.icon;
   const isTerminal = isForumTerminalStatus(post.status);
@@ -698,7 +699,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                 {post.title || "Untitled topic"}
               </h1>
             )}
-            {canManage && !editingTitle && (
+            {canManageContent && !editingTitle && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -730,7 +731,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
           <PostBody
             post={post}
             currentUsername={currentUsername}
-            canEdit={canManage}
+            canEdit={canManageContent}
             onEdit={handleStartEditRoot}
             editing={editingRoot}
             editContent={editRootContent}
@@ -853,7 +854,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
               <CategoryIcon className="h-3.5 w-3.5" />
               Category
             </div>
-            {canManage ? (
+            {canManageMetadata ? (
               <select
                 className="select select-bordered select-sm w-full"
                 value={post.category}
@@ -888,7 +889,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                 </span>
               </Link>
             )}
-            {canManage ? (
+            {canManageMetadata ? (
               <div className="space-y-2">
                 <select
                   className="select select-bordered select-xs w-full"
@@ -1016,7 +1017,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
               <CalendarDays className="h-3.5 w-3.5" />
               Cooldown
             </div>
-            {canManage ? (
+            {canManageMetadata ? (
               <div className="space-y-2">
                 <select
                   className="select select-bordered select-xs w-full"
@@ -1057,7 +1058,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
               <UserRound className="h-3.5 w-3.5" />
               Assignee
             </div>
-            {canManage ? (
+            {canManageMetadata ? (
               <select
                 className="select select-bordered select-xs w-full"
                 value={post.assignee_username ?? ""}
@@ -1088,7 +1089,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
               <Tag className="h-3.5 w-3.5" />
               Labels
             </div>
-            {canManage ? (
+            {canManageMetadata ? (
               <ForumLabelPicker
                 selectedLabels={post.labels ?? []}
                 onToggle={togglePostLabel}
@@ -1117,7 +1118,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
               <StatusIcon className="h-3.5 w-3.5" />
               Status
             </div>
-            {canManage ? (
+            {canManageMetadata ? (
               <select
                 className="select select-bordered select-xs w-full"
                 value={post.status ?? "open"}

--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -257,7 +257,7 @@ function ForumThreadPreviewSidebar({
   postId,
   categories,
   currentUsername,
-  isOwner,
+  canEditMetadata,
   projectId,
   returnQuery,
   onClose,
@@ -265,7 +265,7 @@ function ForumThreadPreviewSidebar({
   postId: string | null;
   categories: ForumCategoryDefinition[];
   currentUsername?: string;
-  isOwner: boolean;
+  canEditMetadata: boolean;
   projectId?: string | null;
   returnQuery: string;
   onClose: () => void;
@@ -305,7 +305,7 @@ function ForumThreadPreviewSidebar({
   const statusDef = getForumStatus(post?.status);
   const StatusIcon = statusDef.icon;
   const targetContext = post ? postTargetContext(post) : null;
-  const canManage = !!post && (isOwner || currentUsername === post.username);
+  const canManageMetadata = !!post && (canEditMetadata || currentUsername === post.username);
   const updateMutation = useUpdateForumPost();
   const members = useMemo(
     () => (membersResponse?.data.members ?? []).filter((member) => member.status === "active"),
@@ -377,7 +377,7 @@ function ForumThreadPreviewSidebar({
     cooldownId?: string | null;
     assigneeUsername?: string | null;
   }) => {
-    if (!post || !canManage) return;
+    if (!post || !canManageMetadata) return;
     const response = await updateMutation.mutateAsync({
       postId: post.id,
       data: {
@@ -505,7 +505,7 @@ function ForumThreadPreviewSidebar({
                     <ExternalLink className="h-3.5 w-3.5" />
                     Open full page
                   </Link>
-                  {canManage && (
+                  {canManageMetadata && (
                     <button
                       type="button"
                       className={`btn btn-sm gap-1 ${editingMetadata ? "btn-neutral" : "btn-outline"}`}
@@ -546,7 +546,7 @@ function ForumThreadPreviewSidebar({
                 </div>
               )}
 
-              {editingMetadata && canManage && (
+              {editingMetadata && canManageMetadata && (
                 <section className="rounded-lg border border-base-300 bg-base-200/40 p-3">
                   <div className="mb-3 flex items-center justify-between gap-2">
                     <h3 className="text-sm font-semibold">Metadata</h3>
@@ -771,7 +771,7 @@ export function ForumPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user } = useAuth();
-  const { isOwner, projectId } = useProject();
+  const { canEdit, isOwner, projectId } = useProject();
   const [category, setCategory] = useState<CategoryFilter>(
     () => (searchParams.get("forum_category") as CategoryFilter | null) ?? "all",
   );
@@ -1329,7 +1329,7 @@ export function ForumPageContent() {
         postId={selectedPostId}
         categories={categories}
         currentUsername={user?.username}
-        isOwner={isOwner}
+        canEditMetadata={canEdit}
         projectId={projectId}
         returnQuery={listReturnQuery}
         onClose={() => setSelectedPostId(null)}


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Allow project editors to manage forum thread metadata created by other users.
- Preserve the existing author/owner-only restriction for titles, post content, and replies; affects the Forum API and UI only.

## Changes
- Separate forum content-edit and metadata-edit authorization in the API service.
- Expose category, target, cooldown, assignee, label, and status controls to editors in `ForumDetailPage` and the forum preview sidebar.
- Add API coverage for allowed editor metadata updates and rejected content rewrites.
- No OpenAPI schema or generated client changes were required.

## Verification
- `UV_CACHE_DIR=/tmp/qdash-uv-cache uv run ruff check src/qdash/api/services/forum_service.py src/qdash/api/routers/forum.py tests/qdash/api/routers/test_forum.py`
- `bunx tsc --noEmit`
- `bunx oxfmt --check src/components/features/forum/ForumPageContent.tsx src/components/features/forum/ForumDetailPage.tsx`
- `git diff --check`
- Focused pytest cases were collected successfully but timed out during test environment initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project editors can update forum thread metadata, including categories, labels, status, targets, cooldowns, and assignees.
  * Content and title editing remains limited to authors and project owners.
  * Metadata editing is now available from both the thread detail view and sidebar.

* **Bug Fixes**
  * Prevented editors from modifying another user’s forum content while allowing permitted metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->