### PR TITLE
fix(workflow): remove duplicate CW readout amplitude input

### DIFF
--- a/src/qdash/workflow/calibtasks/qubex/base.py
+++ b/src/qdash/workflow/calibtasks/qubex/base.py
@@ -613,16 +613,12 @@ class QubexTask(BaseTask):
         return float(param.value)
 
     def _get_readout_amplitude_value(self) -> float:
-        """Return readout_amplitude from loaded inputs, falling back to run defaults."""
+        """Return readout_amplitude from the resolved calibration inputs."""
         input_param = self.input_parameters.get("readout_amplitude")
         if input_param is not None and input_param.value is not None:
             return float(input_param.value)
 
-        run_param = self.run_parameters.get("readout_amplitude")
-        if run_param is not None:
-            return float(run_param.get_value())
-
-        raise ValueError("readout_amplitude parameter is required")
+        raise ValueError("readout_amplitude input parameter is required")
 
     def _is_frequency_overridden(self, backend: "QubexBackend", qid: str) -> bool:
         """Check if qubit_frequency was explicitly overridden from default.

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_control_amplitude.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_control_amplitude.py
@@ -62,16 +62,6 @@ class CheckControlAmplitude(QubexTask):
             default=0.0025,
             description="Frequency step (default 2.5 MHz, ~120 points over ±150 MHz)",
         ),
-        "readout_amplitude": RunParameterSpec(
-            unit="a.u.",
-            value_type="float",
-            default=0.04,
-            description=(
-                "Readout amplitude used during the sweep. Matches the "
-                "CheckQubitSpectroscopy default so the qubit response is "
-                "probed under the same readout conditions."
-            ),
-        ),
         "target_rabi_rate": RunParameterSpec(
             unit="GHz",
             value_type="float",

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
@@ -60,12 +60,6 @@ class CheckQubitSpectroscopy(QubexTask):
                 "qubex's default [-60, 0, 5] dB. The stop value is exclusive."
             ),
         ),
-        "readout_amplitude": RunParameterSpec(
-            unit="a.u.",
-            value_type="float",
-            default=0.04,
-            description="Readout amplitude used during the qubit spectroscopy sweep",
-        ),
     }
     _analysis_config: ClassVar[EstimateQubitFrequencyConfig] = EstimateQubitFrequencyConfig()
     _retry_with_trim: ClassVar[bool] = True
@@ -296,7 +290,7 @@ class CheckQubitSpectroscopy(QubexTask):
         exp = self.get_experiment(backend)
         labels = [self.get_qubit_label(backend, qid) for qid in qids]
         frequency_range = self._frequency_range()
-        readout_amplitude = self.run_parameters["readout_amplitude"].get_value()
+        readout_amplitude = self._get_readout_amplitude_value()
         results = {}
         for label in labels:
             result = exp.qubit_spectroscopy(

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
@@ -54,10 +54,10 @@ class CheckQubitSpectroscopy(QubexTask):
         "power_range": RunParameterSpec(
             unit="dB",
             value_type="np.arange",
-            default=None,
+            default=(-60, 0, 5),
             description=(
-                "Power range as [start, stop, step] in dB. Leave blank to use "
-                "qubex's default [-60, 0, 5] dB. The stop value is exclusive."
+                "Power range as [start, stop, step] in dB. The QDash default is "
+                "[-60, 0, 5] dB. The stop value is exclusive."
             ),
         ),
     }

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -1472,9 +1472,13 @@
             "value_type": "np.arange"
           },
           "power_range": {
-            "description": "Power range as [start, stop, step] in dB. Leave blank to use qubex's default [-60, 0, 5] dB. The stop value is exclusive.",
+            "description": "Power range as [start, stop, step] in dB. The QDash default is [-60, 0, 5] dB. The stop value is exclusive.",
             "unit": "dB",
-            "value": null,
+            "value": [
+              -60,
+              0,
+              5
+            ],
             "value_type": "np.arange"
           }
         },

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -1028,12 +1028,6 @@
             "value": 153600.0,
             "value_type": "int"
           },
-          "readout_amplitude": {
-            "description": "Readout amplitude used during the sweep. Matches the CheckQubitSpectroscopy default so the qubit response is probed under the same readout conditions.",
-            "unit": "a.u.",
-            "value": 0.04,
-            "value_type": "float"
-          },
           "shots": {
             "description": "Number of shots per frequency point. Higher than the usual CALIBRATION_SHOTS (2048) because this is a 1D scan and the phase response can still be small near the spectroscopy-derived seed amplitude — extra averaging is needed to get the signal above the noise floor for a stable sqrt-Lorentzian fit.",
             "unit": "a.u.",
@@ -1482,12 +1476,6 @@
             "unit": "dB",
             "value": null,
             "value_type": "np.arange"
-          },
-          "readout_amplitude": {
-            "description": "Readout amplitude used during the qubit spectroscopy sweep",
-            "unit": "a.u.",
-            "value": 0.04,
-            "value_type": "float"
           }
         },
         "task_type": "qubit"

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
@@ -156,11 +156,12 @@ def test_power_range_is_forwarded_to_qubex(monkeypatch) -> None:
         task, "_modified_qubit_readout_frequencies", lambda *args, **kwargs: nullcontext()
     )
 
-    task.run(backend, "0")
+    task.batch_run(backend, ["0"])
 
     assert list(exp.qubit_spectroscopy.call_args.kwargs["power_range"]) == pytest.approx(
         [-40.0, -30.0, -20.0]
     )
+    assert exp.qubit_spectroscopy.call_args.kwargs["readout_amplitude"] == 0.04
 
 
 def test_frequency_range_can_be_overridden_per_task() -> None:

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
@@ -19,6 +19,7 @@ else:
 def test_check_qubit_spectroscopy_outputs_uplifted_coarse_control_amplitude_and_marks_it(
     monkeypatch,
 ) -> None:
+    """Verify spectroscopy outputs and marks the uplifted coarse control amplitude."""
     task = CheckQubitSpectroscopy()
     raw_fig = go.Figure(go.Heatmap(x=[4.0, 4.1], y=[-20.0, -10.0], z=[[0.0, 1.0], [1.0, 0.0]]))
     marked_fig = go.Figure(raw_fig)
@@ -57,6 +58,7 @@ def test_check_qubit_spectroscopy_outputs_uplifted_coarse_control_amplitude_and_
 
 
 def test_check_qubit_spectroscopy_does_not_output_invalid_frequency(monkeypatch) -> None:
+    """Verify spectroscopy omits invalid frequency estimates from its outputs."""
     task = CheckQubitSpectroscopy()
     raw_fig = go.Figure(go.Heatmap(x=[4.0, 4.1], y=[-20.0, -10.0], z=[[0.0, 1.0], [1.0, 0.0]]))
     marked_fig = go.Figure(raw_fig)
@@ -89,6 +91,7 @@ def test_check_qubit_spectroscopy_does_not_output_invalid_frequency(monkeypatch)
 
 
 def test_check_qubit_spectroscopy_enables_trim_retry(monkeypatch) -> None:
+    """Verify spectroscopy enables the configured trimmed-data retry."""
     task = CheckQubitSpectroscopy()
     raw_fig = go.Figure(go.Heatmap(x=[4.0, 4.1], y=[-20.0, -10.0], z=[[0.0, 1.0], [1.0, 0.0]]))
     marked_fig = go.Figure(raw_fig)
@@ -113,6 +116,7 @@ def test_check_qubit_spectroscopy_enables_trim_retry(monkeypatch) -> None:
 
 
 def test_frequency_range_is_resolved_from_control_box_when_unset(monkeypatch) -> None:
+    """Verify an unset frequency range is resolved from the connected control box."""
     task = CheckQubitSpectroscopy()
     backend = cast("QubexBackend", object())
     exp = MagicMock()
@@ -129,6 +133,7 @@ def test_frequency_range_is_resolved_from_control_box_when_unset(monkeypatch) ->
 
 
 def test_run_parameters_only_expose_measurement_settings() -> None:
+    """Verify the task exposes only non-calibration measurement settings for a run."""
     assert set(CheckQubitSpectroscopy.run_spec) == {
         "frequency_range",
         "power_range",
@@ -136,6 +141,7 @@ def test_run_parameters_only_expose_measurement_settings() -> None:
 
 
 def test_power_range_is_forwarded_to_qubex(monkeypatch) -> None:
+    """Verify the resolved power range is forwarded to the qubex experiment."""
     task = CheckQubitSpectroscopy()
     task.run_parameters = copy.deepcopy(task.run_parameters)
     task.run_parameters["power_range"].value = (-40.0, -19.0, 10.0)
@@ -158,6 +164,7 @@ def test_power_range_is_forwarded_to_qubex(monkeypatch) -> None:
 
 
 def test_frequency_range_can_be_overridden_per_task() -> None:
+    """Verify a task-level frequency range override is honored."""
     task = CheckQubitSpectroscopy()
     task.run_parameters = copy.deepcopy(task.run_parameters)
     task.run_parameters["frequency_range"].value = (3.0, 3.3, 0.1)
@@ -166,6 +173,7 @@ def test_frequency_range_can_be_overridden_per_task() -> None:
 
 
 def test_explicit_frequency_range_is_not_resolved_from_control_box() -> None:
+    """Verify an explicit frequency range does not query the control box default."""
     task = CheckQubitSpectroscopy()
     task.run_parameters["frequency_range"].value = (3.0, 3.3, 0.1)
     backend = cast("QubexBackend", MagicMock())

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
@@ -132,7 +132,6 @@ def test_run_parameters_only_expose_measurement_settings() -> None:
     assert set(CheckQubitSpectroscopy.run_spec) == {
         "frequency_range",
         "power_range",
-        "readout_amplitude",
     }
 
 
@@ -141,6 +140,7 @@ def test_power_range_is_forwarded_to_qubex(monkeypatch) -> None:
     task.run_parameters = copy.deepcopy(task.run_parameters)
     task.run_parameters["power_range"].value = (-40.0, -19.0, 10.0)
     task.input_parameters["readout_frequency"].value = 6.0
+    task.input_parameters["readout_amplitude"].value = 0.04
     backend = cast("QubexBackend", object())
     exp = MagicMock()
     monkeypatch.setattr(task, "get_experiment", lambda _backend: exp)

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
@@ -140,6 +140,15 @@ def test_run_parameters_only_expose_measurement_settings() -> None:
     }
 
 
+def test_power_range_has_qdash_default() -> None:
+    """Verify QDash provides a usable default power sweep."""
+    task = CheckQubitSpectroscopy()
+
+    assert list(task.run_parameters["power_range"].get_value()) == pytest.approx(
+        [-60.0, -55.0, -50.0, -45.0, -40.0, -35.0, -30.0, -25.0, -20.0, -15.0, -10.0, -5.0]
+    )
+
+
 def test_power_range_is_forwarded_to_qubex(monkeypatch) -> None:
     """Verify the resolved power range is forwarded to the qubex experiment."""
     task = CheckQubitSpectroscopy()

--- a/tests/qdash/workflow/calibtasks/qubex/test_readout_amplitude_propagation.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_readout_amplitude_propagation.py
@@ -8,6 +8,7 @@ from qdash.workflow.service.tasks import BRINGUP_TASKS
 
 
 def test_bringup_tasks_prefer_loaded_readout_amplitude() -> None:
+    """Verify bring-up tasks use the resolved readout-amplitude calibration input."""
     for task_cls in (
         CheckQubitSpectroscopy,
         CheckControlAmplitude,
@@ -20,6 +21,7 @@ def test_bringup_tasks_prefer_loaded_readout_amplitude() -> None:
 
 
 def test_readout_amplitude_requires_resolved_calibration_input() -> None:
+    """Verify a missing readout-amplitude calibration input fails explicitly."""
     task = CheckQubitSpectroscopy()
 
     with pytest.raises(ValueError, match="readout_amplitude input parameter is required"):
@@ -27,6 +29,7 @@ def test_readout_amplitude_requires_resolved_calibration_input() -> None:
 
 
 def test_bringup_tasks_declare_readout_amplitude_as_calibration_input() -> None:
+    """Verify bring-up tasks declare readout amplitude as a calibration input."""
     for task_cls in (
         CheckQubitSpectroscopy,
         CheckControlAmplitude,
@@ -36,11 +39,13 @@ def test_bringup_tasks_declare_readout_amplitude_as_calibration_input() -> None:
 
 
 def test_cw_tasks_do_not_declare_readout_amplitude_as_run_parameter() -> None:
+    """Verify CW tasks do not duplicate readout amplitude in their run parameters."""
     for task_cls in (CheckQubitSpectroscopy, CheckControlAmplitude):
         assert "readout_amplitude" not in task_cls.run_spec
 
 
 def test_bringup_uses_adaptive_check_chevron_before_fine_refinement() -> None:
+    """Verify bring-up orders adaptive chevron after CW calibration tasks."""
     assert "CheckChevron" in BRINGUP_TASKS
     assert "CheckCoarseChevron" not in BRINGUP_TASKS
     assert "Configure" not in BRINGUP_TASKS

--- a/tests/qdash/workflow/calibtasks/qubex/test_readout_amplitude_propagation.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_readout_amplitude_propagation.py
@@ -1,3 +1,5 @@
+import pytest
+
 from qdash.datamodel.task import InputParameterModel
 from qdash.workflow.calibtasks.qubex.cw.check_control_amplitude import CheckControlAmplitude
 from qdash.workflow.calibtasks.qubex.cw.check_qubit_spectroscopy import CheckQubitSpectroscopy
@@ -17,10 +19,11 @@ def test_bringup_tasks_prefer_loaded_readout_amplitude() -> None:
         assert task._get_readout_amplitude_value() == 0.017
 
 
-def test_readout_amplitude_falls_back_to_run_parameter_default() -> None:
+def test_readout_amplitude_requires_resolved_calibration_input() -> None:
     task = CheckQubitSpectroscopy()
 
-    assert task._get_readout_amplitude_value() == 0.04
+    with pytest.raises(ValueError, match="readout_amplitude input parameter is required"):
+        task._get_readout_amplitude_value()
 
 
 def test_bringup_tasks_declare_readout_amplitude_as_calibration_input() -> None:
@@ -30,6 +33,11 @@ def test_bringup_tasks_declare_readout_amplitude_as_calibration_input() -> None:
         CheckChevron,
     ):
         assert "readout_amplitude" in task_cls.input_spec
+
+
+def test_cw_tasks_do_not_declare_readout_amplitude_as_run_parameter() -> None:
+    for task_cls in (CheckQubitSpectroscopy, CheckControlAmplitude):
+        assert "readout_amplitude" not in task_cls.run_spec
 
 
 def test_bringup_uses_adaptive_check_chevron_before_fine_refinement() -> None:


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Remove the duplicate CW readout amplitude run parameter so calibration input overrides remain the single source of truth.
- Affects workflow task metadata and execution only; no API schema or generated client changes are required.

## Changes
- Remove readout_amplitude from the run specs of CheckQubitSpectroscopy and CheckControlAmplitude.
- Use the resolved calibration input consistently in regular and batch spectroscopy execution.
- Fail explicitly when the required calibration input is unresolved while preserving user input overrides.
- Regenerate the workflow task catalog and update regression tests.
- Verify with task check: 1543 Python tests and 220 UI tests passed, along with lint, type checking, audit, and leak scanning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Readout amplitude is now supplied through resolved calibration settings for qubit spectroscopy and control-amplitude checks.
  * Removed readout amplitude from the configurable parameters for these tasks.
  * Tasks now require a resolved readout amplitude and report an error when it is missing.
  * Qubit spectroscopy now defaults to a power sweep of -60 to 0 dB in 5 dB steps.

* **Tests**
  * Added coverage for calibration input requirements, default power sweeps, and task parameter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->