### PR TITLE
fix(ui): list every execution task in the topology modal (#1431)

### DIFF
--- a/ui/src/components/features/execution/ExecutionTopologyView.tsx
+++ b/ui/src/components/features/execution/ExecutionTopologyView.tsx
@@ -232,6 +232,10 @@ const CouplingMarker = memo(function CouplingMarker({
   );
 });
 
+/**
+ * Chip topology grid for one execution, with a detail modal listing every task
+ * the clicked qubit or coupling ran
+ */
 export function ExecutionTopologyView({
   chipId,
   executionId,

--- a/ui/src/components/features/execution/ExecutionTopologyView.tsx
+++ b/ui/src/components/features/execution/ExecutionTopologyView.tsx
@@ -12,7 +12,6 @@ import {
   filterTaskGroupsByName,
   groupTasksByEntity,
   resolveInitialTaskIndex,
-  selectTaskNeighborhood,
 } from "@/components/features/execution/executionTopologyTasks";
 import { GridFullscreenButton } from "@/components/ui/GridFullscreenButton";
 import { GridZoomControls } from "@/components/ui/GridZoomControls";
@@ -366,9 +365,8 @@ export function ExecutionTopologyView({
       topologyMode === "2q"
         ? allTasksByEntity.coupling[selectedEntityId]
         : allTasksByEntity.oneQubit[selectedEntityId];
-    if (!entityTasks) return [];
-    return selectTaskNeighborhood(entityTasks, filterTaskName);
-  }, [allTasksByEntity, selectedEntityId, topologyMode, filterTaskName]);
+    return entityTasks ?? [];
+  }, [allTasksByEntity, selectedEntityId, topologyMode]);
 
   const initialTaskIndex = useMemo(
     () => (selectedTasks ? resolveInitialTaskIndex(selectedTasks, filterTaskName) : 0),

--- a/ui/src/components/features/execution/__tests__/ExecutionTopologyView.test.tsx
+++ b/ui/src/components/features/execution/__tests__/ExecutionTopologyView.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Task } from "@/schemas";
@@ -38,6 +38,24 @@ vi.mock("@/hooks/useTopologyConfig", () => ({
       "1": { row: 0, col: 1 },
     },
     gridSize: 2,
+  }),
+}));
+
+vi.mock("@/contexts/AnalysisChatContext", () => ({
+  useAnalysisChatContext: () => ({
+    openMiniChat: vi.fn(),
+  }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    username: "tester",
+  }),
+}));
+
+vi.mock("@/contexts/ProjectContext", () => ({
+  useProject: () => ({
+    isOwner: false,
   }),
 }));
 
@@ -94,5 +112,34 @@ describe("ExecutionTopologyView grid figures", () => {
 
     expect(screen.getByAltText("Result for QID 0-1")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Expand figure" })).toBeNull();
+  });
+});
+
+describe("ExecutionTopologyView task detail modal", () => {
+  it("lists every task of the selected qid regardless of which task name is filtered", () => {
+    const tasks: Task[] = [
+      { task_id: "task-1", qid: "0", name: "CheckStatus", status: "completed" },
+      { task_id: "task-2", qid: "0", name: "CheckRabi", status: "completed" },
+      { task_id: "task-3", qid: "0", name: "CreateHPIPulse", status: "completed" },
+      { task_id: "task-4", qid: "0", name: "CheckT1", status: "completed" },
+    ];
+
+    renderTopologyView({
+      chipId: "chip-1",
+      executionId: "exec-1",
+      executionName: "Execution 1",
+      tasks,
+      topologyMode: "1q",
+      filterTaskName: "CheckRabi",
+      onToggleFullscreen: vi.fn(),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "0" }));
+
+    expect(screen.getAllByText("CheckStatus").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("CheckRabi").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("CreateHPIPulse").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("CheckT1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("2 / 4").length).toBeGreaterThan(0);
   });
 });

--- a/ui/src/components/features/execution/__tests__/executionTopologyTasks.test.ts
+++ b/ui/src/components/features/execution/__tests__/executionTopologyTasks.test.ts
@@ -6,18 +6,10 @@ import {
   filterTaskGroupsByName,
   groupTasksByEntity,
   resolveInitialTaskIndex,
-  selectTaskNeighborhood,
 } from "@/components/features/execution/executionTopologyTasks";
 
 function task(name: string, qid: string): Task {
   return { name, qid, task_id: `${name}-${qid}` };
-}
-
-function chain(names: string[], qid = "0"): Task[] {
-  return names.map((name, index) => ({
-    ...task(name, qid),
-    upstream_id: index === 0 ? "" : `${names[index - 1]}-${qid}`,
-  }));
 }
 
 const tasks: Task[] = [
@@ -65,73 +57,6 @@ describe("filterTaskGroupsByName", () => {
     const { oneQubit } = groupTasksByEntity(tasks);
 
     expect(filterTaskGroupsByName(oneQubit, "")).toEqual({});
-  });
-});
-
-describe("selectTaskNeighborhood", () => {
-  const linked = chain(["CheckFineChevron", "CheckRabi", "CreateHPIPulse", "CheckT1"]);
-
-  it("keeps the upstream and downstream tasks of the selected one", () => {
-    expect(selectTaskNeighborhood(linked, "CheckRabi").map((entry) => entry.name)).toEqual([
-      "CheckFineChevron",
-      "CheckRabi",
-      "CreateHPIPulse",
-    ]);
-  });
-
-  it("drops tasks that are more than one dependency away", () => {
-    expect(selectTaskNeighborhood(linked, "CheckFineChevron").map((entry) => entry.name)).toEqual([
-      "CheckFineChevron",
-      "CheckRabi",
-    ]);
-    expect(selectTaskNeighborhood(linked, "CheckT1").map((entry) => entry.name)).toEqual([
-      "CreateHPIPulse",
-      "CheckT1",
-    ]);
-  });
-
-  it("keeps every branch that depends on the selected task", () => {
-    const branched: Task[] = [
-      { ...task("CheckRabi", "0"), upstream_id: "" },
-      { ...task("CreateHPIPulse", "0"), upstream_id: "CheckRabi-0" },
-      { ...task("CheckT1", "0"), upstream_id: "CheckRabi-0" },
-    ];
-
-    expect(selectTaskNeighborhood(branched, "CheckRabi")).toHaveLength(3);
-    expect(selectTaskNeighborhood(branched, "CreateHPIPulse").map((entry) => entry.name)).toEqual([
-      "CheckRabi",
-      "CreateHPIPulse",
-    ]);
-  });
-
-  it("falls back to the adjacent tasks when the execution has no upstream links", () => {
-    const { oneQubit } = groupTasksByEntity(tasks);
-
-    expect(selectTaskNeighborhood(oneQubit["0"], "CheckRabi").map((entry) => entry.name)).toEqual([
-      "CheckStatus",
-      "CheckRabi",
-      "CreateHPIPulse",
-    ]);
-  });
-
-  it("falls back per task when only part of the group is linked", () => {
-    const partiallyLinked: Task[] = [
-      { ...task("CheckFineChevron", "0"), upstream_id: "" },
-      { ...task("CheckRabi", "0"), upstream_id: "CheckFineChevron-0" },
-      { ...task("CheckT1", "0"), upstream_id: "" },
-      { ...task("CheckT2Echo", "0"), upstream_id: "" },
-    ];
-
-    expect(selectTaskNeighborhood(partiallyLinked, "CheckT1").map((entry) => entry.name)).toEqual([
-      "CheckRabi",
-      "CheckT1",
-      "CheckT2Echo",
-    ]);
-  });
-
-  it("returns the whole group when the task is missing or unset", () => {
-    expect(selectTaskNeighborhood(linked, "CheckT2Echo")).toHaveLength(linked.length);
-    expect(selectTaskNeighborhood(linked, "")).toHaveLength(linked.length);
   });
 });
 

--- a/ui/src/components/features/execution/executionTopologyTasks.ts
+++ b/ui/src/components/features/execution/executionTopologyTasks.ts
@@ -61,50 +61,6 @@ export function filterTaskGroupsByName(groups: TaskGroups, taskName: string): Ta
 }
 
 /**
- * Narrows one entity's tasks to the selected task plus the tasks directly linked
- * to it: its upstream task and every task declaring it as upstream.
- *
- * A task with no link recorded on either side falls back to its neighbours in
- * execution order, so the selected task is never shown on its own.
- */
-export function selectTaskNeighborhood(entityTasks: Task[], taskName: string): Task[] {
-  if (!taskName) return entityTasks;
-
-  const selectedIndexes = entityTasks.reduce<number[]>((indexes, task, index) => {
-    if (task.name === taskName) indexes.push(index);
-    return indexes;
-  }, []);
-  if (selectedIndexes.length === 0) return entityTasks;
-
-  const indexByTaskId = new Map<string, number>();
-  entityTasks.forEach((task, index) => {
-    if (task.task_id) indexByTaskId.set(task.task_id, index);
-  });
-  const kept = new Set<number>(selectedIndexes);
-  for (const selectedIndex of selectedIndexes) {
-    const selected = entityTasks[selectedIndex];
-    const upstreamIndex = selected.upstream_id
-      ? indexByTaskId.get(selected.upstream_id)
-      : undefined;
-    const downstreamIndexes = entityTasks.reduce<number[]>((indexes, task, index) => {
-      if (selected.task_id && task.upstream_id === selected.task_id) indexes.push(index);
-      return indexes;
-    }, []);
-
-    if (upstreamIndex === undefined && downstreamIndexes.length === 0) {
-      if (selectedIndex > 0) kept.add(selectedIndex - 1);
-      if (selectedIndex < entityTasks.length - 1) kept.add(selectedIndex + 1);
-      continue;
-    }
-
-    if (upstreamIndex !== undefined) kept.add(upstreamIndex);
-    for (const downstreamIndex of downstreamIndexes) kept.add(downstreamIndex);
-  }
-
-  return entityTasks.filter((_, index) => kept.has(index));
-}
-
-/**
  * Position of the task selected in the filter, used as the detail modal's
  * initial selection. Falls back to the first task when the name is not present.
  */


### PR DESCRIPTION
## Ticket

- close #1431

## Summary

- Clicking a topology grid cell opened the task detail modal with only the filtered task plus its directly linked tasks, falling back to the tasks immediately before and after it when no upstream link was recorded. The sidebar is headed "Tasks in Execution", so it should hold the whole node tree the entity ran in this execution.
- UI only, limited to the Execution Detail topology view. No API, schema, or generated client changes.

## Changes

- `ExecutionTopologyView`: pass the entity's full task list from `groupTasksByEntity` straight to the detail modal, so the list is now identical for a given qubit or coupling whichever task name the filter selects. Only the initial selection moves, which `resolveInitialTaskIndex` already handles.
- `executionTopologyTasks`: remove `selectTaskNeighborhood` and its tests, now that nothing narrows the list.
- Add a `ExecutionTopologyView` test that opens the modal with a task-name filter applied and asserts all four tasks of the selected qid are listed, with the filtered one selected (`2 / 4`).

## Verification

- `bun run vitest run src/components/features/execution/__tests__/ExecutionTopologyView.test.tsx src/components/features/execution/__tests__/executionTopologyTasks.test.ts` — 2 files, 9 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task details now display all tasks associated with a selected qubit, even when a task-name filter is active.
  * The task count shown in the details view now accurately reflects the full set of tasks for that qubit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->