### PR TITLE
fix(ui): keep the home page grids single column on mobile (#1416)

### DIFF
--- a/ui/src/components/features/home/HomePageContent.tsx
+++ b/ui/src/components/features/home/HomePageContent.tsx
@@ -100,7 +100,7 @@ function QuickActions({ canEdit }: QuickActionsProps) {
       <h2 id="quick-actions-heading" className="mb-3 text-sm font-semibold text-base-content/60">
         Quick actions
       </h2>
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
         {actions.map(({ href, label, description, icon: Icon }) => (
           <Link
             key={href}
@@ -268,7 +268,7 @@ export function HomePageContent() {
 
         <QuickActions canEdit={canEdit} />
 
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">
           <div className="space-y-6">
             <section className="card bg-base-200 shadow-lg">
               <div className="card-body gap-4 p-5">

--- a/ui/src/components/features/home/__tests__/HomePageContent.test.tsx
+++ b/ui/src/components/features/home/__tests__/HomePageContent.test.tsx
@@ -108,6 +108,16 @@ describe("HomePageContent", () => {
     );
   });
 
+  it("keeps the home grids single column until the layout breakpoints", () => {
+    const { container } = render(<HomePageContent />);
+
+    const quickActions = container.querySelector("[aria-labelledby='quick-actions-heading'] > div");
+    expect(quickActions?.className).toContain("grid-cols-1");
+
+    const overview = container.querySelector('[class*="xl:grid-cols-[minmax(0,1.15fr)"]');
+    expect(overview?.className).toContain("grid-cols-1");
+  });
+
   it("shows calm empty states when no work is waiting", () => {
     mockExecutionLock.mockReturnValue({
       data: { data: { lock: false } },


### PR DESCRIPTION
## Ticket

- close #1416

## Summary

- On a phone the home page ran off the right edge of the screen. At 390px the `main` element measured 459px of content against 379px of space, so 80px sat outside the viewport and the failure messages were cut off mid-word with no ellipsis.
- Both grids on the page declared their columns only at a breakpoint. Below `xl` no `grid-template-columns` applied, so the implicit single track fell back to `grid-auto-columns: auto` and took its width from its content instead of its container.
- Adding a base `grid-cols-1` pins the track to `minmax(0, 1fr)`. UI only, below `xl`. Desktop rendering, the API, and the generated client are untouched.

## Scope

The cut-off text is a symptom, not the cause. The failure rows already use `min-w-0 flex-1` with `truncate`, which is the correct pattern, but `min-width: 0` only removes a flex item's automatic minimum size. It does not cap what that item contributes to its container's min-content width. While an ancestor track is content sized, there is no definite width to truncate against, so the `white-space: nowrap` width of the longest message propagates all the way up and carries the card with it. The `xl` definition already uses `minmax(0, ...)`, which is why the same markup behaves on desktop and only breaks on mobile.

`QuickActions` has the identical shape and is fixed in the same commit. It does not overflow today because its labels are short, but it is the same latent defect on the same screen.

Three related problems are deliberately left out. `PageContainer` sets `min-h-screen` inside a `main` that is already shorter than the viewport, which adds about 68px of spurious vertical scroll to every page. Roughly 20 other files declare grid columns only at a breakpoint and can fail the same way. `AppLayout` leaves `overflow-x` unset on `main`, so a computed value of `auto` quietly absorbs layout breaks as invisible horizontal scroll. Each is a separate change with its own blast radius and belongs in its own ticket.

## Changes

- `HomePageContent` overview grid: `grid gap-6 xl:grid-cols-[...]` gains `grid-cols-1`, so below `xl` the single column takes its width from the container rather than from the longest failure message.
- `HomePageContent` quick actions grid: `grid gap-3 sm:grid-cols-2 xl:grid-cols-4` gains `grid-cols-1` for the same reason. The `sm` and `xl` definitions still win at their breakpoints, so nothing changes from 640px up.
- `HomePageContent.test.tsx` gains a case asserting the base column class on both grids. jsdom does not lay out, so the class contract is what a unit test can hold here. Confirmed it fails when the source change is reverted.

No OpenAPI or schema changes, so `task generate` was not needed.

## Verification

Measured in Chrome at 390px against the running app with real project data, applying the exact class to the live DOM.

| | Before | After |
| --- | --- | --- |
| `main.scrollWidth` / `clientWidth` | 459px / 379px | 379px / 379px |
| Horizontal overflow | 80px | 0px |
| Overview grid track | 442.7px, sized by content | 347px, sized by container |
| Failure messages showing an ellipsis | 0 of 10 | 5 of 10 |

The ellipsis count is the point of the issue. Before the change `truncate` had no definite width to work against, so the text was clipped by the viewport with no visual cue. After it, the messages end in `…` inside the card.

`bun run test:run` 229 passed across 50 files, plus `bun run lint`, `bun run fmt`, and `bunx tsc --noEmit` all clean.

One gap worth naming: the desktop layout was not re-measured against the compiled change. `localhost:5714` runs a prebuilt image with no volume mount, so it cannot pick up local edits, and a local dev server returns "No project access" against the current API config. Source order puts `grid-cols-1` before the `xl` definition so the breakpoint still wins, and 1440px showed no overflow, but a manual look at desktop before merge is worthwhile.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the home page’s responsive layout on small screens by displaying quick actions and overview content in a single column.

* **Tests**
  * Added coverage to verify the single-column layout remains active until larger-screen breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->