### PR TITLE
fix(api): lock the execution the moment a run is dispatched (#778)

### DIFF
--- a/docs/development/workflow/engine-architecture.md
+++ b/docs/development/workflow/engine-architecture.md
@@ -288,6 +288,15 @@ Runs that do not go through the API — cron schedules, where the Prefect schedu
 
 Pre-creation is best effort. It is skipped when no `chip_id` can be resolved, and any failure is logged and swallowed: the Prefect flow run already exists at that point, and a bookkeeping failure is not a reason to cancel a healthy calibration. Such a run simply falls back to the cron-schedule path above — `CalibService` allocates its own `execution_id` at flow start — and the API response reports the Prefect flow run ID as `execution_id` until then.
 
+### Mutual Exclusion
+
+`ExecutionLockDocument` is taken by `CalibService._initialize()` when the flow process starts and released when the execution is closed, so it says nothing during the seconds between the button press and the flow start. The pre-created `scheduled` row covers exactly that window: the row only becomes `running` inside `CalibOrchestrator.initialize()`, which runs after the lock has been acquired, so the two signals overlap rather than leaving a gap.
+
+- `GET /executions/lock-status` reports `lock=true` when the lock document is held **or** the project's latest execution is still `scheduled`, so the UI locks as soon as a run is dispatched.
+- `FlowService._reject_when_execution_in_progress()` reads the same execution and applies the same rule to `execute_flow`, `re_execute_from_snapshot` and `execute_single_task_from_snapshot`, which answer `409` instead of dispatching a second flow run. A rejection therefore always matches the locked state the UI is showing.
+
+A `scheduled` execution is reconciled against Prefect before the lock status is reported, so a run that dies before its flow process starts does not keep the project locked. Started executions are deliberately left to the lock document, which the finalizer releases together with the execution record.
+
 ### Reconciliation with Prefect
 
 Hooks only fire while the Prefect runner is alive. When the runner itself dies, nothing closes the execution and it stays `running` forever. `ExecutionService._reconcile_with_prefect()` (API) closes that gap when an execution detail is read: open executions holding a `note.flow_run_id` are looked up in Prefect and finalized when their flow run has already reached a terminal state. Execution-list reads do not call Prefect synchronously, so history remains available when Prefect is slow or unavailable.

--- a/src/qdash/api/dependencies/__init__.py
+++ b/src/qdash/api/dependencies/__init__.py
@@ -515,6 +515,7 @@ def get_flow_service() -> "FlowService":
     return FlowService(
         flow_repository=get_flow_repository(),
         execution_lock_repository=get_execution_lock_repository(),
+        execution_history_repository=get_execution_history_repository(),
     )
 
 

--- a/src/qdash/api/services/execution_service.py
+++ b/src/qdash/api/services/execution_service.py
@@ -25,6 +25,7 @@ from qdash.api.schemas.execution import (
     Task,
 )
 from qdash.common.utils.datetime import now, parse_elapsed_time
+from qdash.datamodel.execution import ExecutionStatusModel
 from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 from qdash.repository.execution_finalizer import finalize_executions_by_flow_run_id
 
@@ -283,6 +284,16 @@ class ExecutionService:
     def get_lock_status(self, project_id: str) -> ExecutionLockStatusResponse:
         """Get the execution lock status.
 
+        The ``ExecutionLockDocument`` is only taken once the flow process
+        starts, which leaves a window of several seconds after the user
+        presses execute where nothing looks locked. The ``scheduled``
+        execution the API records at trigger time covers that window, so the
+        status flips the moment a run is dispatched.
+
+        Such an execution is reconciled against Prefect first, so a run that
+        died before its flow process started does not keep the project locked
+        forever.
+
         Parameters
         ----------
         project_id : str
@@ -298,8 +309,10 @@ class ExecutionService:
         latest = self._history_repo.find_latest_by_project(project_id)
         if latest is None:
             return ExecutionLockStatusResponse(lock=bool(status))
+        if latest.status == ExecutionStatusModel.SCHEDULED:
+            self._reconcile_with_prefect([latest])
         return ExecutionLockStatusResponse(
-            lock=bool(status),
+            lock=bool(status) or latest.status == ExecutionStatusModel.SCHEDULED,
             execution_id=latest.execution_id,
             chip_id=latest.chip_id,
             name=latest.name,

--- a/src/qdash/api/services/flow_service.py
+++ b/src/qdash/api/services/flow_service.py
@@ -42,10 +42,14 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from qdash.repository import MongoExecutionLockRepository, MongoFlowRepository
+    from qdash.repository.execution_history import MongoExecutionHistoryRepository
 
 logger = logging.getLogger("uvicorn.app")
 
 DEPLOYMENT_SERVICE_URL = os.getenv("DEPLOYMENT_SERVICE_URL", "http://deployment-service:8001")
+EXECUTION_IN_PROGRESS_DETAIL = (
+    "Another calibration execution is already in progress for this project"
+)
 
 
 def _to_deployment_service_path(file_path: Path) -> Path:
@@ -66,10 +70,12 @@ class FlowService:
         self,
         flow_repository: MongoFlowRepository,
         execution_lock_repository: MongoExecutionLockRepository | None = None,
+        execution_history_repository: MongoExecutionHistoryRepository | None = None,
     ) -> None:
         """Initialize the service with a flow repository."""
         self._flow_repo = flow_repository
         self._execution_lock_repo = execution_lock_repository
+        self._execution_history_repo = execution_history_repository
         self._project_flows_base_dir = USER_FLOWS_DIR
 
     async def save_flow(
@@ -381,6 +387,8 @@ class FlowService:
                 ),
             )
 
+        self._reject_when_execution_in_progress(project_id)
+
         parameters: dict[str, Any] = {
             **flow.default_parameters,
             **request.parameters,
@@ -483,6 +491,8 @@ class FlowService:
                     " Please re-save the flow to register a deployment."
                 ),
             )
+
+        self._reject_when_execution_in_progress(project_id)
 
         parameters: dict[str, Any] = {
             **flow.default_parameters,
@@ -593,13 +603,7 @@ class FlowService:
         settings = get_settings()
         deployment_name = "single-task-executor/system-single-task"
 
-        if self._execution_lock_repo is not None and self._execution_lock_repo.is_locked(
-            project_id
-        ):
-            raise HTTPException(
-                status_code=409,
-                detail="Another calibration execution is already running for this project",
-            )
+        self._reject_when_execution_in_progress(project_id)
 
         try:
             async with get_client() as client:
@@ -858,6 +862,41 @@ class FlowService:
             raise HTTPException(status_code=500, detail=f"Failed to read file: {e}")
 
     # --- Private helpers ---
+
+    def _reject_when_execution_in_progress(self, project_id: str) -> None:
+        """Reject a new run while the project already has one in flight.
+
+        The ``ExecutionLockDocument`` is only taken once the flow process
+        starts, so it alone leaves the seconds between the trigger and the
+        flow start unguarded. The ``scheduled`` execution the API records at
+        trigger time covers that window, which is what keeps a repeated press
+        from dispatching a second flow run. This reads the same execution as
+        ``ExecutionService.get_lock_status()``, so a rejection here always
+        matches the locked state the UI is showing.
+
+        Parameters
+        ----------
+        project_id : str
+            The project whose calibration runs are mutually exclusive.
+
+        Raises
+        ------
+        HTTPException
+            409 when the project is locked or already has a dispatched run
+            waiting to start.
+
+        """
+        if self._execution_lock_repo is not None and self._execution_lock_repo.is_locked(
+            project_id
+        ):
+            raise HTTPException(status_code=409, detail=EXECUTION_IN_PROGRESS_DETAIL)
+
+        if self._execution_history_repo is None:
+            return
+
+        latest = self._execution_history_repo.find_latest_by_project(project_id)
+        if latest is not None and latest.status == ExecutionStatusModel.SCHEDULED:
+            raise HTTPException(status_code=409, detail=EXECUTION_IN_PROGRESS_DETAIL)
 
     def _create_scheduled_execution(
         self,

--- a/tests/qdash/api/services/test_execution_service.py
+++ b/tests/qdash/api/services/test_execution_service.py
@@ -495,3 +495,83 @@ def test_get_lock_status_without_execution_returns_lock_only() -> None:
 
     assert result.lock is False
     assert result.execution_id is None
+
+
+def test_get_lock_status_locks_on_scheduled_execution_before_the_flow_starts() -> None:
+    """A scheduled execution locks the project even before the flow takes the lock."""
+    history_repository = MagicMock()
+    history_repository.find_latest_by_project.return_value = SimpleNamespace(
+        execution_id="exec-scheduled",
+        chip_id="chip-1",
+        name="full-calibration",
+        status="scheduled",
+        note={},
+        project_id="project-1",
+    )
+    lock_repository = MagicMock()
+    lock_repository.get_lock_status.return_value = False
+    service = ExecutionService(history_repository, lock_repository)
+
+    result = service.get_lock_status("project-1")
+
+    assert result.lock is True
+    assert result.status == "scheduled"
+
+
+def test_get_lock_status_leaves_a_started_execution_to_the_lock_document() -> None:
+    """Once the flow has started, the lock document alone decides."""
+    history_repository = MagicMock()
+    history_repository.find_latest_by_project.return_value = SimpleNamespace(
+        execution_id="exec-running",
+        chip_id="chip-1",
+        name="full-calibration",
+        status="running",
+        note={},
+        project_id="project-1",
+    )
+    lock_repository = MagicMock()
+    lock_repository.get_lock_status.return_value = False
+    service = ExecutionService(history_repository, lock_repository)
+
+    result = service.get_lock_status("project-1")
+
+    assert result.lock is False
+
+
+def test_get_lock_status_unlocks_after_reconciling_a_dead_scheduled_execution(
+    monkeypatch: Any, init_db: Any
+) -> None:
+    """A scheduled execution whose flow run crashed stops locking the project."""
+    flow_run_id = str(uuid4())
+    _make_execution(execution_id="exec-1", status="scheduled", note={"flow_run_id": flow_run_id})
+
+    calls: list[dict[str, Any]] = []
+    client = _FakeSyncClient([_make_run(flow_run_id, "CRASHED")])
+    monkeypatch.setattr(execution_service, "get_client", _make_get_client(client, calls))
+
+    result = _make_service().get_lock_status(PROJECT_ID)
+
+    assert len(calls) == 1
+    assert result.lock is False
+    assert result.status == "failed"
+
+    reloaded = _reload_execution("exec-1")
+    assert reloaded is not None
+    assert reloaded.status == "failed"
+
+
+def test_get_lock_status_does_not_query_prefect_for_terminal_executions(
+    monkeypatch: Any, init_db: Any
+) -> None:
+    """A finished execution needs no reconciliation, so the poll stays Prefect-free."""
+    _make_execution(execution_id="exec-1", status="completed", note={"flow_run_id": str(uuid4())})
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        execution_service, "get_client", _make_get_client(_RaisingSyncClient(), calls)
+    )
+
+    result = _make_service().get_lock_status(PROJECT_ID)
+
+    assert calls == []
+    assert result.lock is False

--- a/tests/qdash/api/services/test_flow_service.py
+++ b/tests/qdash/api/services/test_flow_service.py
@@ -517,3 +517,145 @@ async def test_execute_single_task_supports_quick_run_without_snapshot(
     assert parameters["backend_name"] == "fake"
     assert parameters["default_run_parameters"] == defaults
     assert parameters["persist_output_parameters"] is False
+
+
+@pytest.mark.asyncio
+async def test_execute_flow_rejects_locked_project() -> None:
+    """execute_flow refuses to dispatch while the project lock is held."""
+    lock_repository = MagicMock()
+    lock_repository.is_locked.return_value = True
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow()
+
+    service = FlowService(
+        flow_repository=flow_repo,
+        execution_lock_repository=lock_repository,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.execute_flow(
+            name="my-flow",
+            request=ExecuteFlowRequest(parameters={}),
+            username="operator",
+            project_id="project-1",
+        )
+
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_execute_flow_rejects_project_with_a_dispatched_run() -> None:
+    """A run recorded at the previous press blocks the next one before the lock is taken."""
+    lock_repository = MagicMock()
+    lock_repository.is_locked.return_value = False
+    history_repository = MagicMock()
+    history_repository.find_latest_by_project.return_value = SimpleNamespace(
+        execution_id="exec-scheduled", status="scheduled"
+    )
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow()
+
+    service = FlowService(
+        flow_repository=flow_repo,
+        execution_lock_repository=lock_repository,
+        execution_history_repository=history_repository,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.execute_flow(
+            name="my-flow",
+            request=ExecuteFlowRequest(parameters={}),
+            username="operator",
+            project_id="project-1",
+        )
+
+    assert exc_info.value.status_code == 409
+    history_repository.find_latest_by_project.assert_called_once_with("project-1")
+
+
+@pytest.mark.asyncio
+async def test_re_execute_from_snapshot_rejects_project_with_a_dispatched_run() -> None:
+    """Snapshot re-execution is blocked while the project already has a run in flight."""
+    history_repository = MagicMock()
+    history_repository.find_latest_by_project.return_value = SimpleNamespace(
+        execution_id="exec-scheduled", status="scheduled"
+    )
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow()
+
+    service = FlowService(
+        flow_repository=flow_repo,
+        execution_history_repository=history_repository,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.re_execute_from_snapshot(
+            flow_name="my-flow",
+            source_execution_id="exec-1",
+            parameter_overrides={},
+            username="operator",
+            project_id="project-1",
+        )
+
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_execute_single_task_rejects_project_with_a_dispatched_run() -> None:
+    """Single-task execution is blocked while the project already has a run in flight."""
+    history_repository = MagicMock()
+    history_repository.find_latest_by_project.return_value = SimpleNamespace(
+        execution_id="exec-scheduled", status="scheduled"
+    )
+
+    service = FlowService(
+        flow_repository=MagicMock(),
+        execution_history_repository=history_repository,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.execute_single_task_from_snapshot(
+            task_name="CheckRabi",
+            qid="Q00",
+            chip_id="chip-1",
+            source_execution_id=None,
+            username="operator",
+            project_id="project-1",
+        )
+
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_execute_flow_dispatches_when_the_last_run_has_finished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finished run leaves the project idle, and both guards are consulted."""
+    monkeypatch.setattr(FlowService, "_create_scheduled_execution", lambda self, **_: "exec-1")
+    monkeypatch.setattr(
+        flow_service, "get_client", lambda: _FakeExecuteFlowClientContext("flow-run-3")
+    )
+
+    lock_repository = MagicMock()
+    lock_repository.is_locked.return_value = False
+    history_repository = MagicMock()
+    history_repository.find_latest_by_project.return_value = SimpleNamespace(
+        execution_id="exec-done", status="completed"
+    )
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow()
+
+    response = await FlowService(
+        flow_repository=flow_repo,
+        execution_lock_repository=lock_repository,
+        execution_history_repository=history_repository,
+    ).execute_flow(
+        name="my-flow",
+        request=ExecuteFlowRequest(parameters={}),
+        username="operator",
+        project_id="project-1",
+    )
+
+    assert response.flow_run_id == "flow-run-3"
+    lock_repository.is_locked.assert_called_once_with("project-1")
+    history_repository.find_latest_by_project.assert_called_once_with("project-1")

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -23,6 +23,7 @@ import {
 import { useGetCurrentUser } from "@/client/auth/auth";
 import { useListChips } from "@/client/chip/chip";
 import {
+  getGetExecutionLockStatusQueryKey,
   useCancelExecution,
   useGetExecution,
   useGetExecutionLockStatus,
@@ -227,6 +228,9 @@ export function WorkflowEditorPageContent() {
         setLastFlowRunId(response.data.flow_run_id || null);
         toast.success(`Flow execution started! Execution ID: ${execId || "N/A"}`);
       },
+      // Awaited, so the button stays busy until the refreshed lock status arrives.
+      onSettled: () =>
+        queryClient.invalidateQueries({ queryKey: getGetExecutionLockStatusQueryKey() }),
     },
   });
 
@@ -247,6 +251,11 @@ export function WorkflowEditorPageContent() {
   });
 
   const canCancel = !!lastFlowRunId && !!lockStatus?.data.lock;
+  const executeErrorMessage =
+    (executeMutation.error as { response?: { data?: { detail?: string } } } | null)?.response?.data
+      ?.detail ||
+    (executeMutation.error as Error | null)?.message ||
+    "Unknown error";
   useEffect(() => {
     if (data?.data) {
       const flow = data.data;
@@ -780,7 +789,8 @@ export function WorkflowEditorPageContent() {
                 saveMutation.isPending ||
                 deleteMutation.isPending ||
                 executeMutation.isPending ||
-                isLockStatusLoading
+                isLockStatusLoading ||
+                !!lockStatus?.data.lock
               }
               title={
                 lockStatus?.data.lock
@@ -855,9 +865,7 @@ export function WorkflowEditorPageContent() {
 
         {executeMutation.isError && (
           <div className="alert alert-error mx-4 mt-2">
-            <span>
-              Failed to execute flow: {(executeMutation.error as Error)?.message || "Unknown error"}
-            </span>
+            <span>Failed to execute flow: {executeErrorMessage}</span>
           </div>
         )}
 
@@ -1475,7 +1483,8 @@ export function WorkflowEditorPageContent() {
                 saveMutation.isPending ||
                 deleteMutation.isPending ||
                 executeMutation.isPending ||
-                isLockStatusLoading
+                isLockStatusLoading ||
+                !!lockStatus?.data.lock
               }
             >
               {executeMutation.isPending ? (

--- a/ui/src/components/features/tasks/TaskWorkbench.tsx
+++ b/ui/src/components/features/tasks/TaskWorkbench.tsx
@@ -194,7 +194,6 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
         ?.detail;
       toast.error(detail ?? (error instanceof Error ? error.message : "Failed to start task"));
     } finally {
-      // Awaited, so the button stays busy until the refreshed lock status arrives.
       await queryClient.invalidateQueries({ queryKey: getGetExecutionLockStatusQueryKey() });
       setIsStarting(false);
     }

--- a/ui/src/components/features/tasks/TaskWorkbench.tsx
+++ b/ui/src/components/features/tasks/TaskWorkbench.tsx
@@ -3,13 +3,18 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, Lock, Play, RefreshCw, RotateCcw } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 
 import type { ExecutionResponseDetail, TaskInfo } from "@/schemas";
 
 import { getChipCoupling, getChipQubit, useListChips } from "@/client/chip/chip";
-import { useGetExecution, useGetExecutionLockStatus } from "@/client/execution/execution";
+import {
+  getGetExecutionLockStatusQueryKey,
+  useGetExecution,
+  useGetExecutionLockStatus,
+} from "@/client/execution/execution";
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { ParametersTable } from "@/components/features/metrics/ParametersTable";
 import { useToast } from "@/components/ui/Toast";
@@ -31,6 +36,7 @@ function badgeClass(status?: string | null) {
 
 export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
   const toast = useToast();
+  const queryClient = useQueryClient();
   const { data: chipsData } = useListChips();
   const chips = chipsData?.data?.chips ?? [];
   const defaultChipId = chips[0]?.chip_id ?? "";
@@ -188,6 +194,8 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
         ?.detail;
       toast.error(detail ?? (error instanceof Error ? error.message : "Failed to start task"));
     } finally {
+      // Awaited, so the button stays busy until the refreshed lock status arrives.
+      await queryClient.invalidateQueries({ queryKey: getGetExecutionLockStatusQueryKey() });
       setIsStarting(false);
     }
   };


### PR DESCRIPTION
### Ticket

close #778

### Summary

- The execution lock is taken by `CalibService` when the flow process starts, which is several seconds after the user presses Execute. Until then nothing looked locked, and the UI only polled `lock-status` every 5 seconds, so pressing Execute again dispatched a second flow run that the worker could reject only after the fact.
- The `scheduled` execution row that #1350 records at trigger time already marks that window, so it now drives the lock as well. Affected areas: API (`ExecutionService.get_lock_status`, `FlowService` dispatch guards) and UI (Workflow editor, Task workbench). No OpenAPI, schema, or generated client changes, so no regeneration is needed. No new database queries either: both sides reuse the `find_latest_by_project` call that `get_lock_status` already made.

### Changes

#### Lock status covers the window before the flow starts

- `get_lock_status` reports `lock=true` while the project's latest execution is still `scheduled`. It already read that execution for the response metadata, so this adds no query.
- A `scheduled` execution is reconciled against Prefect before the status is reported, so a run that dies before its flow process starts does not keep the project locked. Terminal executions skip the Prefect call, which keeps a routine poll as cheap as it was.
- Started executions are deliberately left to the lock document. The row only becomes `running` inside `CalibOrchestrator.initialize()`, after the lock has been acquired, so the two signals overlap without leaving a gap. It also means a stale `running` row whose Prefect run has been pruned cannot wedge the project.

#### Repeated presses are rejected server side

- `FlowService._reject_when_execution_in_progress()` guards `execute_flow`, `re_execute_from_snapshot` and `execute_single_task_from_snapshot` with 409. It replaces the lock-only check that only the single-task path had.
- The guard and `get_lock_status` read the same execution through `find_latest_by_project`, so a rejection always matches the locked state the UI is showing.

#### The button locks without waiting for the next poll

- `WorkflowEditorPageContent` invalidates the lock status in the execute mutation's `onSettled`. TanStack Query awaits a promise returned there before the mutation settles, so the button stays busy until the refreshed status arrives and then moves straight from the spinner to Locked.
- The same refetch is awaited in `TaskWorkbench.handleRun()` before `isStarting` is cleared.
- Both Execute buttons now include the locked state in `disabled` instead of relying on the `btn-disabled` class alone.
- The flow editor error alert shows the server `detail`, which is where the 409 message lands. It previously showed the axios message, which read as "Request failed with status code 409".

### Verification

- `uv run pytest tests/qdash/api tests/qdash/repository tests/qdash/dbmodel`: 708 passed. The two failures in `test_task_file_service.py` and `test_task_result_history.py` are pre-existing and caused by `qubex` being absent from the local environment, confirmed by stashing the branch and rerunning them.
- 9 tests added: `get_lock_status` locking on a scheduled execution, leaving a started one to the lock document, unlocking after reconciling a crashed run, and skipping Prefect for terminal ones, plus 409 coverage for all three dispatch paths and the idle case.
- `ruff check`, `ruff format --check` and `mypy` are clean.
- UI: `bunx tsc --noEmit`, `bun run lint`, and `bun run test` (50 files, 228 tests) all pass.

### Out of scope

- Two clients that press Execute inside the same request window can still both dispatch, because the `scheduled` row is written after the Prefect flow run is created. Closing that gap fully would need the API to claim the lock before dispatch and the worker to adopt it, which is a larger change to `CalibService`.
- Cron scheduled runs are unchanged. They never reach these API paths, and `CalibService` still enforces the lock for them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate workflow and task executions while another execution is scheduled or running.
  * Execute buttons are now disabled while execution status is loading or locked.
  * Lock status refreshes automatically after execution attempts.
  * Improved handling of failed or interrupted scheduled executions so projects do not remain locked incorrectly.
  * Execution errors now display clearer messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->