### PR TITLE
ci(repo): limit Pullfrog reviews to pull requests targeting develop (#1437)

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -27,34 +27,32 @@ jobs:
       OPENAI_COMPATIBLE_CONTEXT: "131072"
       OPENAI_COMPATIBLE_MAX_OUTPUT: "32768"
     steps:
-      # Pullfrog dispatches this workflow itself, so the base branch has to be
-      # read out of its payload rather than filtered with `on: pull_request`.
-      - name: Check the review target branch
-        id: target
+      - name: Check the pull request target branch
+        id: gate
         env:
           PULLFROG_PROMPT: ${{ inputs.prompt }}
-          REVIEW_BASE_REF: develop
+          REVIEW_TARGET_BRANCH: develop
         run: |
           set -euo pipefail
 
-          trigger=$(jq -r 'if type == "object" then (.event.trigger // "") else "" end' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
-          base_ref=$(jq -r 'if type == "object" then (.event.context.base_ref // "") else "" end' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
+          trigger=$(jq -r 'try (.event.trigger // "") catch ""' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
+          target_branch=$(jq -r 'try (.event.context.base_ref // "") catch ""' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
 
-          if [ -n "${base_ref}" ] && [ "${base_ref}" != "${REVIEW_BASE_REF}" ] && [[ "${trigger}" != *comment* ]]; then
-            echo "run=false" >> "${GITHUB_OUTPUT}"
-            echo "::notice::Skipping the review. This pull request targets ${base_ref}, and reviews are limited to ${REVIEW_BASE_REF}."
-          else
+          if [ -z "${target_branch}" ] || [ "${target_branch}" = "${REVIEW_TARGET_BRANCH}" ] || [[ "${trigger}" == *comment* ]]; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "run=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::Skipping the review. Only pull requests targeting ${REVIEW_TARGET_BRANCH} are reviewed, and this one targets ${target_branch}."
           fi
 
       - name: Checkout code
-        if: steps.target.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true'
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           fetch-depth: 1
 
       - name: Run agent
-        if: steps.target.outputs.run == 'true'
+        if: steps.gate.outputs.run == 'true'
         uses: pullfrog/pullfrog@1ab92a2eb5c2268dcd803ac8bfb0984375e210ab
         with:
           prompt: ${{ inputs.prompt }}

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          trigger=$(jq -r 'try (.event.trigger // "") catch ""' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
-          target_branch=$(jq -r 'try (.event.context.base_ref // "") catch ""' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
+          trigger=$(jq -r 'try (.event.trigger) catch null | strings // ""' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
+          target_branch=$(jq -r 'try (.event.context.base_ref) catch null | strings // ""' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
 
           if [ -z "${target_branch}" ] || [ "${target_branch}" = "${REVIEW_TARGET_BRANCH}" ] || [[ "${trigger}" == *comment* ]]; then
             echo "run=true" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -37,8 +37,11 @@ jobs:
 
           trigger=$(jq -r 'try (.event.trigger) catch null | strings // ""' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
           target_branch=$(jq -r 'try (.event.context.base_ref) catch null | strings // ""' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
+          target_branch=${target_branch//[$'\n\r']/ }
 
-          if [ -z "${target_branch}" ] || [ "${target_branch}" = "${REVIEW_TARGET_BRANCH}" ] || [[ "${trigger}" == *comment* ]]; then
+          if [[ "${trigger}" == *comment* ]]; then
+            echo "run=true" >> "${GITHUB_OUTPUT}"
+          elif [ -z "${target_branch}" ] || [ "${target_branch}" = "${REVIEW_TARGET_BRANCH}" ]; then
             echo "run=true" >> "${GITHUB_OUTPUT}"
           else
             echo "run=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -27,12 +27,34 @@ jobs:
       OPENAI_COMPATIBLE_CONTEXT: "131072"
       OPENAI_COMPATIBLE_MAX_OUTPUT: "32768"
     steps:
+      # Pullfrog dispatches this workflow itself, so the base branch has to be
+      # read out of its payload rather than filtered with `on: pull_request`.
+      - name: Check the review target branch
+        id: target
+        env:
+          PULLFROG_PROMPT: ${{ inputs.prompt }}
+          REVIEW_BASE_REF: develop
+        run: |
+          set -euo pipefail
+
+          trigger=$(jq -r 'if type == "object" then (.event.trigger // "") else "" end' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
+          base_ref=$(jq -r 'if type == "object" then (.event.context.base_ref // "") else "" end' <<<"${PULLFROG_PROMPT}" 2>/dev/null || true)
+
+          if [ -n "${base_ref}" ] && [ "${base_ref}" != "${REVIEW_BASE_REF}" ] && [[ "${trigger}" != *comment* ]]; then
+            echo "run=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::Skipping the review. This pull request targets ${base_ref}, and reviews are limited to ${REVIEW_BASE_REF}."
+          else
+            echo "run=true" >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: Checkout code
+        if: steps.target.outputs.run == 'true'
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           fetch-depth: 1
 
       - name: Run agent
+        if: steps.target.outputs.run == 'true'
         uses: pullfrog/pullfrog@1ab92a2eb5c2268dcd803ac8bfb0984375e210ab
         with:
           prompt: ${{ inputs.prompt }}


### PR DESCRIPTION
## Ticket

- close #1437

## Summary

- Pullfrog reviewed every pull request in the repository, including the release pull requests that git-pr-release opens from `develop` into `main`. Those carry an aggregate of commits that were already reviewed on the way into `develop`, so the review adds nothing and spends gateway capacity on a large diff.
- Pullfrog's control plane dispatches this workflow itself through `workflow_dispatch`, so an `on: pull_request` branch filter never applies and there is no base branch setting in the Pullfrog console. The base branch has to be read out of the dispatch payload inside the job.
- CI only, limited to `.github/workflows/pullfrog.yml`. No API, schema, generated client, or application code changes.

## Changes

- Add a "Check the review target branch" step that reads `.event.context.base_ref` and `.event.trigger` from the dispatch payload and sets a `run` output. The checkout and agent steps now carry `if: steps.target.outputs.run == 'true'`.
- Skip the agent only when the payload names a base branch other than `develop`. The allowed branch sits in a `REVIEW_BASE_REF` step variable so it reads as configuration rather than a literal buried in the condition.
- Keep comment triggers working. A mention payload carries no base branch at all, so gating on its presence would have silenced `@pullfrog` on every pull request. The condition also excludes comment triggers explicitly.
- Pass the payload through the step environment instead of interpolating it into the script, so a pull request title or branch name cannot reach the shell.
- Fall through to running the agent whenever the payload is missing, empty, or not JSON. A manual dispatch with a plain text prompt behaves exactly as it does today.

## Scope

The Pullfrog console has no base branch, path, or label filter for PR reviews, so the workflow is the only place this can live. Reading the dispatch payload does depend on a shape that Pullfrog does not document. If that shape changes, the parse fails and the guard falls open to today's behavior rather than blocking reviews.

## Verification

`actionlint` passes on the workflow.

The guard was exercised end to end on `dvlpwork/pullfrog-trial`, the scratch repository that carries this same workflow against the same gateway. A `develop` branch was added and two pull requests were opened.

| Case | Guard decision | Agent | Result |
| --- | --- | --- | --- |
| Pull request into `main`, `pull_request_opened` | skipped, `base_ref=main` | not run | finished in 9s, no review posted |
| Pull request into `develop`, `pull_request_opened` | ran, `base_ref=develop` | run | review posted as usual |
| `@pullfrog` mention on the `main` pull request | ran, no `base_ref` in payload | run | question answered, still no review |

Skipping the agent leaves nothing stranded. Pullfrog creates its check run and progress comment server side before dispatch, and both were cleaned up when the job finished without the agent: the check settled at `success` with "Pullfrog run completed", and the pre created progress comment was deleted, leaving no comments on that pull request.

The step was also run against three captured payloads and eleven malformed ones, covering invalid JSON, an empty prompt, a plain text prompt, a null `base_ref`, and quote characters inside `base_ref`. Every case matched the intended decision and nothing escaped into the shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow**
  - Pull request reviews now run only for pull requests targeting the `develop` branch, pull requests without a specified target branch, or comment-triggered events.
  - Reviews are skipped for other target branches.
  - Target branch values are handled more reliably when evaluating whether a review should run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->