### PR TITLE
ci(repo): add the Pullfrog review workflow (#1425)

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -28,11 +28,11 @@ jobs:
       OPENAI_COMPATIBLE_MAX_OUTPUT: "32768"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           fetch-depth: 1
 
       - name: Run agent
-        uses: pullfrog/pullfrog@v0
+        uses: pullfrog/pullfrog@1ab92a2eb5c2268dcd803ac8bfb0984375e210ab
         with:
           prompt: ${{ inputs.prompt }}

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -1,0 +1,38 @@
+name: Pullfrog
+run-name: ${{ inputs.name || github.workflow }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        type: string
+        description: Agent prompt
+      name:
+        type: string
+        description: Run name
+
+permissions: {}
+
+jobs:
+  pullfrog:
+    name: Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      OPENAI_COMPATIBLE_BASE_URL: ${{ secrets.OPENAI_COMPATIBLE_BASE_URL }}
+      OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+      OPENAI_COMPATIBLE_MODEL: qwen3.8-27b
+      OPENAI_COMPATIBLE_CONTEXT: "131072"
+      OPENAI_COMPATIBLE_MAX_OUTPUT: "32768"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run agent
+        uses: pullfrog/pullfrog@v0
+        with:
+          prompt: ${{ inputs.prompt }}


### PR DESCRIPTION
## Ticket

- close #1425

## Summary

- Adds the GitHub Actions workflow that lets Pullfrog run code reviews on QDash pull requests, backed by a self-hosted OpenAI-compatible gateway rather than a hosted model vendor.
- The workflow is inert on its own. Pullfrog's control plane dispatches it, so nothing runs until the triggers are enabled in the Pullfrog console. Adding the file changes no existing check and cannot fail another job.

## Scope

Only the YAML lands here. Everything else Pullfrog needs lives outside the repository: the GitHub App installation, the review instructions, and the trigger settings are all console side, and the endpoint credentials are repository secrets. That split is not a simplification for this PR, it is how the product works. The workflow carries nothing but the model wiring.

Two decisions are worth recording because the alternatives look reasonable until you check them.

There is no self-hosted runner. Colocating the runner with the model would remove the network hop, but QDash is public with 19 forks, so untrusted code would land on the runner. The gateway turned out to be reachable from GitHub hosted runners anyway, which removes the reason to consider it.

There is no endpoint precheck step. An extra curl before the agent would catch a misconfigured endpoint early, at the cost of a step that duplicates what the agent already does. The tradeoff is that a bad URL surfaces as an agent failure a few minutes in rather than a clear error in a few seconds.

## Changes

- New `.github/workflows/pullfrog.yml`, triggered by `workflow_dispatch` only. Pullfrog's control plane calls the dispatch API as `pullfrog[bot]` and passes its own JSON envelope through `inputs.prompt`, which the workflow forwards to the action verbatim.
- Model configuration sits in a job level `env` block. It has to be job level rather than workflow level because workflow level `env` cannot read the `secrets` context.
- Both the endpoint and the key come from repository secrets (`OPENAI_COMPATIBLE_BASE_URL`, `OPENAI_COMPATIBLE_API_KEY`). Pullfrog treats only the key as sensitive, but keeping the endpoint out of the file avoids publishing internal infrastructure in a public repository.
- `OPENAI_COMPATIBLE_CONTEXT` and `OPENAI_COMPATIBLE_MAX_OUTPUT` are set explicitly. Left unset they fall back to 32000 tokens and auto compaction is disabled, which the endpoint does not need but the agent does.
- Permissions are empty at the workflow level and granted at the job level: `contents: read` for checkout, `id-token: write` so the action can mint its own installation token over OIDC. The action does not use `GITHUB_TOKEN`.

No API or schema changes, so `task generate` was not needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered Pullfrog workflow.
  * Supports custom prompts and names when starting the workflow.
  * Runs automated repository analysis using the configured AI model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->