### PR TITLE
feat(ui): preview task result links in forum

### DIFF
--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -32,7 +32,6 @@ import {
   useListForumPosts,
   useUpdateForumPost,
 } from "@/client/forum/forum";
-import { MarkdownContent } from "@/components/ui/MarkdownContent";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
 import { QdashBotAvatar, UserAvatar } from "@/components/ui/UserAvatar";
@@ -53,7 +52,8 @@ import {
   toForumCategoryDefinition,
 } from "./categories";
 import { ForumLabelPicker } from "./ForumLabelSelector";
-import { ForumBlockViewer, type ForumBlockSnapshotGetter } from "./ForumBlockEditor";
+import { type ForumBlockSnapshotGetter } from "./ForumBlockEditor";
+import { ForumPostContent } from "./ForumPostContent";
 
 const ForumBlockEditor = dynamic(
   () => import("./ForumBlockEditor").then((m) => ({ default: m.ForumBlockEditor })),
@@ -246,14 +246,11 @@ function PostBody({
           </div>
         </div>
       ) : (
-        (() => {
-          const displayBlocks = (post.content_blocks ?? []) as Record<string, unknown>[];
-          return displayBlocks.length > 0 ? (
-            <ForumBlockViewer blocks={displayBlocks} />
-          ) : (
-            <MarkdownContent content={post.content} className="text-sm text-base-content/80" />
-          );
-        })()
+        <ForumPostContent
+          content={post.content}
+          contentBlocks={post.content_blocks}
+          markdownClassName="text-sm text-base-content/80"
+        />
       )}
     </div>
   );

--- a/ui/src/components/features/forum/ForumPageContent.tsx
+++ b/ui/src/components/features/forum/ForumPageContent.tsx
@@ -61,7 +61,7 @@ import {
   type ForumCategoryDefinition,
 } from "./categories";
 import { ForumLabelPicker } from "./ForumLabelSelector";
-import { ForumBlockViewer } from "./ForumBlockEditor";
+import { ForumPostContent } from "./ForumPostContent";
 
 const PAGE_SIZE = 30;
 
@@ -706,16 +706,11 @@ function ForumThreadPreviewSidebar({
               <section>
                 <h3 className="mb-2 text-sm font-semibold">Root thread</h3>
                 <div className="rounded-lg border border-base-300 bg-base-100 p-4">
-                  {(post.content_blocks ?? []).length > 0 ? (
-                    <ForumBlockViewer
-                      blocks={(post.content_blocks ?? []) as Record<string, unknown>[]}
-                    />
-                  ) : (
-                    <MarkdownContent
-                      content={post.content}
-                      className="text-sm text-base-content/80"
-                    />
-                  )}
+                  <ForumPostContent
+                    content={post.content}
+                    contentBlocks={post.content_blocks}
+                    markdownClassName="text-sm text-base-content/80"
+                  />
                 </div>
               </section>
 
@@ -738,17 +733,12 @@ function ForumThreadPreviewSidebar({
                           <span>{reply.username}</span>
                           <span>{formatRelativeTime(reply.created_at)}</span>
                         </div>
-                        {(reply.content_blocks ?? []).length > 0 ? (
-                          <ForumBlockViewer
-                            blocks={(reply.content_blocks ?? []) as Record<string, unknown>[]}
-                          />
-                        ) : (
-                          <MarkdownContent
-                            content={reply.content}
-                            preview
-                            className="line-clamp-3 text-sm text-base-content/70"
-                          />
-                        )}
+                        <ForumPostContent
+                          content={reply.content}
+                          contentBlocks={reply.content_blocks}
+                          markdownPreview
+                          markdownClassName="line-clamp-3 text-sm text-base-content/70"
+                        />
                       </div>
                     ))}
                   </div>

--- a/ui/src/components/features/forum/ForumPostContent.tsx
+++ b/ui/src/components/features/forum/ForumPostContent.tsx
@@ -1,0 +1,35 @@
+import { MarkdownContent } from "@/components/ui/MarkdownContent";
+
+import { ForumBlockViewer } from "./ForumBlockEditor";
+import { TaskResultLinkPreviews } from "./TaskResultLinkPreviews";
+import { extractLinkedTaskResultIds } from "./taskResultLinks";
+
+export function ForumPostContent({
+  content,
+  contentBlocks,
+  markdownClassName,
+  markdownPreview = false,
+}: {
+  content: string;
+  contentBlocks?: unknown[] | null;
+  markdownClassName?: string;
+  markdownPreview?: boolean;
+}) {
+  const blocks = (contentBlocks ?? []) as Record<string, unknown>[];
+  const linkedTaskResultIds = extractLinkedTaskResultIds(content, blocks);
+
+  return (
+    <>
+      {blocks.length > 0 ? (
+        <ForumBlockViewer blocks={blocks} />
+      ) : (
+        <MarkdownContent
+          content={content}
+          className={markdownClassName}
+          preview={markdownPreview}
+        />
+      )}
+      <TaskResultLinkPreviews taskIds={linkedTaskResultIds} />
+    </>
+  );
+}

--- a/ui/src/components/features/forum/TaskResultLinkPreviews.tsx
+++ b/ui/src/components/features/forum/TaskResultLinkPreviews.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { Activity, ArrowUpRight, Clock } from "lucide-react";
+
+import { useGetTaskResult } from "@/client/task/task";
+import { TaskFigure } from "@/components/charts/TaskFigure";
+import { formatRelativeTime } from "@/lib/utils/datetime";
+
+function statusClass(status: string): string {
+  if (status === "success") return "badge-success";
+  if (status === "failed") return "badge-error";
+  if (status === "running") return "badge-warning";
+  return "badge-ghost";
+}
+
+function TaskResultLinkPreview({ taskId }: { taskId: string }) {
+  const { data, isLoading, isError } = useGetTaskResult(taskId, {
+    query: { staleTime: 30_000, retry: false },
+  });
+  const taskResult = data?.data;
+
+  if (isError) return null;
+
+  if (isLoading || !taskResult) {
+    return (
+      <div className="flex min-h-20 items-center gap-3 rounded-lg border border-base-300 bg-base-100 px-4 py-3">
+        <span className="loading loading-spinner loading-sm text-primary" />
+        <span className="text-xs text-base-content/50">Loading task result…</span>
+      </div>
+    );
+  }
+
+  const figurePath = taskResult.figure_path[0];
+  const jsonFigurePath = taskResult.json_figure_path[0];
+
+  return (
+    <Link
+      href={`/task-results/${encodeURIComponent(taskId)}`}
+      className="group grid overflow-hidden rounded-lg border border-base-300 bg-base-100 transition-colors hover:border-primary/50 sm:grid-cols-[minmax(0,1fr)_12rem]"
+    >
+      <div className="min-w-0 p-3">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+          <span className="truncate text-sm font-semibold">{taskResult.task_name}</span>
+          <span className={`badge badge-sm ${statusClass(taskResult.status)}`}>
+            {taskResult.status}
+          </span>
+          <ArrowUpRight
+            className="ml-auto h-4 w-4 shrink-0 text-base-content/35 transition-colors group-hover:text-primary"
+            aria-hidden="true"
+          />
+        </div>
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-base-content/55">
+          <span className="badge badge-sm badge-neutral">Q{taskResult.qid}</span>
+          {taskResult.chip_id && <span>{taskResult.chip_id}</span>}
+          {taskResult.end_at && (
+            <span className="inline-flex items-center gap-1">
+              <Clock className="h-3 w-3" aria-hidden="true" />
+              {formatRelativeTime(taskResult.end_at)}
+            </span>
+          )}
+        </div>
+        <div className="mt-2 truncate font-mono text-[11px] text-base-content/40">{taskId}</div>
+      </div>
+      {(figurePath || jsonFigurePath) && (
+        <div className="hidden h-28 items-center justify-center overflow-hidden border-l border-base-300 bg-base-200/40 p-2 sm:flex">
+          <TaskFigure
+            path={figurePath ?? jsonFigurePath}
+            jsonFigurePath={jsonFigurePath}
+            qid={taskResult.qid}
+            className="max-h-full max-w-full object-contain"
+            hideExpandButton
+          />
+        </div>
+      )}
+    </Link>
+  );
+}
+
+export function TaskResultLinkPreviews({ taskIds }: { taskIds: string[] }) {
+  if (taskIds.length === 0) return null;
+
+  return (
+    <div className="mt-4 space-y-2">
+      <div className="text-xs font-semibold uppercase tracking-wide text-base-content/45">
+        Linked task results
+      </div>
+      {taskIds.map((taskId) => (
+        <TaskResultLinkPreview key={taskId} taskId={taskId} />
+      ))}
+    </div>
+  );
+}

--- a/ui/src/components/features/forum/__tests__/taskResultLinks.test.ts
+++ b/ui/src/components/features/forum/__tests__/taskResultLinks.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { extractLinkedTaskResultIds } from "../taskResultLinks";
+
+describe("extractLinkedTaskResultIds", () => {
+  it("extracts relative and absolute task-result links", () => {
+    expect(
+      extractLinkedTaskResultIds(
+        "Compare [first](/task-results/task-001) with https://qdash.example/task-results/task-002?tab=figure.",
+        [],
+      ),
+    ).toEqual(["task-001", "task-002"]);
+  });
+
+  it("extracts links from BlockNote values and removes duplicates", () => {
+    const blocks = [
+      {
+        type: "paragraph",
+        content: [{ type: "link", href: "/task-results/task-003", content: "result" }],
+      },
+    ];
+
+    expect(extractLinkedTaskResultIds("/task-results/task-003", blocks)).toEqual(["task-003"]);
+  });
+
+  it("limits previews to three linked results", () => {
+    expect(
+      extractLinkedTaskResultIds(
+        [1, 2, 3, 4].map((id) => `/task-results/task-${id}`).join(" "),
+        [],
+      ),
+    ).toEqual(["task-1", "task-2", "task-3"]);
+  });
+
+  it("ignores unrelated links", () => {
+    expect(extractLinkedTaskResultIds("See /forum/123 and https://example.com", [])).toEqual([]);
+  });
+});

--- a/ui/src/components/features/forum/taskResultLinks.ts
+++ b/ui/src/components/features/forum/taskResultLinks.ts
@@ -1,0 +1,39 @@
+const TASK_RESULT_LINK_RE = /(?:https?:\/\/[^\s/]+)?\/task-results\/([^\s/?#)\]}>,"']+)/g;
+
+const MAX_TASK_RESULT_PREVIEWS = 3;
+
+function collectStrings(value: unknown, strings: string[]): void {
+  if (typeof value === "string") {
+    strings.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectStrings(item, strings));
+    return;
+  }
+  if (value && typeof value === "object") {
+    Object.values(value).forEach((item) => collectStrings(item, strings));
+  }
+}
+
+/** Find unique task-result IDs linked from legacy Markdown or BlockNote content. */
+export function extractLinkedTaskResultIds(
+  content: string,
+  blocks: Record<string, unknown>[],
+): string[] {
+  const strings = [content];
+  collectStrings(blocks, strings);
+
+  const ids = new Set<string>();
+  for (const value of strings) {
+    for (const match of value.matchAll(TASK_RESULT_LINK_RE)) {
+      try {
+        ids.add(decodeURIComponent(match[1]));
+      } catch {
+        ids.add(match[1]);
+      }
+      if (ids.size === MAX_TASK_RESULT_PREVIEWS) return [...ids];
+    }
+  }
+  return [...ids];
+}


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Show linked task-result metadata and figures directly in forum conversations for faster calibration review.
- UI-only change affecting forum detail pages and the forum list preview sidebar; no API, schema, configuration, or generated client changes.

## Changes

- Detect up to three unique task-result links in Markdown and BlockNote forum content.
- Add reusable task-result preview cards with task name, status, qubit, chip, timestamp, and figure thumbnail.
- Reuse the same forum post renderer in ForumDetailPage and the ForumPageContent preview sidebar, including recent replies.
- Preserve original links and gracefully omit cards when a linked task result cannot be loaded.
- Add unit coverage for relative, absolute, duplicate, unrelated, and over-limit links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent forum post rendering for both standard text and block-based content.
  - Forum posts now display previews for linked task results, including status, metadata, and associated figures when available.
  - Supports linked task-result references from both Markdown and block-based posts, with up to three previews shown.

- **Bug Fixes**
  - Improved handling of task-result links across forum content formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->