### PR TITLE
[!DO NOT MERGE] Pullfrog Test: revert of #1422

### DIFF
--- a/docs/development/ui/guidelines.md
+++ b/docs/development/ui/guidelines.md
@@ -554,26 +554,6 @@ Use Tailwind CSS utility classes for styling:
 </div>
 ```
 
-### Selector Width
-
-Selectors (`components/selectors/`) fill 100% of their parent. The container decides the width; `useSelectStyles` returns theme styles only and does not compute widths.
-
-```tsx
-// ✅ Good - container sets a fixed width
-<PageFiltersBar.Item className="sm:w-64">
-  <ChipSelector selectedChip={chip} onChipSelect={setChip} />
-</PageFiltersBar.Item>
-
-// ❌ Bad - no width on a shrink-to-fit container (selector collapses to placeholder width)
-<PageFiltersBar.Item>
-  <ChipSelector selectedChip={chip} onChipSelect={setChip} />
-</PageFiltersBar.Item>
-```
-
-- Use a fixed `sm:w-*`, not `sm:min-w-*`, so the control width stays constant across selections. Mobile keeps the `w-full` default from `PageFiltersBar.Item`.
-- When a selector shares a row with a button (for example a clear button), wrap it in `min-w-0 flex-1` so it shrinks instead of pushing the button out.
-- Long labels ellipsize inside the control; the dropdown menu grows to `max-content` so the full option text stays readable.
-
 ### DaisyUI Components
 
 Use DaisyUI component classes for consistent UI:

--- a/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitId]/page.tsx
+++ b/ui/src/app/(auth)/chip/[chipId]/qubit/[qubitId]/page.tsx
@@ -23,9 +23,6 @@ import { TimeRangeSelector } from "@/components/ui/TimeRangeSelector";
 import { useChipUrlState, useRangeModeUrlState } from "@/hooks/useUrlState";
 import { dateToDateTimeLocal, toIsoSeconds } from "@/lib/utils/datetime";
 
-/**
- * Qubit detail page with dashboard, history, and time-series views for a single qubit
- */
 function QubitDetailPageContent() {
   const params = useParams();
   const chipId = params.chipId as string;
@@ -128,7 +125,7 @@ function QubitDetailPageContent() {
           {/* Controls */}
           <PageFiltersBar>
             <PageFiltersBar.Group>
-              <PageFiltersBar.Item className="sm:w-64">
+              <PageFiltersBar.Item>
                 <ChipSelector
                   selectedChip={chipId}
                   onChipSelect={(newChipId) => {
@@ -136,7 +133,7 @@ function QubitDetailPageContent() {
                   }}
                 />
               </PageFiltersBar.Item>
-              <PageFiltersBar.Item className="sm:w-56">
+              <PageFiltersBar.Item>
                 <CooldownSelector
                   chipId={chipId}
                   selectedCooldownId={selectedCooldownId}
@@ -152,7 +149,7 @@ function QubitDetailPageContent() {
                 />
               </PageFiltersBar.Item>
               {viewMode === "history" && (
-                <PageFiltersBar.Item className="sm:w-80">
+                <PageFiltersBar.Item>
                   <TaskSelector
                     tasks={filteredTasks}
                     selectedTask={selectedTask}

--- a/ui/src/components/features/ai-reviews/AiReviewRunsPageContent.tsx
+++ b/ui/src/components/features/ai-reviews/AiReviewRunsPageContent.tsx
@@ -119,9 +119,6 @@ function RunCard({ run }: { run: AiReviewRunSummary }) {
   );
 }
 
-/**
- * Page listing AI review runs with chip/task filters and pagination
- */
 export function AiReviewRunsPageContent() {
   const { data: taskFileSettings } = useGetTaskFileSettings();
   const defaultBackend = taskFileSettings?.data?.default_backend || "qubex";
@@ -180,14 +177,12 @@ export function AiReviewRunsPageContent() {
       <div className="mb-4 rounded-lg border border-base-300 bg-base-100 p-3">
         <PageFiltersBar>
           <PageFiltersBar.Group>
-            <PageFiltersBar.Item label="Chip" className="sm:w-72">
+            <PageFiltersBar.Item label="Chip" className="sm:min-w-56">
               <div className="flex items-center gap-2">
-                <div className="min-w-0 flex-1">
-                  <ChipSelector
-                    selectedChip={filters.chipId}
-                    onChipSelect={(chipId) => updateFilter({ chipId })}
-                  />
-                </div>
+                <ChipSelector
+                  selectedChip={filters.chipId}
+                  onChipSelect={(chipId) => updateFilter({ chipId })}
+                />
                 {filters.chipId && (
                   <button
                     type="button"
@@ -200,16 +195,14 @@ export function AiReviewRunsPageContent() {
                 )}
               </div>
             </PageFiltersBar.Item>
-            <PageFiltersBar.Item label="Task" className="sm:w-80">
+            <PageFiltersBar.Item label="Task" className="sm:min-w-80">
               <div className="flex items-center gap-2">
-                <div className="min-w-0 flex-1">
-                  <TaskSelector
-                    tasks={aiReviewTasks}
-                    selectedTask={filters.taskName}
-                    onTaskSelect={(taskName) => updateFilter({ taskName })}
-                    disabled={aiReviewTasks.length === 0}
-                  />
-                </div>
+                <TaskSelector
+                  tasks={aiReviewTasks}
+                  selectedTask={filters.taskName}
+                  onTaskSelect={(taskName) => updateFilter({ taskName })}
+                  disabled={aiReviewTasks.length === 0}
+                />
                 {filters.taskName && (
                   <button
                     type="button"

--- a/ui/src/components/features/analysis/CDFView.tsx
+++ b/ui/src/components/features/analysis/CDFView.tsx
@@ -32,9 +32,6 @@ function isPercentageMetric(unit: string | undefined): boolean {
   return unit === "%";
 }
 
-/**
- * Cumulative distribution function view for comparing chip metrics across qubits or couplings
- */
 export function CDFView() {
   // URL state management
   const {
@@ -697,7 +694,7 @@ export function CDFView() {
                 </button>
               </div>
 
-              <div className="w-full sm:w-64">
+              <div className="w-full sm:w-48">
                 <ChipSelector selectedChip={selectedChip} onChipSelect={setSelectedChip} />
               </div>
 

--- a/ui/src/components/features/analysis/CorrelationView/index.tsx
+++ b/ui/src/components/features/analysis/CorrelationView/index.tsx
@@ -63,9 +63,6 @@ function calculatePearsonCorrelation(x: number[], y: number[]): { r: number; n: 
   return { r, n };
 }
 
-/**
- * Scatter plot view for correlating two chip metrics across qubits or couplings
- */
 export function CorrelationView() {
   // URL state management
   const {
@@ -546,7 +543,7 @@ export function CorrelationView() {
                 </button>
               </div>
 
-              <div className="w-full sm:w-64">
+              <div className="w-full sm:w-48">
                 <ChipSelector selectedChip={selectedChip} onChipSelect={setSelectedChip} />
               </div>
 

--- a/ui/src/components/features/analysis/HistogramView.tsx
+++ b/ui/src/components/features/analysis/HistogramView.tsx
@@ -35,9 +35,6 @@ function isPercentageMetric(unit: string | undefined): boolean {
   return unit === "%";
 }
 
-/**
- * Histogram view showing the distribution of a chip metric across qubits or couplings
- */
 export function HistogramView() {
   // URL state management
   const {
@@ -722,7 +719,7 @@ export function HistogramView() {
                 </button>
               </div>
 
-              <div className="w-full sm:w-64">
+              <div className="w-full sm:w-48">
                 <ChipSelector selectedChip={selectedChip} onChipSelect={setSelectedChip} />
               </div>
 

--- a/ui/src/components/features/chip/ChipPageContent.tsx
+++ b/ui/src/components/features/chip/ChipPageContent.tsx
@@ -50,9 +50,6 @@ function dateKeyToRange(dateKey: string): { start: string; end: string } {
   return { start: `${formatted}T00:00`, end: `${formatted}T23:59` };
 }
 
-/**
- * Chip experiments page showing qubit/coupling grids and task history for a selected chip
- */
 export function ChipPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -492,10 +489,10 @@ export function ChipPageContent() {
           {/* Selection Controls */}
           <PageFiltersBar>
             <PageFiltersBar.Group>
-              <PageFiltersBar.Item className="sm:w-64">
+              <PageFiltersBar.Item className="sm:min-w-48">
                 <ChipSelector selectedChip={selectedChip} onChipSelect={handleChipSelect} />
               </PageFiltersBar.Item>
-              <PageFiltersBar.Item className="sm:w-56">
+              <PageFiltersBar.Item className="sm:min-w-48">
                 <CooldownSelector
                   chipId={selectedChip}
                   selectedCooldownId={selectedCooldownId}
@@ -510,7 +507,7 @@ export function ChipPageContent() {
                   }}
                 />
               </PageFiltersBar.Item>
-              <PageFiltersBar.Item className="sm:w-96">
+              <PageFiltersBar.Item className="sm:min-w-96">
                 <TaskSelector
                   tasks={filteredTasks}
                   selectedTask={selectedTask}

--- a/ui/src/components/features/dashboard/DashboardPageContent.tsx
+++ b/ui/src/components/features/dashboard/DashboardPageContent.tsx
@@ -141,9 +141,6 @@ function EmptyMetricDisclosure({ children }: { children: ReactNode }) {
   );
 }
 
-/**
- * Chip dashboard page summarizing qubit/coupling metrics, notes, and forum activity for a cooldown
- */
 export function DashboardPageContent() {
   const { user } = useAuth();
   const { projectId } = useProject();
@@ -543,7 +540,7 @@ export function DashboardPageContent() {
           <div className="flex flex-col gap-4">
             <PageFiltersBar className="gap-3">
               <PageFiltersBar.Group className="gap-3">
-                <PageFiltersBar.Item label="Chip" className="sm:w-64">
+                <PageFiltersBar.Item label="Chip">
                   <ChipSelector
                     selectedChip={selectedChip}
                     onChipSelect={(chipId) => {
@@ -555,7 +552,7 @@ export function DashboardPageContent() {
                 </PageFiltersBar.Item>
                 <PageFiltersBar.Item
                   label="Cooldown"
-                  className="sm:w-56 [&:not(:has(.cooldown-selector-control))]:hidden"
+                  className="[&:not(:has(.cooldown-selector-control))]:hidden"
                 >
                   <CooldownSelector
                     chipId={selectedChip}

--- a/ui/src/components/features/execution/ExecutionDurationBreakdownPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionDurationBreakdownPageContent.tsx
@@ -49,9 +49,6 @@ function PaginationControls({
   );
 }
 
-/**
- * Page analyzing task duration breakdown across executions for a selected chip and time range
- */
 export function ExecutionDurationBreakdownPageContent() {
   const { selectedChip, setSelectedChip, isInitialized } = useExecutionUrlState();
   const { startDate, endDate, setStartDate, setEndDate, setQuickRange } = useRangeModeUrlState();
@@ -132,10 +129,10 @@ export function ExecutionDurationBreakdownPageContent() {
 
       <PageFiltersBar className="mb-4 sm:mb-6">
         <PageFiltersBar.Group>
-          <PageFiltersBar.Item className="sm:w-64">
+          <PageFiltersBar.Item>
             <ChipSelector selectedChip={selectedChip || ""} onChipSelect={handleChipChange} />
           </PageFiltersBar.Item>
-          <PageFiltersBar.Item className="sm:w-56">
+          <PageFiltersBar.Item>
             <CooldownSelector
               chipId={selectedChip || ""}
               selectedCooldownId={selectedCooldownId}

--- a/ui/src/components/features/execution/ExecutionPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionPageContent.tsx
@@ -105,9 +105,6 @@ function PaginationControls({
   );
 }
 
-/**
- * Execution history page listing workflow runs with task results and cancellation controls
- */
 export function ExecutionPageContent() {
   // URL state management
   const { selectedChip, setSelectedChip, isInitialized } = useExecutionUrlState();
@@ -326,10 +323,10 @@ export function ExecutionPageContent() {
       <PageHeader title="Execution History" description="Monitor workflow runs and task results" />
       <PageFiltersBar className="mb-4 sm:mb-6">
         <PageFiltersBar.Group>
-          <PageFiltersBar.Item className="sm:w-64">
+          <PageFiltersBar.Item>
             <ChipSelector selectedChip={selectedChip || ""} onChipSelect={handleChipChange} />
           </PageFiltersBar.Item>
-          <PageFiltersBar.Item className="sm:w-44">
+          <PageFiltersBar.Item>
             <DateSelector
               chipId={selectedChip || ""}
               selectedDate={selectedDate}

--- a/ui/src/components/features/metrics/MetricsPageContent.tsx
+++ b/ui/src/components/features/metrics/MetricsPageContent.tsx
@@ -56,9 +56,6 @@ const getFromLocalStorage = (key: string): string | null => {
   }
 };
 
-/**
- * Chip metrics dashboard showing qubit/coupling metric grids, CDF chart, and export options
- */
 export function MetricsPageContent() {
   const {
     selectedChip,
@@ -391,13 +388,13 @@ export function MetricsPageContent() {
             <div className="flex flex-col gap-4">
               <PageFiltersBar className="gap-3">
                 <PageFiltersBar.Group className="gap-3">
-                  <PageFiltersBar.Item label="Chip" className="sm:w-64">
+                  <PageFiltersBar.Item label="Chip">
                     <ChipSelector selectedChip={selectedChip} onChipSelect={setSelectedChip} />
                   </PageFiltersBar.Item>
 
                   <PageFiltersBar.Item
                     label="Cooldown"
-                    className="sm:w-56 [&:not(:has(.cooldown-selector-control))]:hidden"
+                    className="[&:not(:has(.cooldown-selector-control))]:hidden"
                   >
                     <CooldownSelector
                       chipId={selectedChip}

--- a/ui/src/components/features/task-results/TaskResultsPageContent.tsx
+++ b/ui/src/components/features/task-results/TaskResultsPageContent.tsx
@@ -212,9 +212,6 @@ function TaskResultRow({
   );
 }
 
-/**
- * Dropdown for filtering task results by execution within a selected chip
- */
 function ExecutionFilter({
   chipId,
   selectedExecutionId,
@@ -249,7 +246,10 @@ function ExecutionFilter({
     return items;
   }, [executionData?.data?.executions, selectedExecutionId]);
 
-  const styles = useSelectStyles<ExecutionOption>();
+  const { styles } = useSelectStyles<ExecutionOption>({
+    labels: options.map((option) => option.label),
+    placeholder: "Select an execution",
+  });
 
   if (isLoading) {
     return <div className="h-[38px] animate-pulse rounded bg-base-300" />;
@@ -509,9 +509,6 @@ function TaskResultPreviewSidebar({
   );
 }
 
-/**
- * Task results page listing outcomes across executions with filters and a preview sidebar
- */
 export function TaskResultsPageContent() {
   const router = useRouter();
   const pathname = usePathname();
@@ -631,16 +628,14 @@ export function TaskResultsPageContent() {
       <form onSubmit={handleSubmit}>
         <PageFiltersBar className="mb-4 sm:mb-6">
           <PageFiltersBar.Group className="flex-1">
-            <PageFiltersBar.Item label="Chip" className="sm:w-72">
+            <PageFiltersBar.Item label="Chip" className="sm:min-w-40">
               <div className="flex items-center gap-2">
-                <div className="min-w-0 flex-1">
-                  <ChipSelector
-                    selectedChip={draftFilters.chipId}
-                    onChipSelect={(chipId) =>
-                      setDraftFilters((current) => ({ ...current, chipId, executionId: "" }))
-                    }
-                  />
-                </div>
+                <ChipSelector
+                  selectedChip={draftFilters.chipId}
+                  onChipSelect={(chipId) =>
+                    setDraftFilters((current) => ({ ...current, chipId, executionId: "" }))
+                  }
+                />
                 {draftFilters.chipId && (
                   <button
                     type="button"
@@ -655,17 +650,15 @@ export function TaskResultsPageContent() {
                 )}
               </div>
             </PageFiltersBar.Item>
-            <PageFiltersBar.Item label="Execution" className="sm:w-72">
+            <PageFiltersBar.Item label="Execution" className="sm:min-w-44">
               <div className="flex items-center gap-2">
-                <div className="min-w-0 flex-1">
-                  <ExecutionFilter
-                    chipId={draftFilters.chipId}
-                    selectedExecutionId={draftFilters.executionId}
-                    onExecutionSelect={(executionId) =>
-                      setDraftFilters((current) => ({ ...current, executionId }))
-                    }
-                  />
-                </div>
+                <ExecutionFilter
+                  chipId={draftFilters.chipId}
+                  selectedExecutionId={draftFilters.executionId}
+                  onExecutionSelect={(executionId) =>
+                    setDraftFilters((current) => ({ ...current, executionId }))
+                  }
+                />
                 {draftFilters.executionId && (
                   <button
                     type="button"
@@ -678,18 +671,16 @@ export function TaskResultsPageContent() {
                 )}
               </div>
             </PageFiltersBar.Item>
-            <PageFiltersBar.Item label="Task" className="sm:w-72">
+            <PageFiltersBar.Item label="Task" className="sm:min-w-44">
               <div className="flex items-center gap-2">
-                <div className="min-w-0 flex-1">
-                  <TaskSelector
-                    tasks={tasks}
-                    selectedTask={draftFilters.taskName}
-                    onTaskSelect={(taskName) =>
-                      setDraftFilters((current) => ({ ...current, taskName }))
-                    }
-                    disabled={tasks.length === 0}
-                  />
-                </div>
+                <TaskSelector
+                  tasks={tasks}
+                  selectedTask={draftFilters.taskName}
+                  onTaskSelect={(taskName) =>
+                    setDraftFilters((current) => ({ ...current, taskName }))
+                  }
+                  disabled={tasks.length === 0}
+                />
                 {draftFilters.taskName && (
                   <button
                     type="button"

--- a/ui/src/components/selectors/ChipSelector/index.tsx
+++ b/ui/src/components/selectors/ChipSelector/index.tsx
@@ -57,11 +57,18 @@ export function ChipSelector({ selectedChip, onChipSelect }: ChipSelectorProps) 
       });
   }, [chips]);
 
-  const styles = useSelectStyles<ChipOption>();
+  const { minWidth, styles } = useSelectStyles<ChipOption>({
+    labels: sortedOptions.map((opt) => opt.label),
+    placeholder: PLACEHOLDER,
+    // Chip labels include the id plus an install-date suffix (e.g. "seed-chip (2026-07-02)"),
+    // whose rendered width slightly exceeds the default per-char estimate. Widen the estimate
+    // so the longest label always fits and the control width stays constant across selections.
+    charWidth: 9,
+  });
 
   if (isLoading) {
     return (
-      <div className="w-full animate-pulse">
+      <div className="animate-pulse" style={{ minWidth }}>
         <div className="h-[38px] bg-base-300 rounded"></div>
       </div>
     );
@@ -76,13 +83,15 @@ export function ChipSelector({ selectedChip, onChipSelect }: ChipSelectorProps) 
   };
 
   return (
-    <Select<ChipOption>
-      options={sortedOptions}
-      value={sortedOptions.find((option) => option.value === selectedChip) ?? null}
-      onChange={handleChange}
-      placeholder={PLACEHOLDER}
-      className="text-base-content"
-      styles={styles}
-    />
+    <div style={{ minWidth }}>
+      <Select<ChipOption>
+        options={sortedOptions}
+        value={sortedOptions.find((option) => option.value === selectedChip) ?? null}
+        onChange={handleChange}
+        placeholder={PLACEHOLDER}
+        className="text-base-content"
+        styles={styles}
+      />
+    </div>
   );
 }

--- a/ui/src/components/selectors/CooldownSelector/index.tsx
+++ b/ui/src/components/selectors/CooldownSelector/index.tsx
@@ -54,7 +54,10 @@ export function CooldownSelector({
     [cooldowns],
   );
 
-  const styles = useSelectStyles<CooldownOption>();
+  const { minWidth, styles } = useSelectStyles<CooldownOption>({
+    labels: options.map((o) => o.label),
+    placeholder,
+  });
   const isControlled = selectedCooldownId !== undefined;
   const [internalSelectedCooldownId, setInternalSelectedCooldownId] = useState<string | null>(null);
   const effectiveSelectedCooldownId = isControlled
@@ -90,7 +93,7 @@ export function CooldownSelector({
   if (!chipId) return null;
   if (isLoading) {
     return (
-      <div className="w-full animate-pulse">
+      <div className="animate-pulse" style={{ minWidth }}>
         <div className="h-[38px] bg-base-300 rounded"></div>
       </div>
     );

--- a/ui/src/components/selectors/DateSelector/index.tsx
+++ b/ui/src/components/selectors/DateSelector/index.tsx
@@ -67,12 +67,15 @@ export function DateSelector({
     }));
   }, [datesResponse]);
 
-  const styles = useSelectStyles<DateOption>();
+  const { minWidth, styles } = useSelectStyles<DateOption>({
+    labels: dateOptions.map((opt) => opt.label),
+    placeholder: PLACEHOLDER,
+  });
 
   // Show loading state but keep the current selection visible
   if (isLoading) {
     return (
-      <div className="w-full animate-pulse">
+      <div className="animate-pulse" style={{ minWidth }}>
         <div className="h-[38px] bg-base-300 rounded"></div>
       </div>
     );
@@ -81,26 +84,30 @@ export function DateSelector({
   // Show error state but keep "latest" option available
   if (isError) {
     return (
-      <Select<DateOption>
-        options={[{ value: "latest", label: "Latest" }]}
-        value={{ value: "latest", label: "Latest" }}
-        onChange={handleChange}
-        isDisabled={disabled}
-        className="text-base-content"
-        styles={styles}
-      />
+      <div style={{ minWidth }}>
+        <Select<DateOption>
+          options={[{ value: "latest", label: "Latest" }]}
+          value={{ value: "latest", label: "Latest" }}
+          onChange={handleChange}
+          isDisabled={disabled}
+          className="text-base-content"
+          styles={styles}
+        />
+      </div>
     );
   }
 
   return (
-    <Select<DateOption>
-      options={dateOptions}
-      value={dateOptions.find((option) => option.value === selectedDate) ?? null}
-      onChange={handleChange}
-      placeholder={PLACEHOLDER}
-      className="text-base-content"
-      isDisabled={disabled}
-      styles={styles}
-    />
+    <div style={{ minWidth }}>
+      <Select<DateOption>
+        options={dateOptions}
+        value={dateOptions.find((option) => option.value === selectedDate) ?? null}
+        onChange={handleChange}
+        placeholder={PLACEHOLDER}
+        className="text-base-content"
+        isDisabled={disabled}
+        styles={styles}
+      />
+    </div>
   );
 }

--- a/ui/src/components/selectors/TaskSelector/index.tsx
+++ b/ui/src/components/selectors/TaskSelector/index.tsx
@@ -25,9 +25,6 @@ interface TaskSelectorProps {
 
 const PLACEHOLDER = "Select a task";
 
-/**
- * Component for selecting a task from a list of available tasks
- */
 export function TaskSelector({
   tasks,
   selectedTask,
@@ -39,21 +36,26 @@ export function TaskSelector({
     label: task.name,
   }));
 
-  const styles = useSelectStyles<TaskOption>();
+  const { minWidth, styles } = useSelectStyles<TaskOption>({
+    labels: options.map((opt) => opt.label),
+    placeholder: PLACEHOLDER,
+  });
 
   const handleChange = (option: SingleValue<TaskOption>) => {
     onTaskSelect(option ? option.value : "");
   };
 
   return (
-    <Select<TaskOption>
-      options={options}
-      value={options.find((option) => option.value === selectedTask) ?? null}
-      onChange={handleChange}
-      placeholder={PLACEHOLDER}
-      className="text-base-content"
-      isDisabled={disabled}
-      styles={styles}
-    />
+    <div style={{ minWidth }}>
+      <Select<TaskOption>
+        options={options}
+        value={options.find((option) => option.value === selectedTask) ?? null}
+        onChange={handleChange}
+        placeholder={PLACEHOLDER}
+        className="text-base-content"
+        isDisabled={disabled}
+        styles={styles}
+      />
+    </div>
   );
 }

--- a/ui/src/hooks/useSelectStyles.ts
+++ b/ui/src/hooks/useSelectStyles.ts
@@ -3,15 +3,27 @@ import { useMemo } from "react";
 import type { StylesConfig, GroupBase } from "react-select";
 import { getDaisySelectStyles } from "@/lib/react-select-theme";
 
+interface UseSelectStylesOptions {
+  labels: string[];
+  placeholder: string;
+  charWidth?: number;
+  padding?: number;
+}
+
 /**
- * DaisyUI-compatible React-Select styles. Width is the caller's responsibility.
+ * Hook that provides DaisyUI-compatible React-Select styles with dynamic width calculation
  */
 export function useSelectStyles<
   T,
   IsMulti extends boolean = false,
   Group extends GroupBase<T> = GroupBase<T>,
->(): StylesConfig<T, IsMulti, Group> {
-  return useMemo<StylesConfig<T, IsMulti, Group>>(() => {
+>({ labels, placeholder, charWidth = 8, padding = 60 }: UseSelectStylesOptions) {
+  const minWidth = useMemo(() => {
+    const maxLength = Math.max(...labels.map((l) => l.length), placeholder.length);
+    return maxLength * charWidth + padding;
+  }, [labels, placeholder, charWidth, padding]);
+
+  const styles = useMemo<StylesConfig<T, IsMulti, Group>>(() => {
     const baseStyles = getDaisySelectStyles<T, IsMulti, Group>();
 
     return {
@@ -19,13 +31,15 @@ export function useSelectStyles<
       container: (provided) => ({
         ...provided,
         width: "100%",
+        minWidth: "100%",
       }),
       menu: (provided, state) => ({
         ...(baseStyles.menu?.(provided, state) || provided),
-        width: "max-content",
+        width: "100%",
         minWidth: "100%",
-        maxWidth: "min(28rem, calc(100vw - 2rem))",
       }),
     };
   }, []);
+
+  return { minWidth, styles };
 }


### PR DESCRIPTION
Reverts the selector width refactor from #1422 (17 files, +140 -168).

The change moved width responsibility from the selector components to their outer containers. This PR restores the previous state, where each selector carried its own width classes.

Draft, do not merge. Tracked in #1427.