### PR TITLE
feat: allow editors to update forum thread titles

### DIFF
--- a/src/qdash/api/services/forum_service.py
+++ b/src/qdash/api/services/forum_service.py
@@ -936,9 +936,7 @@ class ForumService:
         content_blocks_changed = content_blocks is not None and content_blocks != doc.content_blocks
         content_changed = content != doc.content
         if not can_edit_content and not (
-            can_edit_metadata
-            and not content_changed
-            and not content_blocks_changed
+            can_edit_metadata and not content_changed and not content_blocks_changed
         ):
             raise HTTPException(
                 status_code=403,

--- a/src/qdash/api/services/forum_service.py
+++ b/src/qdash/api/services/forum_service.py
@@ -935,12 +935,10 @@ class ForumService:
         can_edit_metadata = doc.parent_id is None and role == ProjectRole.EDITOR
         content_blocks_changed = content_blocks is not None and content_blocks != doc.content_blocks
         content_changed = content != doc.content
-        title_changed = title is not None and title != doc.title
         if not can_edit_content and not (
             can_edit_metadata
             and not content_changed
             and not content_blocks_changed
-            and not title_changed
         ):
             raise HTTPException(
                 status_code=403,

--- a/tests/qdash/api/routers/test_forum.py
+++ b/tests/qdash/api/routers/test_forum.py
@@ -565,6 +565,24 @@ def test_editor_can_update_forum_thread_metadata(test_client, init_db):
     assert response.json()["status"] == "investigating"
 
 
+def test_editor_can_update_another_users_forum_thread_title(test_client, init_db):
+    """Project editors can update the title without permission to rewrite the content."""
+    _create_user("owner", "owner_token", ProjectRole.OWNER)
+    _create_user("editor", "editor_token", ProjectRole.EDITOR)
+    _create_project()
+
+    root = _create_post(test_client, _headers("owner_token"))
+    response = test_client.patch(
+        f"/forum/posts/{root.json()['id']}",
+        headers=_headers("editor_token"),
+        json={"title": "Clarified title", "content": root.json()["content"]},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["title"] == "Clarified title"
+    assert response.json()["content"] == root.json()["content"]
+
+
 def test_editor_cannot_update_another_users_forum_content(test_client, init_db):
     """Metadata moderation does not grant editors permission to rewrite post content."""
     _create_user("owner", "owner_token", ProjectRole.OWNER)

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -699,7 +699,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                 {post.title || "Untitled topic"}
               </h1>
             )}
-            {canManageContent && !editingTitle && (
+            {canManageMetadata && !editingTitle && (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Allow project editors to update forum thread titles as part of thread metadata management.
- Preserve the existing restriction that editors cannot rewrite another user’s post body or content blocks.

## Changes
- Permit title-only updates for root forum threads in ForumService.
- Show the title edit action to project editors in ForumDetailPage.
- Add API regression coverage for editor title updates while preserving thread content.
- No OpenAPI schema or generated client changes are required.

## Verification
- Ruff: passed.
- UI lint, formatting, and TypeScript checks: passed.
- The focused API test could not complete locally because the database fixture timed out during setup; CI will run it with the repository test services.