### PR TITLE
style(ui): trim the mobile sidebar drawer (#1415)

### DIFF
--- a/ui/src/components/layout/Sidebar/index.tsx
+++ b/ui/src/components/layout/Sidebar/index.tsx
@@ -40,6 +40,11 @@ type ExternalNavItem = {
   visible?: boolean;
 };
 
+/**
+ * QDash home link shared by both sidebars.
+ * `lg` is the in-nav logo on the expanded desktop rail; `sm` is the compact one
+ * that sits beside the close button in the mobile drawer header.
+ */
 function SidebarLogo({ size, onClick }: { size: "sm" | "lg"; onClick: () => void }) {
   const isLarge = size === "lg";
 
@@ -62,6 +67,10 @@ function SidebarLogo({ size, onClick }: { size: "sm" | "lg"; onClick: () => void
   );
 }
 
+/**
+ * Renders a navigation section label, or nothing while the sidebar is collapsed
+ * to the icon-only desktop rail and there is no room for one.
+ */
 function SectionHeader({ label, visible }: { label: string; visible: boolean }) {
   if (!visible) return null;
   return (
@@ -71,6 +80,11 @@ function SectionHeader({ label, visible }: { label: string; visible: boolean }) 
   );
 }
 
+/**
+ * One in-app navigation row. Marks itself active from `pathname` (exact or
+ * prefix match per `item.match`), truncates its label so a long entry cannot
+ * widen the row, and closes the mobile drawer through `onClick`.
+ */
 function SidebarNavItem({
   item,
   isMobileOpen,
@@ -114,6 +128,10 @@ function SidebarNavItem({
   );
 }
 
+/**
+ * One external-link navigation row (Docs, Prefect, API Docs). Opens in a new tab
+ * and is never marked active, since the current route never matches it.
+ */
 function SidebarExternalNavItem({
   item,
   isMobileOpen,
@@ -148,6 +166,11 @@ function SidebarExternalNavItem({
   );
 }
 
+/**
+ * Primary navigation, rendered as two asides sharing one set of nav rows:
+ * a desktop rail that expands to `w-48` and collapses to `w-16`, and a mobile
+ * drawer (`w-56`) that slides in over an overlay and closes on navigation.
+ */
 export function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();

--- a/ui/src/components/layout/Sidebar/index.tsx
+++ b/ui/src/components/layout/Sidebar/index.tsx
@@ -40,6 +40,28 @@ type ExternalNavItem = {
   visible?: boolean;
 };
 
+function SidebarLogo({ size, onClick }: { size: "sm" | "lg"; onClick: () => void }) {
+  const isLarge = size === "lg";
+
+  return (
+    <Link
+      href="/"
+      className={`flex items-center justify-center rounded-xl ${isLarge ? "min-h-16" : ""}`}
+      aria-label="QDash home"
+      onClick={onClick}
+    >
+      <Image
+        src="/oqtopus_logo.png"
+        alt="Oqtopus Logo"
+        width={72}
+        height={72}
+        className={`object-contain ${isLarge ? "h-16 w-16" : "h-10 w-10"}`}
+        priority
+      />
+    </Link>
+  );
+}
+
 function SectionHeader({ label, visible }: { label: string; visible: boolean }) {
   if (!visible) return null;
   return (
@@ -81,9 +103,11 @@ function SidebarNavItem({
         onClick={onClick}
       >
         <Icon size={18} />
-        {showLabel && <span className="ml-2">{item.label}</span>}
+        {showLabel && <span className="ml-2 truncate">{item.label}</span>}
         {badge > 0 && (
-          <span className="badge badge-primary badge-xs ml-auto">{badge > 99 ? "99+" : badge}</span>
+          <span className="badge badge-primary badge-xs ml-auto shrink-0">
+            {badge > 99 ? "99+" : badge}
+          </span>
         )}
       </Link>
     </li>
@@ -118,7 +142,7 @@ function SidebarExternalNavItem({
         onClick={onClick}
       >
         <Icon size={18} />
-        {(isOpen || isMobileOpen) && <span className="ml-2">{item.label}</span>}
+        {(isOpen || isMobileOpen) && <span className="ml-2 truncate">{item.label}</span>}
       </a>
     </li>
   );
@@ -227,24 +251,10 @@ export function Sidebar() {
 
   const sidebarContent = (
     <>
-      <ul className="menu p-2 py-0">
-        {(isOpen || isMobileOpen) && (
-          <li className="mb-1">
-            <Link
-              href="/"
-              className="flex min-h-16 items-center justify-center rounded-xl"
-              aria-label="QDash home"
-              onClick={handleLinkClick}
-            >
-              <Image
-                src="/oqtopus_logo.png"
-                alt="Oqtopus Logo"
-                width={72}
-                height={72}
-                className="h-16 w-16 object-contain"
-                priority
-              />
-            </Link>
+      <ul className="menu max-lg:w-full max-lg:flex-nowrap max-lg:[&>li]:flex-nowrap p-2 py-0">
+        {isOpen && (
+          <li className="mb-1 hidden lg:block">
+            <SidebarLogo size="lg" onClick={handleLinkClick} />
           </li>
         )}
 
@@ -432,11 +442,12 @@ export function Sidebar() {
       {/* Mobile Sidebar Drawer */}
       <aside
         aria-label="Primary navigation"
-        className={`fixed left-0 top-0 z-50 flex h-full w-72 flex-col border-r border-base-300 bg-base-200 shadow-2xl transition-transform duration-300 lg:hidden ${
+        className={`fixed left-0 top-0 z-50 flex h-full w-56 flex-col border-r border-base-300 bg-base-200 shadow-2xl transition-transform duration-300 lg:hidden ${
           isMobileOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
-        <div className="flex justify-end p-2 flex-shrink-0">
+        <div className="flex flex-shrink-0 items-center justify-between gap-2 p-2">
+          <SidebarLogo size="sm" onClick={handleLinkClick} />
           <button
             onClick={() => setMobileSidebarOpen(false)}
             className="btn btn-ghost btn-sm btn-square"

--- a/ui/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/ui/src/components/layout/__tests__/Sidebar.test.tsx
@@ -47,6 +47,11 @@ vi.mock("@/hooks/useNotifications", () => ({
   }),
 }));
 
+/**
+ * Pulls the desktop and mobile navigation asides out of a render. Both carry the
+ * same aria-label, so they are told apart by their `lg:` visibility class.
+ * Throws when either is missing so a broken render fails here, not on undefined.
+ */
 function getAsides(container: HTMLElement) {
   const asides = container.querySelectorAll('aside[aria-label="Primary navigation"]');
   const desktop = Array.from(asides).find((aside) => aside.className.includes("lg:flex"));

--- a/ui/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/ui/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,156 @@
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Sidebar } from "@/components/layout/Sidebar";
+
+const push = vi.fn();
+const mockPathname = vi.hoisted(() => vi.fn(() => "/dashboard"));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => mockPathname(),
+}));
+
+const setMobileSidebarOpen = vi.fn();
+const toggleSidebar = vi.fn();
+const sidebarState = vi.hoisted(() => ({ isOpen: true, isMobileOpen: false }));
+
+vi.mock("@/contexts/SidebarContext", () => ({
+  useSidebar: () => ({
+    isOpen: sidebarState.isOpen,
+    isMobileOpen: sidebarState.isMobileOpen,
+    toggleSidebar,
+    setSidebarOpen: vi.fn(),
+    toggleMobileSidebar: vi.fn(),
+    setMobileSidebarOpen,
+  }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { username: "tester", system_role: "user" },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("@/contexts/ProjectContext", () => ({
+  useProject: () => ({ canEdit: false }),
+}));
+
+vi.mock("@/contexts/ThemeContext", () => ({
+  useTheme: () => ({ theme: "light", setTheme: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useNotifications", () => ({
+  useUnreadNotificationCount: () => ({
+    data: { data: { unread_count: 0 } },
+  }),
+}));
+
+function getAsides(container: HTMLElement) {
+  const asides = container.querySelectorAll('aside[aria-label="Primary navigation"]');
+  const desktop = Array.from(asides).find((aside) => aside.className.includes("lg:flex"));
+  const mobile = Array.from(asides).find((aside) => aside.className.includes("lg:hidden"));
+  if (!desktop || !mobile) {
+    throw new Error("Expected both desktop and mobile Primary navigation asides");
+  }
+  return { desktop, mobile };
+}
+
+describe("Sidebar", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    sidebarState.isOpen = true;
+    sidebarState.isMobileOpen = false;
+  });
+
+  it("narrows the mobile drawer to w-56 and drops w-72", () => {
+    const { container } = render(<Sidebar />);
+
+    const { mobile } = getAsides(container);
+
+    expect(mobile.className).toContain("w-56");
+    expect(mobile.className).not.toContain("w-72");
+  });
+
+  it("makes the mobile menu rows fill the drawer instead of the widest label", () => {
+    const { container } = render(<Sidebar />);
+
+    const menu = getAsides(container).mobile.querySelector("nav ul.menu");
+
+    expect(menu?.className).toContain("max-lg:w-full");
+    expect(menu?.className).toContain("max-lg:flex-nowrap");
+    expect(menu?.className).toContain("max-lg:[&>li]:flex-nowrap");
+  });
+
+  it("truncates a nav label instead of letting it grow the row", () => {
+    sidebarState.isMobileOpen = true;
+    const { container } = render(<Sidebar />);
+
+    const { mobile } = getAsides(container);
+    const label = within(mobile as HTMLElement).getByText("Task Knowledge");
+
+    expect(label.className).toContain("truncate");
+  });
+
+  it("keeps the desktop sidebar at w-48 when expanded", () => {
+    sidebarState.isOpen = true;
+    const { container } = render(<Sidebar />);
+
+    const { desktop } = getAsides(container);
+
+    expect(desktop.className).toContain("w-48");
+    expect(desktop.className).not.toContain("w-16");
+  });
+
+  it("collapses the desktop sidebar to w-16 when closed", () => {
+    sidebarState.isOpen = false;
+    const { container } = render(<Sidebar />);
+
+    const { desktop } = getAsides(container);
+
+    expect(desktop.className).toContain("w-16");
+    expect(desktop.className).not.toContain("w-48");
+  });
+
+  it("closes the mobile drawer from the Close menu button", () => {
+    sidebarState.isMobileOpen = true;
+    const { container } = render(<Sidebar />);
+
+    const { mobile } = getAsides(container);
+    fireEvent.click(within(mobile as HTMLElement).getByRole("button", { name: "Close menu" }));
+
+    expect(setMobileSidebarOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("pairs the logo with the close button in the mobile drawer header", () => {
+    sidebarState.isMobileOpen = true;
+    const { container } = render(<Sidebar />);
+
+    const { mobile } = getAsides(container);
+    const header = within(mobile.firstElementChild as HTMLElement);
+
+    expect(header.getByRole("link", { name: "QDash home" })).toBeTruthy();
+    expect(header.getByRole("button", { name: "Close menu" })).toBeTruthy();
+  });
+
+  it("keeps the in-nav logo out of the mobile drawer", () => {
+    const { container } = render(<Sidebar />);
+
+    const { mobile } = getAsides(container);
+    const navLogo = mobile.querySelector('nav a[aria-label="QDash home"]');
+
+    expect(navLogo?.closest("li")?.className).toContain("hidden lg:block");
+  });
+
+  it("closes the mobile drawer when a nav link is clicked", () => {
+    sidebarState.isMobileOpen = true;
+    const { container } = render(<Sidebar />);
+
+    const { mobile } = getAsides(container);
+    fireEvent.click(within(mobile as HTMLElement).getByRole("link", { name: "Home" }));
+
+    expect(setMobileSidebarOpen).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Ticket

- close #1415

## Summary

- The expanded sidebar wasted space on a phone in two directions. It was 288px wide on a 390px screen while the desktop sidebar lives in 192px, and the top 116px held nothing but a close button on its own row and a centered 64px logo.
- There was a third source of whitespace inside the drawer: the menu only occupied 189px of the 288px, so every row ended in a dead strip well before the drawer edge.
- The drawer is now 224px, the logo shares the header row with the close button, and the menu fills the drawer instead of sizing itself to its widest label. UI only, below the `lg` breakpoint. Desktop rendering, the API, and the generated client are untouched.

## Scope

Narrowing the `aside` alone would not have removed the whitespace the issue points at. daisyUI lays `ul.menu` and its `li` out as wrapping column flex containers, so the widest child decides the width and the rows keep hugging their labels no matter what the drawer declares. Making the rows fill the drawer is part of the same fix, not a drive-by change, so `Sidebar` now declares the width and its children conform to it.

Those menu classes are scoped to `max-lg`. Applying them at `lg` and above would shrink the desktop rows into `w-48` and put an ellipsis on `Task Knowledge`, and the desktop width is out of scope here.

One pre-existing issue is deliberately left alone: on a desktop sidebar with classic scrollbars the nav already overflows horizontally by 9px (`scrollWidth` 189 against `clientWidth` 180). Fixing it means revisiting `w-48`, which belongs to a separate ticket.

## Changes

- `Sidebar` mobile drawer: `w-72` to `w-56` (288px to 224px), which keeps the drawer wider than the desktop sidebar for touch while leaving 40% of a 390px screen showing behind it.
- `Sidebar` mobile header: the close button no longer owns an empty row. It now sits opposite a 40px logo in a 56px row that matches the navbar's `min-h-14`, so the first nav item starts 60px higher.
- `SidebarLogo` extracted for the two placements (`lg` 64px in the desktop nav, `sm` 40px in the drawer header). The in-nav logo is desktop only via `hidden lg:block`, so the drawer shows exactly one logo.
- `ul.menu` gets `max-lg:w-full max-lg:flex-nowrap max-lg:[&>li]:flex-nowrap`, so below `lg` the menu and its rows take the drawer width rather than the width of the longest label.
- Nav labels truncate and the unread badge gets `shrink-0`, so a longer label yields inside the row instead of pushing the row past the drawer edge.
- New `Sidebar.test.tsx` covering the drawer width, the menu classes, the truncating label, the header pairing, the desktop-only in-nav logo, and the desktop widths.

No OpenAPI or schema changes, so `task generate` was not needed.

## Verification

Measured in Chrome against the dev server, with the real class strings on the live DOM.

| | Before | After |
| --- | --- | --- |
| Drawer width | 288px | 224px |
| Header height | 116px | 56px |
| Menu / row width | 189.3px / 165.3px | 212px / 188px |
| Long label (`Task Knowledge Repository Archive`) | row grows to 293.6px, nav scrolls horizontally | row stays 188px, label truncates, row height unchanged at 36px |
| Unread badge `99+` | n/a | keeps its 36.9px, sits 28px from the drawer edge |
| Desktop `aside` | 192px, menu 189.3px | unchanged |

Confirmed in the compiled CSS that Tailwind emits `.max-lg\:w-full`, `.max-lg\:flex-nowrap`, and `.max-lg\:\[\&\>li\]\:flex-nowrap > li` inside `@media not (min-width: 64rem)`, and that the mobile `aside` is `display: none` at `lg`.

`bun run test:run` 237 passed, `bun run lint`, `bun run fmt:check`, and `bunx tsc --noEmit` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Added responsive Oqtopus logo placement for desktop and mobile navigation.
  * Narrowed the mobile navigation drawer for a more compact layout.
  * Improved navigation label truncation and badge alignment.
  * Updated mobile menu spacing and row behavior.
  * Mobile drawer now closes when selecting a navigation link or using the close button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->