### PR TITLE
refactor(ui): move selector width responsibility to outer containers (#1262)

### DIFF
--- a/docs/development/ui/guidelines.md
+++ b/docs/development/ui/guidelines.md
@@ -554,6 +554,26 @@ Use Tailwind CSS utility classes for styling:
 </div>
 ```
 
+### Selector Width
+
+Selectors (`components/selectors/`) fill 100% of their parent. The container decides the width; `useSelectStyles` returns theme styles only and does not compute widths.
+
+```tsx
+// ✅ Good - container sets a fixed width
+<PageFiltersBar.Item className="sm:w-64">
+  <ChipSelector selectedChip={chip} onChipSelect={setChip} />
+</PageFiltersBar.Item>
+
+// ❌ Bad - no width on a shrink-to-fit container (selector collapses to placeholder width)
+<PageFiltersBar.Item>
+  <ChipSelector selectedChip={chip} onChipSelect={setChip} />
+</PageFiltersBar.Item>
+```
+
+- Use a fixed `sm:w-*`, not `sm:min-w-*`, so the control width stays constant across selections. Mobile keeps the `w-full` default from `PageFiltersBar.Item`.
+- When a selector shares a row with a button (for example a clear button), wrap it in `min-w-0 flex-1` so it shrinks instead of pushing the button out.
+- Long labels ellipsize inside the control; the dropdown menu grows to `max-content` so the full option text stays readable.
+
 ### DaisyUI Components
 
 Use DaisyUI component classes for consistent UI:

--- a/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitId]/page.tsx
+++ b/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitId]/page.tsx
@@ -23,6 +23,9 @@ import { TimeRangeSelector } from "@/components/ui/TimeRangeSelector";
 import { useChipUrlState, useRangeModeUrlState } from "@/hooks/useUrlState";
 import { dateToDateTimeLocal, toIsoSeconds } from "@/lib/utils/datetime";
 
+/**
+ * Qubit detail page with dashboard, history, and time-series views for a single qubit
+ */
 function QubitDetailPageContent() {
   const params = useParams();
   const chipId = params.chipId as string;

--- a/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitId]/page.tsx
+++ b/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitId]/page.tsx
@@ -125,7 +125,7 @@ function QubitDetailPageContent() {
           {/* Controls */}
           <PageFiltersBar>
             <PageFiltersBar.Group>
-              <PageFiltersBar.Item>
+              <PageFiltersBar.Item className="sm:w-64">
                 <ChipSelector
                   selectedChip={chipId}
                   onChipSelect={(newChipId) => {
@@ -133,7 +133,7 @@ function QubitDetailPageContent() {
                   }}
                 />
               </PageFiltersBar.Item>
-              <PageFiltersBar.Item>
+              <PageFiltersBar.Item className="sm:w-56">
                 <CooldownSelector
                   chipId={chipId}
                   selectedCooldownId={selectedCooldownId}
@@ -149,7 +149,7 @@ function QubitDetailPageContent() {
                 />
               </PageFiltersBar.Item>
               {viewMode === "history" && (
-                <PageFiltersBar.Item>
+                <PageFiltersBar.Item className="sm:w-80">
                   <TaskSelector
                     tasks={filteredTasks}
                     selectedTask={selectedTask}

--- a/ui/src/components/features/ai-reviews/AiReviewRunsPageContent.tsx
+++ b/ui/src/components/features/ai-reviews/AiReviewRunsPageContent.tsx
@@ -119,6 +119,9 @@ function RunCard({ run }: { run: AiReviewRunSummary }) {
   );
 }
 
+/**
+ * Page listing AI review runs with chip/task filters and pagination
+ */
 export function AiReviewRunsPageContent() {
   const { data: taskFileSettings } = useGetTaskFileSettings();
   const defaultBackend = taskFileSettings?.data?.default_backend || "qubex";

--- a/ui/src/components/features/ai-reviews/AiReviewRunsPageContent.tsx
+++ b/ui/src/components/features/ai-reviews/AiReviewRunsPageContent.tsx
@@ -177,12 +177,14 @@ export function AiReviewRunsPageContent() {
       <div className="mb-4 rounded-lg border border-base-300 bg-base-100 p-3">
         <PageFiltersBar>
           <PageFiltersBar.Group>
-            <PageFiltersBar.Item label="Chip" className="sm:min-w-56">
+            <PageFiltersBar.Item label="Chip" className="sm:w-72">
               <div className="flex items-center gap-2">
-                <ChipSelector
-                  selectedChip={filters.chipId}
-                  onChipSelect={(chipId) => updateFilter({ chipId })}
-                />
+                <div className="min-w-0 flex-1">
+                  <ChipSelector
+                    selectedChip={filters.chipId}
+                    onChipSelect={(chipId) => updateFilter({ chipId })}
+                  />
+                </div>
                 {filters.chipId && (
                   <button
                     type="button"
@@ -195,14 +197,16 @@ export function AiReviewRunsPageContent() {
                 )}
               </div>
             </PageFiltersBar.Item>
-            <PageFiltersBar.Item label="Task" className="sm:min-w-80">
+            <PageFiltersBar.Item label="Task" className="sm:w-80">
               <div className="flex items-center gap-2">
-                <TaskSelector
-                  tasks={aiReviewTasks}
-                  selectedTask={filters.taskName}
-                  onTaskSelect={(taskName) => updateFilter({ taskName })}
-                  disabled={aiReviewTasks.length === 0}
-                />
+                <div className="min-w-0 flex-1">
+                  <TaskSelector
+                    tasks={aiReviewTasks}
+                    selectedTask={filters.taskName}
+                    onTaskSelect={(taskName) => updateFilter({ taskName })}
+                    disabled={aiReviewTasks.length === 0}
+                  />
+                </div>
                 {filters.taskName && (
                   <button
                     type="button"

--- a/ui/src/components/features/analysis/CDFView.tsx
+++ b/ui/src/components/features/analysis/CDFView.tsx
@@ -32,6 +32,9 @@ function isPercentageMetric(unit: string | undefined): boolean {
   return unit === "%";
 }
 
+/**
+ * Cumulative distribution function view for comparing chip metrics across qubits or couplings
+ */
 export function CDFView() {
   // URL state management
   const {

--- a/ui/src/components/features/analysis/CDFView.tsx
+++ b/ui/src/components/features/analysis/CDFView.tsx
@@ -694,7 +694,7 @@ export function CDFView() {
                 </button>
               </div>
 
-              <div className="w-full sm:w-48">
+              <div className="w-full sm:w-64">
                 <ChipSelector selectedChip={selectedChip} onChipSelect={setSelectedChip} />
               </div>
 

--- a/ui/src/components/features/analysis/CorrelationView/index.tsx
+++ b/ui/src/components/features/analysis/CorrelationView/index.tsx
@@ -63,6 +63,9 @@ function calculatePearsonCorrelation(x: number[], y: number[]): { r: number; n: 
   return { r, n };
 }
 
+/**
+ * Scatter plot view for correlating two chip metrics across qubits or couplings
+ */
 export function CorrelationView() {
   // URL state management
   const {

--- a/ui/src/components/features/analysis/CorrelationView/index.tsx
+++ b/ui/src/components/features/analysis/CorrelationView/index.tsx
@@ -543,7 +543,7 @@ export function CorrelationView() {
                 </button>
               </div>
 
-              <div className="w-full sm:w-48">
+              <div className="w-full sm:w-64">
                 <ChipSelector selectedChip={selectedChip} onChipSelect={setSelectedChip} />
               </div>
 

--- a/ui/src/components/features/analysis/HistogramView.tsx
+++ b/ui/src/components/features/analysis/HistogramView.tsx
@@ -719,7 +719,7 @@ export function HistogramView() {
                 </button>
               </div>
 
-              <div className="w-full sm:w-48">
+              <div className="w-full sm:w-64">
                 <ChipSelector selectedChip={selectedChip} onChipSelect={setSelectedChip} />
               </div>
 

--- a/ui/src/components/features/analysis/HistogramView.tsx
+++ b/ui/src/components/features/analysis/HistogramView.tsx
@@ -35,6 +35,9 @@ function isPercentageMetric(unit: string | undefined): boolean {
   return unit === "%";
 }
 
+/**
+ * Histogram view showing the distribution of a chip metric across qubits or couplings
+ */
 export function HistogramView() {
   // URL state management
   const {

--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -489,10 +489,10 @@ export function ChipPageContent() {
           {/* Selection Controls */}
           <PageFiltersBar>
             <PageFiltersBar.Group>
-              <PageFiltersBar.Item className="sm:min-w-48">
+              <PageFiltersBar.Item className="sm:w-64">
                 <ChipSelector selectedChip={selectedChip} onChipSelect={handleChipSelect} />
               </PageFiltersBar.Item>
-              <PageFiltersBar.Item className="sm:min-w-48">
+              <PageFiltersBar.Item className="sm:w-56">
                 <CooldownSelector
                   chipId={selectedChip}
                   selectedCooldownId={selectedCooldownId}
@@ -507,7 +507,7 @@ export function ChipPageContent() {
                   }}
                 />
               </PageFiltersBar.Item>
-              <PageFiltersBar.Item className="sm:min-w-96">
+              <PageFiltersBar.Item className="sm:w-96">
                 <TaskSelector
                   tasks={filteredTasks}
                   selectedTask={selectedTask}

--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -50,6 +50,9 @@ function dateKeyToRange(dateKey: string): { start: string; end: string } {
   return { start: `${formatted}T00:00`, end: `${formatted}T23:59` };
 }
 
+/**
+ * Chip experiments page showing qubit/coupling grids and task history for a selected chip
+ */
 export function ChipPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -141,6 +141,9 @@ function EmptyMetricDisclosure({ children }: { children: ReactNode }) {
   );
 }
 
+/**
+ * Chip dashboard page summarizing qubit/coupling metrics, notes, and forum activity for a cooldown
+ */
 export function DashboardPageContent() {
   const { user } = useAuth();
   const { projectId } = useProject();

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -540,7 +540,7 @@ export function DashboardPageContent() {
           <div className="flex flex-col gap-4">
             <PageFiltersBar className="gap-3">
               <PageFiltersBar.Group className="gap-3">
-                <PageFiltersBar.Item label="Chip">
+                <PageFiltersBar.Item label="Chip" className="sm:w-64">
                   <ChipSelector
                     selectedChip={selectedChip}
                     onChipSelect={(chipId) => {
@@ -552,7 +552,7 @@ export function DashboardPageContent() {
                 </PageFiltersBar.Item>
                 <PageFiltersBar.Item
                   label="Cooldown"
-                  className="[&:not(:has(.cooldown-selector-control))]:hidden"
+                  className="sm:w-56 [&:not(:has(.cooldown-selector-control))]:hidden"
                 >
                   <CooldownSelector
                     chipId={selectedChip}

--- a/ui/src/components/features/execution/ExecutionDurationBreakdownPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionDurationBreakdownPageContent.tsx
@@ -49,6 +49,9 @@ function PaginationControls({
   );
 }
 
+/**
+ * Page analyzing task duration breakdown across executions for a selected chip and time range
+ */
 export function ExecutionDurationBreakdownPageContent() {
   const { selectedChip, setSelectedChip, isInitialized } = useExecutionUrlState();
   const { startDate, endDate, setStartDate, setEndDate, setQuickRange } = useRangeModeUrlState();

--- a/ui/src/components/features/execution/ExecutionDurationBreakdownPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionDurationBreakdownPageContent.tsx
@@ -129,10 +129,10 @@ export function ExecutionDurationBreakdownPageContent() {
 
       <PageFiltersBar className="mb-4 sm:mb-6">
         <PageFiltersBar.Group>
-          <PageFiltersBar.Item>
+          <PageFiltersBar.Item className="sm:w-64">
             <ChipSelector selectedChip={selectedChip || ""} onChipSelect={handleChipChange} />
           </PageFiltersBar.Item>
-          <PageFiltersBar.Item>
+          <PageFiltersBar.Item className="sm:w-56">
             <CooldownSelector
               chipId={selectedChip || ""}
               selectedCooldownId={selectedCooldownId}

--- a/ui/src/components/features/execution/ExecutionPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionPageContent.tsx
@@ -105,6 +105,9 @@ function PaginationControls({
   );
 }
 
+/**
+ * Execution history page listing workflow runs with task results and cancellation controls
+ */
 export function ExecutionPageContent() {
   // URL state management
   const { selectedChip, setSelectedChip, isInitialized } = useExecutionUrlState();

--- a/ui/src/components/features/execution/ExecutionPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionPageContent.tsx
@@ -323,10 +323,10 @@ export function ExecutionPageContent() {
       <PageHeader title="Execution History" description="Monitor workflow runs and task results" />
       <PageFiltersBar className="mb-4 sm:mb-6">
         <PageFiltersBar.Group>
-          <PageFiltersBar.Item>
+          <PageFiltersBar.Item className="sm:w-64">
             <ChipSelector selectedChip={selectedChip || ""} onChipSelect={handleChipChange} />
           </PageFiltersBar.Item>
-          <PageFiltersBar.Item>
+          <PageFiltersBar.Item className="sm:w-44">
             <DateSelector
               chipId={selectedChip || ""}
               selectedDate={selectedDate}

--- a/ui/src/components/features/metrics/MetricsPageContent.tsx
+++ b/ui/src/components/features/metrics/MetricsPageContent.tsx
@@ -388,13 +388,13 @@ export function MetricsPageContent() {
             <div className="flex flex-col gap-4">
               <PageFiltersBar className="gap-3">
                 <PageFiltersBar.Group className="gap-3">
-                  <PageFiltersBar.Item label="Chip">
+                  <PageFiltersBar.Item label="Chip" className="sm:w-64">
                     <ChipSelector selectedChip={selectedChip} onChipSelect={setSelectedChip} />
                   </PageFiltersBar.Item>
 
                   <PageFiltersBar.Item
                     label="Cooldown"
-                    className="[&:not(:has(.cooldown-selector-control))]:hidden"
+                    className="sm:w-56 [&:not(:has(.cooldown-selector-control))]:hidden"
                   >
                     <CooldownSelector
                       chipId={selectedChip}

--- a/ui/src/components/features/metrics/MetricsPageContent.tsx
+++ b/ui/src/components/features/metrics/MetricsPageContent.tsx
@@ -56,6 +56,9 @@ const getFromLocalStorage = (key: string): string | null => {
   }
 };
 
+/**
+ * Chip metrics dashboard showing qubit/coupling metric grids, CDF chart, and export options
+ */
 export function MetricsPageContent() {
   const {
     selectedChip,

--- a/ui/src/components/features/task-results/TaskResultsPageContent.tsx
+++ b/ui/src/components/features/task-results/TaskResultsPageContent.tsx
@@ -212,6 +212,9 @@ function TaskResultRow({
   );
 }
 
+/**
+ * Dropdown for filtering task results by execution within a selected chip
+ */
 function ExecutionFilter({
   chipId,
   selectedExecutionId,
@@ -506,6 +509,9 @@ function TaskResultPreviewSidebar({
   );
 }
 
+/**
+ * Task results page listing outcomes across executions with filters and a preview sidebar
+ */
 export function TaskResultsPageContent() {
   const router = useRouter();
   const pathname = usePathname();

--- a/ui/src/components/features/task-results/TaskResultsPageContent.tsx
+++ b/ui/src/components/features/task-results/TaskResultsPageContent.tsx
@@ -246,10 +246,7 @@ function ExecutionFilter({
     return items;
   }, [executionData?.data?.executions, selectedExecutionId]);
 
-  const { styles } = useSelectStyles<ExecutionOption>({
-    labels: options.map((option) => option.label),
-    placeholder: "Select an execution",
-  });
+  const styles = useSelectStyles<ExecutionOption>();
 
   if (isLoading) {
     return <div className="h-[38px] animate-pulse rounded bg-base-300" />;
@@ -628,14 +625,16 @@ export function TaskResultsPageContent() {
       <form onSubmit={handleSubmit}>
         <PageFiltersBar className="mb-4 sm:mb-6">
           <PageFiltersBar.Group className="flex-1">
-            <PageFiltersBar.Item label="Chip" className="sm:min-w-40">
+            <PageFiltersBar.Item label="Chip" className="sm:w-72">
               <div className="flex items-center gap-2">
-                <ChipSelector
-                  selectedChip={draftFilters.chipId}
-                  onChipSelect={(chipId) =>
-                    setDraftFilters((current) => ({ ...current, chipId, executionId: "" }))
-                  }
-                />
+                <div className="min-w-0 flex-1">
+                  <ChipSelector
+                    selectedChip={draftFilters.chipId}
+                    onChipSelect={(chipId) =>
+                      setDraftFilters((current) => ({ ...current, chipId, executionId: "" }))
+                    }
+                  />
+                </div>
                 {draftFilters.chipId && (
                   <button
                     type="button"
@@ -650,15 +649,17 @@ export function TaskResultsPageContent() {
                 )}
               </div>
             </PageFiltersBar.Item>
-            <PageFiltersBar.Item label="Execution" className="sm:min-w-44">
+            <PageFiltersBar.Item label="Execution" className="sm:w-72">
               <div className="flex items-center gap-2">
-                <ExecutionFilter
-                  chipId={draftFilters.chipId}
-                  selectedExecutionId={draftFilters.executionId}
-                  onExecutionSelect={(executionId) =>
-                    setDraftFilters((current) => ({ ...current, executionId }))
-                  }
-                />
+                <div className="min-w-0 flex-1">
+                  <ExecutionFilter
+                    chipId={draftFilters.chipId}
+                    selectedExecutionId={draftFilters.executionId}
+                    onExecutionSelect={(executionId) =>
+                      setDraftFilters((current) => ({ ...current, executionId }))
+                    }
+                  />
+                </div>
                 {draftFilters.executionId && (
                   <button
                     type="button"
@@ -671,16 +672,18 @@ export function TaskResultsPageContent() {
                 )}
               </div>
             </PageFiltersBar.Item>
-            <PageFiltersBar.Item label="Task" className="sm:min-w-44">
+            <PageFiltersBar.Item label="Task" className="sm:w-72">
               <div className="flex items-center gap-2">
-                <TaskSelector
-                  tasks={tasks}
-                  selectedTask={draftFilters.taskName}
-                  onTaskSelect={(taskName) =>
-                    setDraftFilters((current) => ({ ...current, taskName }))
-                  }
-                  disabled={tasks.length === 0}
-                />
+                <div className="min-w-0 flex-1">
+                  <TaskSelector
+                    tasks={tasks}
+                    selectedTask={draftFilters.taskName}
+                    onTaskSelect={(taskName) =>
+                      setDraftFilters((current) => ({ ...current, taskName }))
+                    }
+                    disabled={tasks.length === 0}
+                  />
+                </div>
                 {draftFilters.taskName && (
                   <button
                     type="button"

--- a/ui/src/components/selectors/ChipSelector/index.tsx
+++ b/ui/src/components/selectors/ChipSelector/index.tsx
@@ -57,18 +57,11 @@ export function ChipSelector({ selectedChip, onChipSelect }: ChipSelectorProps) 
       });
   }, [chips]);
 
-  const { minWidth, styles } = useSelectStyles<ChipOption>({
-    labels: sortedOptions.map((opt) => opt.label),
-    placeholder: PLACEHOLDER,
-    // Chip labels include the id plus an install-date suffix (e.g. "seed-chip (2026-07-02)"),
-    // whose rendered width slightly exceeds the default per-char estimate. Widen the estimate
-    // so the longest label always fits and the control width stays constant across selections.
-    charWidth: 9,
-  });
+  const styles = useSelectStyles<ChipOption>();
 
   if (isLoading) {
     return (
-      <div className="animate-pulse" style={{ minWidth }}>
+      <div className="w-full animate-pulse">
         <div className="h-[38px] bg-base-300 rounded"></div>
       </div>
     );
@@ -83,15 +76,13 @@ export function ChipSelector({ selectedChip, onChipSelect }: ChipSelectorProps) 
   };
 
   return (
-    <div style={{ minWidth }}>
-      <Select<ChipOption>
-        options={sortedOptions}
-        value={sortedOptions.find((option) => option.value === selectedChip) ?? null}
-        onChange={handleChange}
-        placeholder={PLACEHOLDER}
-        className="text-base-content"
-        styles={styles}
-      />
-    </div>
+    <Select<ChipOption>
+      options={sortedOptions}
+      value={sortedOptions.find((option) => option.value === selectedChip) ?? null}
+      onChange={handleChange}
+      placeholder={PLACEHOLDER}
+      className="text-base-content"
+      styles={styles}
+    />
   );
 }

--- a/ui/src/components/selectors/CooldownSelector/index.tsx
+++ b/ui/src/components/selectors/CooldownSelector/index.tsx
@@ -54,10 +54,7 @@ export function CooldownSelector({
     [cooldowns],
   );
 
-  const { minWidth, styles } = useSelectStyles<CooldownOption>({
-    labels: options.map((o) => o.label),
-    placeholder,
-  });
+  const styles = useSelectStyles<CooldownOption>();
   const isControlled = selectedCooldownId !== undefined;
   const [internalSelectedCooldownId, setInternalSelectedCooldownId] = useState<string | null>(null);
   const effectiveSelectedCooldownId = isControlled
@@ -93,7 +90,7 @@ export function CooldownSelector({
   if (!chipId) return null;
   if (isLoading) {
     return (
-      <div className="animate-pulse" style={{ minWidth }}>
+      <div className="w-full animate-pulse">
         <div className="h-[38px] bg-base-300 rounded"></div>
       </div>
     );

--- a/ui/src/components/selectors/DateSelector/index.tsx
+++ b/ui/src/components/selectors/DateSelector/index.tsx
@@ -67,15 +67,12 @@ export function DateSelector({
     }));
   }, [datesResponse]);
 
-  const { minWidth, styles } = useSelectStyles<DateOption>({
-    labels: dateOptions.map((opt) => opt.label),
-    placeholder: PLACEHOLDER,
-  });
+  const styles = useSelectStyles<DateOption>();
 
   // Show loading state but keep the current selection visible
   if (isLoading) {
     return (
-      <div className="animate-pulse" style={{ minWidth }}>
+      <div className="w-full animate-pulse">
         <div className="h-[38px] bg-base-300 rounded"></div>
       </div>
     );
@@ -84,30 +81,26 @@ export function DateSelector({
   // Show error state but keep "latest" option available
   if (isError) {
     return (
-      <div style={{ minWidth }}>
-        <Select<DateOption>
-          options={[{ value: "latest", label: "Latest" }]}
-          value={{ value: "latest", label: "Latest" }}
-          onChange={handleChange}
-          isDisabled={disabled}
-          className="text-base-content"
-          styles={styles}
-        />
-      </div>
+      <Select<DateOption>
+        options={[{ value: "latest", label: "Latest" }]}
+        value={{ value: "latest", label: "Latest" }}
+        onChange={handleChange}
+        isDisabled={disabled}
+        className="text-base-content"
+        styles={styles}
+      />
     );
   }
 
   return (
-    <div style={{ minWidth }}>
-      <Select<DateOption>
-        options={dateOptions}
-        value={dateOptions.find((option) => option.value === selectedDate) ?? null}
-        onChange={handleChange}
-        placeholder={PLACEHOLDER}
-        className="text-base-content"
-        isDisabled={disabled}
-        styles={styles}
-      />
-    </div>
+    <Select<DateOption>
+      options={dateOptions}
+      value={dateOptions.find((option) => option.value === selectedDate) ?? null}
+      onChange={handleChange}
+      placeholder={PLACEHOLDER}
+      className="text-base-content"
+      isDisabled={disabled}
+      styles={styles}
+    />
   );
 }

--- a/ui/src/components/selectors/TaskSelector/index.tsx
+++ b/ui/src/components/selectors/TaskSelector/index.tsx
@@ -36,26 +36,21 @@ export function TaskSelector({
     label: task.name,
   }));
 
-  const { minWidth, styles } = useSelectStyles<TaskOption>({
-    labels: options.map((opt) => opt.label),
-    placeholder: PLACEHOLDER,
-  });
+  const styles = useSelectStyles<TaskOption>();
 
   const handleChange = (option: SingleValue<TaskOption>) => {
     onTaskSelect(option ? option.value : "");
   };
 
   return (
-    <div style={{ minWidth }}>
-      <Select<TaskOption>
-        options={options}
-        value={options.find((option) => option.value === selectedTask) ?? null}
-        onChange={handleChange}
-        placeholder={PLACEHOLDER}
-        className="text-base-content"
-        isDisabled={disabled}
-        styles={styles}
-      />
-    </div>
+    <Select<TaskOption>
+      options={options}
+      value={options.find((option) => option.value === selectedTask) ?? null}
+      onChange={handleChange}
+      placeholder={PLACEHOLDER}
+      className="text-base-content"
+      isDisabled={disabled}
+      styles={styles}
+    />
   );
 }

--- a/ui/src/components/selectors/TaskSelector/index.tsx
+++ b/ui/src/components/selectors/TaskSelector/index.tsx
@@ -25,6 +25,9 @@ interface TaskSelectorProps {
 
 const PLACEHOLDER = "Select a task";
 
+/**
+ * Component for selecting a task from a list of available tasks
+ */
 export function TaskSelector({
   tasks,
   selectedTask,

--- a/ui/src/hooks/useSelectStyles.ts
+++ b/ui/src/hooks/useSelectStyles.ts
@@ -3,27 +3,15 @@ import { useMemo } from "react";
 import type { StylesConfig, GroupBase } from "react-select";
 import { getDaisySelectStyles } from "@/lib/react-select-theme";
 
-interface UseSelectStylesOptions {
-  labels: string[];
-  placeholder: string;
-  charWidth?: number;
-  padding?: number;
-}
-
 /**
- * Hook that provides DaisyUI-compatible React-Select styles with dynamic width calculation
+ * DaisyUI-compatible React-Select styles. Width is the caller's responsibility.
  */
 export function useSelectStyles<
   T,
   IsMulti extends boolean = false,
   Group extends GroupBase<T> = GroupBase<T>,
->({ labels, placeholder, charWidth = 8, padding = 60 }: UseSelectStylesOptions) {
-  const minWidth = useMemo(() => {
-    const maxLength = Math.max(...labels.map((l) => l.length), placeholder.length);
-    return maxLength * charWidth + padding;
-  }, [labels, placeholder, charWidth, padding]);
-
-  const styles = useMemo<StylesConfig<T, IsMulti, Group>>(() => {
+>(): StylesConfig<T, IsMulti, Group> {
+  return useMemo<StylesConfig<T, IsMulti, Group>>(() => {
     const baseStyles = getDaisySelectStyles<T, IsMulti, Group>();
 
     return {
@@ -31,15 +19,13 @@ export function useSelectStyles<
       container: (provided) => ({
         ...provided,
         width: "100%",
-        minWidth: "100%",
       }),
       menu: (provided, state) => ({
         ...(baseStyles.menu?.(provided, state) || provided),
-        width: "100%",
+        width: "max-content",
         minWidth: "100%",
+        maxWidth: "min(28rem, calc(100vw - 2rem))",
       }),
     };
   }, []);
-
-  return { minWidth, styles };
 }


### PR DESCRIPTION
## Ticket

close #1262

## Summary

- Selectors estimated their own minimum width from label character counts, which needed manual tuning (`charWidth: 9` in ChipSelector) and broke whenever fonts or label formats changed. Width is now decided by the outer container, and selectors simply fill their parent.
- UI-only change with no API or schema updates. Affects the filter bars on the execution, dashboard, chip, metrics, task results, AI reviews, and analysis pages.

## Changes

- `useSelectStyles` no longer takes options or computes `minWidth`; it returns the styles object directly.
- `ChipSelector`, `DateSelector`, `TaskSelector`, and `CooldownSelector` render their Select straight into the parent instead of a `minWidth` wrapper, and loading skeletons fill the parent width.
- Callers set a fixed `sm:w-*` on `PageFiltersBar.Item` (or an existing wrapper) per selector type, replacing the old `sm:min-w-*` classes. Mobile keeps the full-width default.
- Filter rows that pair a selector with a clear button (`TaskResultsPageContent`, `AiReviewRunsPageContent`) wrap the selector in `min-w-0 flex-1` so the button keeps its size.
- The dropdown menu now grows to `max-content` (capped at 28rem or the viewport) so long option labels stay readable inside a fixed-width control.
- Documented the convention in `docs/development/ui/guidelines.md`.
- Verified with oxlint, oxfmt, `tsc --noEmit`, and the vitest suite (53 files, 249 tests passing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized responsive widths for filter controls across chip, task, cooldown, date, execution, and analysis views.
  * Improved filter-bar layouts so selectors share available space more effectively and long labels truncate cleanly.
  * Updated dropdown sizing to provide appropriate space for options while remaining within the viewport.
  * Loading states now fill their available container width consistently.

* **Documentation**
  * Added UI guidance for selector widths, flexible filter rows, fixed responsive sizing, and label ellipsization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->