### PR TITLE
feat(ui): add forum mention suggestions

### DIFF
--- a/ui/src/components/features/forum/ForumBlockEditor.tsx
+++ b/ui/src/components/features/forum/ForumBlockEditor.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useEffect, useState, type MutableRefObject } from "react";
+import { useCallback, useEffect, useState, type MutableRefObject } from "react";
 
 import "@blocknote/core/fonts/inter.css";
 import "@blocknote/mantine/style.css";
-import { useCreateBlockNote } from "@blocknote/react";
+import {
+  SuggestionMenuController,
+  useCreateBlockNote,
+  type DefaultReactSuggestionItem,
+} from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 
 import { DARK_THEMES, type ThemeName } from "@/constants/themes";
@@ -45,6 +49,25 @@ export type ForumBlockSnapshot = {
 
 export type ForumBlockSnapshotGetter = () => Promise<ForumBlockSnapshot>;
 
+export type ForumMentionCandidate = {
+  id: string;
+  label: string;
+  secondaryLabel?: string;
+};
+
+export function filterForumMentionCandidates(
+  candidates: ForumMentionCandidate[],
+  query: string,
+): ForumMentionCandidate[] {
+  const normalizedQuery = query.toLowerCase();
+  return candidates.filter(
+    (candidate) =>
+      candidate.id.toLowerCase().includes(normalizedQuery) ||
+      candidate.label.toLowerCase().includes(normalizedQuery) ||
+      candidate.secondaryLabel?.toLowerCase().includes(normalizedQuery),
+  );
+}
+
 interface ForumBlockEditorProps {
   /** Current document, as opaque BlockNote JSON objects. */
   initialBlocks?: Record<string, unknown>[];
@@ -56,6 +79,7 @@ interface ForumBlockEditorProps {
   onChange: (blocks: Record<string, unknown>[], markdown: string) => void;
   /** Imperative snapshot used by external Save buttons to avoid stale React state. */
   snapshotRef?: MutableRefObject<ForumBlockSnapshotGetter | null>;
+  mentionCandidates?: ForumMentionCandidate[];
   editable?: boolean;
 }
 
@@ -94,6 +118,7 @@ export function ForumBlockEditor({
   onImageUpload,
   onChange,
   snapshotRef,
+  mentionCandidates = [],
   editable = true,
 }: ForumBlockEditorProps) {
   const colorScheme = useThemeScheme();
@@ -110,6 +135,25 @@ export function ForumBlockEditor({
     uploadFile: (file: File) =>
       file.type.startsWith("image/") ? onImageUpload(file) : uploadInlineFile(file),
   });
+  const getMentionItems = useCallback(
+    async (query: string): Promise<DefaultReactSuggestionItem[]> =>
+      filterForumMentionCandidates(mentionCandidates, query).map((candidate) => ({
+        title: candidate.label,
+        subtext: candidate.secondaryLabel
+          ? `@${candidate.id} · ${candidate.secondaryLabel}`
+          : `@${candidate.id}`,
+        onItemClick: () =>
+          editor.insertInlineContent([
+            {
+              type: "text",
+              text: `@${candidate.id}`,
+              styles: { bold: true, textColor: "blue", backgroundColor: "blue" },
+            },
+            { type: "text", text: " ", styles: {} },
+          ]),
+      })),
+    [editor, mentionCandidates],
+  );
 
   useEffect(() => {
     if (!snapshotRef) return;
@@ -152,7 +196,11 @@ export function ForumBlockEditor({
             onChange(blocks, md),
           );
         }}
-      />
+      >
+        {editable && mentionCandidates.length > 0 && (
+          <SuggestionMenuController triggerCharacter="@" getItems={getMentionItems} />
+        )}
+      </BlockNoteView>
     </div>
   );
 }

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -52,7 +52,7 @@ import {
   toForumCategoryDefinition,
 } from "./categories";
 import { ForumLabelPicker } from "./ForumLabelSelector";
-import { type ForumBlockSnapshotGetter } from "./ForumBlockEditor";
+import { type ForumBlockSnapshotGetter, type ForumMentionCandidate } from "./ForumBlockEditor";
 import { ForumPostContent } from "./ForumPostContent";
 
 const ForumBlockEditor = dynamic(
@@ -144,6 +144,7 @@ function PostBody({
   saving,
   onImageUpload,
   editorSnapshotRef,
+  mentionCandidates,
 }: {
   post: ForumPostResponse;
   currentUsername?: string;
@@ -162,6 +163,7 @@ function PostBody({
   saving: boolean;
   onImageUpload: (file: File) => Promise<string>;
   editorSnapshotRef?: MutableRefObject<ForumBlockSnapshotGetter | null>;
+  mentionCandidates?: ForumMentionCandidate[];
 }) {
   const canEdit = canEditOverride ?? currentUsername === post.username;
   const isAi = post.is_ai_reply || post.username === "qdash";
@@ -231,6 +233,7 @@ function PostBody({
             onChange={onEditChange}
             onImageUpload={onImageUpload}
             snapshotRef={editorSnapshotRef}
+            mentionCandidates={mentionCandidates}
           />
           <div className="flex justify-end gap-2">
             <button className="btn btn-ghost btn-sm" onClick={onCancel}>
@@ -310,6 +313,20 @@ export function ForumDetailPage({ postId }: { postId: string }) {
   const members = useMemo(
     () => (membersResponse?.data.members ?? []).filter((member) => member.status === "active"),
     [membersResponse?.data.members],
+  );
+  const mentionCandidates: ForumMentionCandidate[] = useMemo(
+    () => [
+      { id: "qdash", label: "QDash" },
+      { id: "project", label: "Project", secondaryLabel: "Notify all project members" },
+      ...members
+        .filter((member) => member.username !== currentUsername)
+        .map((member) => ({
+          id: member.username,
+          label: member.display_name || member.username,
+          secondaryLabel: member.organization ?? undefined,
+        })),
+    ],
+    [currentUsername, members],
   );
   const { data: chipsResponse } = useListChips({ query: { staleTime: 60_000 } });
   const chips = useMemo(
@@ -743,6 +760,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
             saving={updateMutation.isPending}
             onImageUpload={uploadImage}
             editorSnapshotRef={editRootSnapshotRef}
+            mentionCandidates={mentionCandidates}
           />
 
           <div className="divider text-xs text-base-content/40">
@@ -777,6 +795,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                     saving={updateMutation.isPending}
                     onImageUpload={uploadImage}
                     editorSnapshotRef={editReplySnapshotRef}
+                    mentionCandidates={mentionCandidates}
                   />
                 ))}
                 {replies.length >= replyLimit && (
@@ -821,6 +840,7 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                   }}
                   onImageUpload={uploadImage}
                   snapshotRef={replyComposerSnapshotRef}
+                  mentionCandidates={mentionCandidates}
                 />
                 <div className="mt-2 flex items-center justify-between gap-2">
                   <span className="text-xs text-base-content/50">

--- a/ui/src/components/features/forum/ForumNewPage.tsx
+++ b/ui/src/components/features/forum/ForumNewPage.tsx
@@ -27,7 +27,7 @@ import {
   toForumCategoryDefinition,
 } from "./categories";
 import { ForumLabelPicker } from "./ForumLabelSelector";
-import type { ForumBlockSnapshotGetter } from "./ForumBlockEditor";
+import type { ForumBlockSnapshotGetter, ForumMentionCandidate } from "./ForumBlockEditor";
 
 const ForumBlockEditor = dynamic(
   () => import("./ForumBlockEditor").then((m) => ({ default: m.ForumBlockEditor })),
@@ -128,6 +128,20 @@ export function ForumNewPage() {
     () => (membersResponse?.data.members ?? []).filter((member) => member.status === "active"),
     [membersResponse?.data.members],
   );
+  const mentionCandidates: ForumMentionCandidate[] = useMemo(
+    () => [
+      { id: "qdash", label: "QDash" },
+      { id: "project", label: "Project", secondaryLabel: "Notify all project members" },
+      ...members
+        .filter((member) => member.username !== user?.username)
+        .map((member) => ({
+          id: member.username,
+          label: member.display_name || member.username,
+          secondaryLabel: member.organization ?? undefined,
+        })),
+    ],
+    [members, user?.username],
+  );
 
   const createMutation = useCreateForumPost();
 
@@ -217,6 +231,7 @@ export function ForumNewPage() {
               }}
               onImageUpload={uploadImage}
               snapshotRef={editorSnapshotRef}
+              mentionCandidates={mentionCandidates}
             />
             <div className="mt-2 flex items-center justify-between gap-2">
               <span className="text-xs text-base-content/50">

--- a/ui/src/components/features/forum/__tests__/ForumBlockEditor.test.tsx
+++ b/ui/src/components/features/forum/__tests__/ForumBlockEditor.test.tsx
@@ -1,10 +1,57 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { ForumBlockViewer } from "../ForumBlockEditor";
+import { filterForumMentionCandidates, ForumBlockViewer } from "../ForumBlockEditor";
+
+describe("filterForumMentionCandidates", () => {
+  const candidates = [
+    { id: "qdash", label: "QDash" },
+    { id: "project", label: "Project", secondaryLabel: "Notify all project members" },
+    { id: "alice", label: "Alice Smith", secondaryLabel: "Quantum team" },
+  ];
+
+  it("matches mention IDs and display labels case-insensitively", () => {
+    expect(filterForumMentionCandidates(candidates, "DAS")).toEqual([candidates[0]]);
+    expect(filterForumMentionCandidates(candidates, "smith")).toEqual([candidates[2]]);
+  });
+
+  it("matches secondary labels", () => {
+    expect(filterForumMentionCandidates(candidates, "all project")).toEqual([candidates[1]]);
+    expect(filterForumMentionCandidates(candidates, "quantum")).toEqual([candidates[2]]);
+  });
+});
 
 describe("ForumBlockViewer", () => {
   afterEach(cleanup);
+
+  it("renders a selected mention with persistent emphasis", () => {
+    render(
+      <ForumBlockViewer
+        blocks={[
+          {
+            id: "paragraph-1",
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "@alice",
+                styles: { bold: true, textColor: "blue", backgroundColor: "blue" },
+              },
+              { type: "text", text: " please review", styles: {} },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const mention = screen.getByText("@alice");
+    expect(mention.closest('[data-style-type="textColor"]')?.getAttribute("data-value")).toBe(
+      "blue",
+    );
+    expect(mention.closest('[data-style-type="backgroundColor"]')?.getAttribute("data-value")).toBe(
+      "blue",
+    );
+  });
 
   it("renders links in BlockNote inline content", () => {
     render(


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Add mention autocomplete to the BlockNote-based forum editors so users can reliably select project members and special mentions.
- This is a UI-only change; API contracts, generated clients, and configuration are unchanged.

## Changes
- Add `@` suggestion menus to ForumBlockEditor for new threads, replies, and post editing.
- Include `@qdash`, `@project`, and active project members while excluding the current user.
- Persist selected mentions with distinct styling so they remain recognizable while editing and after posting.
- Add filtering and rendering coverage for forum mentions.

## Verification
- `task test-ui` (49 files, 227 tests)
- `bunx tsc --noEmit`
- `bunx oxlint src/components/features/forum/ForumBlockEditor.tsx src/components/features/forum/ForumNewPage.tsx src/components/features/forum/ForumDetailPage.tsx src/components/features/forum/__tests__/ForumBlockEditor.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `@mention` suggestions when creating or editing forum posts and replies.
  * Search mentions by ID, name, or secondary label.
  * Mention options include QDash, all project members, and eligible active members.
  * Selected mentions are displayed with persistent visual emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->