### PR TITLE
fix(infra): align Prefect server with worker version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -81,7 +81,8 @@ services:
     networks:
       - custom_net
   prefect-server:
-    image: prefecthq/prefect:3-python3.11
+    # Keep aligned with the Prefect version in uv.lock for worker API compatibility.
+    image: prefecthq/prefect:3.8.5-python3.11
     restart: always
     env_file:
       - .env


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Fix the user-flow worker restart loop caused by Prefect 3.8.5 sending an automation filter field that the running 3.7.2 server rejects with HTTP 422 during startup.
- Align the Compose server with the locked worker dependency. Applying this change requires pulling the image and recreating the Prefect server, with a brief service interruption; runtime recovery has not yet been verified.

## Changes
- Pin the Prefect server image to `prefecthq/prefect:3.8.5-python3.11` and document that it must stay aligned with `uv.lock`.
- Validation: `docker compose config --quiet`, `git diff --check`, and the Betterleaks pre-commit scan passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Prefect server to a specific version for more consistent deployments.
  * Updated the configuration guidance to keep the server version aligned with the worker environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->