### PR TITLE
refactor(api): claim the execution lock at dispatch time (#778)

### DIFF
--- a/docs/development/workflow/engine-architecture.md
+++ b/docs/development/workflow/engine-architecture.md
@@ -288,6 +288,14 @@ Runs that do not go through the API — cron schedules, where the Prefect schedu
 
 Pre-creation is best effort. It is skipped when no `chip_id` can be resolved, and any failure is logged and swallowed: the Prefect flow run already exists at that point, and a bookkeeping failure is not a reason to cancel a healthy calibration. Such a run simply falls back to the cron-schedule path above — `CalibService` allocates its own `execution_id` at flow start — and the API response reports the Prefect flow run ID as `execution_id` until then.
 
+### Mutual Exclusion
+
+Calibrations are mutually exclusive per project, guarded by `ExecutionLockDocument`. The lock is claimed by the API at dispatch time rather than by the flow process at start time, so it covers the whole life of a run: `FlowService._claim_execution_lock` mints the `execution_id` and takes the lock with it as owner before the Prefect flow run is created, answering `409` when the lock is held. The claim is a single atomic upsert — it matches an unlocked record, and when the project is already locked it falls through to an insert that the unique index on `project_id` rejects — so two simultaneous requests cannot both dispatch. `CalibService._initialize()` then reacquires the lock owned by the execution it claims (`try_lock` yields to the same owner), while a lock owned by anything else still raises `RuntimeError`.
+
+Runs that do not go through the API, such as cron schedules, find the lock free and take it in `CalibService` as before. The claim is also skipped when no `chip_id` can be resolved, since there is then no `execution_id` to own the lock; those runs fall back to the same path.
+
+Claiming at dispatch means the API takes the lock and the flow releases it, so dispatch failures in between have to release it themselves: `FlowService` does that when the flow run cannot be created, and when the `scheduled` row cannot be saved. Everything after that point is covered by the finalizer, which releases a lock owned by the execution it closes. The one case with no owner left to act is a run that dies before its flow process starts; `ExecutionService.get_lock_status()` reconciles a still `scheduled` execution against Prefect for exactly that reason, on the poll the UI already makes.
+
 ### Reconciliation with Prefect
 
 Hooks only fire while the Prefect runner is alive. When the runner itself dies, nothing closes the execution and it stays `running` forever. `ExecutionService._reconcile_with_prefect()` (API) closes that gap when an execution detail is read: open executions holding a `note.flow_run_id` are looked up in Prefect and finalized when their flow run has already reached a terminal state. Execution-list reads do not call Prefect synchronously, so history remains available when Prefect is slow or unavailable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,8 @@ omit = [
     "src/qdash/dbmodel/*",
     # API schemas - request/response models
     "src/qdash/api/schemas/*",
+    # Repository protocols - interface declarations only
+    "src/qdash/repository/protocols.py",
     # Auto-generated client code
     "clients/python/src/qdash/client/*",
     # Internal service modules

--- a/src/qdash/api/services/execution_service.py
+++ b/src/qdash/api/services/execution_service.py
@@ -25,6 +25,7 @@ from qdash.api.schemas.execution import (
     Task,
 )
 from qdash.common.utils.datetime import now, parse_elapsed_time
+from qdash.datamodel.execution import ExecutionStatusModel
 from qdash.dbmodel.task_result_history import TaskResultHistoryDocument
 from qdash.repository.execution_finalizer import finalize_executions_by_flow_run_id
 
@@ -283,6 +284,10 @@ class ExecutionService:
     def get_lock_status(self, project_id: str) -> ExecutionLockStatusResponse:
         """Get the execution lock status.
 
+        A still ``scheduled`` execution is reconciled against Prefect first: a
+        run that died before its flow process started would otherwise hold the
+        lock with nothing left to release it.
+
         Parameters
         ----------
         project_id : str
@@ -294,8 +299,11 @@ class ExecutionService:
             The lock status response
 
         """
-        status = self._lock_repo.get_lock_status(project_id)
         latest = self._history_repo.find_latest_by_project(project_id)
+        if latest is not None and latest.status == ExecutionStatusModel.SCHEDULED:
+            self._reconcile_with_prefect([latest])
+
+        status = self._lock_repo.get_lock_status(project_id)
         if latest is None:
             return ExecutionLockStatusResponse(lock=bool(status))
         return ExecutionLockStatusResponse(

--- a/src/qdash/api/services/flow_service.py
+++ b/src/qdash/api/services/flow_service.py
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger("uvicorn.app")
 
 DEPLOYMENT_SERVICE_URL = os.getenv("DEPLOYMENT_SERVICE_URL", "http://deployment-service:8001")
+EXECUTION_IN_PROGRESS_DETAIL = (
+    "Another calibration execution is already in progress for this project"
+)
 
 
 def _to_deployment_service_path(file_path: Path) -> Path:
@@ -397,6 +400,11 @@ class FlowService:
             f"with parameters: {parameters}"
         )
 
+        chip_id = str(parameters.get("chip_id") or flow.chip_id or "").strip()
+        claimed_execution_id = self._claim_execution_lock(
+            project_id=project_id, username=username, chip_id=chip_id
+        )
+
         try:
             async with get_client() as client:
                 deployment_id = cast("UUID", flow.deployment_id)
@@ -405,37 +413,37 @@ class FlowService:
                     parameters=parameters,
                 )
 
-                chip_id = str(parameters.get("chip_id") or flow.chip_id or "").strip()
                 flow_run_id = str(flow_run.id)
                 flow_run_url = (
                     f"http://localhost:{settings.prefect_port}/runs/flow-run/{flow_run_id}"
                 )
 
                 logger.info(f"Flow run created: {flow_run_id}")
-
-                qdash_execution_id = self._create_scheduled_execution(
-                    project_id=project_id,
-                    username=username,
-                    chip_id=chip_id,
-                    name=name,
-                    flow_run_id=flow_run_id,
-                    tags=parameters.get("tags") or flow.tags,
-                )
-                qdash_ui_url = self._build_qdash_ui_url(
-                    settings.ui_port, chip_id, qdash_execution_id
-                )
-
-                return ExecuteFlowResponse(
-                    execution_id=qdash_execution_id or flow_run_id,
-                    flow_run_id=flow_run_id,
-                    flow_run_url=flow_run_url,
-                    qdash_ui_url=qdash_ui_url,
-                    message=f"Flow '{name}' execution started successfully",
-                )
-
         except Exception as e:
+            self._release_execution_lock(project_id, claimed_execution_id)
             logger.error(f"Failed to execute flow: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to execute flow: {e}")
+
+        qdash_execution_id = self._create_scheduled_execution(
+            project_id=project_id,
+            username=username,
+            chip_id=chip_id,
+            name=name,
+            flow_run_id=flow_run_id,
+            execution_id=claimed_execution_id,
+            tags=parameters.get("tags") or flow.tags,
+        )
+        if qdash_execution_id is None:
+            self._release_execution_lock(project_id, claimed_execution_id)
+        qdash_ui_url = self._build_qdash_ui_url(settings.ui_port, chip_id, qdash_execution_id)
+
+        return ExecuteFlowResponse(
+            execution_id=qdash_execution_id or flow_run_id,
+            flow_run_id=flow_run_id,
+            flow_run_url=flow_run_url,
+            qdash_ui_url=qdash_ui_url,
+            message=f"Flow '{name}' execution started successfully",
+        )
 
     async def re_execute_from_snapshot(
         self,
@@ -500,6 +508,11 @@ class FlowService:
             f"(deployment={flow.deployment_id}) with parameters: {parameters}"
         )
 
+        chip_id = str(parameters.get("chip_id") or flow.chip_id or "").strip()
+        claimed_execution_id = self._claim_execution_lock(
+            project_id=project_id, username=username, chip_id=chip_id
+        )
+
         try:
             async with get_client() as client:
                 deployment_id = cast("UUID", flow.deployment_id)
@@ -508,37 +521,39 @@ class FlowService:
                     parameters=parameters,
                 )
 
-                chip_id = str(parameters.get("chip_id") or flow.chip_id or "").strip()
                 flow_run_id = str(flow_run.id)
                 flow_run_url = (
                     f"http://localhost:{settings.prefect_port}/runs/flow-run/{flow_run_id}"
                 )
 
                 logger.info(f"Re-execution flow run created: {flow_run_id}")
-
-                qdash_execution_id = self._create_scheduled_execution(
-                    project_id=project_id,
-                    username=username,
-                    chip_id=chip_id,
-                    name=flow_name,
-                    flow_run_id=flow_run_id,
-                    tags=parameters.get("tags") or flow.tags,
-                )
-                qdash_ui_url = self._build_qdash_ui_url(
-                    settings.ui_port, chip_id, qdash_execution_id
-                )
-
-                return ExecuteFlowResponse(
-                    execution_id=qdash_execution_id or flow_run_id,
-                    flow_run_id=flow_run_id,
-                    flow_run_url=flow_run_url,
-                    qdash_ui_url=qdash_ui_url,
-                    message=f"Flow '{flow_name}' re-execution started from snapshot {source_execution_id}",
-                )
-
         except Exception as e:
+            self._release_execution_lock(project_id, claimed_execution_id)
             logger.error(f"Failed to re-execute flow: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to re-execute flow: {e}")
+
+        qdash_execution_id = self._create_scheduled_execution(
+            project_id=project_id,
+            username=username,
+            chip_id=chip_id,
+            name=flow_name,
+            flow_run_id=flow_run_id,
+            execution_id=claimed_execution_id,
+            tags=parameters.get("tags") or flow.tags,
+        )
+        if qdash_execution_id is None:
+            self._release_execution_lock(project_id, claimed_execution_id)
+        qdash_ui_url = self._build_qdash_ui_url(settings.ui_port, chip_id, qdash_execution_id)
+
+        return ExecuteFlowResponse(
+            execution_id=qdash_execution_id or flow_run_id,
+            flow_run_id=flow_run_id,
+            flow_run_url=flow_run_url,
+            qdash_ui_url=qdash_ui_url,
+            message=(
+                f"Flow '{flow_name}' re-execution started from snapshot {source_execution_id}"
+            ),
+        )
 
     async def execute_single_task_from_snapshot(
         self,
@@ -593,14 +608,6 @@ class FlowService:
         settings = get_settings()
         deployment_name = "single-task-executor/system-single-task"
 
-        if self._execution_lock_repo is not None and self._execution_lock_repo.is_locked(
-            project_id
-        ):
-            raise HTTPException(
-                status_code=409,
-                detail="Another calibration execution is already running for this project",
-            )
-
         try:
             async with get_client() as client:
                 deployment = await client.read_deployment_by_name(deployment_name)
@@ -635,6 +642,10 @@ class FlowService:
             f"(deployment={deployment.id}) with parameters: {parameters}"
         )
 
+        claimed_execution_id = self._claim_execution_lock(
+            project_id=project_id, username=username, chip_id=chip_id
+        )
+
         try:
             async with get_client() as client:
                 flow_run = await client.create_flow_run_from_deployment(
@@ -648,36 +659,37 @@ class FlowService:
                 )
 
                 logger.info(f"Single-task flow run created: {flow_run_id}")
-
-                qdash_execution_id = self._create_scheduled_execution(
-                    project_id=project_id,
-                    username=username,
-                    chip_id=chip_id,
-                    name=flow_name,
-                    flow_run_id=flow_run_id,
-                    tags=tags,
-                )
-                qdash_ui_url = self._build_qdash_ui_url(
-                    settings.ui_port, chip_id, qdash_execution_id
-                )
-
-                return ExecuteFlowResponse(
-                    execution_id=qdash_execution_id or flow_run_id,
-                    flow_run_id=flow_run_id,
-                    flow_run_url=flow_run_url,
-                    qdash_ui_url=qdash_ui_url,
-                    message=(
-                        f"Single task '{task_name}' (qid={qid}) "
-                        f"re-execution started from snapshot {source_execution_id}"
-                    ),
-                )
-
         except Exception as e:
+            self._release_execution_lock(project_id, claimed_execution_id)
             logger.error(f"Failed to execute single task: {e}")
             raise HTTPException(
                 status_code=500,
                 detail=f"Failed to execute single task: {e}",
             )
+
+        qdash_execution_id = self._create_scheduled_execution(
+            project_id=project_id,
+            username=username,
+            chip_id=chip_id,
+            name=flow_name,
+            flow_run_id=flow_run_id,
+            execution_id=claimed_execution_id,
+            tags=tags,
+        )
+        if qdash_execution_id is None:
+            self._release_execution_lock(project_id, claimed_execution_id)
+        qdash_ui_url = self._build_qdash_ui_url(settings.ui_port, chip_id, qdash_execution_id)
+
+        return ExecuteFlowResponse(
+            execution_id=qdash_execution_id or flow_run_id,
+            flow_run_id=flow_run_id,
+            flow_run_url=flow_run_url,
+            qdash_ui_url=qdash_ui_url,
+            message=(
+                f"Single task '{task_name}' (qid={qid}) "
+                f"re-execution started from snapshot {source_execution_id}"
+            ),
+        )
 
     async def execute_agent_candidate_apply(
         self,
@@ -859,6 +871,80 @@ class FlowService:
 
     # --- Private helpers ---
 
+    def _claim_execution_lock(self, *, project_id: str, username: str, chip_id: str) -> str | None:
+        """Claim the project execution lock for a run about to be dispatched.
+
+        The claim is atomic, so concurrent requests are serialized before any
+        Prefect flow run is created. It is skipped when no ``chip_id`` can be
+        resolved, since there is then no execution ID to own the lock; such a
+        run falls back to the flow taking the lock itself, as cron schedules
+        do.
+
+        Parameters
+        ----------
+        project_id : str
+            The project whose calibration runs are mutually exclusive.
+        username : str
+            The user triggering the run, used to mint the execution ID.
+        chip_id : str
+            The chip targeted by the run. Empty when it cannot be resolved.
+
+        Returns
+        -------
+        str | None
+            The execution ID that now owns the lock, or None when no lock was
+            claimed. Callers must release a claimed lock if they fail to reach
+            the point where the flow can adopt it.
+
+        Raises
+        ------
+        HTTPException
+            409 when another calibration already holds the lock.
+
+        """
+        if self._execution_lock_repo is None:
+            return None
+
+        # Cheap reject before minting an execution ID; try_lock settles the race.
+        if self._execution_lock_repo.is_locked(project_id):
+            raise HTTPException(status_code=409, detail=EXECUTION_IN_PROGRESS_DETAIL)
+
+        if not chip_id:
+            return None
+
+        execution_id = generate_execution_id(username, chip_id, project_id=project_id)
+        if not self._execution_lock_repo.try_lock(project_id=project_id, execution_id=execution_id):
+            raise HTTPException(status_code=409, detail=EXECUTION_IN_PROGRESS_DETAIL)
+        return execution_id
+
+    def _release_execution_lock(self, project_id: str, execution_id: str | None) -> None:
+        """Release a lock claimed for a run that never reached the flow process.
+
+        Once the ``scheduled`` execution exists, the lock is released by
+        whoever closes it, so this only covers dispatch failures in between.
+        Releasing is best effort: a failure here is logged rather than raised
+        over the original error.
+
+        Parameters
+        ----------
+        project_id : str
+            The project holding the lock.
+        execution_id : str | None
+            The execution the lock was claimed for. None means nothing was
+            claimed and there is nothing to release.
+
+        """
+        if execution_id is None or self._execution_lock_repo is None:
+            return
+        try:
+            self._execution_lock_repo.unlock(project_id=project_id)
+        except Exception:
+            logger.warning(
+                "Failed to release the execution lock claimed for execution_id=%s",
+                execution_id,
+                exc_info=True,
+            )
+
     def _create_scheduled_execution(
         self,
         *,
@@ -867,6 +953,7 @@ class FlowService:
         chip_id: str | None,
         name: str,
         flow_run_id: str,
+        execution_id: str | None = None,
         tags: list[str] | None = None,
     ) -> str | None:
         """Pre-create a scheduled execution row for a freshly created flow run.
@@ -898,6 +985,9 @@ class FlowService:
             Execution/flow name to record.
         flow_run_id : str
             The Prefect flow run ID, stored in ``note.flow_run_id``.
+        execution_id : str | None
+            The execution ID already minted to own the project lock. A new one
+            is generated when the caller claimed no lock.
         tags : list[str] | None
             Tags to record on the execution.
 
@@ -915,7 +1005,8 @@ class FlowService:
             return None
 
         try:
-            execution_id = generate_execution_id(username, chip_id, project_id=project_id)
+            if execution_id is None:
+                execution_id = generate_execution_id(username, chip_id, project_id=project_id)
             calib_data_path = str(execution_calib_data_dir(username, execution_id))
 
             model = ExecutionModel(

--- a/src/qdash/dbmodel/execution_lock.py
+++ b/src/qdash/dbmodel/execution_lock.py
@@ -3,7 +3,9 @@ from typing import ClassVar
 from bunnet import Document
 from pydantic import ConfigDict, Field
 from pymongo import ASCENDING, IndexModel
+from pymongo.errors import DuplicateKeyError
 
+from qdash.common.utils.datetime import now
 from qdash.datamodel.system_info import SystemInfoModel
 
 
@@ -58,6 +60,58 @@ class ExecutionLockDocument(Document):
         doc.locked = lock
         doc.execution_id = owner
         doc.save()
+
+    @classmethod
+    def try_lock(cls, project_id: str, execution_id: str | None = None) -> bool:
+        """Acquire the lock atomically, unless another execution holds it.
+
+        A lock already owned by ``execution_id`` is reacquired, which is how a
+        flow run adopts the lock the API claimed for it at dispatch time.
+        Otherwise the upsert only matches an unlocked record; when the project
+        is locked it falls through to an insert that the unique index on
+        ``project_id`` rejects, so a ``DuplicateKeyError`` is the "someone
+        else holds it" answer rather than a failure.
+
+        Parameters
+        ----------
+        project_id : str
+            The project identifier
+        execution_id : str | None
+            The execution that will own the lock
+
+        Returns
+        -------
+        bool
+            True when the lock was acquired or already owned, False when held
+
+        """
+        query: dict[str, object] = {"project_id": project_id, "locked": False}
+        if execution_id is not None:
+            query = {
+                "project_id": project_id,
+                "$or": [{"locked": False}, {"execution_id": execution_id}],
+            }
+        # Raw pymongo bypasses Bunnet encoding, so system_info is written explicitly.
+        timestamp = now()
+        try:
+            cls.get_motor_collection().update_one(
+                query,
+                {
+                    "$set": {
+                        "locked": True,
+                        "execution_id": execution_id,
+                        "system_info.updated_at": timestamp,
+                    },
+                    "$setOnInsert": {
+                        "project_id": project_id,
+                        "system_info.created_at": timestamp,
+                    },
+                },
+                upsert=True,
+            )
+        except DuplicateKeyError:
+            return False
+        return True
 
     @classmethod
     def lock(cls, project_id: str, execution_id: str | None = None) -> None:

--- a/src/qdash/repository/execution_lock.py
+++ b/src/qdash/repository/execution_lock.py
@@ -63,6 +63,24 @@ class MongoExecutionLockRepository:
         result: bool | None = ExecutionLockDocument.get_lock_status(project_id=project_id)
         return result
 
+    def try_lock(self, project_id: str, execution_id: str | None = None) -> bool:
+        """Atomically acquire the execution lock, unless another execution holds it.
+
+        Parameters
+        ----------
+        project_id : str
+            The project identifier
+        execution_id : str | None
+            The execution that will own the lock
+
+        Returns
+        -------
+        bool
+            True when the lock was acquired or already owned, False when held
+
+        """
+        return ExecutionLockDocument.try_lock(project_id=project_id, execution_id=execution_id)
+
     def lock(self, project_id: str, execution_id: str | None = None) -> None:
         """Acquire the execution lock.
 

--- a/src/qdash/repository/inmemory/execution_lock.py
+++ b/src/qdash/repository/inmemory/execution_lock.py
@@ -43,6 +43,29 @@ class InMemoryExecutionLockRepository:
         """
         return self._locks.get(project_id, False)
 
+    def try_lock(self, project_id: str, execution_id: str | None = None) -> bool:
+        """Atomically acquire the execution lock, unless another execution holds it.
+
+        Parameters
+        ----------
+        project_id : str
+            The project identifier
+        execution_id : str | None
+            The execution that will own the lock
+
+        Returns
+        -------
+        bool
+            True when the lock was acquired or already owned, False when held
+
+        """
+        if self._locks.get(project_id, False) and (
+            execution_id is None or self._owners.get(project_id) != execution_id
+        ):
+            return False
+        self.lock(project_id, execution_id)
+        return True
+
     def lock(self, project_id: str, execution_id: str | None = None) -> None:
         """Acquire the execution lock.
 

--- a/src/qdash/repository/protocols.py
+++ b/src/qdash/repository/protocols.py
@@ -1088,6 +1088,24 @@ class ExecutionLockRepository(Protocol):
         """
         ...
 
+    def try_lock(self, project_id: str, execution_id: str | None = None) -> bool:
+        """Atomically acquire the execution lock, unless another execution holds it.
+
+        Parameters
+        ----------
+        project_id : str
+            The project identifier
+        execution_id : str | None
+            The execution that will own the lock
+
+        Returns
+        -------
+        bool
+            True when the lock was acquired or already owned, False when held
+
+        """
+        ...
+
     def lock(self, project_id: str, execution_id: str | None = None) -> None:
         """Acquire the execution lock.
 

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -531,10 +531,12 @@ class CalibService:
 
                 self._lock_repo = MongoExecutionLockRepository()
 
-            if self._lock_repo.is_locked(project_id=self.project_id):
+            # try_lock also reacquires a lock the API already claimed for this execution.
+            if not self._lock_repo.try_lock(
+                project_id=self.project_id, execution_id=self.execution_id
+            ):
                 msg = "Calibration is already running. Cannot start a new session."
                 raise RuntimeError(msg)
-            self._lock_repo.lock(project_id=self.project_id, execution_id=self.execution_id)
             self._lock_acquired = True
 
         # Wrap all initialization in try/except to ensure lock is released on failure

--- a/tests/qdash/api/services/test_execution_service.py
+++ b/tests/qdash/api/services/test_execution_service.py
@@ -495,3 +495,59 @@ def test_get_lock_status_without_execution_returns_lock_only() -> None:
 
     assert result.lock is False
     assert result.execution_id is None
+
+
+def test_get_lock_status_releases_a_claimed_lock_whose_flow_run_crashed(
+    monkeypatch: Any, init_db: Any
+) -> None:
+    """A lock claimed at dispatch is freed when its run died before the flow started."""
+    flow_run_id = str(uuid4())
+    _make_execution(execution_id="exec-1", status="scheduled", note={"flow_run_id": flow_run_id})
+    MongoExecutionLockRepository().try_lock(project_id=PROJECT_ID, execution_id="exec-1")
+
+    calls: list[dict[str, Any]] = []
+    client = _FakeSyncClient([_make_run(flow_run_id, "CRASHED")])
+    monkeypatch.setattr(execution_service, "get_client", _make_get_client(client, calls))
+
+    result = _make_service().get_lock_status(PROJECT_ID)
+
+    assert len(calls) == 1
+    assert result.lock is False
+    assert result.status == "failed"
+    assert MongoExecutionLockRepository().is_locked(PROJECT_ID) is False
+
+
+def test_get_lock_status_keeps_the_lock_while_the_flow_run_is_still_scheduled(
+    monkeypatch: Any, init_db: Any
+) -> None:
+    """A run that is merely queued keeps its claim; only terminal runs release it."""
+    flow_run_id = str(uuid4())
+    _make_execution(execution_id="exec-1", status="scheduled", note={"flow_run_id": flow_run_id})
+    MongoExecutionLockRepository().try_lock(project_id=PROJECT_ID, execution_id="exec-1")
+
+    calls: list[dict[str, Any]] = []
+    client = _FakeSyncClient([_make_run(flow_run_id, "SCHEDULED")])
+    monkeypatch.setattr(execution_service, "get_client", _make_get_client(client, calls))
+
+    result = _make_service().get_lock_status(PROJECT_ID)
+
+    assert result.lock is True
+    assert result.status == "scheduled"
+
+
+def test_get_lock_status_does_not_query_prefect_once_the_flow_has_started(
+    monkeypatch: Any, init_db: Any
+) -> None:
+    """A running execution needs no reconciliation, so the poll stays Prefect-free."""
+    _make_execution(execution_id="exec-1", status="running", note={"flow_run_id": str(uuid4())})
+    MongoExecutionLockRepository().try_lock(project_id=PROJECT_ID, execution_id="exec-1")
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        execution_service, "get_client", _make_get_client(_RaisingSyncClient(), calls)
+    )
+
+    result = _make_service().get_lock_status(PROJECT_ID)
+
+    assert calls == []
+    assert result.lock is True

--- a/tests/qdash/api/services/test_flow_service.py
+++ b/tests/qdash/api/services/test_flow_service.py
@@ -517,3 +517,496 @@ async def test_execute_single_task_supports_quick_run_without_snapshot(
     assert parameters["backend_name"] == "fake"
     assert parameters["default_run_parameters"] == defaults
     assert parameters["persist_output_parameters"] is False
+
+
+def _make_lock_repo(*, locked: bool = False, acquires: bool = True) -> MagicMock:
+    """Build a lock repository stub with the given is_locked and try_lock answers."""
+    repo = MagicMock()
+    repo.is_locked.return_value = locked
+    repo.try_lock.return_value = acquires
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_execute_flow_claims_the_lock_before_creating_the_flow_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The lock is taken before Prefect is asked for a flow run, not after."""
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        flow_service,
+        "generate_execution_id",
+        lambda *_args, **_kwargs: "20240101-001",
+    )
+    monkeypatch.setattr(
+        FlowService, "_create_scheduled_execution", lambda self, **kw: kw["execution_id"]
+    )
+
+    class _RecordingClient:
+        """Fake Prefect client that records when the flow run is created."""
+
+        async def create_flow_run_from_deployment(self, **_kwargs: object) -> SimpleNamespace:
+            """Record the dispatch and return a stub flow run."""
+            calls.append("create_flow_run")
+            return SimpleNamespace(id="flow-run-1")
+
+    class _RecordingClientContext:
+        """Fake async context manager yielding a _RecordingClient."""
+
+        async def __aenter__(self) -> _RecordingClient:
+            """Return a new _RecordingClient."""
+            return _RecordingClient()
+
+        async def __aexit__(self, *_args: object) -> None:
+            """Do nothing on context exit."""
+            return
+
+    monkeypatch.setattr(flow_service, "get_client", _RecordingClientContext)
+
+    def _record_try_lock(**_kwargs: object) -> bool:
+        """Record the claim and report that the lock was acquired."""
+        calls.append("try_lock")
+        return True
+
+    lock_repository = _make_lock_repo()
+    lock_repository.try_lock.side_effect = _record_try_lock
+
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow(chip_id="chip-1")
+
+    response = await FlowService(
+        flow_repository=flow_repo,
+        execution_lock_repository=lock_repository,
+    ).execute_flow(
+        name="my-flow",
+        request=ExecuteFlowRequest(parameters={}),
+        username="operator",
+        project_id="project-1",
+    )
+
+    assert calls == ["try_lock", "create_flow_run"]
+    assert response.execution_id == "20240101-001"
+    lock_repository.try_lock.assert_called_once_with(
+        project_id="project-1", execution_id="20240101-001"
+    )
+    lock_repository.unlock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_execute_flow_rejects_when_another_run_holds_the_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concurrent dispatch that loses the race is rejected with 409."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-002"
+    )
+
+    lock_repository = _make_lock_repo(acquires=False)
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow(chip_id="chip-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await FlowService(
+            flow_repository=flow_repo,
+            execution_lock_repository=lock_repository,
+        ).execute_flow(
+            name="my-flow",
+            request=ExecuteFlowRequest(parameters={}),
+            username="operator",
+            project_id="project-1",
+        )
+
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_execute_flow_releases_the_lock_when_the_flow_run_cannot_be_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dispatch failure must not leave the project locked."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-003"
+    )
+
+    class _FailingClientContext:
+        """Fake async context manager whose client always fails."""
+
+        async def __aenter__(self) -> SimpleNamespace:
+            """Return a client that raises on flow run creation."""
+
+            async def _raise(**_kwargs: object) -> None:
+                raise RuntimeError("prefect is down")
+
+            return SimpleNamespace(create_flow_run_from_deployment=_raise)
+
+        async def __aexit__(self, *_args: object) -> None:
+            """Do nothing on context exit."""
+            return
+
+    monkeypatch.setattr(flow_service, "get_client", _FailingClientContext)
+
+    lock_repository = _make_lock_repo()
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow(chip_id="chip-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await FlowService(
+            flow_repository=flow_repo,
+            execution_lock_repository=lock_repository,
+        ).execute_flow(
+            name="my-flow",
+            request=ExecuteFlowRequest(parameters={}),
+            username="operator",
+            project_id="project-1",
+        )
+
+    assert exc_info.value.status_code == 500
+    lock_repository.unlock.assert_called_once_with(project_id="project-1")
+
+
+@pytest.mark.asyncio
+async def test_execute_flow_releases_the_lock_when_the_scheduled_row_cannot_be_saved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a scheduled row the flow cannot adopt the lock, so it is released."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-004"
+    )
+    monkeypatch.setattr(FlowService, "_create_scheduled_execution", lambda self, **_kwargs: None)
+    monkeypatch.setattr(
+        flow_service, "get_client", lambda: _FakeExecuteFlowClientContext("flow-run-4")
+    )
+
+    lock_repository = _make_lock_repo()
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow(chip_id="chip-1")
+
+    response = await FlowService(
+        flow_repository=flow_repo,
+        execution_lock_repository=lock_repository,
+    ).execute_flow(
+        name="my-flow",
+        request=ExecuteFlowRequest(parameters={}),
+        username="operator",
+        project_id="project-1",
+    )
+
+    assert response.execution_id == "flow-run-4"
+    lock_repository.unlock.assert_called_once_with(project_id="project-1")
+
+
+@pytest.mark.asyncio
+async def test_execute_flow_skips_the_claim_when_no_chip_id_can_be_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no chip there is no execution ID to own the lock, so the flow takes it."""
+    monkeypatch.setattr(FlowService, "_create_scheduled_execution", lambda self, **_kwargs: None)
+    monkeypatch.setattr(
+        flow_service, "get_client", lambda: _FakeExecuteFlowClientContext("flow-run-5")
+    )
+
+    lock_repository = _make_lock_repo()
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow(chip_id="")
+
+    response = await FlowService(
+        flow_repository=flow_repo,
+        execution_lock_repository=lock_repository,
+    ).execute_flow(
+        name="my-flow",
+        request=ExecuteFlowRequest(parameters={}),
+        username="operator",
+        project_id="project-1",
+    )
+
+    assert response.flow_run_id == "flow-run-5"
+    lock_repository.try_lock.assert_not_called()
+    lock_repository.unlock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_re_execute_from_snapshot_claims_the_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Snapshot re-execution claims the lock with its own pre-minted execution ID."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-006"
+    )
+    monkeypatch.setattr(
+        FlowService, "_create_scheduled_execution", lambda self, **kw: kw["execution_id"]
+    )
+    monkeypatch.setattr(
+        flow_service, "get_client", lambda: _FakeExecuteFlowClientContext("flow-run-6")
+    )
+
+    lock_repository = _make_lock_repo()
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow(chip_id="chip-1")
+
+    response = await FlowService(
+        flow_repository=flow_repo,
+        execution_lock_repository=lock_repository,
+    ).re_execute_from_snapshot(
+        flow_name="my-flow",
+        source_execution_id="exec-1",
+        parameter_overrides={},
+        username="operator",
+        project_id="project-1",
+    )
+
+    assert response.execution_id == "20240101-006"
+    lock_repository.try_lock.assert_called_once_with(
+        project_id="project-1", execution_id="20240101-006"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_single_task_claims_the_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-task execution claims the lock the same way as a full flow."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-007"
+    )
+    monkeypatch.setattr(
+        FlowService, "_create_scheduled_execution", lambda self, **kw: kw["execution_id"]
+    )
+
+    class _FakeClient:
+        """Fake Prefect client returning a stub deployment and flow run."""
+
+        async def read_deployment_by_name(self, _name: str) -> SimpleNamespace:
+            """Return a stub deployment."""
+            return SimpleNamespace(id="deployment-1")
+
+        async def create_flow_run_from_deployment(self, **_kwargs: object) -> SimpleNamespace:
+            """Return a stub flow run."""
+            return SimpleNamespace(id="flow-run-7")
+
+    class _FakeClientContext:
+        """Fake async context manager yielding a _FakeClient."""
+
+        async def __aenter__(self) -> _FakeClient:
+            """Return a new _FakeClient."""
+            return _FakeClient()
+
+        async def __aexit__(self, *_args: object) -> None:
+            """Do nothing on context exit."""
+            return
+
+    monkeypatch.setattr(flow_service, "get_client", _FakeClientContext)
+
+    lock_repository = _make_lock_repo()
+
+    response = await FlowService(
+        flow_repository=MagicMock(),
+        execution_lock_repository=lock_repository,
+    ).execute_single_task_from_snapshot(
+        task_name="CheckRabi",
+        qid="Q00",
+        chip_id="chip-1",
+        source_execution_id=None,
+        username="operator",
+        project_id="project-1",
+    )
+
+    assert response.execution_id == "20240101-007"
+    lock_repository.try_lock.assert_called_once_with(
+        project_id="project-1", execution_id="20240101-007"
+    )
+
+
+@pytest.mark.asyncio
+async def test_re_execute_from_snapshot_releases_the_lock_when_the_flow_run_cannot_be_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A re-execution dispatch failure must not leave the project locked."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-009"
+    )
+
+    class _FailingClientContext:
+        """Fake async context manager whose client always fails."""
+
+        async def __aenter__(self) -> SimpleNamespace:
+            """Return a client that raises on flow run creation."""
+
+            async def _raise(**_kwargs: object) -> None:
+                raise RuntimeError("prefect is down")
+
+            return SimpleNamespace(create_flow_run_from_deployment=_raise)
+
+        async def __aexit__(self, *_args: object) -> None:
+            """Do nothing on context exit."""
+            return
+
+    monkeypatch.setattr(flow_service, "get_client", _FailingClientContext)
+
+    lock_repository = _make_lock_repo()
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow(chip_id="chip-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await FlowService(
+            flow_repository=flow_repo,
+            execution_lock_repository=lock_repository,
+        ).re_execute_from_snapshot(
+            flow_name="my-flow",
+            source_execution_id="exec-1",
+            parameter_overrides={},
+            username="operator",
+            project_id="project-1",
+        )
+
+    assert exc_info.value.status_code == 500
+    lock_repository.unlock.assert_called_once_with(project_id="project-1")
+
+
+@pytest.mark.asyncio
+async def test_re_execute_from_snapshot_releases_the_lock_when_the_scheduled_row_cannot_be_saved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a scheduled row the re-executed flow cannot adopt the lock, so it is released."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-010"
+    )
+    monkeypatch.setattr(FlowService, "_create_scheduled_execution", lambda self, **_kwargs: None)
+    monkeypatch.setattr(
+        flow_service, "get_client", lambda: _FakeExecuteFlowClientContext("flow-run-8")
+    )
+
+    lock_repository = _make_lock_repo()
+    flow_repo = MagicMock()
+    flow_repo.find_by_project_and_name.return_value = _make_fake_flow(chip_id="chip-1")
+
+    response = await FlowService(
+        flow_repository=flow_repo,
+        execution_lock_repository=lock_repository,
+    ).re_execute_from_snapshot(
+        flow_name="my-flow",
+        source_execution_id="exec-1",
+        parameter_overrides={},
+        username="operator",
+        project_id="project-1",
+    )
+
+    assert response.execution_id == "flow-run-8"
+    lock_repository.unlock.assert_called_once_with(project_id="project-1")
+
+
+@pytest.mark.asyncio
+async def test_execute_single_task_releases_the_lock_when_the_flow_run_cannot_be_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single-task dispatch failure must not leave the project locked."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-011"
+    )
+
+    class _FailingClient:
+        """Fake Prefect client that resolves the deployment but fails to dispatch."""
+
+        async def read_deployment_by_name(self, _name: str) -> SimpleNamespace:
+            """Return a stub deployment."""
+            return SimpleNamespace(id="deployment-1")
+
+        async def create_flow_run_from_deployment(self, **_kwargs: object) -> SimpleNamespace:
+            """Raise to simulate a Prefect dispatch failure."""
+            raise RuntimeError("prefect is down")
+
+    class _FailingClientContext:
+        """Fake async context manager yielding a _FailingClient."""
+
+        async def __aenter__(self) -> _FailingClient:
+            """Return a new _FailingClient."""
+            return _FailingClient()
+
+        async def __aexit__(self, *_args: object) -> None:
+            """Do nothing on context exit."""
+            return
+
+    monkeypatch.setattr(flow_service, "get_client", _FailingClientContext)
+
+    lock_repository = _make_lock_repo()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await FlowService(
+            flow_repository=MagicMock(),
+            execution_lock_repository=lock_repository,
+        ).execute_single_task_from_snapshot(
+            task_name="CheckRabi",
+            qid="Q00",
+            chip_id="chip-1",
+            source_execution_id=None,
+            username="operator",
+            project_id="project-1",
+        )
+
+    assert exc_info.value.status_code == 500
+    lock_repository.unlock.assert_called_once_with(project_id="project-1")
+
+
+@pytest.mark.asyncio
+async def test_execute_single_task_releases_the_lock_when_the_scheduled_row_cannot_be_saved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a scheduled row the single-task flow cannot adopt the lock, so it is released."""
+    monkeypatch.setattr(
+        flow_service, "generate_execution_id", lambda *_args, **_kwargs: "20240101-012"
+    )
+    monkeypatch.setattr(FlowService, "_create_scheduled_execution", lambda self, **_kwargs: None)
+
+    class _FakeClient:
+        """Fake Prefect client returning a stub deployment and flow run."""
+
+        async def read_deployment_by_name(self, _name: str) -> SimpleNamespace:
+            """Return a stub deployment."""
+            return SimpleNamespace(id="deployment-1")
+
+        async def create_flow_run_from_deployment(self, **_kwargs: object) -> SimpleNamespace:
+            """Return a stub flow run."""
+            return SimpleNamespace(id="flow-run-9")
+
+    class _FakeClientContext:
+        """Fake async context manager yielding a _FakeClient."""
+
+        async def __aenter__(self) -> _FakeClient:
+            """Return a new _FakeClient."""
+            return _FakeClient()
+
+        async def __aexit__(self, *_args: object) -> None:
+            """Do nothing on context exit."""
+            return
+
+    monkeypatch.setattr(flow_service, "get_client", _FakeClientContext)
+
+    lock_repository = _make_lock_repo()
+
+    response = await FlowService(
+        flow_repository=MagicMock(),
+        execution_lock_repository=lock_repository,
+    ).execute_single_task_from_snapshot(
+        task_name="CheckRabi",
+        qid="Q00",
+        chip_id="chip-1",
+        source_execution_id=None,
+        username="operator",
+        project_id="project-1",
+    )
+
+    assert response.execution_id == "flow-run-9"
+    lock_repository.unlock.assert_called_once_with(project_id="project-1")
+
+
+def test_release_execution_lock_survives_a_failing_unlock() -> None:
+    """_release_execution_lock logs and swallows an unlock failure."""
+    lock_repository = _make_lock_repo()
+    lock_repository.unlock.side_effect = RuntimeError("mongo is down")
+
+    FlowService(
+        flow_repository=MagicMock(),
+        execution_lock_repository=lock_repository,
+    )._release_execution_lock("project-1", "20240101-008")
+
+    lock_repository.unlock.assert_called_once_with(project_id="project-1")

--- a/tests/qdash/repository/test_execution_lock_repository.py
+++ b/tests/qdash/repository/test_execution_lock_repository.py
@@ -61,3 +61,62 @@ def test_is_locked_reflects_lock_state(init_db: object) -> None:
 
     repo.unlock(project_id=PROJECT_ID)
     assert repo.is_locked(project_id=PROJECT_ID) is False
+
+
+def test_try_lock_acquires_a_free_lock_and_records_the_owner(init_db: object) -> None:
+    """try_lock takes a free lock and records the execution that owns it."""
+    repo = MongoExecutionLockRepository()
+
+    assert repo.try_lock(project_id=PROJECT_ID, execution_id="exec-1") is True
+
+    doc = _reload_lock()
+    assert doc is not None
+    assert doc.locked is True
+    assert doc.execution_id == "exec-1"
+
+
+def test_try_lock_refuses_a_held_lock_and_leaves_the_owner_alone(init_db: object) -> None:
+    """A second try_lock is refused and does not overwrite the current owner."""
+    repo = MongoExecutionLockRepository()
+    repo.try_lock(project_id=PROJECT_ID, execution_id="exec-1")
+
+    assert repo.try_lock(project_id=PROJECT_ID, execution_id="exec-2") is False
+
+    doc = _reload_lock()
+    assert doc is not None
+    assert doc.locked is True
+    assert doc.execution_id == "exec-1"
+
+
+def test_try_lock_reacquires_a_lock_owned_by_the_same_execution(init_db: object) -> None:
+    """The owning execution can take the lock again, which is how a flow adopts it."""
+    repo = MongoExecutionLockRepository()
+    repo.try_lock(project_id=PROJECT_ID, execution_id="exec-1")
+
+    assert repo.try_lock(project_id=PROJECT_ID, execution_id="exec-1") is True
+
+    doc = _reload_lock()
+    assert doc is not None
+    assert doc.locked is True
+    assert doc.execution_id == "exec-1"
+
+
+def test_try_lock_succeeds_again_after_unlock(init_db: object) -> None:
+    """Releasing the lock lets the next execution take it."""
+    repo = MongoExecutionLockRepository()
+    repo.try_lock(project_id=PROJECT_ID, execution_id="exec-1")
+    repo.unlock(project_id=PROJECT_ID)
+
+    assert repo.try_lock(project_id=PROJECT_ID, execution_id="exec-2") is True
+
+    doc = _reload_lock()
+    assert doc is not None
+    assert doc.execution_id == "exec-2"
+
+
+def test_try_lock_is_scoped_to_the_project(init_db: object) -> None:
+    """A lock held by one project does not block another."""
+    repo = MongoExecutionLockRepository()
+    repo.try_lock(project_id=PROJECT_ID, execution_id="exec-1")
+
+    assert repo.try_lock(project_id="proj-2", execution_id="exec-2") is True

--- a/tests/qdash/workflow/engine/repository/test_inmemory_impl.py
+++ b/tests/qdash/workflow/engine/repository/test_inmemory_impl.py
@@ -240,6 +240,53 @@ class TestInMemoryExecutionLockRepository:
 
         assert not repo.is_locked("proj-1")
 
+    def test_try_lock_acquires_free_lock(self):
+        """Test try_lock acquires a free lock."""
+        repo = InMemoryExecutionLockRepository()
+
+        result = repo.try_lock("proj-1", "exec-1")
+
+        assert result is True
+        assert repo.is_locked("proj-1")
+
+    def test_try_lock_refuses_lock_held_by_another_execution(self):
+        """Test try_lock refuses a lock held by another execution."""
+        repo = InMemoryExecutionLockRepository()
+        repo.try_lock("proj-1", "exec-1")
+
+        result = repo.try_lock("proj-1", "exec-2")
+
+        assert result is False
+        assert repo.is_locked("proj-1")
+
+    def test_try_lock_reacquires_lock_owned_by_same_execution(self):
+        """Test try_lock succeeds when the same execution already owns the lock."""
+        repo = InMemoryExecutionLockRepository()
+        repo.try_lock("proj-1", "exec-1")
+
+        result = repo.try_lock("proj-1", "exec-1")
+
+        assert result is True
+
+    def test_try_lock_refuses_held_lock_without_owner(self):
+        """Test try_lock refuses a held lock with no recorded owner."""
+        repo = InMemoryExecutionLockRepository()
+        repo.lock("proj-1")
+
+        result = repo.try_lock("proj-1", "exec-1")
+
+        assert result is False
+
+    def test_try_lock_succeeds_after_unlock(self):
+        """Test try_lock succeeds for a new execution after the lock is released."""
+        repo = InMemoryExecutionLockRepository()
+        repo.try_lock("proj-1", "exec-1")
+        repo.unlock("proj-1")
+
+        result = repo.try_lock("proj-1", "exec-2")
+
+        assert result is True
+
 
 class TestInMemoryUserRepository:
     """Test InMemoryUserRepository."""

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -136,14 +136,29 @@ class MockGitHubIntegration:
 class MockExecutionLockRepository:
     """Mock ExecutionLockRepository for testing."""
 
+    def __init__(self, locked: bool = False, owner: str | None = None) -> None:
+        self.locked = locked
+        self.owner = owner
+        self.try_lock_calls: list[str | None] = []
+
     def is_locked(self, project_id: str) -> bool:
-        return False
+        return self.locked
+
+    def try_lock(self, project_id: str, execution_id: str | None = None) -> bool:
+        self.try_lock_calls.append(execution_id)
+        if self.locked and (execution_id is None or self.owner != execution_id):
+            return False
+        self.locked = True
+        self.owner = execution_id
+        return True
 
     def lock(self, project_id: str, execution_id: str | None = None) -> None:
-        pass
+        self.locked = True
+        self.owner = execution_id
 
     def unlock(self, project_id: str) -> None:
-        pass
+        self.locked = False
+        self.owner = None
 
 
 class MockUserRepository:
@@ -347,6 +362,99 @@ class TestCalibServiceInitialization:
         assert fake_repo.calls == [{"project_id": "test_project", "flow_run_id": "flow-run-9"}]
         assert session.execution_id is not None
         assert re.fullmatch(r"\d{8}-007", session.execution_id)
+
+    def test_initialize_adopts_a_lock_claimed_by_the_api_for_this_execution(
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch
+    ):
+        """A lock the API claimed for the execution being claimed is adopted, not contested."""
+        _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
+        monkeypatch.setattr(
+            "qdash.repository.MongoExecutionRepository",
+            lambda: FakeExecutionRepository(claimed_execution_id="20240101-777"),
+        )
+        lock_repo = MockExecutionLockRepository(locked=True, owner="20240101-777")
+
+        session = CalibService(
+            username="test_user",
+            chip_id="chip_1",
+            qids=["0"],
+            project_id="test_project",
+            lock_repo=lock_repo,
+            user_repo=mock_user_repo,
+        )
+
+        assert session.execution_id == "20240101-777"
+        assert session._lock_acquired is True
+        assert lock_repo.try_lock_calls == ["20240101-777"]
+        assert lock_repo.owner == "20240101-777"
+
+    def test_initialize_refuses_a_lock_owned_by_another_execution(
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch
+    ):
+        """A lock owned by a different execution still blocks the session."""
+        _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
+        monkeypatch.setattr(
+            "qdash.repository.MongoExecutionRepository",
+            lambda: FakeExecutionRepository(claimed_execution_id="20240101-777"),
+        )
+        lock_repo = MockExecutionLockRepository(locked=True, owner="20240101-111")
+
+        with pytest.raises(RuntimeError, match="Calibration is already running"):
+            CalibService(
+                username="test_user",
+                chip_id="chip_1",
+                qids=["0"],
+                project_id="test_project",
+                lock_repo=lock_repo,
+                user_repo=mock_user_repo,
+            )
+
+        assert lock_repo.owner == "20240101-111"
+
+    def test_initialize_refuses_an_unowned_lock(
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch
+    ):
+        """A held lock with no recorded owner is not adopted either."""
+        _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
+        monkeypatch.setattr(
+            "qdash.repository.MongoExecutionRepository",
+            lambda: FakeExecutionRepository(claimed_execution_id="20240101-777"),
+        )
+        lock_repo = MockExecutionLockRepository(locked=True, owner=None)
+
+        with pytest.raises(RuntimeError, match="Calibration is already running"):
+            CalibService(
+                username="test_user",
+                chip_id="chip_1",
+                qids=["0"],
+                project_id="test_project",
+                lock_repo=lock_repo,
+                user_repo=mock_user_repo,
+            )
+
+    def test_initialize_takes_a_free_lock_itself(
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch
+    ):
+        """Runs that never went through the API, such as cron schedules, lock here."""
+        _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
+        monkeypatch.setattr(
+            "qdash.repository.MongoExecutionRepository",
+            lambda: FakeExecutionRepository(claimed_execution_id="20240101-777"),
+        )
+        lock_repo = MockExecutionLockRepository()
+
+        session = CalibService(
+            username="test_user",
+            chip_id="chip_1",
+            qids=["0"],
+            project_id="test_project",
+            lock_repo=lock_repo,
+            user_repo=mock_user_repo,
+        )
+
+        assert lock_repo.try_lock_calls == ["20240101-777"]
+        assert lock_repo.locked is True
+        assert lock_repo.owner == session.execution_id
 
 
 class TestCalibServiceParameterManagement:

--- a/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
+++ b/ui/src/components/features/flow/WorkflowEditorPageContent.tsx
@@ -23,6 +23,7 @@ import {
 import { useGetCurrentUser } from "@/client/auth/auth";
 import { useListChips } from "@/client/chip/chip";
 import {
+  getGetExecutionLockStatusQueryKey,
   useCancelExecution,
   useGetExecution,
   useGetExecutionLockStatus,
@@ -227,6 +228,8 @@ export function WorkflowEditorPageContent() {
         setLastFlowRunId(response.data.flow_run_id || null);
         toast.success(`Flow execution started! Execution ID: ${execId || "N/A"}`);
       },
+      onSettled: () =>
+        queryClient.invalidateQueries({ queryKey: getGetExecutionLockStatusQueryKey() }),
     },
   });
 
@@ -247,6 +250,13 @@ export function WorkflowEditorPageContent() {
   });
 
   const canCancel = !!lastFlowRunId && !!lockStatus?.data.lock;
+  const executeErrorDetail = (
+    executeMutation.error as { response?: { data?: { detail?: unknown } } } | null
+  )?.response?.data?.detail;
+  const executeErrorMessage =
+    (typeof executeErrorDetail === "string" ? executeErrorDetail : undefined) ||
+    (executeMutation.error as Error | null)?.message ||
+    "Unknown error";
   useEffect(() => {
     if (data?.data) {
       const flow = data.data;
@@ -780,7 +790,8 @@ export function WorkflowEditorPageContent() {
                 saveMutation.isPending ||
                 deleteMutation.isPending ||
                 executeMutation.isPending ||
-                isLockStatusLoading
+                isLockStatusLoading ||
+                !!lockStatus?.data.lock
               }
               title={
                 lockStatus?.data.lock
@@ -855,9 +866,7 @@ export function WorkflowEditorPageContent() {
 
         {executeMutation.isError && (
           <div className="alert alert-error mx-4 mt-2">
-            <span>
-              Failed to execute flow: {(executeMutation.error as Error)?.message || "Unknown error"}
-            </span>
+            <span>Failed to execute flow: {executeErrorMessage}</span>
           </div>
         )}
 
@@ -1475,7 +1484,8 @@ export function WorkflowEditorPageContent() {
                 saveMutation.isPending ||
                 deleteMutation.isPending ||
                 executeMutation.isPending ||
-                isLockStatusLoading
+                isLockStatusLoading ||
+                !!lockStatus?.data.lock
               }
             >
               {executeMutation.isPending ? (

--- a/ui/src/components/features/tasks/TaskWorkbench.tsx
+++ b/ui/src/components/features/tasks/TaskWorkbench.tsx
@@ -3,13 +3,18 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, Lock, Play, RefreshCw, RotateCcw } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 
 import type { ExecutionResponseDetail, TaskInfo } from "@/schemas";
 
 import { getChipCoupling, getChipQubit, useListChips } from "@/client/chip/chip";
-import { useGetExecution, useGetExecutionLockStatus } from "@/client/execution/execution";
+import {
+  getGetExecutionLockStatusQueryKey,
+  useGetExecution,
+  useGetExecutionLockStatus,
+} from "@/client/execution/execution";
 import { TaskFigure } from "@/components/charts/TaskFigure";
 import { ParametersTable } from "@/components/features/metrics/ParametersTable";
 import { useToast } from "@/components/ui/Toast";
@@ -31,6 +36,7 @@ function badgeClass(status?: string | null) {
 
 export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
   const toast = useToast();
+  const queryClient = useQueryClient();
   const { data: chipsData } = useListChips();
   const chips = chipsData?.data?.chips ?? [];
   const defaultChipId = chips[0]?.chip_id ?? "";
@@ -188,6 +194,7 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
         ?.detail;
       toast.error(detail ?? (error instanceof Error ? error.message : "Failed to start task"));
     } finally {
+      await queryClient.invalidateQueries({ queryKey: getGetExecutionLockStatusQueryKey() });
       setIsStarting(false);
     }
   };


### PR DESCRIPTION
## Ticket

close #778

## Summary

- The project execution lock is now claimed by the API at dispatch time instead of by the flow process at start time, so a repeated Execute press can no longer dispatch a second run during the seconds before the flow starts.
- Affects the API (FlowService, ExecutionService), the workflow engine (CalibService lock handling), and the UI execute buttons. No OpenAPI schema changes, so the generated client is untouched.

## Changes

- `FlowService` atomically claims the lock before creating the Prefect flow run in `execute_flow`, `re_execute_from_snapshot`, and `execute_single_task_from_snapshot`, and answers 409 while another run is in flight. The lock is released when dispatch fails before the `scheduled` execution row exists.
- `ExecutionLockDocument.try_lock()` acquires the lock in a single atomic upsert and lets the owning execution reacquire it, which is how the flow adopts the lock the API claimed for it.
- `CalibService._initialize()` takes the lock with `try_lock`: it adopts an API-claimed lock for its own execution and still refuses a lock owned by anything else. Runs that skip the API, such as cron schedules, keep locking at flow start.
- `ExecutionService.get_lock_status()` reconciles a still `scheduled` execution against Prefect before reading the lock, so a run that dies before its flow process starts stops locking the project on the poll the UI already makes.
- UI: `WorkflowEditorPageContent` and `TaskWorkbench` disable Execute while the lock is held, refetch the lock status before the button leaves its busy state, and the flow editor now surfaces the server's 409 detail message.
- Docs: added a Mutual Exclusion section to `docs/development/workflow/engine-architecture.md`. Tests cover the dispatch-time claim and release paths, `try_lock` semantics, and lock-status reconciliation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prevented multiple calibrations from running concurrently for the same project.
  * Execute controls are disabled while a project execution is locked.
  * Lock status now refreshes automatically after executions and task-start attempts.

* **Bug Fixes**
  * Locks are released when dispatch fails or a scheduled execution cannot start.
  * Stale locks from failed pre-start runs are reconciled automatically.
  * Execution errors now show more specific details when available.

* **Documentation**
  * Documented workflow execution locking and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->