### PR TITLE
fix(ui): make the dashboard metric modal scrollable on mobile (#1390)

### DIFF
--- a/ui/src/components/features/dashboard/DashboardMetricModal.tsx
+++ b/ui/src/components/features/dashboard/DashboardMetricModal.tsx
@@ -98,8 +98,8 @@ export function DashboardMetricModal({
         </div>
 
         {/* Body — history (main) + metric note (side/top panel) */}
-        <div className="flex-1 min-h-0 flex flex-col lg:flex-row overflow-hidden">
-          <div className="flex-1 min-w-0 overflow-auto p-3 sm:p-6 order-2 lg:order-1">
+        <div className="flex-1 min-h-0 flex flex-col lg:flex-row overflow-y-auto lg:overflow-hidden">
+          <div className="w-full flex-none min-w-0 lg:flex-1 lg:min-h-0 lg:overflow-auto p-3 sm:p-6 order-2 lg:order-1">
             {isCoupling ? (
               <CouplingMetricHistoryModal
                 chipId={chipId}

--- a/ui/src/components/features/dashboard/MetricNotePanel.tsx
+++ b/ui/src/components/features/dashboard/MetricNotePanel.tsx
@@ -266,7 +266,7 @@ export function MetricNotePanel({
 
   return (
     <aside
-      className="flex flex-col bg-base-200/40 border-l border-base-300 lg:h-full overflow-hidden"
+      className="flex lg:h-full flex-col bg-base-200/40 lg:border-l border-base-300 lg:overflow-hidden"
       aria-label="Pinned summary"
     >
       {/* Section header */}
@@ -283,7 +283,7 @@ export function MetricNotePanel({
       </div>
 
       {/* Body */}
-      <div className="flex-1 overflow-auto p-4 space-y-3">
+      <div className="flex-1 lg:overflow-auto p-4 space-y-3">
         {mode === "view" ? (
           <ViewState existing={localExisting} onEdit={() => setMode("edit")} />
         ) : (

--- a/ui/src/components/features/dashboard/__tests__/DashboardMetricModal.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardMetricModal.test.tsx
@@ -26,6 +26,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+/** Render `DashboardMetricModal` with default props, allowing overrides. */
 function renderModal(overrides?: Partial<React.ComponentProps<typeof DashboardMetricModal>>) {
   const onClose = overrides?.onClose ?? vi.fn();
 

--- a/ui/src/components/features/dashboard/__tests__/DashboardMetricModal.test.tsx
+++ b/ui/src/components/features/dashboard/__tests__/DashboardMetricModal.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DashboardMetricModal } from "@/components/features/dashboard/DashboardMetricModal";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/components/features/metrics/QubitMetricHistoryModal", () => ({
+  QubitMetricHistoryModal: () => <div data-testid="qubit-history" />,
+}));
+
+vi.mock("@/components/features/metrics/CouplingMetricHistoryModal", () => ({
+  CouplingMetricHistoryModal: () => <div data-testid="coupling-history" />,
+}));
+
+vi.mock("../MetricNotePanel", () => ({
+  MetricNotePanel: () => <div data-testid="note-panel" />,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderModal(overrides?: Partial<React.ComponentProps<typeof DashboardMetricModal>>) {
+  const onClose = overrides?.onClose ?? vi.fn();
+
+  const result = render(
+    <DashboardMetricModal
+      chipId="chip-1"
+      targetId="72"
+      metricKey="t1"
+      metricTitle="T1"
+      metricUnit="us"
+      onClose={onClose}
+      {...overrides}
+    />,
+  );
+
+  return { onClose, ...result };
+}
+
+describe("DashboardMetricModal", () => {
+  it("scrolls the body as a single column on mobile", () => {
+    renderModal();
+
+    const body = screen.getByTestId("note-panel").parentElement?.parentElement;
+
+    expect(body).not.toBeNull();
+    expect(body?.className).toContain("overflow-y-auto");
+    expect(body?.className).toContain("lg:overflow-hidden");
+  });
+
+  it("lets the history pane grow to its content on mobile", () => {
+    renderModal();
+
+    const historyPane = screen.getByTestId("qubit-history").parentElement;
+
+    expect(historyPane).not.toBeNull();
+    expect(historyPane?.className).toContain("flex-none");
+    expect(historyPane?.className).toContain("lg:overflow-auto");
+    expect(historyPane?.className).not.toContain("min-h-0 min-w-0 overflow-auto");
+  });
+
+  it("renders the coupling history for a coupling target", () => {
+    renderModal({ targetId: "72-73" });
+
+    expect(screen.getByTestId("coupling-history")).toBeTruthy();
+    expect(screen.queryByTestId("qubit-history")).toBeNull();
+  });
+
+  it("renders the qubit history for a qubit target", () => {
+    renderModal({ targetId: "72" });
+
+    expect(screen.getByTestId("qubit-history")).toBeTruthy();
+    expect(screen.queryByTestId("coupling-history")).toBeNull();
+  });
+
+  it("hides the lineage link for a coupling target", () => {
+    const { unmount } = renderModal({ targetId: "72-73" });
+
+    expect(screen.queryByText("Lineage")).toBeNull();
+    expect(screen.queryByText("Details")).toBeNull();
+
+    unmount();
+
+    renderModal({ targetId: "72" });
+
+    expect(screen.getByText("Lineage")).toBeTruthy();
+    expect(screen.getByText("Details")).toBeTruthy();
+  });
+
+  it("calls onClose from the header and footer buttons", () => {
+    const { onClose } = renderModal();
+
+    const closeButtons = screen.getAllByRole("button", { name: "Close" });
+    expect(closeButtons).toHaveLength(2);
+
+    fireEvent.click(closeButtons[0]);
+    fireEvent.click(closeButtons[1]);
+
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/components/features/task-history/ExecutionHistoryModalContent.tsx
+++ b/ui/src/components/features/task-history/ExecutionHistoryModalContent.tsx
@@ -14,6 +14,7 @@ interface ExecutionHistoryModalContentProps {
   topContent?: ReactNode;
 }
 
+/** Shared layout for execution-history modals: tabbed panels on mobile, three panes on desktop. */
 export function ExecutionHistoryModalContent({
   mobileTab,
   onMobileTabChange,

--- a/ui/src/components/features/task-history/ExecutionHistoryModalContent.tsx
+++ b/ui/src/components/features/task-history/ExecutionHistoryModalContent.tsx
@@ -52,7 +52,7 @@ export function ExecutionHistoryModalContent({
         </div>
       </div>
 
-      <div className="lg:hidden flex-1 min-h-0 overflow-hidden">
+      <div className="lg:hidden flex-1 min-h-0 overflow-y-auto">
         {mobileTab === "history" && history}
         {mobileTab === "tasks" && tasks}
         {mobileTab === "details" && details}

--- a/ui/src/components/features/task-history/__tests__/ExecutionHistoryModalContent.test.tsx
+++ b/ui/src/components/features/task-history/__tests__/ExecutionHistoryModalContent.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ExecutionHistoryModalContent } from "@/components/features/task-history/ExecutionHistoryModalContent";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderContent(props?: Partial<React.ComponentProps<typeof ExecutionHistoryModalContent>>) {
+  const onMobileTabChange = props?.onMobileTabChange ?? vi.fn();
+
+  const utils = render(
+    <ExecutionHistoryModalContent
+      mobileTab="history"
+      onMobileTabChange={onMobileTabChange}
+      history={<div>History Content</div>}
+      tasks={<div>Tasks Content</div>}
+      details={<div>Details Content</div>}
+      {...props}
+    />,
+  );
+
+  return { ...utils, onMobileTabChange };
+}
+
+function getMobilePanel(container: HTMLElement) {
+  return container.querySelector(".lg\\:hidden.flex-1");
+}
+
+function getDesktopPanel(container: HTMLElement) {
+  return container.querySelector(".hidden.lg\\:flex");
+}
+
+describe("ExecutionHistoryModalContent", () => {
+  it("renders only the selected tab on mobile", () => {
+    const { container } = renderContent({ mobileTab: "details" });
+
+    const mobilePanel = getMobilePanel(container);
+    expect(mobilePanel).toBeTruthy();
+    expect(mobilePanel?.textContent).toContain("Details Content");
+    expect(mobilePanel?.textContent).not.toContain("History Content");
+    expect(mobilePanel?.textContent).not.toContain("Tasks Content");
+  });
+
+  it("keeps the mobile tab panel scrollable", () => {
+    const { container } = renderContent();
+
+    const mobilePanel = getMobilePanel(container);
+    expect(mobilePanel?.className).toContain("overflow-y-auto");
+    expect(mobilePanel?.className).not.toContain("overflow-hidden");
+  });
+
+  it("switches tabs on click", () => {
+    const onMobileTabChange = vi.fn();
+    renderContent({ onMobileTabChange });
+
+    fireEvent.click(screen.getByRole("button", { name: "History" }));
+    expect(onMobileTabChange).toHaveBeenCalledWith("history");
+
+    fireEvent.click(screen.getByRole("button", { name: "Tasks" }));
+    expect(onMobileTabChange).toHaveBeenCalledWith("tasks");
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+    expect(onMobileTabChange).toHaveBeenCalledWith("details");
+  });
+
+  it("renders all three panes on desktop", () => {
+    const { container } = renderContent();
+
+    const desktopPanel = getDesktopPanel(container);
+    expect(desktopPanel).toBeTruthy();
+    expect(desktopPanel?.textContent).toContain("History Content");
+    expect(desktopPanel?.textContent).toContain("Tasks Content");
+    expect(desktopPanel?.textContent).toContain("Details Content");
+  });
+
+  it("renders topContent when provided", () => {
+    const { rerender } = renderContent({ topContent: <div>Top Content</div> });
+
+    expect(screen.getByText("Top Content")).toBeTruthy();
+
+    rerender(
+      <ExecutionHistoryModalContent
+        mobileTab="history"
+        onMobileTabChange={vi.fn()}
+        history={<div>History Content</div>}
+        tasks={<div>Tasks Content</div>}
+        details={<div>Details Content</div>}
+      />,
+    );
+
+    expect(screen.queryByText("Top Content")).toBeNull();
+  });
+});

--- a/ui/src/components/features/task-history/__tests__/ExecutionHistoryModalContent.test.tsx
+++ b/ui/src/components/features/task-history/__tests__/ExecutionHistoryModalContent.test.tsx
@@ -8,6 +8,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+/** Render `ExecutionHistoryModalContent` with default props, allowing overrides. */
 function renderContent(props?: Partial<React.ComponentProps<typeof ExecutionHistoryModalContent>>) {
   const onMobileTabChange = props?.onMobileTabChange ?? vi.fn();
 
@@ -25,10 +26,12 @@ function renderContent(props?: Partial<React.ComponentProps<typeof ExecutionHist
   return { ...utils, onMobileTabChange };
 }
 
+/** Get the mobile tab panel from the rendered output. */
 function getMobilePanel(container: HTMLElement) {
   return container.querySelector(".lg\\:hidden.flex-1");
 }
 
+/** Get the desktop three-pane panel from the rendered output. */
 function getDesktopPanel(container: HTMLElement) {
   return container.querySelector(".hidden.lg\\:flex");
 }


### PR DESCRIPTION
## Ticket

- close #1390

## Summary

- On mobile widths the `/dashboard` metric modal clipped its own content. The note panel kept its full natural height while the body was `overflow-hidden`, squeezing the metric history down to a sliver that nothing could scroll back into view.
- The modal has two independent causes of the same symptom, and both are inside the modal the issue reports, so both are fixed here. See Scope below.
- UI only, below the `lg` breakpoint. The desktop two-pane layout, the API, and the generated client are untouched.

## Scope

`DashboardMetricModal` embeds `CouplingMetricHistoryModal` / `QubitMetricHistoryModal` (`DashboardMetricModal.tsx:103-119`), and those render `ExecutionHistoryModalContent`, which owns the `History` / `Tasks` / `Details` tab bar shown below `lg`. The tab bar visible in the issue screenshot is that component.

So the shared component is not a drive-by fix. Making the modal body scroll gets the user to the tab bar, but the `Details` tab of the same modal stays clipped with no scroller of its own, and #1390 is not closed. The one-line change there is required to close the issue. Four other modals inherit the fix because they reuse the component, which is a consequence of the shared component, not an added scope.

## Changes

- `DashboardMetricModal`: below `lg`, the modal body is now the single scroll container and both panes size to their content, so the modal reads as one continuous column on a phone. At `lg` the body stays `overflow-hidden` in a row and each pane keeps its own scroller.
- `MetricNotePanel`: the panel no longer clips or draws its left border below `lg`, so it can flow inside the body scroller instead of holding a fixed height.
- `ExecutionHistoryModalContent`: the mobile tab panel switches from `overflow-hidden` to `overflow-y-auto`. The `History` and `Tasks` panes root at `h-full` and are unaffected. The `Details` pane roots at a plain flex column with no scroller of its own, which is why it was the only tab that clipped. The modals that reuse this component are `CouplingMetricHistoryModal`, `QubitMetricHistoryModal`, `CouplingTaskHistoryModal`, `TaskHistoryModal`, and `ExecutionTaskDetailModal`.
- Added tests for both fixes. jsdom does not lay out, so they pin the class contracts the fixes depend on. Each was checked against a reverted source line to confirm it fails without the fix.
- Added docstrings to the functions this PR touches that were missing them.

## Verification

- Measured at 390x800 against a harness using the real class strings: the modal body goes from 578px of visible height clipping 1561px of content to a single scroller over 3086px, with no pane scrolling on its own. At 1280px the panes stay bounded and the note body still scrolls internally.
- `bun run vitest run` on both new test files: 11 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scrolling behavior in dashboard metric and execution history modals on small screens.
  - Enabled independent history-panel scrolling on large screens.
  - Adjusted note-panel scrolling and layout behavior across screen sizes.
  - Ensured mobile tabs display and switch content correctly.

- **Tests**
  - Added coverage for responsive scrolling, tab switching, conditional content, links, and modal close actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
