### PR TITLE
feat(workflow): expose simultaneous drive for spectroscopy

### DIFF
--- a/src/qdash/datamodel/task.py
+++ b/src/qdash/datamodel/task.py
@@ -60,7 +60,7 @@ class RunParameterModel(BaseModel):
 
     unit: str = ""
     value_type: str = "float"
-    value: tuple[int | float, ...] | list[int | float] | int | float | str | None = None
+    value: tuple[int | float, ...] | list[int | float] | bool | int | float | str | None = None
     description: str = ""
 
     def get_value(self) -> Any:
@@ -122,7 +122,7 @@ class RunParameterModel(BaseModel):
 class RunParameterSpec(ParameterSpec):
     """Class-level declaration for experiment run configuration."""
 
-    default: tuple[int | float, ...] | list[int | float] | int | float | str | None = None
+    default: tuple[int | float, ...] | list[int | float] | bool | int | float | str | None = None
 
     def create_model(self) -> RunParameterModel:
         """Create an independent runtime model from this declaration."""

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_control_amplitude.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_control_amplitude.py
@@ -50,6 +50,15 @@ class CheckControlAmplitude(QubexTask):
         "coarse_control_amplitude": InputParameterSpec.required_database(),
     }
     run_spec: ClassVar[dict[str, RunParameterSpec]] = {
+        "simultaneous_drive": RunParameterSpec(
+            unit="a.u.",
+            value_type="bool",
+            default=True,
+            description=(
+                "Whether control and readout pulses start together. "
+                "False starts readout after the control pulse ends."
+            ),
+        ),
         "frequency_span": RunParameterSpec(
             unit="GHz",
             value_type="float",
@@ -242,6 +251,7 @@ class CheckControlAmplitude(QubexTask):
         ):
             result = exp.measure_qubit_resonance(
                 label,
+                simultaneous_drive=self.run_parameters["simultaneous_drive"].get_value(),
                 frequency_range=frequency_range,
                 control_amplitude=coarse_control_amplitude,
                 readout_amplitude=readout_amplitude,

--- a/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
+++ b/src/qdash/workflow/calibtasks/qubex/cw/check_qubit_spectroscopy.py
@@ -41,6 +41,15 @@ class CheckQubitSpectroscopy(QubexTask):
         "readout_amplitude": InputParameterSpec.required_database(),
     }
     run_spec: ClassVar[dict[str, RunParameterSpec]] = {
+        "simultaneous_drive": RunParameterSpec(
+            unit="a.u.",
+            value_type="bool",
+            default=True,
+            description=(
+                "Whether control and readout pulses start together. "
+                "False starts readout after the control pulse ends."
+            ),
+        ),
         "frequency_range": RunParameterSpec(
             unit="GHz",
             value_type="np.arange",
@@ -271,6 +280,7 @@ class CheckQubitSpectroscopy(QubexTask):
         ):
             result = exp.qubit_spectroscopy(
                 label,
+                simultaneous_drive=self.run_parameters["simultaneous_drive"].get_value(),
                 frequency_range=self._frequency_range(),
                 power_range=self.run_parameters["power_range"].get_value(),
                 readout_amplitude=self._get_readout_amplitude_value(),
@@ -295,6 +305,7 @@ class CheckQubitSpectroscopy(QubexTask):
         for label in labels:
             result = exp.qubit_spectroscopy(
                 label,
+                simultaneous_drive=self.run_parameters["simultaneous_drive"].get_value(),
                 frequency_range=frequency_range,
                 power_range=self.run_parameters["power_range"].get_value(),
                 readout_amplitude=readout_amplitude,

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -1034,6 +1034,12 @@
             "value": 8192,
             "value_type": "int"
           },
+          "simultaneous_drive": {
+            "description": "Whether control and readout pulses start together. False starts readout after the control pulse ends.",
+            "unit": "a.u.",
+            "value": true,
+            "value_type": "bool"
+          },
           "target_rabi_rate": {
             "description": "Target Rabi rate used to scale the estimated control amplitude",
             "unit": "GHz",
@@ -1480,6 +1486,12 @@
               5
             ],
             "value_type": "np.arange"
+          },
+          "simultaneous_drive": {
+            "description": "Whether control and readout pulses start together. False starts readout after the control pulse ends.",
+            "unit": "a.u.",
+            "value": true,
+            "value_type": "bool"
           }
         },
         "task_type": "qubit"

--- a/tests/qdash/datamodel/test_task.py
+++ b/tests/qdash/datamodel/test_task.py
@@ -151,3 +151,15 @@ class TestRunParameterModelDump:
         assert dumped["value"] == (0, 100, 50)
         assert dumped["value_type"] == "np.linspace"
         assert dumped["unit"] == "ns"
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_boolean_run_parameter_preserves_type_through_serialization(value: bool) -> None:
+    """Boolean settings must reach qubex as booleans, including explicit False."""
+    spec = RunParameterSpec(value_type="bool", default=value)
+    model = spec.create_model()
+    restored = RunParameterModel.model_validate_json(model.model_dump_json())
+
+    assert spec.default is value
+    assert model.get_value() is value
+    assert restored.get_value() is value

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_control_amplitude.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_control_amplitude.py
@@ -2,6 +2,7 @@ from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, cast
 
 import plotly.graph_objects as go
+import pytest
 
 from qdash.datamodel.task import InputParameterModel as ParameterModel
 from qdash.workflow.calibtasks.base import RunResult
@@ -116,14 +117,19 @@ def test_check_control_amplitude_propagates_spectroscopy_coarse_values_when_fit_
     assert result.output_parameters["coarse_qubit_frequency"].value == 4.25
 
 
+@pytest.mark.parametrize("simultaneous_drive", [None, True, False])
 def test_check_control_amplitude_run_uses_coarse_control_amplitude_without_extra_uplift(
     monkeypatch,
+    simultaneous_drive,
 ) -> None:
     task = CheckControlAmplitude()
     task.input_parameters["coarse_qubit_frequency"] = ParameterModel(value=4.25, unit="GHz")
     task.input_parameters["readout_frequency"] = ParameterModel(value=6.1, unit="GHz")
     task.input_parameters["readout_amplitude"] = ParameterModel(value=0.031, unit="a.u.")
     task.input_parameters["coarse_control_amplitude"] = ParameterModel(value=0.07, unit="a.u.")
+
+    if simultaneous_drive is not None:
+        task.run_parameters["simultaneous_drive"].value = simultaneous_drive
 
     captured: dict[str, object] = {}
 
@@ -146,3 +152,7 @@ def test_check_control_amplitude_run_uses_coarse_control_amplitude_without_extra
     assert captured["label"] == "Q00"
     assert captured["control_amplitude"] == 0.07
     assert captured["readout_amplitude"] == 0.031
+
+    assert captured["simultaneous_drive"] is (
+        True if simultaneous_drive is None else simultaneous_drive
+    )

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_qubit_spectroscopy.py
@@ -137,6 +137,7 @@ def test_run_parameters_only_expose_measurement_settings() -> None:
     assert set(CheckQubitSpectroscopy.run_spec) == {
         "frequency_range",
         "power_range",
+        "simultaneous_drive",
     }
 
 
@@ -149,7 +150,11 @@ def test_power_range_has_qdash_default() -> None:
     )
 
 
-def test_power_range_is_forwarded_to_qubex(monkeypatch) -> None:
+@pytest.mark.parametrize("simultaneous_drive", [None, True, False])
+@pytest.mark.parametrize("batch", [False, True])
+def test_measurement_settings_are_forwarded_to_qubex(
+    monkeypatch, simultaneous_drive, batch
+) -> None:
     """Verify the resolved power range is forwarded to the qubex experiment."""
     task = CheckQubitSpectroscopy()
     task.run_parameters = copy.deepcopy(task.run_parameters)
@@ -165,7 +170,19 @@ def test_power_range_is_forwarded_to_qubex(monkeypatch) -> None:
         task, "_modified_qubit_readout_frequencies", lambda *args, **kwargs: nullcontext()
     )
 
-    task.batch_run(backend, ["0"])
+    if simultaneous_drive is not None:
+        task.run_parameters["simultaneous_drive"].value = simultaneous_drive
+
+    if batch:
+        task.batch_run(backend, ["0", "1"])
+    else:
+        task.run(backend, "0")
+
+    assert exp.qubit_spectroscopy.call_count == (2 if batch else 1)
+    for call in exp.qubit_spectroscopy.call_args_list:
+        assert call.kwargs["simultaneous_drive"] is (
+            True if simultaneous_drive is None else simultaneous_drive
+        )
 
     assert list(exp.qubit_spectroscopy.call_args.kwargs["power_range"]) == pytest.approx(
         [-40.0, -30.0, -20.0]


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Allow `CheckQubitSpectroscopy` and `CheckControlAmplitude` to configure `simultaneous_drive`. It defaults to `True`; setting it to `False` starts readout after the control pulse ends.
- Preserve boolean run parameter defaults and values through model creation and JSON serialization so explicit `False` reaches qubex as a boolean.

## Changes
- Forward `simultaneous_drive` to qubex in control-amplitude measurements and both single and batch spectroscopy paths, and update the task catalog.
- Cover default, explicit `True`, and explicit `False` settings and boolean serialization with regression tests.
- Validation: 46 tests passed across the datamodel suite and both affected task test files; Ruff lint and format checks, task catalog consistency, and `git diff --check` passed. Hardware measurements were not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for boolean run parameter values and defaults.
  * Added a `simultaneous_drive` setting to qubit control amplitude and spectroscopy measurements.
  * Users can choose whether control and readout pulses start together or sequentially; the default remains simultaneous operation.

* **Tests**
  * Added coverage for boolean parameter serialization and pulse timing settings in single and batch measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->