### PR TITLE
feat(ui): streamline command palette and execution navigation

### DIFF
--- a/ui/src/components/features/execution/ExecutionPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionPageContent.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 
 import {
   AlertCircle,
   ArrowUpRight,
   BarChart3,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   ExternalLink,
   StopCircle,
   UserRound,
@@ -122,6 +124,9 @@ export function ExecutionPageContent() {
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   const [showDurationBreakdown, setShowDurationBreakdown] = useState(false);
+  const sidebarRef = useRef<HTMLElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const executionCards = useRef(new Map<string, HTMLDivElement>());
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -202,6 +207,27 @@ export function ExecutionPageContent() {
     });
   }, [executionData, selectedDate]);
 
+  const selectedExecutionIndex = cardData.findIndex(
+    (execution) => execution.execution_id === selectedExecutionId,
+  );
+
+  const handleCloseSidebar = useCallback(() => {
+    if (selectedExecutionId) {
+      executionCards.current.get(selectedExecutionId)?.focus({ preventScroll: true });
+    }
+    setIsSidebarOpen(false);
+    setSelectedExecutionId(null);
+    setExpandedTaskIndex(null);
+  }, [selectedExecutionId]);
+
+  useEffect(() => {
+    if (isSidebarOpen) closeButtonRef.current?.focus({ preventScroll: true });
+  }, [isSidebarOpen]);
+
+  useEffect(() => {
+    if (sidebarRef.current) sidebarRef.current.scrollTop = 0;
+  }, [selectedExecutionId]);
+
   const statusSummary = useMemo(
     () => ({
       total: cardData.length,
@@ -218,16 +244,20 @@ export function ExecutionPageContent() {
     if (!isSidebarOpen) return;
 
     const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !showCancelConfirm) {
-        setIsSidebarOpen(false);
-        setSelectedExecutionId(null);
-        setExpandedTaskIndex(null);
+      if (
+        event.key === "Escape" &&
+        !event.defaultPrevented &&
+        !event.isComposing &&
+        !showCancelConfirm &&
+        !document.querySelector('[role="dialog"], [role="alertdialog"]')
+      ) {
+        handleCloseSidebar();
       }
     };
 
     window.addEventListener("keydown", handleEscape);
     return () => window.removeEventListener("keydown", handleEscape);
-  }, [isSidebarOpen, showCancelConfirm]);
+  }, [isSidebarOpen, showCancelConfirm, handleCloseSidebar]);
 
   // Chip selection change handler
   const handleChipChange = (chipId: string) => {
@@ -239,6 +269,7 @@ export function ExecutionPageContent() {
 
   // Wrap date setter to reset page
   const handleDateChange = (date: string) => {
+    handleCloseSidebar();
     setSelectedDate(date);
     setCurrentPage(1);
   };
@@ -265,12 +296,6 @@ export function ExecutionPageContent() {
   const handleCardClick = (execution: ExecutionResponseSummary) => {
     setSelectedExecutionId(execution.execution_id);
     setIsSidebarOpen(true);
-    setExpandedTaskIndex(null);
-  };
-
-  const handleCloseSidebar = () => {
-    setIsSidebarOpen(false);
-    setSelectedExecutionId(null);
     setExpandedTaskIndex(null);
   };
 
@@ -422,7 +447,13 @@ export function ExecutionPageContent() {
             return (
               <div
                 key={executionKey}
+                ref={(element) => {
+                  if (element) executionCards.current.set(execution.execution_id, element);
+                  else executionCards.current.delete(execution.execution_id);
+                }}
                 role="button"
+                aria-expanded={isSelected && isSidebarOpen}
+                aria-controls="execution-details-panel"
                 tabIndex={0}
                 aria-label={`View ${execution.name} execution details`}
                 className={`relative flex cursor-pointer overflow-hidden rounded-box border border-base-200 bg-base-100 p-3 shadow-sm transition-colors hover:border-primary/40 hover:bg-base-200/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary sm:p-4 ${statusBorderStyle}`}
@@ -472,18 +503,25 @@ export function ExecutionPageContent() {
         {shouldShowPagination && (
           <PaginationControls
             currentPage={currentPage}
-            setCurrentPage={setCurrentPage}
+            setCurrentPage={(page) => {
+              handleCloseSidebar();
+              setCurrentPage(page);
+            }}
             hasMore={hasMorePages}
             totalPages={totalPages}
           />
         )}
       </section>
       <aside
+        id="execution-details-panel"
+        ref={sidebarRef}
+        inert={!isSidebarOpen}
         aria-label="Execution details"
         aria-hidden={!isSidebarOpen}
         className={`fixed right-0 top-0 z-50 h-full w-full overflow-y-auto border-l border-base-300 bg-base-100 p-4 shadow-xl transition-transform duration-300 sm:w-3/4 sm:p-6 lg:w-2/5 ${isSidebarOpen ? "translate-x-0" : "translate-x-full"}`}
       >
         <button
+          ref={closeButtonRef}
           onClick={handleCloseSidebar}
           className="btn btn-ghost btn-sm btn-circle absolute top-3 right-3 z-10 sm:top-4 sm:right-4"
           aria-label="Close execution details"
@@ -492,18 +530,47 @@ export function ExecutionPageContent() {
         </button>
         {selectedExecutionId && (
           <div>
+            <nav aria-label="Browse executions" className="mb-4 flex items-center gap-2 pr-10">
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                aria-label="Previous execution"
+                disabled={selectedExecutionIndex <= 0}
+                onClick={() => handleCardClick(cardData[selectedExecutionIndex - 1])}
+              >
+                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                Previous
+              </button>
+              <span className="text-xs text-base-content/60" role="status">
+                {selectedExecutionIndex >= 0
+                  ? `${selectedExecutionIndex + 1} of ${cardData.length} on this page`
+                  : "Outside current results"}
+              </span>
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                aria-label="Next execution"
+                disabled={
+                  selectedExecutionIndex < 0 || selectedExecutionIndex >= cardData.length - 1
+                }
+                onClick={() => handleCardClick(cardData[selectedExecutionIndex + 1])}
+              >
+                Next
+                <ChevronRight className="h-4 w-4" aria-hidden="true" />
+              </button>
+            </nav>
             <div className="p-2 sm:p-4 bg-base-100 mb-4 sm:mb-6">
               <h2 className="text-lg sm:text-2xl font-bold pr-8">
                 {cardData.find((exec) => getExecutionKey(exec) === selectedExecutionId)?.name}
               </h2>
               <div className="mt-3 sm:mt-4 flex flex-wrap gap-2">
-                <a
+                <Link
                   href={`/execution/${selectedChip || ""}/${selectedExecutionId}`}
                   className="btn btn-primary btn-sm sm:btn-md"
                 >
                   <ExternalLink className="w-3 h-3 sm:w-4 sm:h-4" />
                   View Details
-                </a>
+                </Link>
                 {(() => {
                   const selectedExec = cardData.find(
                     (exec) => getExecutionKey(exec) === selectedExecutionId,
@@ -533,7 +600,12 @@ export function ExecutionPageContent() {
             </div>
             <div>
               <h3 className="text-base sm:text-xl font-bold mb-3 sm:mb-4">Execution Details</h3>
-              {isDetailLoading && <div>Loading details...</div>}
+              {isDetailLoading && (
+                <div role="status" className="flex items-center gap-2 py-4 text-base-content/60">
+                  <span className="loading loading-spinner loading-sm" aria-hidden="true" />
+                  Loading details...
+                </div>
+              )}
               {isDetailError && <div>Error loading details.</div>}
               {executionDetailData?.data.status === "failed" &&
                 executionDetailData.data.message && (

--- a/ui/src/components/features/execution/ExecutionPageContent.tsx
+++ b/ui/src/components/features/execution/ExecutionPageContent.tsx
@@ -127,6 +127,8 @@ export function ExecutionPageContent() {
   const sidebarRef = useRef<HTMLElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const executionCards = useRef(new Map<string, HTMLDivElement>());
+  const pendingFocusRestore = useRef<string | null>(null);
+  const executionListHeading = useRef<HTMLHeadingElement>(null);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -212,13 +214,23 @@ export function ExecutionPageContent() {
   );
 
   const handleCloseSidebar = useCallback(() => {
-    if (selectedExecutionId) {
-      executionCards.current.get(selectedExecutionId)?.focus({ preventScroll: true });
-    }
+    if (selectedExecutionId) pendingFocusRestore.current = selectedExecutionId;
+    if (sidebarRef.current) sidebarRef.current.scrollTop = 0;
     setIsSidebarOpen(false);
     setSelectedExecutionId(null);
     setExpandedTaskIndex(null);
   }, [selectedExecutionId]);
+
+  useEffect(() => {
+    if (isSidebarOpen || isLoading || !pendingFocusRestore.current) return;
+    const firstId = cardData[0]?.execution_id;
+    const target =
+      executionCards.current.get(pendingFocusRestore.current) ??
+      (firstId ? executionCards.current.get(firstId) : null) ??
+      executionListHeading.current;
+    target?.focus({ preventScroll: true });
+    pendingFocusRestore.current = null;
+  }, [cardData, isLoading, isSidebarOpen]);
 
   useEffect(() => {
     if (isSidebarOpen) closeButtonRef.current?.focus({ preventScroll: true });
@@ -261,9 +273,8 @@ export function ExecutionPageContent() {
 
   // Chip selection change handler
   const handleChipChange = (chipId: string) => {
+    handleCloseSidebar();
     setSelectedChip(chipId || null);
-    setSelectedExecutionId(null);
-    setIsSidebarOpen(false);
     setCurrentPage(1);
   };
 
@@ -421,7 +432,12 @@ export function ExecutionPageContent() {
       </section>
       <section aria-labelledby="recent-executions-heading">
         <div className="mb-3">
-          <h2 id="recent-executions-heading" className="text-lg font-semibold">
+          <h2
+            ref={executionListHeading}
+            tabIndex={-1}
+            id="recent-executions-heading"
+            className="text-lg font-semibold"
+          >
             Recent executions
           </h2>
           <p className="text-sm text-base-content/60">

--- a/ui/src/components/features/execution/__tests__/ExecutionPageContent.test.tsx
+++ b/ui/src/components/features/execution/__tests__/ExecutionPageContent.test.tsx
@@ -1,8 +1,10 @@
+import { useState } from "react";
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ExecutionPageContent } from "@/components/features/execution/ExecutionPageContent";
 
+let loadingNextPage = false;
 const mockCancelMutate = vi.fn();
 const mockToastSuccess = vi.fn();
 const mockToastError = vi.fn();
@@ -18,30 +20,41 @@ vi.mock("@/client/chip/chip", () => ({
 }));
 
 vi.mock("@/client/execution/execution", () => ({
-  useListExecutions: () => ({
+  useListExecutions: ({ skip, chip_id }: { skip: number; chip_id: string }) => ({
     data: {
       data: {
-        executions: [
-          {
-            execution_id: "exec-1",
-            name: "Running Execution",
-            status: "running",
-            start_at: "2026-06-01T00:00:00Z",
-            elapsed_time: "1m",
-            username: "tester",
-          },
-          {
-            execution_id: "exec-2",
-            name: "Completed Execution",
-            status: "completed",
-            start_at: "2026-06-01T00:00:00Z",
-            username: "tester",
-          },
-        ],
+        total: 40,
+        executions:
+          skip > 0 || chip_id === "chip-2"
+            ? [
+                {
+                  execution_id: "exec-3",
+                  name: "Other Execution",
+                  status: "completed",
+                  start_at: "2026-06-02T00:00:00Z",
+                },
+              ]
+            : [
+                {
+                  execution_id: "exec-1",
+                  name: "Running Execution",
+                  status: "running",
+                  start_at: "2026-06-01T00:00:00Z",
+                  elapsed_time: "1m",
+                  username: "tester",
+                },
+                {
+                  execution_id: "exec-2",
+                  name: "Completed Execution",
+                  status: "completed",
+                  start_at: "2026-06-01T00:00:00Z",
+                  username: "tester",
+                },
+              ],
       },
     },
     isError: false,
-    isLoading: false,
+    isLoading: skip > 0 && loadingNextPage,
   }),
   useGetExecution: () => ({
     data: {
@@ -67,11 +80,10 @@ vi.mock("@/hooks/useDateNavigation", () => ({
 }));
 
 vi.mock("@/hooks/useUrlState", () => ({
-  useExecutionUrlState: () => ({
-    selectedChip: "chip-1",
-    setSelectedChip: vi.fn(),
-    isInitialized: true,
-  }),
+  useExecutionUrlState: () => {
+    const [selectedChip, setSelectedChip] = useState("chip-1");
+    return { selectedChip, setSelectedChip, isInitialized: true };
+  },
 }));
 
 vi.mock("@/components/ui/Toast", () => ({
@@ -98,11 +110,15 @@ vi.mock("@/components/charts/TaskFigure", () => ({
 }));
 
 vi.mock("@/components/selectors/ChipSelector", () => ({
-  ChipSelector: () => <div>ChipSelector</div>,
+  ChipSelector: ({ onChipSelect }: { onChipSelect: (chip: string) => void }) => (
+    <button onClick={() => onChipSelect("chip-2")}>Change chip</button>
+  ),
 }));
 
 vi.mock("@/components/selectors/DateSelector", () => ({
-  DateSelector: () => <div>DateSelector</div>,
+  DateSelector: ({ onDateSelect }: { onDateSelect: (date: string) => void }) => (
+    <button onClick={() => onDateSelect("20260602")}>Change date</button>
+  ),
 }));
 
 vi.mock("@/components/ui/PageContainer", () => ({
@@ -137,6 +153,7 @@ function openSidebarAndClickCancel() {
 describe("ExecutionPageContent cancel confirmation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    loadingNextPage = false;
     // Reset the mutate implementation so callback-driven tests don't leak into others.
     mockCancelMutate.mockReset();
   });
@@ -232,6 +249,54 @@ describe("ExecutionPageContent cancel confirmation", () => {
     expect(document.activeElement).toBe(lastCard);
     expect(lastCard.getAttribute("aria-expanded")).toBe("false");
     expect(document.getElementById("execution-details-panel")?.hasAttribute("inert")).toBe(true);
+  });
+
+  it.each(["Change chip", "Next"])(
+    "restores focus after %s replaces the execution list",
+    (name) => {
+      render(<ExecutionPageContent />);
+      fireEvent.click(screen.getByText("Running Execution"));
+      const panel = screen.getByRole("complementary", { name: "Execution details" });
+      panel.scrollTop = 300;
+      fireEvent.click(screen.getByRole("button", { name }));
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "View Other Execution execution details" }),
+      );
+      expect(panel.scrollTop).toBe(0);
+      expect(panel.getAttribute("aria-hidden")).toBe("true");
+    },
+  );
+
+  it("waits for the new page to load before restoring focus", () => {
+    loadingNextPage = true;
+    const { rerender } = render(<ExecutionPageContent />);
+    fireEvent.click(screen.getByText("Running Execution"));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(screen.getByText("Skeleton")).toBeTruthy();
+    loadingNextPage = false;
+    rerender(<ExecutionPageContent />);
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "View Other Execution execution details" }),
+    );
+  });
+
+  it("focuses the list heading when changing the date leaves no results", () => {
+    render(<ExecutionPageContent />);
+    fireEvent.click(screen.getByText("Running Execution"));
+    fireEvent.click(screen.getByRole("button", { name: "Change date" }));
+    expect(screen.getByText("No executions found")).toBeTruthy();
+    expect(document.activeElement).toBe(screen.getByRole("heading", { name: "Recent executions" }));
+  });
+
+  it("returns focus to the last viewed card after navigating forward then backward", () => {
+    render(<ExecutionPageContent />);
+    fireEvent.click(screen.getByText("Running Execution"));
+    fireEvent.click(screen.getByRole("button", { name: "Next execution" }));
+    fireEvent.click(screen.getByRole("button", { name: "Previous execution" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "View Running Execution execution details" }),
+    );
   });
 
   it("does not close the panel for Escape handled by another dialog or during composition", () => {

--- a/ui/src/components/features/execution/__tests__/ExecutionPageContent.test.tsx
+++ b/ui/src/components/features/execution/__tests__/ExecutionPageContent.test.tsx
@@ -30,6 +30,13 @@ vi.mock("@/client/execution/execution", () => ({
             elapsed_time: "1m",
             username: "tester",
           },
+          {
+            execution_id: "exec-2",
+            name: "Completed Execution",
+            status: "completed",
+            start_at: "2026-06-01T00:00:00Z",
+            username: "tester",
+          },
         ],
       },
     },
@@ -177,6 +184,68 @@ describe("ExecutionPageContent cancel confirmation", () => {
 
     fireEvent.keyDown(document, { key: "Escape" });
     expect(panel.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("browses adjacent executions without closing the panel and resets its scroll", () => {
+    render(<ExecutionPageContent />);
+    fireEvent.click(screen.getByText("Running Execution"));
+    const panel = screen.getByRole("complementary", { name: "Execution details" });
+    const previous = within(panel).getByRole("button", {
+      name: "Previous execution",
+    }) as HTMLButtonElement;
+    const next = within(panel).getByRole("button", { name: "Next execution" }) as HTMLButtonElement;
+    expect(previous.disabled).toBe(true);
+    expect(next.disabled).toBe(false);
+    expect(within(panel).getByText("1 of 2 on this page")).toBeTruthy();
+
+    panel.scrollTop = 300;
+    fireEvent.click(next);
+    expect(panel.scrollTop).toBe(0);
+    expect(within(panel).getByRole("heading", { name: "Completed Execution" })).toBeTruthy();
+    expect(within(panel).getByRole("link", { name: "View Details" }).getAttribute("href")).toBe(
+      "/execution/chip-1/exec-2",
+    );
+    expect(within(panel).getByText("2 of 2 on this page")).toBeTruthy();
+    expect(next.disabled).toBe(true);
+    expect(previous.disabled).toBe(false);
+    expect(within(panel).queryByRole("button", { name: "Cancel" })).toBeNull();
+
+    fireEvent.click(previous);
+    expect(within(panel).getByRole("heading", { name: "Running Execution" })).toBeTruthy();
+  });
+
+  it("moves focus into the panel and returns it to the last viewed execution on close", () => {
+    render(<ExecutionPageContent />);
+    const firstCard = screen.getByRole("button", {
+      name: "View Running Execution execution details",
+    });
+    firstCard.focus();
+    fireEvent.keyDown(firstCard, { key: "Enter" });
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Close execution details" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Next execution" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    const lastCard = screen.getByRole("button", {
+      name: "View Completed Execution execution details",
+    });
+    expect(document.activeElement).toBe(lastCard);
+    expect(lastCard.getAttribute("aria-expanded")).toBe("false");
+    expect(document.getElementById("execution-details-panel")?.hasAttribute("inert")).toBe(true);
+  });
+
+  it("does not close the panel for Escape handled by another dialog or during composition", () => {
+    render(<ExecutionPageContent />);
+    fireEvent.click(screen.getByText("Running Execution"));
+    const panel = screen.getByRole("complementary", { name: "Execution details" });
+    fireEvent.keyDown(document, { key: "Escape", isComposing: true });
+    expect(panel.getAttribute("aria-hidden")).toBe("false");
+    const dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    document.body.appendChild(dialog);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(panel.getAttribute("aria-hidden")).toBe("false");
+    dialog.remove();
   });
 
   it("cancels the execution with its flow_run_id after confirming in the dialog", () => {

--- a/ui/src/components/layout/GlobalCommandPalette.tsx
+++ b/ui/src/components/layout/GlobalCommandPalette.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Braces, Gauge, Search } from "lucide-react";
-import { usePathname, useRouter } from "next/navigation";
+import { Braces, Check, FolderKanban, Gauge, Link, Palette, Search } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { useGetTaskFileSettings, useListTaskInfo } from "@/client/task-file/task-file";
@@ -18,12 +18,19 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import { useProject } from "@/contexts/ProjectContext";
 import { useMetricsConfig } from "@/hooks/useMetricsConfig";
+import { useTheme } from "@/contexts/ThemeContext";
+import { AVAILABLE_THEMES } from "@/constants/themes";
+import { useToast } from "@/components/ui/Toast";
 
 export function GlobalCommandPalette() {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { user } = useAuth();
-  const { canEdit } = useProject();
+  const { canEdit, projects, projectId, switchProject } = useProject();
+  const { theme, setTheme } = useTheme();
+  const toast = useToast();
+  const [shortcut, setShortcut] = useState("Ctrl K");
   const [open, setOpen] = useState(false);
   const isDashboard = pathname === "/dashboard";
   const isMetrics = pathname === "/metrics";
@@ -34,8 +41,7 @@ export function GlobalCommandPalette() {
     query: { enabled: isTasks, staleTime: 60_000 },
   });
   const defaultTaskBackend = taskFileSettings?.data?.default_backend ?? "";
-  const [activeTaskBackend, setActiveTaskBackend] = useState("");
-  const taskBackend = activeTaskBackend || defaultTaskBackend;
+  const taskBackend = searchParams.get("backend") || defaultTaskBackend;
   const { data: taskInfoData } = useListTaskInfo(
     { backend: taskBackend || "__none__" },
     { query: { enabled: isTasks && !!taskBackend, staleTime: 60_000 } },
@@ -47,8 +53,16 @@ export function GlobalCommandPalette() {
   });
 
   useEffect(() => {
+    setShortcut(/Mac|iPhone|iPad/.test(navigator.platform) ? "⌘K" : "Ctrl K");
     const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        event.key.toLowerCase() === "k" &&
+        !event.isComposing &&
+        !event.repeat &&
+        !event.altKey &&
+        !event.defaultPrevented
+      ) {
         event.preventDefault();
         setOpen((current) => !current);
       }
@@ -58,18 +72,19 @@ export function GlobalCommandPalette() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  useEffect(() => {
-    const handleBackendChange = (event: Event) => {
-      const detail = (event as CustomEvent<{ backend?: string }>).detail;
-      if (detail?.backend) setActiveTaskBackend(detail.backend);
-    };
-    window.addEventListener("qdash:task-backend-change", handleBackendChange);
-    return () => window.removeEventListener("qdash:task-backend-change", handleBackendChange);
-  }, []);
-
   const navigate = (href: string) => {
     setOpen(false);
     router.push(href);
+  };
+
+  const copyPageLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setOpen(false);
+      toast.success("Page link copied");
+    } catch {
+      toast.error("Could not copy the link. Please copy it from the address bar.");
+    }
   };
 
   const jumpToMetric = (metricId: string) => {
@@ -97,11 +112,14 @@ export function GlobalCommandPalette() {
     jumpToMetric(`dashboard-${metricType}-metric-${metricKey}`);
   };
 
-  const selectTask = (filePath: string) => {
-    setOpen(false);
-    window.dispatchEvent(
-      new CustomEvent("qdash:open-task-source", { detail: { filePath, backend: taskBackend } }),
-    );
+  const selectTask = (taskName: string) => {
+    const params = new URLSearchParams(window.location.search);
+    params.set("backend", taskBackend);
+    params.set("task", taskName);
+    params.delete("execution");
+    params.delete("executionChip");
+    params.delete("executionTarget");
+    navigate(`/tasks?${params.toString()}`);
   };
 
   return (
@@ -113,38 +131,38 @@ export function GlobalCommandPalette() {
         aria-label="Open navigation search"
       >
         <Search size={15} aria-hidden="true" />
-        <span className="hidden sm:inline">Navigate</span>
+        <span className="hidden sm:inline">Commands</span>
         <kbd className="hidden rounded border border-base-300 bg-base-200 px-1.5 py-0.5 text-xs font-normal md:inline">
-          ⌘K
+          {shortcut}
         </kbd>
       </button>
 
       <CommandDialog
         open={open}
         onOpenChange={setOpen}
-        title="Navigate"
-        description="Search for a page or page-specific item to open."
+        title="Commands"
+        description="Search pages, actions, projects, and themes. Use arrow keys to choose and Enter to run."
       >
         <Command loop label="QDash navigation">
           <CommandInput
             placeholder={
               hasMetricCommands
-                ? "Search pages and metrics..."
+                ? "Search pages, metrics, and actions..."
                 : isTasks
-                  ? "Search pages and tasks..."
-                  : "Search pages..."
+                  ? "Search pages, tasks, and actions..."
+                  : "Search pages and actions..."
             }
           />
           <CommandList>
             <CommandEmpty>No matching results</CommandEmpty>
             {isTasks && taskCommands.length > 0 && (
-              <CommandGroup heading="Switch task source">
+              <CommandGroup heading="Open task">
                 {taskCommands.map((task) => (
                   <CommandItem
                     key={`${task.file_path}-${task.name}`}
-                    value={`${task.name} task source`}
+                    value={`${task.name} task`}
                     keywords={[task.task_type ?? "", task.file_path, taskBackend]}
-                    onSelect={() => selectTask(task.file_path)}
+                    onSelect={() => selectTask(task.name)}
                   >
                     <Braces size={15} className="shrink-0 opacity-60" aria-hidden="true" />
                     <span>{task.name}</span>
@@ -203,7 +221,71 @@ export function GlobalCommandPalette() {
                 </CommandGroup>
               );
             })}
+            <CommandGroup heading="Actions">
+              <CommandItem
+                value="Copy current page link"
+                keywords={["url", "share", "clipboard", "リンク", "コピー", "共有"]}
+                onSelect={() => {
+                  void copyPageLink();
+                }}
+              >
+                <Link size={15} className="shrink-0 opacity-60" aria-hidden="true" />
+                <span>Copy current page link</span>
+              </CommandItem>
+            </CommandGroup>
+            {projects.length > 1 && (
+              <CommandGroup heading="Switch project">
+                {projects.map((project) => (
+                  <CommandItem
+                    key={project.project_id}
+                    value={`project ${project.project_id}`}
+                    keywords={[project.name, "switch", "プロジェクト", "切り替え"]}
+                    disabled={project.project_id === projectId}
+                    onSelect={() => {
+                      switchProject(project.project_id);
+                      setOpen(false);
+                    }}
+                  >
+                    <FolderKanban size={15} className="shrink-0 opacity-60" aria-hidden="true" />
+                    <span>{project.name}</span>
+                    {project.project_id === projectId && (
+                      <span className="ml-auto text-xs">Current</span>
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            <CommandGroup heading="Change theme">
+              {AVAILABLE_THEMES.map((name) => (
+                <CommandItem
+                  key={name}
+                  value={`Use ${name} theme`}
+                  keywords={["appearance", "color", "テーマ", "外観"]}
+                  onSelect={() => {
+                    setTheme(name);
+                    setOpen(false);
+                  }}
+                >
+                  <Palette size={15} className="shrink-0 opacity-60" aria-hidden="true" />
+                  <span>Use {name} theme</span>
+                  {theme === name && (
+                    <Check size={15} className="ml-auto" aria-label="Current theme" />
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
           </CommandList>
+          <div className="flex gap-4 border-t border-base-300 px-3 py-2 text-xs text-base-content/60">
+            <span>
+              <kbd>↑ ↓</kbd> Navigate
+            </span>
+            <span>
+              <kbd>Enter</kbd> Run
+            </span>
+            <span>
+              <kbd>Esc</kbd> Close
+            </span>
+          </div>
         </Command>
       </CommandDialog>
     </>

--- a/ui/src/components/layout/Navbar/index.tsx
+++ b/ui/src/components/layout/Navbar/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronDown, Folder, FolderLock } from "lucide-react";
+import { Suspense } from "react";
 
 import {
   DropdownMenu,
@@ -105,7 +106,9 @@ export function Navbar() {
         <HiddenIcon />
         <ProjectSelector />
         <EnvironmentBadge className="badge-sm sm:badge-md" />
-        <GlobalCommandPalette />
+        <Suspense fallback={null}>
+          <GlobalCommandPalette />
+        </Suspense>
         <div className="ml-auto">
           <GlobalExecutionIndicator />
         </div>

--- a/ui/src/components/layout/__tests__/GlobalCommandPalette.test.tsx
+++ b/ui/src/components/layout/__tests__/GlobalCommandPalette.test.tsx
@@ -4,11 +4,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GlobalCommandPalette } from "@/components/layout/GlobalCommandPalette";
 
 const push = vi.fn();
+const switchProject = vi.fn();
+const setTheme = vi.fn();
+const success = vi.fn();
+const error = vi.fn();
+const taskInfoRequests = vi.fn();
 const mockPathname = vi.hoisted(() => vi.fn(() => "/inbox"));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
   usePathname: () => mockPathname(),
+  useSearchParams: () => new URLSearchParams(window.location.search),
 }));
 
 vi.mock("@/hooks/useMetricsConfig", () => ({
@@ -20,19 +26,22 @@ vi.mock("@/hooks/useMetricsConfig", () => ({
 
 vi.mock("@/client/task-file/task-file", () => ({
   useGetTaskFileSettings: () => ({ data: { data: { default_backend: "qubex" } } }),
-  useListTaskInfo: () => ({
-    data: {
+  useListTaskInfo: (params: { backend: string }) => {
+    taskInfoRequests(params);
+    return {
       data: {
-        tasks: [
-          {
-            name: "CheckRabi",
-            task_type: "qubit",
-            file_path: "one_qubit/check_rabi.py",
-          },
-        ],
+        data: {
+          tasks: [
+            {
+              name: "CheckRabi",
+              task_type: "qubit",
+              file_path: "one_qubit/check_rabi.py",
+            },
+          ],
+        },
       },
-    },
-  }),
+    };
+  },
 }));
 
 vi.mock("@/contexts/AuthContext", () => ({
@@ -40,14 +49,99 @@ vi.mock("@/contexts/AuthContext", () => ({
 }));
 
 vi.mock("@/contexts/ProjectContext", () => ({
-  useProject: () => ({ canEdit: false }),
+  useProject: () => ({
+    canEdit: false,
+    projectId: "project-1",
+    projects: [
+      { project_id: "project-1", name: "Current lab" },
+      { project_id: "project-2", name: "Calibration lab" },
+    ],
+    switchProject,
+  }),
 }));
+
+vi.mock("@/contexts/ThemeContext", () => ({
+  useTheme: () => ({ theme: "light", setTheme }),
+}));
+
+vi.mock("@/components/ui/Toast", () => ({
+  useToast: () => ({ success, error }),
+}));
+
+function mockClipboard(writeText: ReturnType<typeof vi.fn>) {
+  vi.stubGlobal(
+    "navigator",
+    new Proxy(navigator, {
+      get(target, property) {
+        if (property === "clipboard") return { writeText };
+        return Reflect.get(target, property, target);
+      },
+    }),
+  );
+}
 
 describe("GlobalCommandPalette", () => {
   afterEach(() => {
     cleanup();
     push.mockReset();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
     mockPathname.mockReturnValue("/inbox");
+    window.history.replaceState({}, "", "/inbox");
+  });
+
+  it("finds a project by name and switches using Enter", async () => {
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "Calibration lab" } });
+    await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(1));
+    fireEvent.keyDown(input, { key: "Enter", keyCode: 13 });
+    expect(switchProject).toHaveBeenCalledWith("project-2");
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("marks the current project unavailable and changes theme through the existing provider", () => {
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(
+      screen.getByText("Current lab").closest("[cmdk-item]")?.getAttribute("aria-disabled"),
+    ).toBe("true");
+    fireEvent.click(screen.getByRole("option", { name: "Use dark theme" }));
+    expect(setTheme).toHaveBeenCalledWith("dark");
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("copies the full page link including filters and confirms completion", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    mockClipboard(writeText);
+    window.history.replaceState({}, "", "/metrics?project=project-1&chip=chip-1#results");
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.click(screen.getByRole("option", { name: "Copy current page link" }));
+    await waitFor(() => expect(success).toHaveBeenCalledWith("Page link copied"));
+    expect(writeText).toHaveBeenCalledWith(window.location.href);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("keeps the palette open and reports a clipboard failure", async () => {
+    mockClipboard(vi.fn().mockRejectedValue(new Error("Permission denied")));
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.click(screen.getByRole("option", { name: "Copy current page link" }));
+    await waitFor(() => expect(error).toHaveBeenCalledOnce());
+    expect(success).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("ignores shortcut repeats and IME composition", () => {
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true, isComposing: true });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true, repeat: true });
+    expect(screen.getByRole("dialog")).toBeTruthy();
   });
 
   it("opens with the platform shortcut and navigates to a selected page", () => {
@@ -106,21 +200,41 @@ describe("GlobalCommandPalette", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("opens task source commands on the tasks page", () => {
+  it("opens the selected task workbench using the configured default backend", () => {
     mockPathname.mockReturnValue("/tasks");
-    const onOpenTask = vi.fn();
-    window.addEventListener("qdash:open-task-source", onOpenTask);
+    window.history.replaceState({}, "", "/tasks");
 
     render(<GlobalCommandPalette />);
     fireEvent.keyDown(window, { key: "k", metaKey: true });
     fireEvent.click(screen.getByRole("option", { name: /CheckRabi.*qubit/i }));
 
-    expect(onOpenTask).toHaveBeenCalledTimes(1);
-    expect((onOpenTask.mock.calls[0][0] as CustomEvent).detail).toEqual({
-      filePath: "one_qubit/check_rabi.py",
-      backend: "qubex",
-    });
+    expect(push).toHaveBeenCalledWith("/tasks?backend=qubex&task=CheckRabi");
     expect(screen.queryByRole("dialog")).toBeNull();
-    window.removeEventListener("qdash:open-task-source", onOpenTask);
+  });
+
+  it("uses the active URL backend and preserves project and chip while clearing old execution state", () => {
+    mockPathname.mockReturnValue("/tasks");
+    window.history.replaceState(
+      {},
+      "",
+      "/tasks?project=project-1&chip=chip-1&backend=custom&task=CheckT1&execution=old-run&executionChip=old-chip&executionTarget=0",
+    );
+    render(<GlobalCommandPalette />);
+    expect(taskInfoRequests).toHaveBeenLastCalledWith({ backend: "custom" });
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.click(screen.getByRole("option", { name: /CheckRabi.*qubit/i }));
+    expect(push).toHaveBeenCalledWith(
+      "/tasks?project=project-1&chip=chip-1&backend=custom&task=CheckRabi",
+    );
+  });
+
+  it("updates task commands when the backend in the URL changes", () => {
+    mockPathname.mockReturnValue("/tasks");
+    window.history.replaceState({}, "", "/tasks?backend=first");
+    const { rerender } = render(<GlobalCommandPalette />);
+    expect(taskInfoRequests).toHaveBeenLastCalledWith({ backend: "first" });
+    window.history.replaceState({}, "", "/tasks?backend=second");
+    rerender(<GlobalCommandPalette />);
+    expect(taskInfoRequests).toHaveBeenLastCalledWith({ backend: "second" });
   });
 });

--- a/ui/src/components/ui/SearchInput.tsx
+++ b/ui/src/components/ui/SearchInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Search, X } from "lucide-react";
+import { useEffect, useRef } from "react";
 
 interface SearchInputProps {
   /** Current input value */
@@ -34,22 +35,79 @@ export function SearchInput({
   placeholder,
   className = "w-full max-w-sm",
 }: SearchInputProps) {
-  const handleClear = onClear ?? (() => onChange(""));
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleClear = () => {
+    if (onClear) onClear();
+    else onChange("");
+    inputRef.current?.focus();
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key !== "/" ||
+        event.defaultPrevented ||
+        event.isComposing ||
+        event.repeat ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.altKey
+      )
+        return;
+
+      const activeElement = document.activeElement;
+      if (
+        activeElement?.closest(
+          'input, textarea, select, [contenteditable]:not([contenteditable="false"]), [role="textbox"], [role="combobox"], [role="menu"]',
+        ) ||
+        document.querySelector('[role="dialog"], [role="alertdialog"], dialog[open]')
+      )
+        return;
+
+      const input = inputRef.current;
+      if (!input || input.getClientRects().length === 0) return;
+      event.preventDefault();
+      input.focus();
+      input.select();
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   return (
     <label className={`input input-bordered input-sm flex items-center gap-2 ${className}`}>
       <Search className="h-4 w-4 shrink-0 text-base-content/40" />
       <input
+        ref={inputRef}
         type="text"
+        aria-label={placeholder || "Search"}
+        aria-keyshortcuts="/"
         className="grow"
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && !event.nativeEvent.isComposing && value) {
+            event.preventDefault();
+            event.stopPropagation();
+            handleClear();
+          }
+        }}
       />
+      <kbd
+        className="hidden rounded border border-base-300 px-1 text-xs text-base-content/60 sm:inline"
+        title="Press / to focus search; Esc to clear"
+        aria-hidden="true"
+      >
+        /
+      </kbd>
       {value && (
         <button
           type="button"
           onClick={handleClear}
+          aria-label="Clear search"
+          title="Clear search (Esc)"
           className="btn btn-ghost btn-xs p-0 h-auto min-h-0 shrink-0"
         >
           <X className="h-3 w-3" />

--- a/ui/src/components/ui/__tests__/SearchInput.test.tsx
+++ b/ui/src/components/ui/__tests__/SearchInput.test.tsx
@@ -79,6 +79,22 @@ describe("SearchInput", () => {
     },
   );
 
+  it.each(["combobox", "menu"])("does not steal focus from a %s", (role) => {
+    render(
+      <>
+        <SearchInput value="" onChange={vi.fn()} />
+        <div role={role} tabIndex={0}>
+          Editor
+        </div>
+      </>,
+    );
+    makeVisible(screen.getByRole("textbox"));
+    const editor = screen.getByRole(role);
+    editor.focus();
+    fireEvent.keyDown(editor, { key: "/" });
+    expect(editor).toHaveFocus();
+  });
+
   it("ignores shortcuts while a dialog is open", () => {
     render(
       <>

--- a/ui/src/components/ui/__tests__/SearchInput.test.tsx
+++ b/ui/src/components/ui/__tests__/SearchInput.test.tsx
@@ -1,0 +1,118 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SearchInput } from "@/components/ui/SearchInput";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+function makeVisible(input: HTMLElement) {
+  vi.spyOn(input, "getClientRects").mockReturnValue(
+    Object.assign([new DOMRect()], { item: () => new DOMRect() }),
+  );
+}
+
+describe("SearchInput", () => {
+  it("focuses and selects the query with / without typing a slash", () => {
+    const onChange = vi.fn();
+    render(<SearchInput value="rabi" onChange={onChange} />);
+    const input = screen.getByRole("textbox", { name: "Search" }) as HTMLInputElement;
+    makeVisible(input);
+    expect(fireEvent.keyDown(window, { key: "/" })).toBe(false);
+    expect(input).toHaveFocus();
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(4);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("clears with Escape, keeps focus and lets empty-search Escape propagate", () => {
+    const onChange = vi.fn();
+    const onKeyDown = vi.fn();
+    const { rerender } = render(
+      <div onKeyDown={onKeyDown}>
+        <SearchInput value="rabi" onChange={onChange} />
+      </div>,
+    );
+    const input = screen.getByRole("textbox");
+    fireEvent.keyDown(input, { key: "Escape", isComposing: true });
+    expect(onChange).not.toHaveBeenCalled();
+    onKeyDown.mockClear();
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onChange).toHaveBeenCalledWith("");
+    expect(input).toHaveFocus();
+    expect(onKeyDown).not.toHaveBeenCalled();
+    rerender(
+      <div onKeyDown={onKeyDown}>
+        <SearchInput value="" onChange={onChange} />
+      </div>,
+    );
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onKeyDown).toHaveBeenCalledOnce();
+  });
+
+  it("uses the custom clear handler and returns focus after clicking clear", () => {
+    const onClear = vi.fn();
+    const onChange = vi.fn();
+    render(<SearchInput value="rabi" onChange={onChange} onClear={onClear} />);
+    const button = screen.getByRole("button", { name: "Clear search" });
+    button.focus();
+    fireEvent.click(button);
+    expect(onClear).toHaveBeenCalledOnce();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("textbox")).toHaveFocus();
+  });
+
+  it.each(["input", "textarea", "select", "contenteditable"])(
+    "does not interrupt typing in %s",
+    (tag) => {
+      render(<SearchInput value="" onChange={vi.fn()} />);
+      makeVisible(screen.getByRole("textbox"));
+      const editor = document.createElement(tag === "contenteditable" ? "div" : tag);
+      if (tag === "contenteditable") editor.setAttribute("contenteditable", "true");
+      editor.tabIndex = 0;
+      document.body.appendChild(editor);
+      editor.focus();
+      fireEvent.keyDown(editor, { key: "/" });
+      expect(editor).toHaveFocus();
+      editor.remove();
+    },
+  );
+
+  it("ignores shortcuts while a dialog is open", () => {
+    render(
+      <>
+        <SearchInput value="" onChange={vi.fn()} />
+        <div role="dialog" />
+      </>,
+    );
+    const input = screen.getByRole("textbox");
+    makeVisible(input);
+    fireEvent.keyDown(window, { key: "/" });
+    expect(input).not.toHaveFocus();
+  });
+
+  it("ignores modifiers, composition and repeated key presses", () => {
+    render(<SearchInput value="" onChange={vi.fn()} />);
+    const input = screen.getByRole("textbox");
+    makeVisible(input);
+    for (const modifier of ["ctrlKey", "metaKey", "altKey", "isComposing", "repeat"]) {
+      fireEvent.keyDown(window, { key: "/", [modifier]: true });
+      expect(input).not.toHaveFocus();
+    }
+  });
+
+  it("skips hidden fields and focuses only the first visible search", () => {
+    render(
+      <>
+        <SearchInput value="" onChange={vi.fn()} placeholder="Hidden" />
+        <SearchInput value="" onChange={vi.fn()} placeholder="First" />
+        <SearchInput value="" onChange={vi.fn()} placeholder="Second" />
+      </>,
+    );
+    makeVisible(screen.getByRole("textbox", { name: "First" }));
+    makeVisible(screen.getByRole("textbox", { name: "Second" }));
+    fireEvent.keyDown(window, { key: "/" });
+    expect(screen.getByRole("textbox", { name: "First" })).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Make repeated navigation and result inspection faster through the command palette, keyboard search, and execution details panel.
- UI-only changes; no API, workflow, schema, or configuration changes.

## Changes

- `GlobalCommandPalette`: switch projects, copy the current page link with success/error feedback, and change themes. Show platform-specific shortcuts and keyboard guidance.
- `GlobalCommandPalette`: open the selected task workbench through its URL, use the active backend, and clear previous execution parameters while retaining project and chip context.
- `Navbar`: isolate the command palette with Suspense so URL-dependent commands do not break production prerendering.
- `ExecutionPageContent`: browse previous/next executions on the current page without closing the panel, reset panel scrolling, and return focus to the last viewed execution when closing.
- `SearchInput`: focus and select the query with `/`, clear with Escape, and retain focus after clearing. Avoid interrupting text entry, IME composition, and open dialogs.
- Validation: production Turbopack build passed, including all 29 static pages; TypeScript, lint, formatting, and focused command palette, search, execution, and task workbench tests passed. Pre-commit secret scanning passed. Browser interaction and Docker deployment were not rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Previous/Next navigation for execution details.
  - Improved keyboard navigation, focus restoration, loading feedback, and accessibility in the execution sidebar.
  - Expanded the command palette with page-link copying, project switching, and theme controls.
  - Added platform-aware command palette shortcuts and URL-based task navigation.
  - Added `/` to focus and select the search field, with Escape-to-clear support.

- **Bug Fixes**
  - Improved handling of keyboard shortcuts during text composition, dialogs, and repeated key presses.
  - Sidebar state now resets appropriately when filters, dates, pages, or selections change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->