### PR TITLE
feat(workflow): add coarse and fine 1Q calibration flows

### DIFF
--- a/config/app/backend.yaml
+++ b/config/app/backend.yaml
@@ -29,6 +29,7 @@ backends:
       One Qubit:
         - CheckChevron
         - CheckOptimalReadoutAmplitude
+        - CheckOptimalReadoutFrequency
         - RabiOscillation
         - CheckRabi
         - CheckCoarseReadoutParams

--- a/config/app/backend.yaml
+++ b/config/app/backend.yaml
@@ -2,8 +2,8 @@
 # =====================
 # This file defines available backends and their tasks.
 #
-# Tasks not listed here will NOT be shown in the UI or available
-# for workflow execution, even if the code exists in the codebase.
+# Tasks not listed here may appear in the task catalog, but cannot be run
+# from the UI or workflows, even if the code exists in the codebase.
 #
 # Use this to:
 #   - Control which tasks are exposed to users per backend
@@ -31,6 +31,7 @@ backends:
         - CheckOptimalReadoutAmplitude
         - RabiOscillation
         - CheckRabi
+        - CheckCoarseReadoutParams
         - CreateHPIPulse
         - CheckHPIPulse
         - CreatePIPulse

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -184,6 +184,7 @@ export default withMermaid(
                 { text: "Quickstart", link: "/development/workflow/quickstart" },
                 { text: "Engine Architecture", link: "/development/workflow/engine-architecture" },
                 { text: "Parameter Resolution", link: "/development/workflow/parameter-resolution" },
+                { text: "Frequency Parameter Policy", link: "/development/workflow/frequency-parameter-policy" },
                 { text: "Testing", link: "/development/workflow/testing" },
               ],
             },

--- a/docs/development/workflow/engine-architecture.md
+++ b/docs/development/workflow/engine-architecture.md
@@ -279,10 +279,15 @@ An execution record exists from the moment a run is requested, not from the mome
 | Step | Actor | Effect |
 |------|-------|--------|
 | Trigger | API (`FlowService._create_scheduled_execution`) | Creates the `execution_history` row with `status=scheduled` and `note.flow_run_id`, immediately after the Prefect flow run is created |
-| Flow start | `CalibService._initialize()` | Claims that row via `MongoExecutionRepository.claim_scheduled_execution()` and reuses its `execution_id`; `scheduled` → `running` |
-| Flow end | `finish_calibration()` / `fail_calibration()` / `cancel_calibration()` | `running` → `completed` / `failed` / `cancelled` |
+| First calibration step | `CalibService._initialize()` | Claims that row via `MongoExecutionRepository.claim_scheduled_execution()` and reuses its `execution_id`; `scheduled` → `running` |
+| Later calibration steps | `CalibService._run_pipeline()` | Creates a separate Execution for each calibration step |
+| Step end | `finish_calibration()` / `fail_calibration()` / `cancel_calibration()` | The current step becomes `completed`, `failed`, or `cancelled`; earlier completed steps retain their status |
 
-The claim is a single atomic `find_one_and_update` guarded by `note.claimed_at`, so only the first eligible session of a flow run adopts the row. A wrapper with `skip_execution=True` and `use_lock=True` also claims the API-created row: it uses the same execution ID to acquire its reserved lock and sets `skip_execution=False` to own the row's start and terminal states. Without a pre-created row, the wrapper keeps skipping execution creation. Isolated workers with `skip_execution=True` and `use_lock=False` never claim or finalize the parent's row. Subsequent strategy sessions allocate their own execution IDs.
+`CalibService.run(targets, steps=...)` owns the Execution lifecycle. Each calibration step gets one Execution, and its tasks, scheduling rounds, and isolated workers share that ID. Transform steps, such as filters and schedule generation, do not create Executions. No additional parent Execution is created. For example, `coarse_one` creates one Execution for `OneQubitCheck`, while the `one_qubit` template creates separate Executions for `OneQubitCheck` and `OneQubitFineTune`.
+
+The first calibration step adopts the API reservation through an atomic `find_one_and_update` guarded by `note.claimed_at`. Later calibration steps allocate their own IDs. Each step records `step_name`, its position in the pipeline as `step_index`, and `pipeline_name` in its note; `flow_run_id` associates all steps with the same Prefect run.
+
+Templates do not configure `skip_execution`. Saved templates that still pass `skip_execution=True` are supported: `run()` automatically enables Execution persistence for calibration steps. The flag remains an internal option for isolated workers, which borrow their step's Execution without claiming, creating, or finalizing another row. Strategies execute within the session supplied by the pipeline and do not call `init_calibration()` or `finish_calibration()` themselves.
 
 Runs that do not go through the API — cron schedules, where the Prefect scheduler creates the flow run directly — have no pre-created row, so `CalibService` allocates the `execution_id` itself as before.
 
@@ -294,7 +299,7 @@ Calibrations are mutually exclusive per project, guarded by `ExecutionLockDocume
 
 Runs that do not go through the API, such as cron schedules, find the lock free and take it in `CalibService` as before. The claim is also skipped when no `chip_id` can be resolved, since there is then no `execution_id` to own the lock; those runs fall back to the same path.
 
-Claiming at dispatch means the API takes the lock and the flow releases it, so dispatch failures in between have to release it themselves: `FlowService` does that when the flow run cannot be created, and when the `scheduled` row cannot be saved. Everything after that point is covered by the finalizer, which releases a lock owned by the execution it closes. The one case with no owner left to act is a run that dies before its flow process starts; `ExecutionService.get_lock_status()` reconciles a still `scheduled` execution against Prefect for exactly that reason, on the poll the UI already makes.
+Claiming at dispatch means the API takes the lock and the flow releases it, so dispatch failures in between have to release it themselves: `FlowService` does that when the flow run cannot be created, and when the `scheduled` row cannot be saved. The lock remains owned by the first step throughout the pipeline, including between steps, and is released only when the pipeline exits. Terminal flow hooks also release a lock owned by an already completed step from the same flow, so a crash during a later step or a transform does not strand the lock. The one case with no owner left to act is a run that dies before its flow process starts; `ExecutionService.get_lock_status()` reconciles a still `scheduled` execution against Prefect for exactly that reason, on the poll the UI already makes.
 
 ### Reconciliation with Prefect
 
@@ -339,7 +344,7 @@ The hook:
 3. Finds the execution by `note.flow_run_id` in `execution_history`
 4. Updates all non-terminal tasks (running/scheduled/pending) to `cancelled`
 5. Sets the execution status to `cancelled`
-6. Releases the execution lock, but only when it is unowned or owned by the execution being closed
+6. Releases the execution lock when it is owned by an Execution from this flow, including a completed earlier step; legacy unowned locks are released when an open Execution is closed
 
 ### flow_run_id Bridge
 

--- a/docs/development/workflow/engine-architecture.md
+++ b/docs/development/workflow/engine-architecture.md
@@ -282,7 +282,7 @@ An execution record exists from the moment a run is requested, not from the mome
 | Flow start | `CalibService._initialize()` | Claims that row via `MongoExecutionRepository.claim_scheduled_execution()` and reuses its `execution_id`; `scheduled` → `running` |
 | Flow end | `finish_calibration()` / `fail_calibration()` / `cancel_calibration()` | `running` → `completed` / `failed` / `cancelled` |
 
-The claim is a single atomic `find_one_and_update` guarded by `note.claimed_at`, so only the first session of a flow run adopts the row. Sessions with `skip_execution=True` never claim, because they do not persist an execution document. A flow that creates several executions (one per strategy invocation) adopts the pre-created row for the first one and allocates new IDs for the rest.
+The claim is a single atomic `find_one_and_update` guarded by `note.claimed_at`, so only the first eligible session of a flow run adopts the row. A wrapper with `skip_execution=True` and `use_lock=True` also claims the API-created row: it uses the same execution ID to acquire its reserved lock and sets `skip_execution=False` to own the row's start and terminal states. Without a pre-created row, the wrapper keeps skipping execution creation. Isolated workers with `skip_execution=True` and `use_lock=False` never claim or finalize the parent's row. Subsequent strategy sessions allocate their own execution IDs.
 
 Runs that do not go through the API — cron schedules, where the Prefect scheduler creates the flow run directly — have no pre-created row, so `CalibService` allocates the `execution_id` itself as before.
 

--- a/docs/development/workflow/frequency-parameter-policy.md
+++ b/docs/development/workflow/frequency-parameter-policy.md
@@ -1,0 +1,208 @@
+# Frequency Parameter Policy
+
+QDash frequency parameters distinguish exploration results, calibrated frequencies, and the drive frequencies used for an execution.
+
+This is the agreed design policy for parameter updates, Qubex YAML export, and execution UX. It is not a description of fully implemented behavior; the implementation gaps are recorded below. Input resolution and snapshot semantics follow [Parameter Resolution](./parameter-resolution.md).
+
+## Parameter roles
+
+| Parameter | Meaning | Independent persistent QDash parameter |
+| --- | --- | --- |
+| `coarse_qubit_frequency` | Exploration estimate used to start or repeat qubit calibration | Yes |
+| `qubit_frequency` | Calibrated qubit frequency obtained from Chevron or Ramsey | Yes |
+| `control_frequency` | Default control drive frequency resolved from `qubit_frequency` | No |
+| `resonator_frequency` | Resonator frequency estimated by an experiment | Yes |
+| `optimal_readout_frequency` | Frequency selected by readout optimization | Yes |
+| `readout_frequency` | Default readout drive frequency resolved from the readout parameters | No |
+
+The persistent values are the accepted results used by subsequent tasks. Task history retains measurements regardless of whether they are accepted. A newer history record does not necessarily replace a persistent value.
+
+`coarse_qubit_frequency` is an exploration input, not simply a less precise alias for `qubit_frequency`. Keeping the values separate allows spectroscopy to be repeated without replacing a working calibration. They may differ normally. Chevron and Ramsey do not copy their results back into the exploration parameter.
+
+`resonator_frequency` and `optimal_readout_frequency` describe different measurement objectives. Readout optimization does not replace the measured resonator frequency.
+
+## Task update targets
+
+Task update targets are fixed and have the same meaning in standalone runs and workflows. Publication requires both enabled output persistence and successful validation.
+
+| Experiment | Frequency output to publish | Effect |
+| --- | --- | --- |
+| Qubit Spectroscopy, including 2D and 1D frequency estimation | `coarse_qubit_frequency` | Update the exploration estimate |
+| CheckControlAmplitude, when its frequency fit succeeds | `coarse_qubit_frequency` | Refine the exploration estimate |
+| Chevron | `qubit_frequency` | Update the calibrated qubit frequency |
+| Ramsey | `qubit_frequency` | Update the calibrated qubit frequency |
+| Resonator Spectroscopy | `resonator_frequency` | Update the measured resonator frequency |
+| CKP, for its resonator-frequency estimate | `resonator_frequency` | Update the measured resonator frequency |
+| Optimal Readout Frequency | `optimal_readout_frequency` | Update the readout optimization result |
+
+The spectroscopy rows describe measurement methods, not a requirement to introduce a task class for each method. The CKP mapping assumes that the relevant output estimates the resonator frequency; its concrete task and output contract require verification before implementation.
+
+`CheckCoarseReadoutParams` extracts a result named `optimal_readout_frequency`, selected by maximizing the Rabi IQ response range across readout frequencies and amplitudes. This objective is different from directly optimizing readout fidelity. If this output is treated as readout optimization, its destination is `optimal_readout_frequency`, and the UI must disclose replacement of a value from another optimization task. Confirm that this shared destination is appropriate before changing its output name.
+
+Update targets are specified per output, not by classifying the entire task as exploration or calibration. Amplitude and other outputs retain their own declared destinations. In particular, Resonator Spectroscopy also produces `readout_amplitude`; maintaining the readout frequency does not imply that every readout setting remains unchanged.
+
+### Replacement within the same parameter
+
+There is no automatic ranking of task names or calibration stages. With publication enabled, a validated Chevron result can replace a Ramsey result in `qubit_frequency`. Likewise, a validated Resonator Spectroscopy result can replace a CKP result in `resonator_frequency` when that mapping is confirmed.
+
+The execution UI explains the current source and the replacement before the run. Operators can choose measurement-only execution. This policy protects calibrated qubit frequencies from exploration updates; it does not guarantee that every accepted recalibration improves precision or device performance.
+
+## Runtime frequency resolution
+
+For an ordinary execution without explicit overrides, resolve the default drive frequencies as follows:
+
+```text
+control_frequency = qubit_frequency
+
+readout_frequency = optimal_readout_frequency, if set
+                    otherwise resonator_frequency
+```
+
+“Set” means a usable, accepted value, not truthiness of a number. Invalid values fail validation rather than silently selecting a fallback. If a required frequency cannot be resolved, fail with the missing parameter identified.
+
+Do not automatically copy or fall back from `coarse_qubit_frequency` into `qubit_frequency` or the default control drive frequency. Exploration and Chevron tasks explicitly consume the exploration value where required. Experiments investigating the resonator explicitly consume `resonator_frequency` for their measurement needs; this is separate from resolving a default readout drive frequency.
+
+Permitted per-execution overrides remain explicit inputs. An arbitrary drive override does not become a measured qubit or resonator frequency. Record the actual resolved drive frequencies, their sources, and overrides in execution history even though the drive frequencies are not independent persistent calibration parameters.
+
+Snapshot re-execution uses the recorded effective inputs and permitted overrides, not current database values or current YAML defaults. Preserve enough source information in the snapshot to reproduce the frequency selection.
+
+## Bringup and repeated measurements
+
+Bringup uses the normal task destinations rather than a separate calibration-stage reset or an all-workflow publication checkpoint:
+
+1. Qubit Spectroscopy updates `coarse_qubit_frequency` after validation.
+2. CheckControlAmplitude consumes and refines the exploration parameters.
+3. Chevron consumes the exploration parameters and publishes `qubit_frequency` after validation.
+4. Subsequent calibration tasks consume the updated calibrated values.
+
+Validated outputs are published as the workflow progresses when persistence is enabled. A failure in a later task does not roll back earlier accepted outputs. Report the outputs already updated and the tasks that did not complete. Failed outputs must not become the normal inputs of downstream tasks.
+
+An initial bringup can reach Chevron without an existing `qubit_frequency`, using its explicit exploration inputs. Repeating only Qubit Spectroscopy on a calibrated device updates the exploration value while retaining the calibrated value. Repeating bringup can replace the calibrated value when Chevron succeeds; the start screen identifies bringup as a recalibration operation.
+
+### Readout transitions
+
+| Operation with publication enabled and validation passed | `resonator_frequency` | `optimal_readout_frequency` | Resolved `readout_frequency` |
+| --- | --- | --- | --- |
+| First Resonator Spectroscopy | Update | Unset | New resonator frequency |
+| Readout frequency optimization | Retain | Update | New optimized frequency |
+| Repeat Resonator Spectroscopy after optimization | Update | Retain | Retained optimized frequency |
+| Explicitly clear the accepted optimization value | Retain | Unset | Current resonator frequency |
+
+Remeasuring the resonator does not automatically erase readout optimization. Changes to cooldown or readout conditions can require optimization to be repeated. Provide an explicit action to clear the accepted optimization value and use the resonator frequency again. Retain the old measurement in history and record the clearing action.
+
+Frequency selection alone does not establish that an old optimization remains suitable after other readout settings change. Show other updated outputs, such as readout amplitude, alongside the frequency behavior. Do not claim that all readout settings are preserved when only the frequency is retained.
+
+### Coarse readout scan settings
+
+`CheckCoarseReadoutParams` declares the calibration inputs used by both the readout scan and its underlying Rabi measurements:
+
+| Input parameter | Purpose | Resolution |
+| --- | --- | --- |
+| `qubit_frequency` | Qubit drive frequency for the Rabi measurements | Required database value |
+| `control_amplitude` | Control pulse amplitude for the Rabi measurements | Required database value |
+| `readout_frequency` | Center frequency of the readout scan | Required database value |
+| `readout_amplitude` | Reference amplitude of the readout scan | Required database value |
+| `readout_duration` | Readout pulse duration, including reference measurements | Database value or the declared Qubex default |
+
+All five inputs are recorded for snapshot re-execution. Explicit input overrides define the values for that run; the scan does not independently reload them from Qubex YAML. Drive frequency and amplitude overrides are scoped to the scan and restored on success or failure. The Qubex contrib helper has no readout-duration argument, so a task-local adapter forwards the resolved duration to each underlying Rabi call without replacing methods on the shared Experiment instance.
+
+| Run parameter | Default | Meaning |
+| --- | --- | --- |
+| `detuning_range` | `(-0.015, 0.015, 13)` | Frequency offsets in GHz, as `(start, stop, number of points)` |
+| `readout_amplitude_ratio_range` | `(0.8, 1.2, 5)` | Multipliers of the reference amplitude, as `(start, stop, number of points)` |
+| `time_range` | `(0, 101, 4)` | Rabi drive durations in ns, as `(start, exclusive stop, step)` |
+| `shots` | `1024` | Shots per Rabi drive duration at each readout point |
+| `interval` | Existing Qubex default | Shot interval in ns |
+
+The default scan includes the current frequency and amplitude: 13 frequency points over ±15 MHz and 5 amplitude points over ±20%. Amplitudes are capped at 1 and duplicate points are removed, so a reference near the upper bound can produce fewer than 5 amplitude points. The reference amplitude must be finite and within `(0, 1]`; invalid references fail rather than being replaced or clipped.
+
+Normally this performs 65 Rabi traces, compared with the previous 147-point grid using ±25 MHz and amplitudes from zero to the configured value. The shot count is halved from 2048 to 1024, while the default Rabi time window and shot interval are retained. These are adjustable starting settings, not a claim of equivalent measurement quality. Operators can widen the scan, change the Rabi time window, or restore 2048 shots using run parameters.
+
+The progress plan uses the effective frequency count multiplied by the effective amplitude count, after clipping and duplicate removal. The UI shows all-sweep progress from the first Rabi trace: normally 65 sweeps, or 39 with a reference amplitude of 1 and the default ranges. The displayed count is completed sweeps out of the total; the percentage also includes progress within the active sweep. After the first sweep completes, the remaining-time estimate extrapolates the total elapsed measurement time across the planned sweeps. It includes time between sweeps and remains an estimate, since measurement speed can vary. The UI hides the inner Rabi time-point count and per-sweep ETA for this search.
+
+Older snapshots without the newly declared reference inputs cannot silently use current settings; handle missing snapshot inputs according to [Parameter Resolution](./parameter-resolution.md#effective-input-validation).
+
+### Coarse readout R² validation
+
+`CheckCoarseReadoutParams` validates the Rabi fit at the selected readout frequency and amplitude before accepting either output. In the installed Qubex revision pinned by `uv.lock`, `rabi_results` contains the scan results in amplitude-major order; each result exposes `rabi_params[qubit_label].r2`. Use this stored R² without refitting or averaging the scan.
+
+The default threshold is shared with QDash's `CheckRabi`: `0.6`. As with the existing task executor, a value must be strictly greater than the threshold to pass. Missing, non-finite, or greater-than-one R² values also fail validation. Selection metadata that cannot identify the matching scan point is a validation failure, not permission to skip the check.
+
+Do not require every scan point to pass: exploration can include low readout amplitudes and other settings with poor responses. Conversely, a good fit at an unrelated point must not authorize publishing a noisy selected point. Do not silently choose a different candidate when the selected point fails.
+
+Preserve the heatmap and available raw scan data for inspection, mark the task failed, and publish neither frequency nor amplitude on rejection. The selected R² is recorded as task quality metadata when finite. This gate is implemented in the task; it does not establish that the response maximum is the fidelity optimum or guarantee rejection of every possible noise realization.
+
+## YAML export
+
+YAML files represent accepted parameter values and the default drive configuration derived from them. They do not export every new measurement automatically.
+
+| YAML file | Exported value |
+| --- | --- |
+| `coarse_qubit_frequency.yaml` | Accepted exploration qubit frequency |
+| `qubit_frequency.yaml` | Accepted calibrated qubit frequency |
+| `control_frequency.yaml` | Accepted `qubit_frequency` |
+| `resonator_frequency.yaml` | Accepted measured resonator frequency |
+| `optimal_readout_frequency.yaml` | Accepted readout optimization result, when set |
+| `readout_frequency.yaml` | Result of the runtime readout selection rule |
+
+`coarse_qubit_frequency.yaml` and `optimal_readout_frequency.yaml` preserve and share their respective values even if Qubex does not consume them directly. Verify compatibility with the deployed Qubex parameter loader before placing additional files in its parameter directory.
+
+On accepted exploration updates, update only the exploration frequency file among the qubit frequency files. On accepted Chevron or Ramsey updates, update both `qubit_frequency.yaml` and `control_frequency.yaml`.
+
+On accepted resonator updates, update `resonator_frequency.yaml` and recompute `readout_frequency` from the full accepted state. An existing optimized frequency remains selected. On accepted optimization updates, update `optimal_readout_frequency.yaml` and the derived `readout_frequency.yaml`. Do not overwrite `resonator_frequency.yaml` with an optimized drive frequency.
+
+Clearing an optimization value must remove or unset the affected target's exported optimization value and rewrite its readout drive frequency using the resonator fallback. Do not leave a stale optimized value in either file or remove other targets' values. If the fallback cannot be resolved, report missing configuration rather than silently retaining the old drive frequency.
+
+Use one frequency selection rule for execution and YAML generation. A static mapping that copies each changed source into `readout_frequency.yaml` cannot implement the required precedence. Publication must keep the accepted database state, normal downstream inputs, and exported defaults consistent; export failures must be visible rather than reported as fully applied updates.
+
+QDash-generated defaults are managed outputs. Independent edits to `control_frequency.yaml` or `readout_frequency.yaml` are not QDash calibration inputs. For standalone Qubex experiments requiring different defaults, use separate configuration or explicit execution overrides. QDash cannot guarantee identical behavior while ignoring independent edits to shared drive-frequency files.
+
+## Execution UX
+
+### Execution intent
+
+Expose the execution purpose and update destinations in user-facing language rather than relying on an ambiguous “Update params” switch.
+
+| Action | Input baseline | Default publication behavior |
+| --- | --- | --- |
+| Measure only | Current calibration state, plus permitted overrides | History only |
+| Calibrate and apply | Current calibration state, plus permitted overrides | Publish validated outputs to declared destinations |
+| Repeat with the same conditions | Recorded snapshot, plus permitted overrides | History only |
+| Bringup | Current calibration state and outputs from preceding steps | Publish validated outputs as tasks complete |
+
+Keep measurement-only execution as the initial selection for Tasks quick runs. A new run using current settings and a snapshot re-execution must be distinguishable in navigation and labels. Publication is separate from input selection and from bypassing validation.
+
+### Before execution
+
+Show the update destinations and their current source task near the execution action. For spectroscopy that publishes exploration results, use explanatory text such as:
+
+> Updates the exploration frequency (`coarse_qubit_frequency`). The calibrated qubit frequency is retained; its current source is Chevron.
+
+For Chevron replacing a Ramsey calibration:
+
+> Updates `qubit_frequency`. The current value comes from Ramsey. A validated result will replace it with this Chevron measurement.
+
+For Resonator Spectroscopy after readout optimization:
+
+> Updates `resonator_frequency`. Readout continues to use the accepted Optimal Readout Frequency result.
+
+List other updated outputs separately. Generate the source descriptions from the selected target's actual calibration metadata. Measurement-only runs must instead state that results are recorded without applying parameter updates. Keep the measurement-only choice near the action; routine execution does not require another confirmation dialog.
+
+### After execution
+
+Display execution outcome and publication outcome separately. For each output, show the measured value, whether it was applied, the previous accepted value where applicable, and the reason when it was not applied. Show the retained operating frequency and its source when an exploration result was updated.
+
+Use explicit outcomes such as “Applied,” “History only,” and “Not applied: validation failed.” A successful measurement alone does not mean the calibration database or YAML was updated. YAML synchronization failures must remain distinguishable from measurement failures.
+
+## Implementation gaps
+
+The policy requires changes beyond adding YAML mappings. At the time this policy was added:
+
+- Qubit Spectroscopy and CheckControlAmplitude already output `coarse_qubit_frequency`; Chevron and Ramsey already output `qubit_frequency`.
+- Resonator Spectroscopy outputs its resonator estimate as `readout_frequency`. Optimal Readout Frequency and CheckCoarseReadoutParams also output `readout_frequency`, conflating the measured resonator frequency and readout optimization.
+- `config/app/workflow.yaml` maps `resonator_frequency` to `readout_frequency.yaml`. It already exports `qubit_frequency` to both qubit and control frequency files, but does not map the coarse qubit or optimal readout frequency files. The publication allowlist also needs to include the new exports.
+- Many task inputs request `readout_frequency` directly from the database. These inputs, snapshot handling, and the Qubex adapter need a shared resolution path before the independent database parameter can be retired.
+- The executor clears rejected outputs before calling `BackendSaver` for postprocess and R² validation failures. `BackendSaver` itself writes non-empty calibration outputs before its backend-success gate. Preserve the executor's rejection path when implementing this policy; setting only the backend-success flag is insufficient to protect database values.
+- `persist_output_parameters` controls output publication. In the single-task flow, `update_params` is passed as `force_update_params`, which can bypass the backend quality gate. The re-execution UI labels it “Update backend params”; this must not serve as the ordinary “Calibrate and apply” control.
+
+Existing `readout_frequency` records may originate from spectroscopy or optimization. Migration must use task provenance where available rather than copying every legacy value into both new parameters. Ambiguous records require an explicit classification or remeasurement. Preserve historical records and their original meanings, including snapshots used for re-execution.

--- a/docs/development/workflow/parameter-resolution.md
+++ b/docs/development/workflow/parameter-resolution.md
@@ -2,6 +2,8 @@
 
 The workflow engine resolves task inputs, experiment configuration, snapshots, user overrides, and output persistence at different lifecycle stages.
 
+The [Frequency Parameter Policy](./frequency-parameter-policy.md) specifies the agreed design for exploration and calibrated frequencies, derived drive frequencies, YAML export, and update UX. Its implementation gaps are tracked separately from the current lifecycle described here.
+
 ## Parameter model contracts
 
 `BaseTask` defines three symmetric declaration/runtime pairs:

--- a/src/qdash/repository/execution_finalizer.py
+++ b/src/qdash/repository/execution_finalizer.py
@@ -39,8 +39,8 @@ def finalize_executions_by_flow_run_id(
         from_statuses: Execution statuses eligible to be closed
         close_tasks: Whether to also close open TaskResultHistoryDocument rows
         release_lock: Whether to release the project's ExecutionLockDocument. Only
-            released when the lock is unowned or owned by one of the closed
-            executions.
+            released when the lock is unowned or owned by an execution from
+            this flow, including an already completed first pipeline step.
         context: Label used in log messages to identify the caller
         logger: Logger to use. Defaults to a module-level logger.
 
@@ -57,7 +57,6 @@ def finalize_executions_by_flow_run_id(
         {
             "project_id": project_id,
             "note.flow_run_id": flow_run_id,
-            "status": {"$in": list(from_statuses)},
         }
     ).run()
 
@@ -72,6 +71,8 @@ def finalize_executions_by_flow_run_id(
     closed_execution_ids: list[str] = []
 
     for execution in executions:
+        if execution.status not in from_statuses:
+            continue
         execution_id = execution.execution_id
         logger.info(
             "%s: closing execution %s as %s (flow_run_id=%s)",
@@ -132,14 +133,22 @@ def finalize_executions_by_flow_run_id(
 
         closed_execution_ids.append(execution_id)
 
-    if release_lock and closed_execution_ids:
+    lock_owner_ids = [
+        execution.execution_id
+        for execution in executions
+        if execution.execution_id in closed_execution_ids
+        or execution.status in ("completed", "failed", "cancelled")
+    ]
+    if release_lock and lock_owner_ids:
         try:
             result = (
                 ExecutionLockDocument.find(
                     {
                         "project_id": project_id,
                         "locked": True,
-                        "execution_id": {"$in": [None, *closed_execution_ids]},
+                        "execution_id": {
+                            "$in": ([None] if closed_execution_ids else []) + lock_owner_ids
+                        },
                     }
                 )
                 .update_many({"$set": {"locked": False, "execution_id": None}})

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_coarse_readout_params.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_coarse_readout_params.py
@@ -1,7 +1,10 @@
-from typing import ClassVar
+import math
+from typing import Any, ClassVar
 
+import numpy as np
+from numpy.typing import NDArray
 from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
-from qubex.measurement.measurement_defaults import DEFAULT_INTERVAL
+from qubex.measurement.measurement_defaults import DEFAULT_INTERVAL, DEFAULT_READOUT_DURATION
 
 from qdash.datamodel.task import (
     InputParameterSpec,
@@ -13,7 +16,52 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import (
+    DEFAULT_RABI_R2_THRESHOLD,
+    finite_value_error,
+    first_validation_error,
+)
 from qdash.workflow.engine.backend.qubex import QubexBackend
+from qdash.workflow.engine.progress import ProgressPlan
+
+
+class _ReadoutSweepExperiment:
+    """Forward the resolved duration through the Qubex contrib Rabi sweep."""
+
+    def __init__(self, experiment: Any, readout_duration: float) -> None:
+        self.ctx = experiment.ctx
+        self._experiment = experiment
+        self._readout_duration = readout_duration
+
+    def rabi_experiment(self, **kwargs: Any) -> Any:
+        return self._experiment.rabi_experiment(readout_duration=self._readout_duration, **kwargs)
+
+
+def _selected_rabi_r2(result: Any, label: str) -> float | None:
+    """Read the stored R² for the selected frequency/amplitude, without refitting."""
+    data = result.data
+    try:
+        frequencies = np.asarray(data["frequency_range"], dtype=float)
+        amplitudes = np.asarray(data["readout_amplitudes"], dtype=float)
+        if frequencies.ndim != 1 or amplitudes.ndim != 1:
+            return None
+        frequency_indices = np.flatnonzero(frequencies == data["optimal_readout_frequency"])
+        amplitude_indices = np.flatnonzero(amplitudes == data["optimal_readout_amplitude"])
+        if frequency_indices.size != 1 or amplitude_indices.size != 1:
+            return None
+
+        # Qubex scans amplitudes in the outer loop and frequencies in the inner loop.
+        rabi_results = data["rabi_results"]
+        if len(rabi_results) != amplitudes.size * frequencies.size:
+            return None
+        index = int(amplitude_indices[0]) * frequencies.size + int(frequency_indices[0])
+        rabi_params = rabi_results[index].rabi_params
+        if rabi_params is None:
+            return None
+        r2 = float(rabi_params[label].r2)
+    except (KeyError, IndexError, TypeError, ValueError, AttributeError):
+        return None
+    return r2 if math.isfinite(r2) else None
 
 
 class CheckCoarseReadoutParams(QubexTask):
@@ -21,13 +69,57 @@ class CheckCoarseReadoutParams(QubexTask):
 
     name: str = "CheckCoarseReadoutParams"
     task_type: str = "qubit"
-    input_spec: ClassVar[dict[str, InputParameterSpec]] = {}
+    r2_threshold: float = DEFAULT_RABI_R2_THRESHOLD
+    input_spec: ClassVar[dict[str, InputParameterSpec]] = {
+        "qubit_frequency": InputParameterSpec.required_database(
+            unit="GHz", greater_than=0, description="Qubit drive frequency for the Rabi sweep"
+        ),
+        "control_amplitude": InputParameterSpec.required_database(
+            unit="a.u.",
+            greater_than=0,
+            less_than=1,
+            description="Control pulse amplitude for the Rabi sweep",
+        ),
+        "readout_frequency": InputParameterSpec.required_database(
+            unit="GHz", greater_than=0, description="Center frequency of the readout sweep"
+        ),
+        "readout_amplitude": InputParameterSpec.required_database(
+            unit="a.u.", greater_than=0, description="Reference amplitude of the readout sweep"
+        ),
+        "readout_duration": InputParameterSpec.database_or_default(
+            default=DEFAULT_READOUT_DURATION,
+            unit="ns",
+            greater_than=0,
+            description="Readout pulse duration for reference and Rabi measurements",
+        ),
+    }
     run_spec: ClassVar[dict[str, RunParameterSpec]] = {
+        "detuning_range": RunParameterSpec(
+            unit="GHz",
+            value_type="np.linspace",
+            default=(-0.015, 0.015, 13),
+            description="Offsets from readout_frequency (start, stop, number of points)",
+        ),
+        "readout_amplitude_ratio_range": RunParameterSpec(
+            unit="",
+            value_type="np.linspace",
+            default=(0.8, 1.2, 5),
+            description=(
+                "Multipliers of readout_amplitude (start, stop, number of points). "
+                "Sweep amplitudes are capped at 1 and duplicate points are removed."
+            ),
+        ),
+        "time_range": RunParameterSpec(
+            unit="ns",
+            value_type="np.arange",
+            default=(0, 101, 4),
+            description="Rabi drive durations at each readout point (start, stop, step)",
+        ),
         "shots": RunParameterSpec(
             unit="a.u.",
             value_type="int",
-            default=CALIBRATION_SHOTS,
-            description="Number of shots for Rabi oscillation",
+            default=CALIBRATION_SHOTS // 2,
+            description="Number of shots per Rabi drive duration at each readout point",
         ),
         "interval": RunParameterSpec(
             unit="ns",
@@ -45,6 +137,39 @@ class CheckCoarseReadoutParams(QubexTask):
         ),
     }
 
+    def _readout_sweep(self) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+        frequency = self._get_calibration_value("readout_frequency")
+        amplitude = self._get_calibration_value("readout_amplitude")
+        if not math.isfinite(frequency) or frequency <= 0:
+            raise ValueError("readout_frequency must be finite and positive")
+        if not math.isfinite(amplitude) or not 0 < amplitude <= 1:
+            raise ValueError("readout_amplitude must be finite and within (0, 1]")
+
+        detunings = np.asarray(self.run_parameters["detuning_range"].get_value(), dtype=float)
+        ratios = np.asarray(
+            self.run_parameters["readout_amplitude_ratio_range"].get_value(), dtype=float
+        )
+        if detunings.ndim != 1 or detunings.size == 0 or not np.isfinite(detunings).all():
+            raise ValueError("detuning_range must contain finite frequency offsets")
+        if (
+            ratios.ndim != 1
+            or ratios.size == 0
+            or not np.isfinite(ratios).all()
+            or np.any(ratios <= 0)
+        ):
+            raise ValueError("readout_amplitude_ratio_range must contain finite positive ratios")
+        frequencies = np.unique(frequency + detunings)
+        if not np.isfinite(frequencies).all() or np.any(frequencies <= 0):
+            raise ValueError("Readout sweep frequencies must be finite and positive")
+        amplitudes = np.unique(np.minimum(amplitude * ratios, 1.0))
+        return frequencies, amplitudes
+
+    def get_progress_plan(self) -> ProgressPlan:
+        """Count one Rabi sweep per effective readout frequency/amplitude pair."""
+        frequencies, amplitudes = self._readout_sweep()
+        n_sweeps = int(frequencies.size * amplitudes.size)
+        return ProgressPlan(n_sweeps, n_sweeps)
+
     def postprocess(
         self, backend: QubexBackend, execution_id: str, run_result: RunResult, qid: str
     ) -> PostProcessResult:
@@ -55,23 +180,44 @@ class CheckCoarseReadoutParams(QubexTask):
         output_parameters = self.attach_execution_id(execution_id)
         fig = result.figure
         figures = [fig]
-        return PostProcessResult(output_parameters=output_parameters, figures=figures)
+        selected_r2 = run_result.r2.get(qid) if run_result.r2 is not None else None
+        validation_error = first_validation_error(
+            finite_value_error(selected_r2, "Selected readout point R²", maximum=1.0),
+            finite_value_error(result.data["optimal_readout_frequency"], "readout_frequency"),
+            finite_value_error(result.data["optimal_readout_amplitude"], "readout_amplitude"),
+        )
+        return PostProcessResult(
+            output_parameters=output_parameters,
+            figures=figures,
+            validation_error=validation_error,
+        )
 
     def run(self, backend: QubexBackend, qid: str) -> RunResult:
         """Run the task."""
         import qubex
 
+        frequencies, amplitudes = self._readout_sweep()
+        readout_duration = self._get_calibration_value("readout_duration")
+        if not math.isfinite(readout_duration) or readout_duration <= 0:
+            raise ValueError("readout_duration must be finite and positive")
         exp = self.get_experiment(backend)
         label = self.get_qubit_label(backend, qid)
 
-        # Apply frequency override if qubit_frequency was explicitly provided
-        with self._apply_frequency_override(backend, qid):
+        # The contrib helper reads drive settings from ctx and has no duration argument.
+        # Keep temporary drive overrides scoped to this sweep; forward duration to Rabi.
+        sweep_exp: Any = _ReadoutSweepExperiment(exp, readout_duration)
+        with self._apply_parameter_overrides(backend, qid):
             result = qubex.contrib.characterize_coarse_readout_parameters(
-                exp,
+                sweep_exp,
                 target=label,
+                frequency_range=frequencies,
+                readout_amplitudes=amplitudes,
+                time_range=self.run_parameters["time_range"].get_value(),
                 n_shots=self.run_parameters["shots"].get_value(),
                 shot_interval=self.run_parameters["interval"].get_value(),
             )
 
-        self.save_calibration(backend)
-        return RunResult(raw_result=result)
+        r2 = _selected_rabi_r2(result, label)
+        if r2 is not None and r2 <= 1.0 and not self.r2_is_lower_than_threshold(r2):
+            self.save_calibration(backend)
+        return RunResult(raw_result=result, r2={qid: r2})

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_rabi.py
@@ -17,6 +17,7 @@ from qdash.workflow.calibtasks.base import (
     RunResult,
 )
 from qdash.workflow.calibtasks.qubex.base import QubexTask
+from qdash.workflow.calibtasks.qubex.validation import DEFAULT_RABI_R2_THRESHOLD
 from qdash.workflow.engine.backend.qubex import QubexBackend
 
 DEFAULT_READOUT_AMPLITUDE = 0.2
@@ -127,8 +128,8 @@ def _rabi_validation_error(result: Any, label: str) -> str | None:
     if error is not None:
         return error
     assert r2 is not None
-    if float(r2) < 0.6:
-        return f"CheckRabi produced rabi_r2 below 0.6 for {label}: {r2}"
+    if float(r2) < DEFAULT_RABI_R2_THRESHOLD:
+        return f"CheckRabi produced rabi_r2 below {DEFAULT_RABI_R2_THRESHOLD} for {label}: {r2}"
     return None
 
 
@@ -137,7 +138,7 @@ class CheckRabi(QubexTask):
 
     name: str = "CheckRabi"
     task_type: str = "qubit"
-    r2_threshold: float = 0.6
+    r2_threshold: float = DEFAULT_RABI_R2_THRESHOLD
     input_spec: ClassVar[dict[str, InputParameterSpec]] = {
         "qubit_frequency": InputParameterSpec.required_database(),
         "control_amplitude": InputParameterSpec.database_or_default(

--- a/src/qdash/workflow/calibtasks/qubex/validation.py
+++ b/src/qdash/workflow/calibtasks/qubex/validation.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import math
 from typing import Any
 
+DEFAULT_RABI_R2_THRESHOLD = 0.6
+
 
 def finite_value_error(
     value: Any, name: str, *, minimum: float | None = None, maximum: float | None = None

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -964,20 +964,92 @@
         "class_name": "CheckCoarseReadoutParams",
         "description": "Task to check the Optimal Readout Frequency",
         "file_path": "one_qubit_coarse/check_coarse_readout_params.py",
-        "input_parameters": {},
+        "input_parameters": {
+          "control_amplitude": {
+            "default_value": null,
+            "description": "Control pulse amplitude for the Rabi sweep",
+            "greater_than": 0,
+            "less_than": 1,
+            "resolution": "database_required",
+            "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "qubit_frequency": {
+            "default_value": null,
+            "description": "Qubit drive frequency for the Rabi sweep",
+            "greater_than": 0,
+            "resolution": "database_required",
+            "unit": "GHz",
+            "user_override": "allowed"
+          },
+          "readout_amplitude": {
+            "default_value": null,
+            "description": "Reference amplitude of the readout sweep",
+            "greater_than": 0,
+            "resolution": "database_required",
+            "unit": "a.u.",
+            "user_override": "allowed"
+          },
+          "readout_duration": {
+            "default_value": 384.0,
+            "description": "Readout pulse duration for reference and Rabi measurements",
+            "greater_than": 0,
+            "resolution": "database_or_default",
+            "unit": "ns",
+            "user_override": "allowed"
+          },
+          "readout_frequency": {
+            "default_value": null,
+            "description": "Center frequency of the readout sweep",
+            "greater_than": 0,
+            "resolution": "database_required",
+            "unit": "GHz",
+            "user_override": "allowed"
+          }
+        },
         "name": "CheckCoarseReadoutParams",
         "run_parameters": {
+          "detuning_range": {
+            "description": "Offsets from readout_frequency (start, stop, number of points)",
+            "unit": "GHz",
+            "value": [
+              -0.015,
+              0.015,
+              13
+            ],
+            "value_type": "np.linspace"
+          },
           "interval": {
             "description": "Time interval for Rabi oscillation",
             "unit": "ns",
             "value": 153600.0,
             "value_type": "int"
           },
+          "readout_amplitude_ratio_range": {
+            "description": "Multipliers of readout_amplitude (start, stop, number of points). Sweep amplitudes are capped at 1 and duplicate points are removed.",
+            "unit": "",
+            "value": [
+              0.8,
+              1.2,
+              5
+            ],
+            "value_type": "np.linspace"
+          },
           "shots": {
-            "description": "Number of shots for Rabi oscillation",
+            "description": "Number of shots per Rabi drive duration at each readout point",
             "unit": "a.u.",
-            "value": 2048,
+            "value": 1024,
             "value_type": "int"
+          },
+          "time_range": {
+            "description": "Rabi drive durations at each readout point (start, stop, step)",
+            "unit": "ns",
+            "value": [
+              0,
+              101,
+              4
+            ],
+            "value_type": "np.arange"
           }
         },
         "task_type": "qubit"

--- a/src/qdash/workflow/engine/backend/plugins/qubex_progress.py
+++ b/src/qdash/workflow/engine/backend/plugins/qubex_progress.py
@@ -30,6 +30,7 @@ _active_bar: ContextVar[object | None] = ContextVar(
     default=None,
 )
 _phase: ContextVar[int] = ContextVar("qdash_qubex_progress_phase", default=0)
+_started_at: ContextVar[float | None] = ContextVar("qdash_qubex_progress_started_at", default=None)
 _installed = False
 
 # These tasks are known to open multiple sequential top-level progress bars.
@@ -127,6 +128,25 @@ class ReportingTqdm(Tqdm):
         if total is not None and self.n > 0 and elapsed > 0:
             eta = max(elapsed * (total - self.n) / self.n, 0.0)
 
+        overall_eta = None
+        plan = self._qdash_plan
+        started_at = _started_at.get()
+        if (
+            plan is not None
+            and plan.minimum_phases == plan.maximum_phases
+            and plan.maximum_phases >= self._qdash_phase
+            and started_at is not None
+            and total is not None
+            and total > 0
+        ):
+            completed = self._qdash_phase - 1 + min(max(self.n / total, 0.0), 1.0)
+            # Wait for a complete sweep before extrapolating. Use elapsed time
+            # across sweeps, including the gaps for reference measurements/fits.
+            if completed >= 1:
+                overall_eta = max(
+                    (now - started_at) * (plan.maximum_phases - completed) / completed, 0.0
+                )
+
         try:
             reporter(
                 TaskProgress(
@@ -135,6 +155,7 @@ class ReportingTqdm(Tqdm):
                     description=self._qdash_description,
                     elapsed_seconds=elapsed,
                     eta_seconds=eta,
+                    overall_eta_seconds=overall_eta,
                     updated_at=datetime.now(UTC).isoformat(),
                     phase=self._qdash_phase,
                     has_multiple_phases=self._qdash_has_multiple_phases,
@@ -170,6 +191,7 @@ def _progress_description(task_name: str, description: str) -> str:
     task_labels = {
         "CheckChevron": "Chevron sweep",
         "CheckRabi": "Rabi time sweep",
+        "CheckCoarseReadoutParams": "Readout parameter search",
         "CheckRamsey": "Ramsey delay sweep",
         "CheckT1": "T1 delay sweep",
         "CheckT1Average": "T1 measurement sweep",
@@ -211,9 +233,11 @@ def capture_qubex_progress(
     task_name_token = _task_name.set(task_name)
     plan_token = _plan.set(plan)
     phase_token = _phase.set(0)
+    started_at_token = _started_at.set(time.monotonic())
     try:
         yield
     finally:
+        _started_at.reset(started_at_token)
         _phase.reset(phase_token)
         _plan.reset(plan_token)
         _task_name.reset(task_name_token)

--- a/src/qdash/workflow/engine/config.py
+++ b/src/qdash/workflow/engine/config.py
@@ -40,7 +40,7 @@ class CalibConfig:
     project_id: str | None = None
     enable_github_pull: bool = True
     enable_provenance_tracking: bool = True
-    skip_execution: bool = False  # Skip Execution creation (for wrapper/parent sessions)
+    skip_execution: bool = False  # Isolated worker borrowing its step's Execution
     force_update_params: bool = False  # Force backend params update regardless of R² validation
     persist_output_parameters: bool = True  # Write task outputs to calibration/backend stores
     configuration_mode: str | None = field(

--- a/src/qdash/workflow/engine/progress.py
+++ b/src/qdash/workflow/engine/progress.py
@@ -27,6 +27,7 @@ class TaskProgress:
     has_multiple_phases: bool = False
     phase_total_min: int | None = None
     phase_total_max: int | None = None
+    overall_eta_seconds: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-safe representation for task metadata."""

--- a/src/qdash/workflow/engine/task/executor.py
+++ b/src/qdash/workflow/engine/task/executor.py
@@ -188,6 +188,11 @@ class TaskExecutor:
     @staticmethod
     def _progress_plan(task: TaskProtocol) -> ProgressPlan | None:
         """Return honest phase-count bounds for tasks with sequential sweeps."""
+        # Tasks with input-dependent sweep sizes calculate their own plan after
+        # database/snapshot resolution and user overrides have been applied.
+        get_progress_plan = getattr(task, "get_progress_plan", None)
+        if callable(get_progress_plan):
+            return cast("ProgressPlan | None", get_progress_plan())
         name = task.get_name()
         if name in {"CheckRamsey"}:
             return ProgressPlan(2, 2)

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -325,10 +325,9 @@ class CalibService:
             muxes: List of MUX IDs for system-level tasks (default: None)
             project_id: Project ID for multi-tenancy support. If None, auto-resolved
                 from username's default_project_id.
-            skip_execution: Skip Execution document creation (for wrapper/parent sessions
-                where child sessions will create their own Executions). A lock-owning
-                wrapper still adopts and finalizes an execution pre-created by the API
-                for its flow run. Default: False.
+            skip_execution: Internal option for isolated workers borrowing an existing
+                Execution. Pipelines automatically create one Execution per calibration
+                step, including when older templates pass this option. Default: False.
             user_repo: Repository for user lookup (DI). If None, uses MongoUserRepository.
             lock_repo: Repository for lock operations (DI). If None, uses MongoExecutionLockRepository.
             counter_repo: Repository for counter operations (DI). If None, uses MongoExecutionCounterRepository.
@@ -403,6 +402,7 @@ class CalibService:
 
         # Session state
         self._initialized = False
+        self._pipeline_active = False
         self.execution_id: str | None = execution_id
         self._orchestrator: CalibOrchestrator | None = None
         self.github_integration: GitHubIntegration | None = None
@@ -535,7 +535,7 @@ class CalibService:
             self.github_push_config = GitHubPushConfig()
 
         # Acquire lock if requested
-        if self.use_lock:
+        if self.use_lock and not self._lock_acquired:
             if self._lock_repo is None:
                 from qdash.repository import MongoExecutionLockRepository
 
@@ -1180,6 +1180,8 @@ class CalibService:
 
     def _release_lock_if_acquired(self) -> None:
         """Release the execution lock if it was acquired by this session."""
+        if getattr(self, "_pipeline_active", False):
+            return
         if self.use_lock and self._lock_acquired and self._lock_repo is not None:
             self._lock_repo.unlock(project_id=self.project_id)
             self._lock_acquired = False
@@ -1305,18 +1307,20 @@ class CalibService:
             set_current_session,
         )
         from qdash.workflow.service.steps import Pipeline, StepContext
+        from qdash.workflow.service.steps.base import TransformStep
 
         logger = get_run_logger()
 
         # Set this CalibService as the current session for task execution
         set_current_session(self)
+        self._pipeline_active = True
+        active_step = False
+        completed_steps = 0
+        pipeline_flow_name = self.flow_name
+        pipeline_note = self.note
 
         try:
-            # Initialize session if not already initialized
             qids = targets.to_qids(self.chip_id)
-            if not self._initialized:
-                self._initialize(qids, self.tags, self.note)
-
             # Validate pipeline dependencies
             pipeline = Pipeline(steps)
             logger.info(f"Starting calibration pipeline with {len(pipeline)} steps")
@@ -1329,15 +1333,44 @@ class CalibService:
             for i, step in enumerate(pipeline):
                 logger.info(f"Step {i + 1}/{len(pipeline)}: {step.name}")
                 try:
+                    # Transform-only steps do not create an Execution. Hardware
+                    # steps share one session across all workers and strategies.
+                    if not isinstance(step, TransformStep):
+                        if completed_steps:
+                            self._initialized = False
+                            self._orchestrator = None
+                            self.execution_id = None
+                        self.flow_name = (
+                            f"{pipeline_flow_name}_{step.name}" if pipeline_flow_name else step.name
+                        )
+                        self.note = {
+                            **(pipeline_note or {}),
+                            "step_name": step.name,
+                            "step_index": i + 1,
+                            "pipeline_name": pipeline_flow_name,
+                        }
+                        active_step = True
+                        # Compatibility with saved templates that still pass
+                        # skip_execution=True for the old wrapper session.
+                        was_skipped = self.skip_execution
+                        self.skip_execution = False
+                        if not self._initialized:
+                            self._initialize(ctx.candidate_qids, self.tags, self.note)
+                        elif was_skipped and self.execution_service is not None:
+                            assert self._orchestrator is not None
+                            self._orchestrator.config.skip_execution = False
+                            self.execution_service.save().start()
                     ctx = step.execute(self, targets, ctx)
+                    if active_step:
+                        self.finish_calibration()
+                        active_step = False
+                        completed_steps += 1
                 except Exception as e:
                     logger.error(f"Step {step.name} failed: {e}")
                     raise
 
             logger.info("Pipeline completed successfully")
 
-            # Finalize execution (mark as completed, update chip history)
-            self.finish_calibration()
         except BaseException as exc:
             # Distinguish cancellation from failure.
             # Prefect 3 raises CancelledRun (subclass of BaseException) on cancel.
@@ -1349,15 +1382,20 @@ class CalibService:
                     type(exc.__context__).__name__ if exc.__context__ else None,
                     [type(sub).__name__ for sub in getattr(exc, "exceptions", [])] or None,
                 )
-                if _is_cancellation(exc):
+                if active_step and _is_cancellation(exc):
                     logger.info("Execution was cancelled")
                     self.cancel_calibration()
-                else:
+                elif active_step:
                     self.fail_calibration()
             raise
         finally:
-            # Clear session when done
-            clear_current_session()
+            self.flow_name = pipeline_flow_name
+            self.note = pipeline_note
+            self._pipeline_active = False
+            try:
+                self._release_lock_if_acquired()
+            finally:
+                clear_current_session()
 
         # Build results from typed context fields
         results: dict[str, Any] = {

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -326,7 +326,9 @@ class CalibService:
             project_id: Project ID for multi-tenancy support. If None, auto-resolved
                 from username's default_project_id.
             skip_execution: Skip Execution document creation (for wrapper/parent sessions
-                where child sessions will create their own Executions). Default: False.
+                where child sessions will create their own Executions). A lock-owning
+                wrapper still adopts and finalizes an execution pre-created by the API
+                for its flow run. Default: False.
             user_repo: Repository for user lookup (DI). If None, uses MongoUserRepository.
             lock_repo: Repository for lock operations (DI). If None, uses MongoExecutionLockRepository.
             counter_repo: Repository for counter operations (DI). If None, uses MongoExecutionCounterRepository.
@@ -485,13 +487,21 @@ class CalibService:
 
         if self.execution_id is None:
             claimed_execution_id: str | None = None
-            if not self.skip_execution and flow_run_id is not None:
+            # Lock-owning wrappers must adopt the API's execution ID as well:
+            # minting another ID would collide with their own pre-acquired lock.
+            # Isolated workers (skip_execution=True, use_lock=False) must never
+            # claim the parent execution or take over its lifecycle.
+            if flow_run_id is not None and (not self.skip_execution or self.use_lock):
                 from qdash.repository import MongoExecutionRepository
 
                 claimed_execution_id = MongoExecutionRepository().claim_scheduled_execution(
                     project_id=self.project_id, flow_run_id=flow_run_id
                 )
                 if claimed_execution_id is not None:
+                    # The API has already created a visible parent row. Own its
+                    # start/terminal states even if this wrapper normally skips
+                    # creating an Execution and delegates measurements to children.
+                    self.skip_execution = False
                     logger.info(
                         "Adopted pre-created execution_id=%s for flow_run_id=%s",
                         claimed_execution_id,

--- a/src/qdash/workflow/service/steps/base.py
+++ b/src/qdash/workflow/service/steps/base.py
@@ -73,8 +73,9 @@ class Step(ABC):
 class CalibrationStep(Step):
     """Base class for steps that execute actual calibration on hardware.
 
-    CalibrationSteps create execution history entries because they involve
-    real hardware interaction and produce calibration data.
+    The pipeline creates one Execution for each CalibrationStep and owns its
+    completion, failure, and cancellation. Steps and their strategies use the
+    supplied session without creating additional execution history entries.
 
     Examples: OneQubitCheck, OneQubitFineTune, TwoQubitCalibration
     """

--- a/src/qdash/workflow/service/steps/one_qubit.py
+++ b/src/qdash/workflow/service/steps/one_qubit.py
@@ -34,39 +34,15 @@ def _execute_direct_one_qubit(
     from qdash.workflow.service._internal.scheduling_tasks import (
         run_qubit_calibrations_parallel,
     )
-    from qdash.workflow.service.calib_service import finish_calibration, init_calibration
-    from qdash.workflow.service.github import ConfigFileType, GitHubPushConfig
 
     if not qids:
         return {"direct": {}}
-
-    stage_flow_name = f"{service.flow_name}_{stage_name}" if service.flow_name else stage_name
-    session = init_calibration(
-        service.username,
-        service.chip_id,
-        qids,
-        flow_name=stage_flow_name,
-        backend_name=service.backend_name,
-        tags=service.tags,
-        project_id=service.project_id,
-        use_lock=False,
-        enable_github_pull=True,
-        github_push_config=GitHubPushConfig(
-            enabled=True,
-            file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
-        ),
-        note={
-            "type": "1-qubit-direct",
-            "stage": stage_name,
-            "total_qubits": len(qids),
-        },
-    )
 
     session_config = {
         "username": service.username,
         "chip_id": service.chip_id,
         "backend_name": service.backend_name,
-        "execution_id": session.execution_id,
+        "execution_id": service.execution_id,
         "project_id": service.project_id,
         "default_run_parameters": service.default_run_parameters,
         "tags": service.tags,
@@ -80,8 +56,7 @@ def _execute_direct_one_qubit(
         session_config=session_config,
     )
     wrapped_results = {"direct": results}
-    session.record_stage_result(stage_name, wrapped_results)
-    finish_calibration()
+    service.record_stage_result(stage_name, wrapped_results)
     return wrapped_results
 
 

--- a/src/qdash/workflow/service/steps/one_qubit.py
+++ b/src/qdash/workflow/service/steps/one_qubit.py
@@ -390,7 +390,12 @@ class OneQubitFineTune(CalibrationStep):
             tasks.insert(0, "Configure")
 
         # Use filtered candidates from context if available
-        qids = ctx.candidate_qids if ctx.candidate_qids else targets.to_qids(service.chip_id)
+        has_previous_selection = bool(ctx.filters) or ctx.get_latest_one_qubit_result() is not None
+        qids = (
+            ctx.candidate_qids
+            if ctx.candidate_qids or has_previous_selection
+            else targets.to_qids(service.chip_id)
+        )
 
         logger.info(
             f"[{self.name}] Starting with mode={self.mode}, {len(tasks)} tasks, {len(qids)} qubits"

--- a/src/qdash/workflow/service/steps/two_qubit.py
+++ b/src/qdash/workflow/service/steps/two_qubit.py
@@ -117,47 +117,17 @@ class CustomTwoQubit(CalibrationStep):
         from qdash.workflow.service._internal.scheduling_tasks import (
             run_coupling_calibrations_parallel,
         )
-        from qdash.workflow.service.calib_service import (
-            finish_calibration,
-            get_session,
-            init_calibration,
-        )
-        from qdash.workflow.service.github import ConfigFileType, GitHubPushConfig
 
-        init_calibration(
-            service.username,
-            service.chip_id,
-            candidate_qubits,
-            flow_name=f"{service.flow_name}_{self.name}" if service.flow_name else self.name,
-            tags=service.tags,
-            project_id=service.project_id,
-            use_lock=False,  # Parent pipeline already holds the lock
-            enable_github_pull=False,
-            github_push_config=GitHubPushConfig(
-                enabled=True,
-                file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
-            ),
-            note={
-                "type": "2-qubit",
-                "step_name": self.step_name,
-                "tasks": self.tasks,
-                "candidate_qubits": candidate_qubits,
-                "schedule": coupling_groups,
-            },
-        )
-
-        # Get session config for multiprocess execution
-        session = get_session()
         session_config = {
-            "username": session.username,
-            "chip_id": session.chip_id,
-            "backend_name": session.backend_name,
-            "execution_id": session.execution_id,
-            "project_id": session.project_id,
-            "default_run_parameters": session.default_run_parameters,
-            "tags": session.tags,
-            "flow_name": session.flow_name,
-            "note": session.note,
+            "username": service.username,
+            "chip_id": service.chip_id,
+            "backend_name": service.backend_name,
+            "execution_id": service.execution_id,
+            "project_id": service.project_id,
+            "default_run_parameters": service.default_run_parameters,
+            "tags": service.tags,
+            "flow_name": service.flow_name,
+            "note": service.note,
         }
 
         # Execute groups sequentially (groups are scheduled to avoid resource conflicts)
@@ -171,8 +141,7 @@ class CustomTwoQubit(CalibrationStep):
             )
             all_raw_results.update(group_results)
 
-        session.record_stage_result(self.name, all_raw_results)
-        finish_calibration()
+        service.record_stage_result(self.name, all_raw_results)
 
         # Build typed result
         result = self._build_result(all_raw_results)
@@ -440,45 +409,17 @@ class TwoQubitCalibration(CalibrationStep):
         from qdash.workflow.service._internal.scheduling_tasks import (
             run_coupling_calibrations_parallel,
         )
-        from qdash.workflow.service.calib_service import (
-            finish_calibration,
-            get_session,
-            init_calibration,
-        )
-        from qdash.workflow.service.github import ConfigFileType, GitHubPushConfig
 
-        init_calibration(
-            service.username,
-            service.chip_id,
-            candidate_qubits,
-            flow_name=f"{service.flow_name}_{self.name}" if service.flow_name else self.name,
-            tags=service.tags,
-            project_id=service.project_id,
-            use_lock=False,  # Parent pipeline already holds the lock
-            enable_github_pull=False,
-            github_push_config=GitHubPushConfig(
-                enabled=True,
-                file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
-            ),
-            note={
-                "type": "2-qubit",
-                "candidate_qubits": candidate_qubits,
-                "schedule": coupling_groups,
-            },
-        )
-
-        # Get session config for multiprocess execution
-        session = get_session()
         session_config = {
-            "username": session.username,
-            "chip_id": session.chip_id,
-            "backend_name": session.backend_name,
-            "execution_id": session.execution_id,
-            "project_id": session.project_id,
-            "default_run_parameters": session.default_run_parameters,
-            "tags": session.tags,
-            "flow_name": session.flow_name,
-            "note": session.note,
+            "username": service.username,
+            "chip_id": service.chip_id,
+            "backend_name": service.backend_name,
+            "execution_id": service.execution_id,
+            "project_id": service.project_id,
+            "default_run_parameters": service.default_run_parameters,
+            "tags": service.tags,
+            "flow_name": service.flow_name,
+            "note": service.note,
         }
 
         # Execute groups sequentially (groups are scheduled to avoid resource conflicts)
@@ -492,8 +433,7 @@ class TwoQubitCalibration(CalibrationStep):
             )
             all_raw_results.update(group_results)
 
-        session.record_stage_result(self.name, all_raw_results)
-        finish_calibration()
+        service.record_stage_result(self.name, all_raw_results)
 
         # Build typed result
         result = self._build_result(all_raw_results)

--- a/src/qdash/workflow/service/strategy.py
+++ b/src/qdash/workflow/service/strategy.py
@@ -20,8 +20,6 @@ from qdash.workflow.service._internal.scheduling_tasks import (
     run_mux_calibrations_parallel,
     run_qubit_calibrations_parallel,
 )
-from qdash.workflow.service.calib_service import finish_calibration, get_session, init_calibration
-from qdash.workflow.service.github import ConfigFileType, GitHubPushConfig
 
 if TYPE_CHECKING:
     from qdash.workflow.service.calib_service import CalibService
@@ -161,41 +159,14 @@ class OneQubitScheduledStrategy(OneQubitStrategy):
         # Deduplicate while preserving order
         all_qids = list(dict.fromkeys(all_qids))
 
-        # Create a SINGLE execution for the entire strategy
-        # This ensures the execution only completes after ALL box types finish
-        stage_flow_name = config.flow_name or "1q_scheduled"
-
-        init_calibration(
-            cal_service.username,
-            cal_service.chip_id,
-            all_qids,
-            flow_name=stage_flow_name,
-            backend_name=cal_service.backend_name,
-            tags=cal_service.tags,
-            project_id=config.project_id,
-            use_lock=False,
-            enable_github_pull=True,
-            github_push_config=GitHubPushConfig(
-                enabled=True,
-                file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
-            ),
-            note={
-                "type": "1-qubit-scheduled",
-                "box_types": list(box_sequential_groups.keys()),
-                "total_qubits": len(all_qids),
-            },
-        )
-
-        parent_session = get_session()
-        parent_execution_id = parent_session.execution_id
-
+        # Workers borrow the Execution owned by the pipeline step.
         session_config = {
             "username": cal_service.username,
             "chip_id": cal_service.chip_id,
             "backend_name": cal_service.backend_name,
             "project_id": config.project_id,
             "muxes": None,
-            "execution_id": parent_execution_id,
+            "execution_id": cal_service.execution_id,
             "default_run_parameters": cal_service.default_run_parameters,
             "tags": cal_service.tags,
             "flow_name": cal_service.flow_name,
@@ -217,10 +188,8 @@ class OneQubitScheduledStrategy(OneQubitStrategy):
 
             all_results[stage_name] = stage_results
 
-        # Record results and finish the single execution after ALL box types complete
-        session = get_session()
-        session.record_stage_result("1q_scheduled", all_results)
-        finish_calibration()
+        # Record all box results within the current step Execution
+        cal_service.record_stage_result("1q_scheduled", all_results)
 
         return all_results
 
@@ -269,41 +238,14 @@ class OneQubitSynchronizedStrategy(OneQubitStrategy):
         if not all_qids:
             return {}
 
-        # Create a SINGLE execution for the entire strategy
-        # This ensures the execution only completes after ALL box types finish
-        stage_flow_name = config.flow_name or "1q_synchronized"
-
-        init_calibration(
-            cal_service.username,
-            cal_service.chip_id,
-            all_qids,
-            flow_name=stage_flow_name,
-            backend_name=cal_service.backend_name,
-            tags=cal_service.tags,
-            project_id=config.project_id,
-            use_lock=False,
-            enable_github_pull=True,
-            github_push_config=GitHubPushConfig(
-                enabled=True,
-                file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
-            ),
-            note={
-                "type": "1-qubit-synchronized",
-                "total_steps": schedule.total_steps,
-                "total_qubits": len(all_qids),
-            },
-        )
-
-        parent_session = get_session()
-        parent_execution_id = parent_session.execution_id
-
+        # Workers borrow the Execution owned by the pipeline step.
         session_config = {
             "username": cal_service.username,
             "chip_id": cal_service.chip_id,
             "backend_name": cal_service.backend_name,
             "project_id": config.project_id,
             "muxes": None,
-            "execution_id": parent_execution_id,
+            "execution_id": cal_service.execution_id,
             "default_run_parameters": cal_service.default_run_parameters,
             "tags": cal_service.tags,
             "flow_name": cal_service.flow_name,
@@ -328,10 +270,8 @@ class OneQubitSynchronizedStrategy(OneQubitStrategy):
                 all_results[box_key] = {}
             all_results[box_key].update(step_results)
 
-        # Record results and finish the single execution after ALL steps complete
-        session = get_session()
-        session.record_stage_result("1q_synchronized", all_results)
-        finish_calibration()
+        # Record all scheduling rounds within the current step Execution
+        cal_service.record_stage_result("1q_synchronized", all_results)
 
         return all_results
 
@@ -362,38 +302,13 @@ class OneQubitSimultaneousSpectroscopyStrategy(OneQubitStrategy):
         if not all_qids:
             return {}
 
-        stage_flow_name = config.flow_name or "simultaneous_spectroscopy"
-        init_calibration(
-            cal_service.username,
-            cal_service.chip_id,
-            all_qids,
-            flow_name=stage_flow_name,
-            backend_name=cal_service.backend_name,
-            tags=cal_service.tags,
-            project_id=config.project_id,
-            use_lock=False,
-            enable_github_pull=True,
-            github_push_config=GitHubPushConfig(
-                enabled=True,
-                file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
-            ),
-            note={
-                "type": "experimental-simultaneous-spectroscopy",
-                "strategy": schedule.metadata["strategy"],
-                "total_qubits": len(all_qids),
-                "total_steps": schedule.total_steps,
-            },
-        )
-
         all_results = runner.execute_simultaneous_spectroscopy_schedule(
             schedule,
             tasks=config.tasks,
             allowed_qids=config.qids,
         )
 
-        session = get_session()
-        session.record_stage_result("experimental_simultaneous_spectroscopy", all_results)
-        finish_calibration()
+        cal_service.record_stage_result("experimental_simultaneous_spectroscopy", all_results)
         return all_results
 
 
@@ -435,30 +350,6 @@ class OneQubitSerialStrategy(OneQubitStrategy):
         if not all_qids:
             return {}
 
-        # Single session for all MUXes
-        stage_flow_name = f"{config.flow_name}_serial" if config.flow_name else "serial"
-
-        init_calibration(
-            cal_service.username,
-            cal_service.chip_id,
-            all_qids,
-            flow_name=stage_flow_name,
-            backend_name=cal_service.backend_name,
-            tags=cal_service.tags,
-            project_id=config.project_id,
-            use_lock=False,
-            enable_github_pull=True,
-            github_push_config=GitHubPushConfig(
-                enabled=True,
-                file_types=[ConfigFileType.CALIB_NOTE, ConfigFileType.ALL_PARAMS],
-            ),
-            note={
-                "type": "1-qubit-serial",
-                "total_mux_groups": len(all_mux_groups),
-                "total_qubits": len(all_qids),
-            },
-        )
-
         # Execute MUX groups one by one (completely serial)
         all_results = {}
         for mux_group in all_mux_groups:
@@ -466,9 +357,7 @@ class OneQubitSerialStrategy(OneQubitStrategy):
             result = _calibrate_mux_qubits(qids=mux_group, tasks=config.tasks)
             all_results.update(result)
 
-        session = get_session()
-        session.record_stage_result("1q_serial", all_results)
-        finish_calibration()
+        cal_service.record_stage_result("1q_serial", all_results)
 
         return {"serial": all_results}
 

--- a/src/qdash/workflow/service/strategy.py
+++ b/src/qdash/workflow/service/strategy.py
@@ -308,6 +308,16 @@ class OneQubitSimultaneousSpectroscopyStrategy(OneQubitStrategy):
             allowed_qids=config.qids,
         )
 
+        # Match the per-qubit status supplied by the other strategies so a
+        # successful batch remains eligible for the pipeline's status filter.
+        for step_results in all_results.values():
+            for qubit_results in step_results.values():
+                qubit_results["status"] = (
+                    "success"
+                    if all(task_name in qubit_results for task_name in config.tasks)
+                    else "failed"
+                )
+
         cal_service.record_stage_result("experimental_simultaneous_spectroscopy", all_results)
         return all_results
 

--- a/src/qdash/workflow/templates/bringup.py
+++ b/src/qdash/workflow/templates/bringup.py
@@ -124,7 +124,6 @@ def bringup(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,
         default_run_parameters=default_run_parameters,
     )
     return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/check_waveform.py
+++ b/src/qdash/workflow/templates/check_waveform.py
@@ -77,7 +77,6 @@ def check_waveform(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,
         default_run_parameters={
             "interval": {"value": 150 * 1024, "value_type": "int"},
         },

--- a/src/qdash/workflow/templates/coarse_one.py
+++ b/src/qdash/workflow/templates/coarse_one.py
@@ -1,0 +1,92 @@
+"""Coarse 1-qubit calibration through Ramsey, based on the one_qubit check stage.
+
+Run this after bring-up has established the qubit frequency, control amplitude,
+and readout settings. The flow applies the current hardware configuration,
+refines readout settings, calibrates Rabi/HPI, and measures T1/T2Echo and Ramsey
+for explicitly selected MUXes or qubits.
+
+Example:
+    coarse_one(username="alice", chip_id="64Qv3", mux_ids=[0, 1])
+"""
+
+from typing import Any
+
+from prefect import flow
+
+from qdash.workflow.service import CalibService
+from qdash.workflow.service.calib_service import (
+    on_flow_cancellation,
+    on_flow_crashed,
+    on_flow_failure,
+)
+from qdash.workflow.service.steps import OneQubitCheck
+from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
+
+COARSE_ONE_TASKS: list[str] = [
+    "Configure",  # Apply the starting configuration before the readout search.
+    "CheckCoarseReadoutParams",
+    "Configure",  # Apply the updated readout settings before pulse calibration.
+    "CheckRabi",  # Update control amplitude from the measured Rabi frequency.
+    "CheckRabi",  # Measure again at the updated amplitude for HPI creation.
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CheckT1",
+    "CheckT2Echo",
+    "CheckRamsey",
+]
+
+
+@flow(
+    on_cancellation=[on_flow_cancellation],
+    on_failure=[on_flow_failure],
+    on_crashed=[on_flow_crashed],
+)
+def coarse_one(
+    username: str,
+    chip_id: str,
+    mux_ids: list[int] | None = None,
+    exclude_qids: list[str] | None = None,
+    qids: list[str] | None = None,
+    tags: list[str] | None = None,
+    flow_name: str | None = None,
+    project_id: str | None = None,
+) -> Any:
+    """Run the coarse 1-qubit check stage through Ramsey.
+
+    Args:
+        username: User name (from UI)
+        chip_id: Chip ID (from UI)
+        mux_ids: MUX IDs to calibrate when using MUX-based scheduling
+        exclude_qids: Qubit IDs to exclude when using mux_ids
+        qids: Qubit IDs to calibrate when mux_ids is not set
+        tags: Flow tags
+        flow_name: Flow name (auto-injected)
+        project_id: Project ID (auto-injected)
+
+    Returns:
+        Pipeline results with one_qubit_check output
+    """
+    targets: Target
+    if mux_ids is not None:
+        targets = MuxTargets(mux_ids=mux_ids, exclude_qids=exclude_qids or [])
+    elif qids is not None:
+        targets = QubitTargets(qids=qids)
+    else:
+        raise ValueError("mux_ids or qids is required; select targets before running this flow")
+
+    steps = [OneQubitCheck(mode="synchronized", tasks=COARSE_ONE_TASKS)]
+
+    cal = CalibService(
+        username,
+        chip_id,
+        flow_name=flow_name,
+        tags=tags,
+        project_id=project_id,
+        skip_execution=True,
+        default_run_parameters={
+            "hpi_duration": {"value": 32, "value_type": "int"},
+            "pi_duration": {"value": 32, "value_type": "int"},
+            "interval": {"value": 150 * 1024, "value_type": "int"},
+        },
+    )
+    return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/coarse_one.py
+++ b/src/qdash/workflow/templates/coarse_one.py
@@ -82,7 +82,6 @@ def coarse_one(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,
         default_run_parameters={
             "hpi_duration": {"value": 32, "value_type": "int"},
             "pi_duration": {"value": 32, "value_type": "int"},

--- a/src/qdash/workflow/templates/coherence_limit.py
+++ b/src/qdash/workflow/templates/coherence_limit.py
@@ -103,7 +103,6 @@ def coherence_limit(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,
         default_run_parameters={
             "drag_hpi_duration": {"value": 16, "value_type": "int"},
         },

--- a/src/qdash/workflow/templates/fake_backend.py
+++ b/src/qdash/workflow/templates/fake_backend.py
@@ -113,6 +113,5 @@ def fake_calibration(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=False,  # Child sessions create their own Executions
     )
     return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/fast_full_calibration.py
+++ b/src/qdash/workflow/templates/fast_full_calibration.py
@@ -125,7 +125,6 @@ def fast_full_calibration(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,
         default_run_parameters={
             "hpi_duration": {"value": 32, "value_type": "int"},
             "pi_duration": {"value": 32, "value_type": "int"},

--- a/src/qdash/workflow/templates/fine_one.py
+++ b/src/qdash/workflow/templates/fine_one.py
@@ -2,8 +2,11 @@
 
 Run this after coarse_one or an equivalent calibration has established the
 qubit frequency, control amplitude, and readout settings. The flow applies
-those settings, calibrates HPI/PI and DRAG pulses, classifies readout, and
-measures coherence and randomized benchmarking for selected MUXes or qubits.
+those settings and tunes readout amplitude -> frequency -> amplitude -> frequency.
+Each optimization starts with fresh Rabi, HPI, and DRAG PI calibration: the
+sweep prepares |1> with DRAG PI, and its final classifier uses two HPI pulses.
+After both rounds, all pulses are calibrated at the final readout settings
+before readout classification, coherence measurements, and randomized benchmarking.
 
 Example:
     fine_one(username="alice", chip_id="64Qv3", mux_ids=[0, 1])
@@ -23,7 +26,36 @@ from qdash.workflow.service.steps import OneQubitFineTune
 from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
 
 FINE_ONE_TASKS: list[str] = [
-    "Configure",  # Apply the current calibrated settings before fine-tuning.
+    "Configure",
+    # Round 1: prepare HPI and DRAG PI at current readout settings, then tune amplitude.
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "CheckOptimalReadoutAmplitude",
+    # Round 1: prepare HPI and DRAG PI at current readout settings, then tune frequency.
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "CheckOptimalReadoutFrequency",
+    # Round 2: prepare HPI and DRAG PI at current readout settings, then tune amplitude.
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "CheckOptimalReadoutAmplitude",
+    # Round 2: prepare HPI and DRAG PI at current readout settings, then tune frequency.
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "CheckOptimalReadoutFrequency",
+    # Calibrate all pulses at the final readout settings before classification and RB.
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",

--- a/src/qdash/workflow/templates/fine_one.py
+++ b/src/qdash/workflow/templates/fine_one.py
@@ -3,6 +3,7 @@
 Run this after coarse_one or an equivalent calibration has established the
 qubit frequency, control amplitude, and readout settings. The flow applies
 those settings and tunes readout amplitude -> frequency -> amplitude -> frequency.
+Configure applies the updated frequency after each amplitude/frequency pair.
 Each amplitude/frequency pair starts with fresh Rabi, HPI, and DRAG PI calibration: the
 sweep prepares |1> with DRAG PI, and its final classifier uses two HPI pulses.
 After both rounds, all pulses are calibrated at the final readout settings
@@ -35,6 +36,7 @@ FINE_ONE_TASKS: list[str] = [
     "CheckDRAGPIPulse",
     "CheckOptimalReadoutAmplitude",
     "CheckOptimalReadoutFrequency",
+    "Configure",  # Apply round 1's readout frequency before recalibrating pulses.
     # Round 2: refresh the state pulses at the updated settings, then repeat the pair.
     "CheckRabi",
     "CreateHPIPulse",
@@ -43,6 +45,7 @@ FINE_ONE_TASKS: list[str] = [
     "CheckDRAGPIPulse",
     "CheckOptimalReadoutAmplitude",
     "CheckOptimalReadoutFrequency",
+    "Configure",  # Apply the final readout frequency before final pulse calibration.
     # Calibrate all pulses at the final readout settings before classification and RB.
     "CheckRabi",
     "CreateHPIPulse",

--- a/src/qdash/workflow/templates/fine_one.py
+++ b/src/qdash/workflow/templates/fine_one.py
@@ -1,0 +1,99 @@
+"""Fine 1-qubit calibration based on the one_qubit fine-tuning stage.
+
+Run this after coarse_one or an equivalent calibration has established the
+qubit frequency, control amplitude, and readout settings. The flow applies
+those settings, calibrates HPI/PI and DRAG pulses, classifies readout, and
+measures coherence and randomized benchmarking for selected MUXes or qubits.
+
+Example:
+    fine_one(username="alice", chip_id="64Qv3", mux_ids=[0, 1])
+"""
+
+from typing import Any
+
+from prefect import flow
+
+from qdash.workflow.service import CalibService
+from qdash.workflow.service.calib_service import (
+    on_flow_cancellation,
+    on_flow_crashed,
+    on_flow_failure,
+)
+from qdash.workflow.service.steps import OneQubitFineTune
+from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
+
+FINE_ONE_TASKS: list[str] = [
+    "Configure",  # Apply the current calibrated settings before fine-tuning.
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "ReadoutClassification",
+    "CheckT1Average",
+    "CheckT2EchoAverage",
+    "Check1QGateCoherenceLimit",
+    "RandomizedBenchmarking",
+    "X90InterleavedRandomizedBenchmarking",
+]
+
+
+@flow(
+    on_cancellation=[on_flow_cancellation],
+    on_failure=[on_flow_failure],
+    on_crashed=[on_flow_crashed],
+)
+def fine_one(
+    username: str,
+    chip_id: str,
+    mux_ids: list[int] | None = None,
+    exclude_qids: list[str] | None = None,
+    qids: list[str] | None = None,
+    tags: list[str] | None = None,
+    flow_name: str | None = None,
+    project_id: str | None = None,
+) -> Any:
+    """Run the 1-qubit fine-tuning stage using existing coarse calibration.
+
+    Args:
+        username: User name (from UI)
+        chip_id: Chip ID (from UI)
+        mux_ids: MUX IDs to calibrate when using MUX-based scheduling
+        exclude_qids: Qubit IDs to exclude when using mux_ids
+        qids: Qubit IDs to calibrate when mux_ids is not set
+        tags: Flow tags
+        flow_name: Flow name (auto-injected)
+        project_id: Project ID (auto-injected)
+
+    Returns:
+        Pipeline results with one_qubit_fine_tune output
+    """
+    targets: Target
+    if mux_ids is not None:
+        targets = MuxTargets(mux_ids=mux_ids, exclude_qids=exclude_qids or [])
+    elif qids is not None:
+        targets = QubitTargets(qids=qids)
+    else:
+        raise ValueError("mux_ids or qids is required; select targets before running this flow")
+
+    steps = [OneQubitFineTune(mode="synchronized", tasks=FINE_ONE_TASKS)]
+
+    cal = CalibService(
+        username,
+        chip_id,
+        flow_name=flow_name,
+        tags=tags,
+        project_id=project_id,
+        default_run_parameters={
+            "hpi_duration": {"value": 32, "value_type": "int"},
+            "pi_duration": {"value": 32, "value_type": "int"},
+            "drag_hpi_duration": {"value": 16, "value_type": "int"},
+            "drag_pi_duration": {"value": 24, "value_type": "int"},
+            "interval": {"value": 150 * 1024, "value_type": "int"},
+        },
+    )
+    return cal.run(targets, steps=steps)

--- a/src/qdash/workflow/templates/fine_one.py
+++ b/src/qdash/workflow/templates/fine_one.py
@@ -3,10 +3,10 @@
 Run this after coarse_one or an equivalent calibration has established the
 qubit frequency, control amplitude, and readout settings. The flow applies
 those settings and tunes readout amplitude -> frequency -> amplitude -> frequency.
-Each optimization starts with fresh Rabi, HPI, and DRAG PI calibration: the
+Each amplitude/frequency pair starts with fresh Rabi, HPI, and DRAG PI calibration: the
 sweep prepares |1> with DRAG PI, and its final classifier uses two HPI pulses.
 After both rounds, all pulses are calibrated at the final readout settings
-before readout classification, coherence measurements, and randomized benchmarking.
+before readout classification and randomized benchmarking.
 
 Example:
     fine_one(username="alice", chip_id="64Qv3", mux_ids=[0, 1])
@@ -27,33 +27,21 @@ from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
 
 FINE_ONE_TASKS: list[str] = [
     "Configure",
-    # Round 1: prepare HPI and DRAG PI at current readout settings, then tune amplitude.
+    # Round 1: prepare the state pulses, then tune amplitude and frequency consecutively.
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",
     "CreateDRAGPIPulse",
     "CheckDRAGPIPulse",
     "CheckOptimalReadoutAmplitude",
-    # Round 1: prepare HPI and DRAG PI at current readout settings, then tune frequency.
-    "CheckRabi",
-    "CreateHPIPulse",
-    "CheckHPIPulse",
-    "CreateDRAGPIPulse",
-    "CheckDRAGPIPulse",
     "CheckOptimalReadoutFrequency",
-    # Round 2: prepare HPI and DRAG PI at current readout settings, then tune amplitude.
+    # Round 2: refresh the state pulses at the updated settings, then repeat the pair.
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",
     "CreateDRAGPIPulse",
     "CheckDRAGPIPulse",
     "CheckOptimalReadoutAmplitude",
-    # Round 2: prepare HPI and DRAG PI at current readout settings, then tune frequency.
-    "CheckRabi",
-    "CreateHPIPulse",
-    "CheckHPIPulse",
-    "CreateDRAGPIPulse",
-    "CheckDRAGPIPulse",
     "CheckOptimalReadoutFrequency",
     # Calibrate all pulses at the final readout settings before classification and RB.
     "CheckRabi",
@@ -66,9 +54,6 @@ FINE_ONE_TASKS: list[str] = [
     "CreateDRAGPIPulse",
     "CheckDRAGPIPulse",
     "ReadoutClassification",
-    "CheckT1Average",
-    "CheckT2EchoAverage",
-    "Check1QGateCoherenceLimit",
     "RandomizedBenchmarking",
     "X90InterleavedRandomizedBenchmarking",
 ]

--- a/src/qdash/workflow/templates/full_calibration.py
+++ b/src/qdash/workflow/templates/full_calibration.py
@@ -168,7 +168,6 @@ def full_calibration(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,  # Child sessions create their own Executions
         default_run_parameters={
             "hpi_duration": {"value": 32, "value_type": "int"},
             "pi_duration": {"value": 32, "value_type": "int"},

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -1,6 +1,7 @@
 """1-Qubit calibration using step-based pipeline.
 
-This template demonstrates the step-based API for 1-qubit calibration.
+This template combines coarse_one and fine_one, advancing successful qubits
+from the coarse stage to the fine stage. Each stage has its own Execution.
 
 Example:
     one_qubit(
@@ -28,39 +29,12 @@ from qdash.workflow.service.steps import (
     Step,
 )
 from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
+from qdash.workflow.templates.coarse_one import COARSE_ONE_TASKS
+from qdash.workflow.templates.fine_one import FINE_ONE_TASKS
 
-ONE_QUBIT_CHECK_TASKS: list[str] = [
-    "CheckCoarseReadoutParams",
-    "Configure",
-    "CheckRabi",
-    "CheckRabi",
-    "CreateHPIPulse",
-    "CheckHPIPulse",
-    "CheckRabi",
-    "CreateHPIPulse",
-    "CheckHPIPulse",
-    "CheckT1",
-    "CheckT2Echo",
-    "CheckRamsey",
-]
-
-ONE_QUBIT_FINE_TUNE_TASKS: list[str] = [
-    "CheckRabi",
-    "CreateHPIPulse",
-    "CheckHPIPulse",
-    "CreatePIPulse",
-    "CheckPIPulse",
-    "CreateDRAGHPIPulse",
-    "CheckDRAGHPIPulse",
-    "CreateDRAGPIPulse",
-    "CheckDRAGPIPulse",
-    "ReadoutClassification",
-    "CheckT1Average",
-    "CheckT2EchoAverage",
-    "Check1QGateCoherenceLimit",
-    "RandomizedBenchmarking",
-    "X90InterleavedRandomizedBenchmarking",
-]
+# Keep the standalone templates as the source of truth for both stages.
+ONE_QUBIT_CHECK_TASKS: list[str] = list(COARSE_ONE_TASKS)
+ONE_QUBIT_FINE_TUNE_TASKS: list[str] = list(FINE_ONE_TASKS)
 
 
 @flow(
@@ -89,7 +63,7 @@ def one_qubit(
         qids: Qubit IDs to calibrate when mux_ids is not set
         flow_name: Flow name (auto-injected)
         project_id: Project ID (auto-injected)
-        check_only: If True, only run basic check (no fine-tune)
+        check_only: If True, run only the coarse_one stage
 
     Returns:
         Pipeline results with typed step outputs

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -125,7 +125,6 @@ def one_qubit(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,  # Child sessions create their own Executions
         default_run_parameters={
             "hpi_duration": {"value": 32, "value_type": "int"},
             "pi_duration": {"value": 32, "value_type": "int"},

--- a/src/qdash/workflow/templates/simple.py
+++ b/src/qdash/workflow/templates/simple.py
@@ -120,7 +120,6 @@ def simple_calibration(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,  # Child sessions create their own Executions
         default_run_parameters={
             "hpi_duration": {"value": 32, "value_type": "int"},
             "interval": {"value": 150 * 1024, "value_type": "int"},

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -26,7 +26,7 @@
   {
     "id": "one_qubit",
     "name": "1Q Calibration",
-    "description": "1-qubit calibration using step-based pipeline. Requires explicit mux_ids or qids and supports check-only or full calibration with fine-tune.",
+    "description": "Combined coarse_one and fine_one calibration, proceeding to fine-tuning only for successful qubits. Requires explicit mux_ids or qids; check_only runs the coarse stage alone. Each calibration stage has its own Execution.",
     "category": "production",
     "filename": "one_qubit.py",
     "function_name": "one_qubit"

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -32,6 +32,14 @@
     "function_name": "one_qubit"
   },
   {
+    "id": "coarse_one",
+    "name": "Coarse 1Q Calibration",
+    "description": "Coarse 1-qubit calibration after bring-up: Configure -> readout parameter search -> Configure -> Rabi/HPI calibration -> T1/T2Echo -> Ramsey. Requires explicit mux_ids or qids and ends after the check stage.",
+    "category": "production",
+    "filename": "coarse_one.py",
+    "function_name": "coarse_one"
+  },
+  {
     "id": "full_calibration",
     "name": "Full Calibration",
     "description": "Complete calibration for explicitly selected mux_ids using step-based pipeline: ConfigureAll -> 1Q Check -> 1Q Fine-tune -> Filter -> CR Schedule (forward/reverse) -> 2Q.",

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -42,7 +42,7 @@
   {
     "id": "fine_one",
     "name": "Fine 1Q Calibration",
-    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> two consecutive amplitude/frequency optimization pairs, recalibrating Rabi/HPI/DRAG PI before each pair -> final pulse calibration -> readout classification -> randomized benchmarking. Requires explicit mux_ids or qids.",
+    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> two amplitude/frequency optimization pairs, recalibrating Rabi/HPI/DRAG PI before each pair and applying Configure after each frequency update -> final pulse calibration -> readout classification -> randomized benchmarking. Requires explicit mux_ids or qids.",
     "category": "production",
     "filename": "fine_one.py",
     "function_name": "fine_one"

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -42,7 +42,7 @@
   {
     "id": "fine_one",
     "name": "Fine 1Q Calibration",
-    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> Rabi/HPI/PI -> DRAG -> readout classification -> coherence averages -> randomized benchmarking. Requires explicit mux_ids or qids and runs only the fine-tuning stage.",
+    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> readout amplitude/frequency optimization twice, recalibrating Rabi/HPI/DRAG PI before each optimization -> final pulse calibration -> readout classification -> coherence averages -> randomized benchmarking. Requires explicit mux_ids or qids.",
     "category": "production",
     "filename": "fine_one.py",
     "function_name": "fine_one"

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -40,6 +40,14 @@
     "function_name": "coarse_one"
   },
   {
+    "id": "fine_one",
+    "name": "Fine 1Q Calibration",
+    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> Rabi/HPI/PI -> DRAG -> readout classification -> coherence averages -> randomized benchmarking. Requires explicit mux_ids or qids and runs only the fine-tuning stage.",
+    "category": "production",
+    "filename": "fine_one.py",
+    "function_name": "fine_one"
+  },
+  {
     "id": "full_calibration",
     "name": "Full Calibration",
     "description": "Complete calibration for explicitly selected mux_ids using step-based pipeline: ConfigureAll -> 1Q Check -> 1Q Fine-tune -> Filter -> CR Schedule (forward/reverse) -> 2Q.",

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -42,7 +42,7 @@
   {
     "id": "fine_one",
     "name": "Fine 1Q Calibration",
-    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> readout amplitude/frequency optimization twice, recalibrating Rabi/HPI/DRAG PI before each optimization -> final pulse calibration -> readout classification -> coherence averages -> randomized benchmarking. Requires explicit mux_ids or qids.",
+    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> two consecutive amplitude/frequency optimization pairs, recalibrating Rabi/HPI/DRAG PI before each pair -> final pulse calibration -> readout classification -> randomized benchmarking. Requires explicit mux_ids or qids.",
     "category": "production",
     "filename": "fine_one.py",
     "function_name": "fine_one"

--- a/src/qdash/workflow/templates/two_qubit.py
+++ b/src/qdash/workflow/templates/two_qubit.py
@@ -189,7 +189,6 @@ def two_qubit(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,  # Child sessions create their own Executions
         default_run_parameters={
             "interval": {"value": 150 * 1024, "value_type": "int"},
         },

--- a/src/qdash/workflow/templates/two_qubit_scheduled.py
+++ b/src/qdash/workflow/templates/two_qubit_scheduled.py
@@ -158,7 +158,6 @@ def two_qubit_scheduled(
         flow_name=flow_name,
         tags=tags,
         project_id=project_id,
-        skip_execution=True,  # Child sessions create their own Executions
         default_run_parameters={
             "interval": {"value": 150 * 1024, "value_type": "int"},
         },

--- a/tests/qdash/api/services/test_flow_service.py
+++ b/tests/qdash/api/services/test_flow_service.py
@@ -94,8 +94,10 @@ async def test_list_templates_uses_resolved_templates_metadata(
 
 
 @pytest.mark.asyncio
-async def test_coarse_one_template_is_listed_and_loads_its_flow_code(
+@pytest.mark.parametrize("template_id", ["coarse_one", "fine_one"])
+async def test_partial_one_qubit_template_is_listed_and_loads_its_flow_code(
     monkeypatch: pytest.MonkeyPatch,
+    template_id: str,
 ) -> None:
     templates_dir = Path(__file__).resolve().parents[4] / "src/qdash/workflow/templates"
     monkeypatch.setattr(flow_service, "TEMPLATES_DIR", templates_dir)
@@ -103,10 +105,10 @@ async def test_coarse_one_template_is_listed_and_loads_its_flow_code(
     service = FlowService(flow_repository=MagicMock())
 
     templates = await service.list_templates()
-    assert any(template.id == "coarse_one" for template in templates)
-    template = await service.get_template("coarse_one")
-    assert template.function_name == "coarse_one"
-    assert template.code == (templates_dir / "coarse_one.py").read_text(encoding="utf-8")
+    assert any(template.id == template_id for template in templates)
+    template = await service.get_template(template_id)
+    assert template.function_name == template_id
+    assert template.code == (templates_dir / f"{template_id}.py").read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize(

--- a/tests/qdash/api/services/test_flow_service.py
+++ b/tests/qdash/api/services/test_flow_service.py
@@ -93,6 +93,22 @@ async def test_list_templates_uses_resolved_templates_metadata(
     assert any(template.id == "full_calibration" for template in templates)
 
 
+@pytest.mark.asyncio
+async def test_coarse_one_template_is_listed_and_loads_its_flow_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    templates_dir = Path(__file__).resolve().parents[4] / "src/qdash/workflow/templates"
+    monkeypatch.setattr(flow_service, "TEMPLATES_DIR", templates_dir)
+    monkeypatch.setattr(flow_service, "TEMPLATES_METADATA_FILE", templates_dir / "templates.json")
+    service = FlowService(flow_repository=MagicMock())
+
+    templates = await service.list_templates()
+    assert any(template.id == "coarse_one" for template in templates)
+    template = await service.get_template("coarse_one")
+    assert template.function_name == "coarse_one"
+    assert template.code == (templates_dir / "coarse_one.py").read_text(encoding="utf-8")
+
+
 @pytest.mark.parametrize(
     ("execution_name", "expected_flow_name"),
     [

--- a/tests/qdash/api/services/test_task_file_service.py
+++ b/tests/qdash/api/services/test_task_file_service.py
@@ -138,9 +138,10 @@ def test_list_task_info_uses_configured_category_and_task_order() -> None:
     enabled_tasks = [task for task in tasks if task.enabled]
 
     assert [task.category for task in enabled_tasks[:3]] == ["One Qubit"] * 3
-    assert [task.name for task in enabled_tasks[:3]] == [
+    assert [task.name for task in enabled_tasks[:4]] == [
         "CheckChevron",
         "CheckOptimalReadoutAmplitude",
+        "CheckOptimalReadoutFrequency",
         "CheckRabi",
     ]
     assert list(dict.fromkeys(task.category for task in enabled_tasks)) == [

--- a/tests/qdash/api/services/test_task_file_service.py
+++ b/tests/qdash/api/services/test_task_file_service.py
@@ -161,6 +161,27 @@ def test_list_task_info_extracts_input_parameter_metadata() -> None:
     assert task.input_parameters["qubit_frequency"]["resolution"] == "default_only"
 
 
+def test_coarse_readout_task_is_enabled_with_resolvable_input_metadata() -> None:
+    clear_backend_config_cache()
+    task = next(
+        task
+        for task in TaskFileService().list_task_info("qubex", enabled_only=True).tasks
+        if task.name == "CheckCoarseReadoutParams"
+    )
+
+    assert task.enabled
+    assert set(task.input_parameters) == {
+        "qubit_frequency",
+        "control_amplitude",
+        "readout_frequency",
+        "readout_amplitude",
+        "readout_duration",
+    }
+    duration = task.input_parameters["readout_duration"]["default_value"]
+    assert isinstance(duration, (int, float))
+    assert duration > 0
+
+
 def test_list_task_info_resolves_local_and_qubex_constants() -> None:
     from qubex.experiment.experiment_constants import CALIBRATION_SHOTS
     from qubex.measurement.measurement_defaults import DEFAULT_READOUT_DURATION

--- a/tests/qdash/repository/test_execution_finalizer.py
+++ b/tests/qdash/repository/test_execution_finalizer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 from qdash.datamodel.system_info import SystemInfoModel
 from qdash.dbmodel.execution_history import ExecutionHistoryDocument
 from qdash.dbmodel.execution_lock import ExecutionLockDocument
@@ -372,6 +374,34 @@ def test_returns_empty_list_when_nothing_matches(init_db) -> None:
     )
 
     assert closed == []
+
+
+@pytest.mark.parametrize("has_running_step", [False, True])
+@pytest.mark.parametrize("release_lock", [False, True])
+def test_terminal_flow_releases_lock_owned_by_completed_first_step(
+    init_db, has_running_step: bool, release_lock: bool
+) -> None:
+    """A crash between or during later steps preserves the completed first step."""
+    _make_execution(status="completed", execution_id="exec-first")
+    if has_running_step:
+        _make_execution(status="running", execution_id="exec-second")
+    ExecutionLockDocument(project_id=PROJECT_ID, locked=True, execution_id="exec-first").save()
+
+    closed = finalize_executions_by_flow_run_id(
+        project_id=PROJECT_ID,
+        flow_run_id=FLOW_RUN_ID,
+        status="failed",
+        message="Flow crashed",
+        release_lock=release_lock,
+    )
+
+    assert closed == (["exec-second"] if has_running_step else [])
+    first = _reload_execution("exec-first")
+    assert first is not None
+    assert first.status == "completed"
+    lock = ExecutionLockDocument.find_one({"project_id": PROJECT_ID}).run()
+    assert lock is not None
+    assert lock.locked is not release_lock
 
 
 def test_release_lock_swallows_lookup_failure(init_db) -> None:

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_coarse_readout_params.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_coarse_readout_params.py
@@ -1,0 +1,423 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import numpy as np
+import plotly.graph_objects as go
+import pytest
+import qubex
+from qubex.contrib.experiment.readout_parameters_characterization import (
+    characterize_coarse_readout_parameters,
+)
+
+from qdash.datamodel.task import InputParameterModel, TaskStatusModel
+from qdash.workflow.calibtasks.qubex.one_qubit_coarse.check_coarse_readout_params import (
+    CheckCoarseReadoutParams,
+)
+from qdash.workflow.calibtasks.qubex.one_qubit_coarse.check_rabi import CheckRabi
+from qdash.workflow.engine.backend.plugins.qubex_progress import (
+    ReportingTqdm,
+    capture_qubex_progress,
+)
+from qdash.workflow.engine.progress import ProgressPlan, TaskProgress
+from qdash.workflow.engine.task.executor import TaskExecutor
+from qdash.workflow.engine.task.state_manager import TaskStateManager
+
+
+@pytest.fixture
+def coarse_readout(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    task = CheckCoarseReadoutParams()
+    task.input_parameters["qubit_frequency"] = InputParameterModel(value=5.1, unit="GHz")
+    task.input_parameters["control_amplitude"] = InputParameterModel(value=0.03, unit="a.u.")
+    task.input_parameters["readout_frequency"] = InputParameterModel(value=6.0, unit="GHz")
+    task.input_parameters["readout_amplitude"] = InputParameterModel(value=0.1, unit="a.u.")
+    # Qubex flattens a (2 amplitudes, 3 frequencies) scan in amplitude-major order.
+    # The selected point is index 4, not the last scan or the point with highest R².
+    rabi_results = [
+        SimpleNamespace(rabi_params={"Q00": SimpleNamespace(r2=0.99)}) for _ in range(6)
+    ]
+    result = SimpleNamespace(
+        data={
+            "frequency_range": np.array([6.0, 6.01, 6.02]),
+            "readout_amplitudes": np.array([0.0, 0.1]),
+            "optimal_readout_frequency": 6.01,
+            "optimal_readout_amplitude": 0.1,
+            "rabi_results": rabi_results,
+        },
+        figure=go.Figure(),
+    )
+    params = SimpleNamespace(control_amplitude={"Q00": 0.01}, readout_amplitude={"Q00": 0.2})
+    qubit = SimpleNamespace(frequency=5.0)
+
+    @contextmanager
+    def modified_frequencies(frequencies: dict[str, float]) -> Iterator[None]:
+        original = qubit.frequency
+        qubit.frequency = frequencies["Q00"]
+        try:
+            yield
+        finally:
+            qubit.frequency = original
+
+    experiment = SimpleNamespace(
+        params=params,
+        ctx=SimpleNamespace(params=params),
+        experiment_system=SimpleNamespace(
+            control_params=SimpleNamespace(
+                get_readout_amplitude=lambda label: params.readout_amplitude[label],
+                get_control_amplitude=lambda label: params.control_amplitude[label],
+            ),
+            quantum_system=SimpleNamespace(get_qubit=lambda _label: qubit),
+        ),
+        modified_frequencies=modified_frequencies,
+        rabi_experiment=MagicMock(),
+    )
+    backend = cast("Any", SimpleNamespace(name="qubex", update_note=MagicMock()))
+    save_calibration = MagicMock()
+    characterize = MagicMock(return_value=result)
+    monkeypatch.setattr(task, "get_experiment", lambda _backend: experiment)
+    monkeypatch.setattr(task, "get_qubit_label", lambda _backend, _qid: "Q00")
+    monkeypatch.setattr(task, "save_calibration", save_calibration)
+    monkeypatch.setattr(task, "prepare_run", lambda *_args: None)
+    monkeypatch.setattr(task, "preprocess", lambda *_args: None)
+    monkeypatch.setattr(qubex.contrib, "characterize_coarse_readout_parameters", characterize)
+    return SimpleNamespace(
+        task=task,
+        backend=backend,
+        result=result,
+        rabi_results=rabi_results,
+        save_calibration=save_calibration,
+        characterize=characterize,
+        experiment=experiment,
+        qubit=qubit,
+    )
+
+
+def test_selected_r2_ignores_unselected_poor_fits(coarse_readout: SimpleNamespace) -> None:
+    for result in coarse_readout.rabi_results:
+        result.rabi_params["Q00"].r2 = np.nan
+    coarse_readout.rabi_results[4].rabi_params["Q00"].r2 = np.float64(0.61)
+
+    run_result = coarse_readout.task.run(coarse_readout.backend, "0")
+    postprocess = coarse_readout.task.postprocess(coarse_readout.backend, "exec-1", run_result, "0")
+
+    assert coarse_readout.task.r2_threshold == CheckRabi.r2_threshold == 0.6
+    assert run_result.r2 == {"0": 0.61}
+    assert postprocess.validation_error is None
+    assert postprocess.output_parameters["readout_frequency"].value == 6.01
+    assert postprocess.output_parameters["readout_amplitude"].value == 0.1
+    coarse_readout.save_calibration.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("amplitude", "frequency_range", "ratio_range", "n_sweeps"),
+    [
+        (0.1, (-0.015, 0.015, 13), (0.8, 1.2, 5), 65),
+        (1.0, (-0.015, 0.015, 13), (0.8, 1.2, 5), 39),
+        (0.1, (-0.005, 0.005, 3), (0.9, 1.1, 3), 9),
+        (0.1, (0, 0, 3), (1, 1, 3), 1),
+    ],
+)
+def test_progress_plan_counts_the_effective_scan_grid(
+    coarse_readout: SimpleNamespace,
+    amplitude: float,
+    frequency_range: tuple[float, float, int],
+    ratio_range: tuple[float, float, int],
+    n_sweeps: int,
+) -> None:
+    task = coarse_readout.task
+    task.input_parameters["readout_amplitude"].value = amplitude
+    task.run_parameters["detuning_range"].value = frequency_range
+    task.run_parameters["readout_amplitude_ratio_range"].value = ratio_range
+
+    assert TaskExecutor._progress_plan(task) == ProgressPlan(n_sweeps, n_sweeps)
+    coarse_readout.characterize.assert_not_called()
+
+
+@pytest.mark.parametrize(("amplitude", "n_sweeps"), [(0.1, 65), (1.0, 39)])
+def test_real_readout_search_reports_all_sweeps_from_the_first_measurement(
+    coarse_readout: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    amplitude: float,
+    n_sweeps: int,
+) -> None:
+    task = coarse_readout.task
+    task.input_parameters["readout_amplitude"].value = amplitude
+    exp = coarse_readout.experiment
+    exp.ctx.resolve_qubit_label = lambda target: target
+    exp.ctx.resonators = {"Q00": SimpleNamespace(label="RQ00", frequency=6.5)}
+    events: list[TaskProgress] = []
+
+    def rabi_experiment(**kwargs: Any) -> SimpleNamespace:
+        # Each real Rabi experiment opens one disabled parameter-sweep tqdm.
+        list(
+            ReportingTqdm(
+                kwargs["time_range"],
+                desc="Sweeping parameters",
+                disable=True,
+                file=StringIO(),
+            )
+        )
+        return SimpleNamespace(
+            data={"Q00": SimpleNamespace(data=np.array([0j, 1j, -1j]))},
+            rabi_params={"Q00": SimpleNamespace(r2=0.95)},
+        )
+
+    def characterize(sweep_exp: Any, **kwargs: Any) -> Any:
+        return characterize_coarse_readout_parameters(
+            sweep_exp, plot=False, save_image=False, **kwargs
+        )
+
+    monkeypatch.setattr(exp, "rabi_experiment", rabi_experiment)
+    monkeypatch.setattr(qubex.contrib, "characterize_coarse_readout_parameters", characterize)
+    with capture_qubex_progress(
+        events.append, task_name=task.name, plan=TaskExecutor._progress_plan(task)
+    ):
+        task.run(coarse_readout.backend, "0")
+
+    assert events[0].phase == 1
+    assert events[0].current == 0
+    assert events[-1].phase == n_sweeps
+    assert events[-1].current == events[-1].total == 26
+    assert all(event.has_multiple_phases for event in events)
+    assert all(event.phase_total_min == event.phase_total_max == n_sweeps for event in events)
+    assert all(event.description == "Readout parameter search" for event in events)
+    fractions = []
+    for event in events:
+        assert event.total is not None
+        fractions.append((event.phase - 1 + event.current / event.total) / n_sweeps)
+    assert fractions == sorted(fractions)
+    assert fractions[0] == 0
+    assert fractions[-1] == 1
+    assert all(
+        fraction < 1
+        for event, fraction in zip(events, fractions, strict=True)
+        if event.phase < n_sweeps
+    )
+
+
+@pytest.mark.parametrize("r2", [0.59, 0.6, None, np.nan, np.inf, -np.inf, 1.1])
+def test_rejected_selected_fit_preserves_figure_and_blocks_outputs(
+    coarse_readout: SimpleNamespace,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    r2: float | None,
+) -> None:
+    coarse_readout.rabi_results[4].rabi_params["Q00"].r2 = r2
+    state = TaskStateManager(qids=["0"])
+    saver = MagicMock()
+    saver.save_figures.return_value = (["heatmap.png"], ["heatmap.json"])
+    executor = TaskExecutor(
+        state_manager=state,
+        calib_dir=str(tmp_path),
+        execution_id="exec-1",
+        username="test",
+        task_manager_id="tm-1",
+        data_saver=saver,
+    )
+
+    with pytest.raises(ValueError, match="R²"):
+        executor.execute_task(coarse_readout.task, coarse_readout.backend, "0")
+
+    model = state.get_task(coarse_readout.task.name, "qubit", "0")
+    assert model.status == TaskStatusModel.FAILED
+    assert model.output_parameters == {}
+    assert state.get_qubit_calib_data("0") == {}
+    saver.save_figures.assert_called_once()
+    assert saver.save_figures.call_args.args[0] == [coarse_readout.result.figure]
+    coarse_readout.save_calibration.assert_not_called()
+
+    # Even a forced backend save cannot publish the rejected candidate after rollback.
+    qubit_repo = MagicMock()
+    coupling_repo = MagicMock()
+    update_params = MagicMock()
+    monkeypatch.setattr("qdash.repository.MongoQubitCalibrationRepository", lambda: qubit_repo)
+    monkeypatch.setattr(
+        "qdash.repository.MongoCouplingCalibrationRepository", lambda: coupling_repo
+    )
+    executor._backend_saver._force_update_params = True
+    monkeypatch.setattr(executor._backend_saver, "_update_backend_params", update_params)
+    executor._backend_saver.save(
+        coarse_readout.task,
+        cast("Any", SimpleNamespace(chip_id="chip", project_id="project", execution_id="exec-1")),
+        "0",
+        coarse_readout.backend,
+        False,
+    )
+    qubit_repo.update_calib_data.assert_not_called()
+    coupling_repo.update_calib_data.assert_not_called()
+    update_params.assert_not_called()
+
+
+@pytest.mark.parametrize("missing", ["rabi_results", "frequency_range", "readout_amplitudes"])
+def test_missing_selection_metadata_fails_after_postprocess(
+    coarse_readout: SimpleNamespace, missing: str
+) -> None:
+    del coarse_readout.result.data[missing]
+    run_result = coarse_readout.task.run(coarse_readout.backend, "0")
+    postprocess = coarse_readout.task.postprocess(coarse_readout.backend, "exec-1", run_result, "0")
+
+    assert run_result.r2 == {"0": None}
+    assert postprocess.validation_error == "Selected readout point R² is missing"
+    assert postprocess.figures == [coarse_readout.result.figure]
+    coarse_readout.save_calibration.assert_not_called()
+
+
+def test_selected_result_must_belong_to_requested_qubit(coarse_readout: SimpleNamespace) -> None:
+    coarse_readout.rabi_results[4].rabi_params = {"Q01": SimpleNamespace(r2=0.99)}
+    run_result = coarse_readout.task.run(coarse_readout.backend, "0")
+
+    assert run_result.r2 == {"0": None}
+    coarse_readout.save_calibration.assert_not_called()
+
+
+@pytest.mark.parametrize("time_range", [(0, 101, 4), (0, 401, 10)])
+def test_rabi_time_range_is_passed_to_qubex(
+    coarse_readout: SimpleNamespace, time_range: tuple[int, int, int]
+) -> None:
+    coarse_readout.task.run_parameters["time_range"].value = time_range
+    coarse_readout.task.run_parameters["shots"].value = 4096
+    coarse_readout.task.run(coarse_readout.backend, "0")
+
+    kwargs = coarse_readout.characterize.call_args.kwargs
+    np.testing.assert_array_equal(kwargs["time_range"], np.arange(*time_range))
+    assert kwargs["n_shots"] == 4096
+
+
+def test_default_sweep_is_local_and_uses_half_the_shots(coarse_readout: SimpleNamespace) -> None:
+    coarse_readout.task.run(coarse_readout.backend, "0")
+    kwargs = coarse_readout.characterize.call_args.kwargs
+
+    np.testing.assert_allclose(kwargs["frequency_range"], np.linspace(5.985, 6.015, 13))
+    np.testing.assert_allclose(kwargs["readout_amplitudes"], [0.08, 0.09, 0.1, 0.11, 0.12])
+    assert kwargs["frequency_range"][6] == 6.0
+    assert kwargs["readout_amplitudes"][2] == 0.1
+    assert kwargs["n_shots"] == 1024
+    np.testing.assert_array_equal(kwargs["time_range"], np.arange(0, 101, 4))
+
+
+def test_sweep_respects_effective_inputs_and_run_overrides(
+    coarse_readout: SimpleNamespace,
+) -> None:
+    task = coarse_readout.task
+    task.input_parameters["readout_frequency"].value = 7.0
+    task.input_parameters["readout_amplitude"].value = 0.2
+    task.run_parameters["detuning_range"].value = (-0.025, 0.025, 21)
+    task.run_parameters["readout_amplitude_ratio_range"].value = (0.5, 1.5, 7)
+    task.run(coarse_readout.backend, "0")
+    kwargs = coarse_readout.characterize.call_args.kwargs
+
+    np.testing.assert_allclose(kwargs["frequency_range"], np.linspace(6.975, 7.025, 21))
+    np.testing.assert_allclose(kwargs["readout_amplitudes"], np.linspace(0.1, 0.3, 7))
+    assert task.input_parameters["readout_amplitude"].value == 0.2
+
+
+def test_sweep_caps_amplitude_without_duplicate_measurements(
+    coarse_readout: SimpleNamespace,
+) -> None:
+    coarse_readout.task.input_parameters["readout_amplitude"].value = 1.0
+    coarse_readout.task.run(coarse_readout.backend, "0")
+    np.testing.assert_allclose(
+        coarse_readout.characterize.call_args.kwargs["readout_amplitudes"], [0.8, 0.9, 1.0]
+    )
+    assert coarse_readout.task.input_parameters["readout_amplitude"].value == 1.0
+
+
+@pytest.mark.parametrize("amplitude", [None, 0.0, -0.1, 1.1, np.nan, np.inf])
+def test_invalid_reference_amplitude_stops_before_measurement(
+    coarse_readout: SimpleNamespace, amplitude: float | None
+) -> None:
+    coarse_readout.task.input_parameters["readout_amplitude"].value = amplitude
+    with pytest.raises(ValueError, match="readout_amplitude"):
+        coarse_readout.task.run(coarse_readout.backend, "0")
+    coarse_readout.characterize.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("detuning_range", (-0.01, 0.01, 0)),
+        ("detuning_range", (-8.0, -7.0, 3)),
+        ("readout_amplitude_ratio_range", (-0.5, 0.5, 3)),
+        ("readout_amplitude_ratio_range", (0.8, 1.2, 0)),
+    ],
+)
+def test_invalid_scan_stops_before_measurement(
+    coarse_readout: SimpleNamespace, name: str, value: tuple[float, float, int]
+) -> None:
+    coarse_readout.task.run_parameters[name].value = value
+    with pytest.raises(ValueError):
+        coarse_readout.task.run(coarse_readout.backend, "0")
+    coarse_readout.characterize.assert_not_called()
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_real_qubex_helper_uses_resolved_rabi_inputs_and_restores_context(
+    coarse_readout: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+    fail: bool,
+) -> None:
+    task = coarse_readout.task
+    exp = coarse_readout.experiment
+    task.input_parameters["qubit_frequency"].value = 5.4
+    task.input_parameters["control_amplitude"].value = 0.04
+    task.input_parameters["readout_duration"].value = 2300
+    exp.ctx.resolve_qubit_label = lambda target: target
+    exp.ctx.resonators = {"Q00": SimpleNamespace(label="RQ00", frequency=6.5)}
+    observed: list[dict[str, Any]] = []
+
+    def rabi_experiment(**kwargs: Any) -> SimpleNamespace:
+        assert coarse_readout.qubit.frequency == 5.4
+        assert kwargs["amplitudes"] == {"Q00": 0.04}
+        assert kwargs["readout_duration"] == 2300
+        assert kwargs["n_shots"] == 1024
+        assert kwargs["store_params"] is False
+        observed.append(kwargs)
+        if fail:
+            raise RuntimeError("measurement failed")
+        return SimpleNamespace(
+            data={
+                "Q00": SimpleNamespace(
+                    data=np.array([0j, 1j, -1j]) * exp.params.readout_amplitude["Q00"]
+                )
+            },
+            rabi_params={"Q00": SimpleNamespace(r2=0.95)},
+        )
+
+    def characterize(sweep_exp: Any, **kwargs: Any) -> Any:
+        return characterize_coarse_readout_parameters(
+            sweep_exp, plot=False, save_image=False, **kwargs
+        )
+
+    monkeypatch.setattr(exp, "rabi_experiment", rabi_experiment)
+    monkeypatch.setattr(qubex.contrib, "characterize_coarse_readout_parameters", characterize)
+    if fail:
+        with pytest.raises(RuntimeError, match="measurement failed"):
+            task.run(coarse_readout.backend, "0")
+        coarse_readout.save_calibration.assert_not_called()
+    else:
+        result = task.run(coarse_readout.backend, "0")
+        assert result.r2 == {"0": 0.95}
+        assert len(observed) == 65
+        np.testing.assert_allclose(
+            [kwargs["frequencies"]["RQ00"] for kwargs in observed[:13]],
+            np.linspace(5.985, 6.015, 13),
+        )
+
+    assert coarse_readout.qubit.frequency == 5.0
+    assert exp.params.control_amplitude == {"Q00": 0.01}
+    assert exp.params.readout_amplitude == {"Q00": 0.2}
+    assert task.input_parameters["readout_duration"].value == 2300
+
+
+@pytest.mark.parametrize("duration", [0, -1, np.nan, np.inf])
+def test_invalid_readout_duration_stops_before_measurement(
+    coarse_readout: SimpleNamespace, duration: float
+) -> None:
+    coarse_readout.task.input_parameters["readout_duration"].value = duration
+    with pytest.raises(ValueError, match="readout_duration"):
+        coarse_readout.task.run(coarse_readout.backend, "0")
+    coarse_readout.characterize.assert_not_called()

--- a/tests/qdash/workflow/engine/test_qubex_progress.py
+++ b/tests/qdash/workflow/engine/test_qubex_progress.py
@@ -90,6 +90,58 @@ def test_capture_qubex_progress_includes_phase_count_bounds() -> None:
 
     assert events[-1].phase_total_min == 2
     assert events[-1].phase_total_max == 4
+    assert events[-1].overall_eta_seconds is None
+
+
+def test_overall_eta_uses_elapsed_time_across_sweeps_and_resets_per_task(monkeypatch) -> None:
+    """Whole-search ETA survives phase boundaries and includes time between sweeps."""
+    clock = [100.0]
+    monkeypatch.setattr(
+        "qdash.workflow.engine.backend.plugins.qubex_progress.time.monotonic", lambda: clock[0]
+    )
+    events: list[TaskProgress] = []
+    with capture_qubex_progress(events.append, plan=ProgressPlan(3, 3)):
+        with ReportingTqdm(total=2, disable=True, file=StringIO()) as bar:
+            assert events[-1].overall_eta_seconds is None
+            clock[0] = 102
+            bar.update()
+            bar.display()
+            assert events[-1].overall_eta_seconds is None
+            clock[0] = 104
+            bar.update()
+            bar.display()
+            assert events[-1].overall_eta_seconds == pytest.approx(8)
+        clock[0] = 106
+        with ReportingTqdm(total=2, disable=True, file=StringIO()) as bar:
+            assert events[-1].current == 0
+            assert events[-1].overall_eta_seconds == pytest.approx(12)
+            clock[0] = 108
+            bar.update()
+            bar.display()
+            assert events[-1].overall_eta_seconds == pytest.approx(8)
+            clock[0] = 110
+            bar.update()
+            bar.display()
+            assert events[-1].overall_eta_seconds == pytest.approx(5)
+        clock[0] = 112
+        with ReportingTqdm(total=2, disable=True, file=StringIO()) as bar:
+            assert events[-1].overall_eta_seconds == pytest.approx(6)
+            clock[0] = 116
+            bar.update(2)
+            bar.display()
+            assert events[-1].overall_eta_seconds == 0
+
+    clock[0] = 200
+    with (
+        capture_qubex_progress(events.append, plan=ProgressPlan(2, 2)),
+        ReportingTqdm(total=2, disable=True, file=StringIO()) as bar,
+    ):
+        assert events[-1].phase == 1
+        assert events[-1].overall_eta_seconds is None
+        clock[0] = 204
+        bar.update(2)
+        bar.display()
+        assert events[-1].overall_eta_seconds == pytest.approx(4)
 
 
 def test_capture_qubex_progress_reports_before_first_iteration() -> None:

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -804,3 +804,253 @@ class TestRunPipelineFailureLogging:
 
         with pytest.raises(RuntimeError, match="boom"):
             session._run_pipeline(QubitTargets(["0"]), [BoomStep()])
+
+
+@pytest.fixture
+def pipeline_execution_env(mock_flow_session_deps, monkeypatch):
+    """Exercise real pipeline/strategy lifecycle without hardware or database I/O."""
+    records = []
+    lock = MockExecutionLockRepository(locked=True, owner="exec-reserved")
+    claims = MagicMock(side_effect=["exec-reserved", None])
+    monkeypatch.setattr(CalibService, "_read_flow_run_id_from_context", lambda self: "flow-1")
+    monkeypatch.setattr(
+        "qdash.repository.MongoExecutionRepository",
+        lambda: SimpleNamespace(claim_scheduled_execution=claims),
+    )
+
+    class RecordingOrchestrator(MockCalibOrchestrator):
+        def initialize(self):
+            super().initialize()
+            record = SimpleNamespace(config=self.config, status="running")
+            records.append(record)
+            for method, status in (
+                ("complete", "completed"),
+                ("fail", "failed"),
+                ("cancel", "cancelled"),
+            ):
+
+                def close(status=status):
+                    assert lock.locked  # No stage may release the pipeline lock.
+                    record.status = status
+                    return self._execution_service
+
+                setattr(self._execution_service, method, close)
+
+    monkeypatch.setattr(
+        "qdash.workflow.service.calib_service.CalibOrchestrator", RecordingOrchestrator
+    )
+    for method in (
+        "record_stage_result",
+        "_finalize_stale_running_tasks",
+        "_finalize_tasks_on_cancel",
+        "_update_chip_history",
+        "_push_to_github_if_configured",
+    ):
+        monkeypatch.setattr(CalibService, method, MagicMock())
+    schedule = SimpleNamespace(
+        stages=[SimpleNamespace(box_type="A", parallel_groups=[["0", "1"]])],
+        steps=[SimpleNamespace(box_type="A", parallel_qids=["0", "1"], step_index=0)],
+        total_steps=1,
+        metadata={"strategy": "test"},
+    )
+    scheduler = MagicMock()
+    scheduler.generate_from_mux.return_value = schedule
+    scheduler.generate_synchronized_from_mux.return_value = schedule
+    scheduler.generate_simultaneous_spectroscopy_batches_from_mux.return_value = schedule
+    monkeypatch.setattr("qdash.workflow.service.strategy.OneQubitScheduler", lambda **kw: scheduler)
+    return SimpleNamespace(records=records, lock=lock, claims=claims)
+
+
+@pytest.mark.parametrize("skip_execution", [False, True])
+@pytest.mark.parametrize(
+    "mode", ["synchronized", "scheduled", "serial", "simultaneous_spectroscopy"]
+)
+def test_pipeline_owns_one_execution_per_calibration_step(
+    pipeline_execution_env, monkeypatch, skip_execution, mode
+):
+    from qdash.workflow.service.steps import FilterByStatus, OneQubitCheck, OneQubitFineTune
+
+    env = pipeline_execution_env
+    worker_ids = []
+
+    def run_workers(*, tasks, qids=None, mux_groups=None, session_config=None):
+        session = get_session()
+        assert env.lock.owner == "exec-reserved"
+        assert all(record.status == "completed" for record in env.records[:-1])
+        worker_ids.append(
+            session_config["execution_id"] if session_config else session.execution_id
+        )
+        return {"0": {"status": "success"}, "1": {"status": "success"}}
+
+    for method in (
+        "run_qubit_calibrations_parallel",
+        "run_mux_calibrations_parallel",
+        "_calibrate_mux_qubits",
+    ):
+        monkeypatch.setattr(f"qdash.workflow.service.strategy.{method}", run_workers)
+    monkeypatch.setattr(
+        CalibService, "execute_task_batch", lambda self, name, qids: run_workers(tasks=[name])
+    )
+    session = CalibService(
+        "alice",
+        "chip-1",
+        project_id="project-1",
+        flow_name="one",
+        skip_execution=skip_execution,
+        enable_github=False,
+        lock_repo=env.lock,
+        counter_repo=FakeExecutionCounterRepository(2),
+    )
+
+    session.run(
+        QubitTargets(["0", "1"]),
+        steps=[
+            OneQubitCheck(mode=mode, tasks=["CheckRabi"]),
+            FilterByStatus(),
+            OneQubitFineTune(mode=mode, tasks=["CheckRamsey"]),
+        ],
+    )
+
+    assert len(env.records) == 2
+    first, second = env.records
+    assert first.config.execution_id == "exec-reserved"
+    assert second.config.execution_id != first.config.execution_id
+    assert worker_ids == [first.config.execution_id, second.config.execution_id]
+    assert [record.status for record in env.records] == ["completed", "completed"]
+    assert [record.config.flow_name for record in env.records] == [
+        "one_one_qubit_check",
+        "one_one_qubit_fine_tune",
+    ]
+    assert [record.config.note["step_index"] for record in env.records] == [1, 3]
+    assert all(record.config.note["flow_run_id"] == "flow-1" for record in env.records)
+    assert all(record.config.skip_execution is False for record in env.records)
+    assert env.lock.try_lock_calls == ["exec-reserved"]
+    assert env.lock.locked is False
+    assert session.flow_name == "one"
+    with pytest.raises(RuntimeError, match="No active"):
+        get_session()
+
+
+@pytest.mark.parametrize("cancel", [False, True])
+@pytest.mark.parametrize("transform_failure", [False, True])
+def test_pipeline_failure_preserves_completed_steps(
+    pipeline_execution_env, cancel, transform_failure
+):
+    from qdash.workflow.service.steps.base import TransformStep
+
+    env = pipeline_execution_env
+
+    class CancelledRun(BaseException):
+        pass
+
+    class FirstStep(BoomStep):
+        def execute(self, service, targets, ctx):
+            return ctx
+
+    class FailureStep(BoomStep):
+        def execute(self, service, targets, ctx):
+            assert env.lock.locked
+            assert env.records[0].status == "completed"
+            raise CancelledRun() if cancel else RuntimeError("boom")
+
+    class FailureTransform(FailureStep, TransformStep):
+        pass
+
+    session = CalibService(
+        "alice",
+        "chip-1",
+        project_id="project-1",
+        enable_github=False,
+        lock_repo=env.lock,
+        counter_repo=FakeExecutionCounterRepository(2),
+    )
+    with pytest.raises(CancelledRun if cancel else RuntimeError):
+        session.run(
+            QubitTargets(["0"]),
+            steps=[
+                FirstStep(),
+                FailureTransform() if transform_failure else FailureStep(),
+            ],
+        )
+    expected = (
+        ["completed"] if transform_failure else ["completed", "cancelled" if cancel else "failed"]
+    )
+    assert [record.status for record in env.records] == expected
+    assert env.lock.locked is False
+
+
+@pytest.mark.parametrize("skip_execution", [False, True])
+def test_single_step_without_api_reservation_creates_one_execution(
+    pipeline_execution_env, monkeypatch, skip_execution
+):
+    from qdash.workflow.service.steps import CustomOneQubit
+
+    env = pipeline_execution_env
+    env.lock.unlock("project-1")
+    env.claims.side_effect = [None]
+    worker = MagicMock(return_value={"0": {"status": "success"}})
+    monkeypatch.setattr(
+        "qdash.workflow.service.strategy.run_qubit_calibrations_parallel",
+        worker,
+    )
+    session = CalibService(
+        "alice",
+        "chip-1",
+        project_id="project-1",
+        enable_github=False,
+        skip_execution=skip_execution,
+        lock_repo=env.lock,
+        counter_repo=FakeExecutionCounterRepository(2),
+    )
+    session.run(QubitTargets(["0"]), steps=[CustomOneQubit(tasks=["CheckRabi"])])
+
+    assert len(env.records) == 1
+    assert env.records[0].status == "completed"
+    assert env.records[0].config.skip_execution is False
+    assert (
+        worker.call_args.kwargs["session_config"]["execution_id"]
+        == env.records[0].config.execution_id
+    )
+    assert env.lock.locked is False
+
+
+def test_two_qubit_steps_reuse_their_pipeline_execution(pipeline_execution_env, monkeypatch):
+    from qdash.workflow.service.steps import CustomTwoQubit, TwoQubitCalibration
+
+    env = pipeline_execution_env
+    scheduler = MagicMock()
+    scheduler.generate.return_value = SimpleNamespace(parallel_groups=[[("0", "1")]])
+    monkeypatch.setattr("qdash.workflow.engine.CRScheduler", lambda *a, **kw: scheduler)
+    worker = MagicMock(return_value={"0-1": {"status": "success"}})
+    monkeypatch.setattr(
+        "qdash.workflow.service._internal.scheduling_tasks.run_coupling_calibrations_parallel",
+        worker,
+    )
+    session = CalibService(
+        "alice",
+        "chip-1",
+        project_id="project-1",
+        backend_name="fake",
+        enable_github=False,
+        lock_repo=env.lock,
+        counter_repo=FakeExecutionCounterRepository(2),
+        default_run_parameters={"interval": {"value": 1024, "value_type": "int"}},
+    )
+    session.run(
+        QubitTargets(["0", "1"]),
+        steps=[
+            CustomTwoQubit(tasks=["CheckCrossResonance"]),
+            TwoQubitCalibration(),
+        ],
+    )
+    assert len(env.records) == 2
+    configs = [call.kwargs["session_config"] for call in worker.call_args_list]
+    assert [config["execution_id"] for config in configs] == [
+        record.config.execution_id for record in env.records
+    ]
+    assert all(config["backend_name"] == "fake" for config in configs)
+    assert all(
+        config["default_run_parameters"] == session.default_run_parameters for config in configs
+    )
+    assert [record.status for record in env.records] == ["completed", "completed"]
+    assert env.lock.locked is False

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -363,8 +363,9 @@ class TestCalibServiceInitialization:
         assert session.execution_id is not None
         assert re.fullmatch(r"\d{8}-007", session.execution_id)
 
+    @pytest.mark.parametrize("skip_execution", [False, True])
     def test_initialize_adopts_a_lock_claimed_by_the_api_for_this_execution(
-        self, mock_flow_session_deps, mock_user_repo, monkeypatch
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch, skip_execution
     ):
         """A lock the API claimed for the execution being claimed is adopted, not contested."""
         _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
@@ -381,15 +382,21 @@ class TestCalibServiceInitialization:
             project_id="test_project",
             lock_repo=lock_repo,
             user_repo=mock_user_repo,
+            skip_execution=skip_execution,
+            counter_repo=FakeExecutionCounterRepository(next_index=7),
         )
 
         assert session.execution_id == "20240101-777"
         assert session._lock_acquired is True
         assert lock_repo.try_lock_calls == ["20240101-777"]
         assert lock_repo.owner == "20240101-777"
+        assert session.skip_execution is False
+        assert session._orchestrator is not None
+        assert session._orchestrator.config.skip_execution is False
 
+    @pytest.mark.parametrize("skip_execution", [False, True])
     def test_initialize_refuses_a_lock_owned_by_another_execution(
-        self, mock_flow_session_deps, mock_user_repo, monkeypatch
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch, skip_execution
     ):
         """A lock owned by a different execution still blocks the session."""
         _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
@@ -407,12 +414,15 @@ class TestCalibServiceInitialization:
                 project_id="test_project",
                 lock_repo=lock_repo,
                 user_repo=mock_user_repo,
+                skip_execution=skip_execution,
+                counter_repo=FakeExecutionCounterRepository(next_index=7),
             )
 
         assert lock_repo.owner == "20240101-111"
 
+    @pytest.mark.parametrize("skip_execution", [False, True])
     def test_initialize_refuses_an_unowned_lock(
-        self, mock_flow_session_deps, mock_user_repo, monkeypatch
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch, skip_execution
     ):
         """A held lock with no recorded owner is not adopted either."""
         _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
@@ -430,7 +440,107 @@ class TestCalibServiceInitialization:
                 project_id="test_project",
                 lock_repo=lock_repo,
                 user_repo=mock_user_repo,
+                skip_execution=skip_execution,
+                counter_repo=FakeExecutionCounterRepository(next_index=7),
             )
+
+    @pytest.mark.parametrize("terminal", ["complete", "fail", "cancel"])
+    def test_api_wrapper_finalizes_its_adopted_execution_and_releases_lock(
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch, terminal
+    ):
+        """The UI's parent row must reach a terminal state when its pipeline ends."""
+        _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
+        monkeypatch.setattr(
+            "qdash.repository.MongoExecutionRepository",
+            lambda: FakeExecutionRepository(claimed_execution_id="20240101-777"),
+        )
+        lock_repo = MockExecutionLockRepository(locked=True, owner="20240101-777")
+        session = CalibService(
+            username="test_user",
+            chip_id="chip_1",
+            qids=["0"],
+            project_id="test_project",
+            skip_execution=True,
+            lock_repo=lock_repo,
+            user_repo=mock_user_repo,
+            counter_repo=FakeExecutionCounterRepository(next_index=7),
+        )
+        execution_service = MagicMock()
+        session.execution_service = execution_service
+        monkeypatch.setattr(session, "_finalize_stale_running_tasks", MagicMock())
+        monkeypatch.setattr(session, "_finalize_tasks_on_cancel", MagicMock())
+
+        if terminal == "complete":
+            session.finish_calibration(update_chip_history=False, push_to_github=False)
+        elif terminal == "fail":
+            session.fail_calibration("measurement failed")
+        else:
+            session.cancel_calibration()
+
+        getattr(execution_service.reload.return_value, terminal).assert_called_once()
+        assert lock_repo.locked is False
+        assert session._lock_acquired is False
+
+    @pytest.mark.parametrize("execution_id", [None, "parent-execution"])
+    def test_isolated_worker_does_not_claim_or_finalize_parent_execution(
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch, execution_id
+    ):
+        """Workers borrowing a parent's execution must not take over its lifecycle."""
+        _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
+        fake_repo = FakeExecutionRepository(claimed_execution_id="20240101-777")
+        monkeypatch.setattr("qdash.repository.MongoExecutionRepository", lambda: fake_repo)
+        lock_repo = MockExecutionLockRepository(locked=True, owner="parent-execution")
+        session = CalibService(
+            username="test_user",
+            chip_id="chip_1",
+            qids=["0"],
+            project_id="test_project",
+            execution_id=execution_id,
+            skip_execution=True,
+            use_lock=False,
+            lock_repo=lock_repo,
+            user_repo=mock_user_repo,
+            counter_repo=FakeExecutionCounterRepository(next_index=7),
+        )
+        execution_service = MagicMock()
+        session.execution_service = execution_service
+
+        session.finish_calibration(update_chip_history=False, push_to_github=False)
+        session.fail_calibration()
+        session.cancel_calibration()
+
+        assert fake_repo.calls == []
+        assert session.skip_execution is True
+        assert lock_repo.try_lock_calls == []
+        assert lock_repo.owner == "parent-execution"
+        assert lock_repo.locked is True
+        execution_service.reload.assert_not_called()
+
+    def test_wrapper_without_api_execution_keeps_skipping_execution_creation(
+        self, mock_flow_session_deps, mock_user_repo, monkeypatch
+    ):
+        """Scheduled or direct pipelines can still run without a pre-created parent row."""
+        _stub_prefect_flow_run_context(monkeypatch, flow_run_id="flow-run-9")
+        fake_repo = FakeExecutionRepository(claimed_execution_id=None)
+        monkeypatch.setattr("qdash.repository.MongoExecutionRepository", lambda: fake_repo)
+        lock_repo = MockExecutionLockRepository()
+        session = CalibService(
+            username="test_user",
+            chip_id="chip_1",
+            qids=["0"],
+            project_id="test_project",
+            skip_execution=True,
+            lock_repo=lock_repo,
+            user_repo=mock_user_repo,
+            counter_repo=FakeExecutionCounterRepository(next_index=7),
+        )
+
+        assert session.skip_execution is True
+        assert session.execution_id is not None
+        assert re.fullmatch(r"\d{8}-007", session.execution_id)
+        assert lock_repo.owner == session.execution_id
+        session.finish_calibration(update_chip_history=False, push_to_github=False)
+        assert lock_repo.locked is False
 
     def test_initialize_takes_a_free_lock_itself(
         self, mock_flow_session_deps, mock_user_repo, monkeypatch

--- a/tests/qdash/workflow/service/test_one_qubit_steps.py
+++ b/tests/qdash/workflow/service/test_one_qubit_steps.py
@@ -7,90 +7,41 @@ if TYPE_CHECKING:
     from qdash.workflow.service.calib_service import CalibService
 
 
-def test_custom_one_qubit_direct_targets_create_visible_execution(monkeypatch) -> None:
-    init_calls = []
-    run_calls = []
-    finish_calls = []
-    recorded = []
+def test_custom_one_qubit_direct_targets_reuse_step_execution(monkeypatch) -> None:
+    from unittest.mock import MagicMock
 
-    session = SimpleNamespace(
-        execution_id="exec-visible",
-        record_stage_result=lambda stage_name, result: recorded.append((stage_name, result)),
-    )
-
-    def fake_init_calibration(*args, **kwargs):
-        init_calls.append((args, kwargs))
-        return session
-
-    def fake_run_qubit_calibrations_parallel(*, qids, tasks, session_config):
-        run_calls.append(
-            {
-                "qids": qids,
-                "tasks": tasks,
-                "session_config": session_config,
-            }
-        )
-        return {qid: {"status": "success"} for qid in qids}
-
-    def fake_finish_calibration():
-        finish_calls.append(True)
-
-    monkeypatch.setattr(
-        "qdash.workflow.service.calib_service.init_calibration",
-        fake_init_calibration,
-    )
-    monkeypatch.setattr(
-        "qdash.workflow.service.calib_service.finish_calibration",
-        fake_finish_calibration,
-    )
+    init = MagicMock(side_effect=AssertionError("must reuse the step Execution"))
+    finish = MagicMock(side_effect=AssertionError("pipeline owns completion"))
+    run = MagicMock(return_value={"1": {"status": "success"}})
+    monkeypatch.setattr("qdash.workflow.service.calib_service.init_calibration", init)
+    monkeypatch.setattr("qdash.workflow.service.calib_service.finish_calibration", finish)
     monkeypatch.setattr(
         "qdash.workflow.service._internal.scheduling_tasks.run_qubit_calibrations_parallel",
-        fake_run_qubit_calibrations_parallel,
+        run,
     )
-
     service = SimpleNamespace(
         username="alice",
         chip_id="64Qv3",
         backend_name="qubex",
         project_id="project-1",
-        default_run_parameters={"interval": {"value": 128, "value_type": "int"}},
-        tags=["simple"],
-        flow_name="simple_calibration",
-        note={"source": "test"},
+        execution_id="exec-step",
+        default_run_parameters={},
+        tags=[],
+        flow_name="simple_tasks",
+        note={},
+        record_stage_result=MagicMock(),
     )
     step = CustomOneQubit(step_name="simple_tasks", tasks=["CheckRabi"])
+    result = step._execute_direct(cast("CalibService", service), ["1"])
 
-    result = step._execute_direct(cast("CalibService", service), ["1", "2"])
-
-    assert result == {"direct": {"1": {"status": "success"}, "2": {"status": "success"}}}
-    assert init_calls
-    assert init_calls[0][0][:3] == ("alice", "64Qv3", ["1", "2"])
-    assert init_calls[0][1]["flow_name"] == "simple_calibration_simple_tasks"
-    assert init_calls[0][1]["project_id"] == "project-1"
-    assert init_calls[0][1]["note"] == {
-        "type": "1-qubit-direct",
-        "stage": "simple_tasks",
-        "total_qubits": 2,
-    }
-    assert run_calls == [
-        {
-            "qids": ["1", "2"],
-            "tasks": ["CheckRabi"],
-            "session_config": {
-                "username": "alice",
-                "chip_id": "64Qv3",
-                "backend_name": "qubex",
-                "execution_id": "exec-visible",
-                "project_id": "project-1",
-                "default_run_parameters": {"interval": {"value": 128, "value_type": "int"}},
-                "tags": ["simple"],
-                "flow_name": "simple_calibration",
-                "note": {"source": "test"},
-            },
-        }
-    ]
-    assert recorded == [("simple_tasks", result)]
-    assert finish_calls == [True]
+    assert result == {"direct": {"1": {"status": "success"}}}
+    config = run.call_args.kwargs["session_config"]
+    assert config["execution_id"] == "exec-step"
+    assert config["tags"] == []
+    assert config["flow_name"] == "simple_tasks"
+    service.record_stage_result.assert_called_once_with("simple_tasks", result)
+    init.assert_not_called()
+    finish.assert_not_called()
 
 
 def test_custom_one_qubit_qubit_targets_use_scheduled_strategy(monkeypatch) -> None:
@@ -166,45 +117,3 @@ def test_one_qubit_check_qubit_targets_use_scheduled_strategy(monkeypatch) -> No
     assert calls[0].qids == ["2", "5"]
     assert calls[0].tasks == ["CheckRabi"]
     assert calls[0].flow_name == "one_qubit_one_qubit_check"
-
-
-def test_custom_one_qubit_direct_targets_do_not_fallback_tags_to_flow_name(monkeypatch) -> None:
-    init_calls = []
-    session = SimpleNamespace(
-        execution_id="exec-visible",
-        record_stage_result=lambda stage_name, result: None,
-    )
-
-    def fake_init_calibration(*args, **kwargs):
-        init_calls.append((args, kwargs))
-        return session
-
-    monkeypatch.setattr(
-        "qdash.workflow.service.calib_service.init_calibration",
-        fake_init_calibration,
-    )
-    monkeypatch.setattr(
-        "qdash.workflow.service.calib_service.finish_calibration",
-        lambda: None,
-    )
-    monkeypatch.setattr(
-        "qdash.workflow.service._internal.scheduling_tasks.run_qubit_calibrations_parallel",
-        lambda *, qids, tasks, session_config: {qid: {"status": "success"} for qid in qids},
-    )
-
-    service = SimpleNamespace(
-        username="alice",
-        chip_id="64Qv3",
-        backend_name="qubex",
-        project_id="project-1",
-        default_run_parameters={},
-        tags=[],
-        flow_name="t1_simple_tasks",
-        note={},
-    )
-    step = CustomOneQubit(step_name="simple_tasks", tasks=["CheckRabi"])
-
-    step._execute_direct(cast("CalibService", service), ["1"])
-
-    assert init_calls[0][1]["flow_name"] == "t1_simple_tasks_simple_tasks"
-    assert init_calls[0][1]["tags"] == []

--- a/tests/qdash/workflow/service/test_one_qubit_steps.py
+++ b/tests/qdash/workflow/service/test_one_qubit_steps.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 
+import pytest
+
 from qdash.workflow.service.steps.one_qubit import CustomOneQubit
 
 if TYPE_CHECKING:
@@ -117,3 +119,34 @@ def test_one_qubit_check_qubit_targets_use_scheduled_strategy(monkeypatch) -> No
     assert calls[0].qids == ["2", "5"]
     assert calls[0].tasks == ["CheckRabi"]
     assert calls[0].flow_name == "one_qubit_one_qubit_check"
+
+
+@pytest.mark.parametrize("successful_qids", [[], ["1"]])
+def test_fine_tune_respects_coarse_status_filter(monkeypatch, successful_qids) -> None:
+    from unittest.mock import MagicMock
+
+    from qdash.workflow.service.results import OneQubitResult, QubitCalibData
+    from qdash.workflow.service.steps import FilterByStatus, OneQubitFineTune, StepContext
+    from qdash.workflow.service.targets import QubitTargets
+
+    coarse_result = OneQubitResult()
+    for qid in ["0", "1"]:
+        coarse_result.add_qubit(
+            qid, QubitCalibData(status="success" if qid in successful_qids else "failed")
+        )
+    ctx = StepContext(candidate_qids=["0", "1"], one_qubit_check=coarse_result)
+    service = cast("CalibService", SimpleNamespace(chip_id="64Q"))
+    targets = QubitTargets(["0", "1"])
+    ctx = FilterByStatus().execute(service, targets, ctx)
+    execute = MagicMock(return_value={})
+    step = OneQubitFineTune()
+    monkeypatch.setattr(step, "_execute_with_qids", execute)
+
+    step.execute(service, targets, ctx)
+
+    if successful_qids:
+        assert execute.call_args.args[1] == successful_qids
+    else:
+        execute.assert_not_called()
+        assert ctx.one_qubit_fine_tune is not None
+        assert ctx.one_qubit_fine_tune.qubits == {}

--- a/tests/qdash/workflow/test_coarse_one_template.py
+++ b/tests/qdash/workflow/test_coarse_one_template.py
@@ -1,0 +1,94 @@
+"""Verify coarse template targets, stage boundaries, and execution configuration."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+from qdash.workflow.service.steps import OneQubitCheck
+from qdash.workflow.service.targets import MuxTargets, QubitTargets
+
+coarse_one_module = importlib.import_module("qdash.workflow.templates.coarse_one")
+
+
+class FakeCalibService:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self, targets: Any, *, steps: list[Any]) -> dict[str, Any]:
+        return {"targets": targets, "steps": steps, "args": self.args, "kwargs": self.kwargs}
+
+
+@pytest.fixture(autouse=True)
+def fake_calibration_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(coarse_one_module, "CalibService", FakeCalibService)
+
+
+def test_coarse_one_configures_before_readout_search_and_runs_one_hpi_cycle() -> None:
+    result = coarse_one_module.coarse_one(username="alice", chip_id="64Q", qids=["0"])
+
+    assert len(result["steps"]) == 1
+    step = result["steps"][0]
+    assert isinstance(step, OneQubitCheck)
+    assert step.mode == "synchronized"
+    assert step.tasks == [
+        "Configure",
+        "CheckCoarseReadoutParams",
+        "Configure",
+        "CheckRabi",
+        "CheckRabi",
+        "CreateHPIPulse",
+        "CheckHPIPulse",
+        "CheckT1",
+        "CheckT2Echo",
+        "CheckRamsey",
+    ]
+
+
+def test_coarse_one_uses_explicit_qubits() -> None:
+    result = coarse_one_module.coarse_one(username="alice", chip_id="64Q", qids=["0", "1"])
+
+    assert isinstance(result["targets"], QubitTargets)
+    assert result["targets"].qids == ["0", "1"]
+
+
+def test_coarse_one_prefers_mux_targets_and_preserves_exclusions() -> None:
+    result = coarse_one_module.coarse_one(
+        username="alice", chip_id="64Q", mux_ids=[0, 1], exclude_qids=["2"], qids=["8"]
+    )
+
+    assert isinstance(result["targets"], MuxTargets)
+    assert result["targets"].mux_ids == [0, 1]
+    assert result["targets"].exclude_qids == ["2"]
+
+
+def test_coarse_one_requires_explicit_targets() -> None:
+    with pytest.raises(ValueError, match="mux_ids or qids is required"):
+        coarse_one_module.coarse_one(username="alice", chip_id="64Q")
+
+
+def test_coarse_one_forwards_execution_context_and_preserves_task_scan_defaults() -> None:
+    result = coarse_one_module.coarse_one(
+        username="alice",
+        chip_id="64Q",
+        qids=["0"],
+        project_id="project-1",
+        flow_name="coarse-check",
+        tags=["coarse"],
+    )
+
+    assert result["args"] == ("alice", "64Q")
+    assert result["kwargs"] == {
+        "project_id": "project-1",
+        "flow_name": "coarse-check",
+        "tags": ["coarse"],
+        "skip_execution": True,
+        "default_run_parameters": {
+            "hpi_duration": {"value": 32, "value_type": "int"},
+            "pi_duration": {"value": 32, "value_type": "int"},
+            "interval": {"value": 150 * 1024, "value_type": "int"},
+        },
+    }

--- a/tests/qdash/workflow/test_coarse_one_template.py
+++ b/tests/qdash/workflow/test_coarse_one_template.py
@@ -85,7 +85,6 @@ def test_coarse_one_forwards_execution_context_and_preserves_task_scan_defaults(
         "project_id": "project-1",
         "flow_name": "coarse-check",
         "tags": ["coarse"],
-        "skip_execution": True,
         "default_run_parameters": {
             "hpi_duration": {"value": 32, "value_type": "int"},
             "pi_duration": {"value": 32, "value_type": "int"},

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -54,23 +54,32 @@ def test_one_qubit_template_requires_explicit_targets(monkeypatch) -> None:
 
 
 def test_one_qubit_template_passes_template_task_lists(monkeypatch) -> None:
+    from qdash.workflow.service.steps import FilterByStatus
+    from qdash.workflow.templates.coarse_one import COARSE_ONE_TASKS
+    from qdash.workflow.templates.fine_one import FINE_ONE_TASKS
+
     monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
 
     result = one_qubit_module.one_qubit(username="alice", chip_id="64Q", mux_ids=[0])
 
     steps = result["steps"]
-    assert steps[0].tasks == one_qubit_module.ONE_QUBIT_CHECK_TASKS
-    assert steps[2].tasks == one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS
+    assert len(steps) == 3
+    assert steps[0].tasks == COARSE_ONE_TASKS
+    assert isinstance(steps[1], FilterByStatus)
+    assert steps[2].tasks == FINE_ONE_TASKS
 
 
 def test_one_qubit_template_check_only_passes_template_task_list(monkeypatch) -> None:
+    from qdash.workflow.templates.coarse_one import COARSE_ONE_TASKS
+
     monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
 
     result = one_qubit_module.one_qubit(
         username="alice", chip_id="64Q", mux_ids=[0], check_only=True
     )
 
-    assert result["steps"][0].tasks == one_qubit_module.ONE_QUBIT_CHECK_TASKS
+    assert len(result["steps"]) == 1
+    assert result["steps"][0].tasks == COARSE_ONE_TASKS
 
 
 @pytest.mark.parametrize("use_mux", [False, True])
@@ -134,7 +143,18 @@ def test_fine_one_optimizes_readout_before_classification_in_fine_tune_stage(
     omitted_tasks = {"CheckT1Average", "CheckT2EchoAverage", "Check1QGateCoherenceLimit"}
     assert omitted_tasks.isdisjoint(tasks)
     assert tasks[optimization_indices[-1] + 2 :] == [
-        name for name in one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS if name not in omitted_tasks
+        "CheckRabi",
+        "CreateHPIPulse",
+        "CheckHPIPulse",
+        "CreatePIPulse",
+        "CheckPIPulse",
+        "CreateDRAGHPIPulse",
+        "CheckDRAGHPIPulse",
+        "CreateDRAGPIPulse",
+        "CheckDRAGPIPulse",
+        "ReadoutClassification",
+        "RandomizedBenchmarking",
+        "X90InterleavedRandomizedBenchmarking",
     ]
     full = one_qubit_module.one_qubit(username="alice", chip_id="64Q", qids=["8"])
     assert result["kwargs"]["default_run_parameters"] == full["kwargs"]["default_run_parameters"]

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -120,6 +120,7 @@ def test_fine_one_optimizes_readout_before_classification_in_fine_tune_stage(
         optimization_indices[::2], optimization_indices[1::2], strict=True
     ):
         assert frequency_index == amplitude_index + 1
+        assert tasks[frequency_index + 1] == "Configure"
         # Both the sweep's DRAG PI preparation and classifier's HPI preparation
         # must be recalibrated before each amplitude/frequency pair.
         assert tasks[amplitude_index - 5 : amplitude_index] == [
@@ -132,7 +133,7 @@ def test_fine_one_optimizes_readout_before_classification_in_fine_tune_stage(
     # Finish with the full pulse calibration at the final readout settings.
     omitted_tasks = {"CheckT1Average", "CheckT2EchoAverage", "Check1QGateCoherenceLimit"}
     assert omitted_tasks.isdisjoint(tasks)
-    assert tasks[optimization_indices[-1] + 1 :] == [
+    assert tasks[optimization_indices[-1] + 2 :] == [
         name for name in one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS if name not in omitted_tasks
     ]
     full = one_qubit_module.one_qubit(username="alice", chip_id="64Q", qids=["8"])

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -116,10 +116,13 @@ def test_fine_one_optimizes_readout_before_classification_in_fine_tune_stage(
         "CheckOptimalReadoutAmplitude",
         "CheckOptimalReadoutFrequency",
     ]
-    for index in optimization_indices:
+    for amplitude_index, frequency_index in zip(
+        optimization_indices[::2], optimization_indices[1::2], strict=True
+    ):
+        assert frequency_index == amplitude_index + 1
         # Both the sweep's DRAG PI preparation and classifier's HPI preparation
-        # must be recalibrated after the preceding readout update.
-        assert tasks[index - 5 : index] == [
+        # must be recalibrated before each amplitude/frequency pair.
+        assert tasks[amplitude_index - 5 : amplitude_index] == [
             "CheckRabi",
             "CreateHPIPulse",
             "CheckHPIPulse",
@@ -127,7 +130,11 @@ def test_fine_one_optimizes_readout_before_classification_in_fine_tune_stage(
             "CheckDRAGPIPulse",
         ]
     # Finish with the full pulse calibration at the final readout settings.
-    assert tasks[optimization_indices[-1] + 1 :] == one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS
+    omitted_tasks = {"CheckT1Average", "CheckT2EchoAverage", "Check1QGateCoherenceLimit"}
+    assert omitted_tasks.isdisjoint(tasks)
+    assert tasks[optimization_indices[-1] + 1 :] == [
+        name for name in one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS if name not in omitted_tasks
+    ]
     full = one_qubit_module.one_qubit(username="alice", chip_id="64Q", qids=["8"])
     assert result["kwargs"]["default_run_parameters"] == full["kwargs"]["default_run_parameters"]
     assert result["kwargs"]["flow_name"] == "fine-check"

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -74,7 +74,9 @@ def test_one_qubit_template_check_only_passes_template_task_list(monkeypatch) ->
 
 
 @pytest.mark.parametrize("use_mux", [False, True])
-def test_fine_one_runs_only_configure_and_existing_fine_tune_stage(monkeypatch, use_mux) -> None:
+def test_fine_one_optimizes_readout_before_classification_in_fine_tune_stage(
+    monkeypatch, use_mux
+) -> None:
     from qdash.workflow.service.steps import OneQubitFineTune
 
     fine_one_module = importlib.import_module("qdash.workflow.templates.fine_one")
@@ -102,7 +104,30 @@ def test_fine_one_runs_only_configure_and_existing_fine_tune_stage(monkeypatch, 
     step = result["steps"][0]
     assert isinstance(step, OneQubitFineTune)
     assert step.mode == "synchronized"
-    assert step.tasks == ["Configure", *one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS]
+    tasks = step.tasks
+    assert tasks is not None
+    assert tasks[0] == "Configure"
+    optimization_indices = [
+        i for i, name in enumerate(tasks) if name.startswith("CheckOptimalReadout")
+    ]
+    assert [tasks[i] for i in optimization_indices] == [
+        "CheckOptimalReadoutAmplitude",
+        "CheckOptimalReadoutFrequency",
+        "CheckOptimalReadoutAmplitude",
+        "CheckOptimalReadoutFrequency",
+    ]
+    for index in optimization_indices:
+        # Both the sweep's DRAG PI preparation and classifier's HPI preparation
+        # must be recalibrated after the preceding readout update.
+        assert tasks[index - 5 : index] == [
+            "CheckRabi",
+            "CreateHPIPulse",
+            "CheckHPIPulse",
+            "CreateDRAGPIPulse",
+            "CheckDRAGPIPulse",
+        ]
+    # Finish with the full pulse calibration at the final readout settings.
+    assert tasks[optimization_indices[-1] + 1 :] == one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS
     full = one_qubit_module.one_qubit(username="alice", chip_id="64Q", qids=["8"])
     assert result["kwargs"]["default_run_parameters"] == full["kwargs"]["default_run_parameters"]
     assert result["kwargs"]["flow_name"] == "fine-check"

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -16,7 +16,7 @@ class FakeCalibService:
         self.kwargs = kwargs
 
     def run(self, targets: Any, *, steps: list[Any]) -> dict[str, Any]:
-        return {"targets": targets, "steps": steps}
+        return {"targets": targets, "steps": steps, "kwargs": self.kwargs}
 
 
 def test_one_qubit_template_uses_explicit_qids(monkeypatch) -> None:
@@ -71,3 +71,48 @@ def test_one_qubit_template_check_only_passes_template_task_list(monkeypatch) ->
     )
 
     assert result["steps"][0].tasks == one_qubit_module.ONE_QUBIT_CHECK_TASKS
+
+
+@pytest.mark.parametrize("use_mux", [False, True])
+def test_fine_one_runs_only_configure_and_existing_fine_tune_stage(monkeypatch, use_mux) -> None:
+    from qdash.workflow.service.steps import OneQubitFineTune
+
+    fine_one_module = importlib.import_module("qdash.workflow.templates.fine_one")
+    monkeypatch.setattr(fine_one_module, "CalibService", FakeCalibService)
+    monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
+    result = fine_one_module.fine_one(
+        username="alice",
+        chip_id="64Q",
+        qids=["8"],
+        mux_ids=[0] if use_mux else None,
+        exclude_qids=["2"],
+        flow_name="fine-check",
+        tags=["fine"],
+        project_id="project-1",
+    )
+
+    if use_mux:
+        assert isinstance(result["targets"], MuxTargets)
+        assert result["targets"].mux_ids == [0]
+        assert result["targets"].exclude_qids == ["2"]
+    else:
+        assert isinstance(result["targets"], QubitTargets)
+        assert result["targets"].qids == ["8"]
+    assert len(result["steps"]) == 1
+    step = result["steps"][0]
+    assert isinstance(step, OneQubitFineTune)
+    assert step.mode == "synchronized"
+    assert step.tasks == ["Configure", *one_qubit_module.ONE_QUBIT_FINE_TUNE_TASKS]
+    full = one_qubit_module.one_qubit(username="alice", chip_id="64Q", qids=["8"])
+    assert result["kwargs"]["default_run_parameters"] == full["kwargs"]["default_run_parameters"]
+    assert result["kwargs"]["flow_name"] == "fine-check"
+    assert result["kwargs"]["project_id"] == "project-1"
+    assert result["kwargs"]["tags"] == ["fine"]
+    assert "skip_execution" not in result["kwargs"]
+
+
+def test_fine_one_requires_explicit_targets(monkeypatch) -> None:
+    fine_one_module = importlib.import_module("qdash.workflow.templates.fine_one")
+    monkeypatch.setattr(fine_one_module, "CalibService", FakeCalibService)
+    with pytest.raises(ValueError, match="mux_ids or qids is required"):
+        fine_one_module.fine_one(username="alice", chip_id="64Q")

--- a/ui/src/components/features/execution/ExecutionTaskProgress.tsx
+++ b/ui/src/components/features/execution/ExecutionTaskProgress.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Check } from "lucide-react";
+import { LoaderCircle } from "lucide-react";
 
 type TaskProgress = {
   current: number;
   total: number | null;
   description: string;
   etaSeconds: number | null;
+  overallEtaSeconds: number | null;
   updatedAt: string;
   phase: number;
   hasMultiplePhases: boolean;
@@ -25,15 +26,23 @@ function readProgress(note?: Record<string, unknown> | null): TaskProgress | nul
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
 
   const value = raw as Record<string, unknown>;
-  if (typeof value.current !== "number") return null;
-  if (value.total !== null && typeof value.total !== "number") return null;
+  if (typeof value.current !== "number" || !Number.isFinite(value.current)) return null;
+  if (value.total !== null && (typeof value.total !== "number" || !Number.isFinite(value.total)))
+    return null;
   if (typeof value.updated_at !== "string") return null;
 
   return {
     current: value.current,
     total: value.total as number | null,
     description: typeof value.description === "string" ? value.description : "",
-    etaSeconds: typeof value.eta_seconds === "number" ? value.eta_seconds : null,
+    etaSeconds:
+      typeof value.eta_seconds === "number" && Number.isFinite(value.eta_seconds)
+        ? value.eta_seconds
+        : null,
+    overallEtaSeconds:
+      typeof value.overall_eta_seconds === "number" && Number.isFinite(value.overall_eta_seconds)
+        ? value.overall_eta_seconds
+        : null,
     updatedAt: value.updated_at,
     phase: typeof value.phase === "number" && value.phase >= 1 ? value.phase : 1,
     hasMultiplePhases: value.has_multiple_phases === true,
@@ -61,22 +70,54 @@ export function ExecutionTaskProgress({ status, note }: ExecutionTaskProgressPro
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
-    if (status !== "running" || progress?.etaSeconds == null) return;
+    if (
+      status !== "running" ||
+      (progress?.etaSeconds == null && progress?.overallEtaSeconds == null)
+    )
+      return;
     const timer = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(timer);
-  }, [progress?.etaSeconds, status]);
+  }, [progress?.etaSeconds, progress?.overallEtaSeconds, status]);
 
-  if (status !== "running" || progress === null) return null;
+  if (!["running", "scheduled", "pending"].includes(status ?? "")) return null;
+
+  if (status !== "running" || progress === null) {
+    return (
+      <div
+        className="mt-3 flex items-center gap-3 rounded-lg bg-base-200/60 p-3"
+        role="status"
+        aria-label="Task progress"
+      >
+        <LoaderCircle
+          className="h-4 w-4 shrink-0 animate-spin text-primary motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <p className="text-sm font-medium">
+            {status === "running" ? "Preparing measurement" : "Waiting to start"}
+          </p>
+          <p className="text-xs text-base-content/60">
+            Measurement progress will appear when available.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   const percentage =
     progress.total && progress.total > 0
       ? Math.min(Math.max((progress.current / progress.total) * 100, 0), 100)
       : null;
-  const ageSeconds = Math.max((now - Date.parse(progress.updatedAt)) / 1000, 0);
-  const remainingSeconds =
-    progress.etaSeconds == null ? null : Math.max(progress.etaSeconds - ageSeconds, 0);
+  const updatedAt = Date.parse(progress.updatedAt);
+  const ageSeconds = Number.isFinite(updatedAt) ? Math.max((now - updatedAt) / 1000, 0) : 0;
   const hasExactPhaseTotal =
     progress.phaseTotalMin !== null && progress.phaseTotalMin === progress.phaseTotalMax;
+  const etaSeconds = hasExactPhaseTotal ? progress.overallEtaSeconds : progress.etaSeconds;
+  const remainingSeconds = etaSeconds == null ? null : Math.max(etaSeconds - ageSeconds, 0);
+  const completedSweeps = Math.min(
+    progress.phase - 1 + (percentage === 100 ? 1 : 0),
+    progress.phaseTotalMax ?? progress.phase,
+  );
   const overallPercentage =
     percentage !== null && hasExactPhaseTotal && progress.phaseTotalMax !== null
       ? Math.min(
@@ -91,56 +132,79 @@ export function ExecutionTaskProgress({ status, note }: ExecutionTaskProgressPro
         ? `${progress.phase} / ${progress.phaseTotalMax}`
         : `${progress.phase} / ${progress.phaseTotalMin}–${progress.phaseTotalMax}`;
 
+  const displayedPercentage = overallPercentage ?? percentage;
+  const progressLabel = hasExactPhaseTotal
+    ? "All sweeps"
+    : progress.hasMultiplePhases
+      ? "Current sweep"
+      : "Measurement progress";
+  const estimateLabel = hasExactPhaseTotal
+    ? "All sweeps"
+    : progress.hasMultiplePhases
+      ? "This sweep"
+      : "This measurement";
+
   return (
-    <div className="mt-3 space-y-1.5" aria-label="Task progress">
-      {progress.hasMultiplePhases && (
-        <div className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="badge badge-info badge-sm">Sweep {phaseCount}</span>
-          {progress.phase > 1 && (
-            <span className="inline-flex items-center gap-1 text-success">
-              <Check size={14} aria-hidden="true" />
-              {progress.phase - 1} {progress.phase === 2 ? "sweep" : "sweeps"} completed
-            </span>
-          )}
+    <div
+      className="mt-3 min-w-0 space-y-3 rounded-lg bg-base-200/60 p-3"
+      aria-label="Task progress"
+    >
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="text-sm font-medium">{progressLabel}</span>
+        {displayedPercentage !== null && (
+          <span className="shrink-0 text-lg font-semibold tabular-nums text-primary">
+            {displayedPercentage < 100 ? Math.min(Math.round(displayedPercentage), 99) : 100}%
+          </span>
+        )}
+      </div>
+      {displayedPercentage !== null ? (
+        <progress
+          className="progress progress-primary block h-2 w-full"
+          value={displayedPercentage}
+          max={100}
+          aria-label={progressLabel}
+        />
+      ) : (
+        <div className="flex items-center gap-2 text-xs text-base-content/60" role="status">
+          <LoaderCircle
+            className="h-3.5 w-3.5 animate-spin text-primary motion-reduce:animate-none"
+            aria-hidden="true"
+          />
+          Measuring · total count unavailable
         </div>
       )}
-      <div className="flex items-center justify-between gap-3 text-xs text-base-content/70">
-        <span className="truncate">{progress.description || "Measurement in progress"}</span>
-        <span className="shrink-0 tabular-nums">
-          {progress.total == null ? progress.current : `${progress.current} / ${progress.total}`}
-        </span>
+      <div className="space-y-1.5 text-xs">
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+          <span className="min-w-0 break-words text-base-content/80">
+            {progress.description || "Measurement in progress"}
+          </span>
+          <span className="shrink-0 tabular-nums text-base-content/60">
+            {hasExactPhaseTotal
+              ? `${completedSweeps} / ${progress.phaseTotalMax} sweeps completed`
+              : `${progress.hasMultiplePhases ? "Current sweep · " : ""}${
+                  progress.total != null && progress.total > 0
+                    ? `${progress.current} / ${progress.total} points`
+                    : `${progress.current} points measured`
+                }`}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 text-base-content/60">
+          {progress.hasMultiplePhases && !hasExactPhaseTotal && (
+            <span className="tabular-nums">Sweep {phaseCount}</span>
+          )}
+          <span>
+            {hasExactPhaseTotal && completedSweeps === progress.phaseTotalMax
+              ? "Finishing measurement…"
+              : remainingSeconds == null
+                ? hasExactPhaseTotal
+                  ? "Estimating remaining time for all sweeps…"
+                  : "Estimating remaining time…"
+                : remainingSeconds <= 0
+                  ? "Updating time estimate…"
+                  : `${estimateLabel} · ~${formatEta(remainingSeconds)} remaining`}
+          </span>
+        </div>
       </div>
-      {overallPercentage !== null ? (
-        <progress
-          className="progress progress-info w-full"
-          value={overallPercentage}
-          max={100}
-          aria-label={`${Math.round(overallPercentage)}% of task complete`}
-        />
-      ) : percentage === null ? (
-        <progress className="progress progress-info w-full" />
-      ) : (
-        <progress
-          className="progress progress-info w-full"
-          value={percentage}
-          max={100}
-          aria-label={`${Math.round(percentage)}% complete`}
-        />
-      )}
-      <p className="text-right text-xs text-base-content/60 tabular-nums">
-        {remainingSeconds == null
-          ? "Calculating phase estimate…"
-          : `Estimated ${formatEta(remainingSeconds)} remaining in this phase`}
-      </p>
-      {progress.hasMultiplePhases && (
-        <p className="text-xs text-base-content/60">
-          {hasExactPhaseTotal
-            ? "Progress includes all planned sweeps."
-            : progress.phaseTotalMin !== null && progress.phaseTotalMax !== null
-              ? `This adaptive task will run ${progress.phaseTotalMin} to ${progress.phaseTotalMax} sweeps in total.`
-              : "This task runs multiple sweeps. Another progress bar may start after this one."}
-        </p>
-      )}
     </div>
   );
 }

--- a/ui/src/components/features/execution/__tests__/ExecutionTaskProgress.test.tsx
+++ b/ui/src/components/features/execution/__tests__/ExecutionTaskProgress.test.tsx
@@ -30,9 +30,13 @@ describe("ExecutionTaskProgress", () => {
     );
 
     expect(screen.getByText("control power sweep for Q00")).toBeTruthy();
-    expect(screen.getByText("4 / 12")).toBeTruthy();
-    expect(screen.getByText("Estimated 35s remaining in this phase")).toBeTruthy();
-    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("33% complete");
+    expect(screen.getByText("4 / 12 points")).toBeTruthy();
+    expect(screen.getByText("This measurement · ~35s remaining")).toBeTruthy();
+    expect(screen.getByText("33%")).toBeTruthy();
+    expect(screen.getByRole("progressbar", { name: "Measurement progress" })).toHaveAttribute(
+      "value",
+      String((4 / 12) * 100),
+    );
   });
 
   it("does not show stale progress for a completed task", () => {
@@ -54,7 +58,7 @@ describe("ExecutionTaskProgress", () => {
     expect(screen.queryByLabelText("Task progress")).toBeNull();
   });
 
-  it("warns that another sweep may follow and shows completed sweeps", () => {
+  it("uses completed sweep counts for all-sweep progress", () => {
     render(
       <ExecutionTaskProgress
         status="running"
@@ -74,11 +78,90 @@ describe("ExecutionTaskProgress", () => {
       />,
     );
 
-    expect(screen.getByText("Sweep 2 / 4")).toBeTruthy();
-    expect(screen.getByText("1 sweep completed")).toBeTruthy();
-    expect(screen.getByText("Progress includes all planned sweeps.")).toBeTruthy();
-    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("28% of task complete");
+    expect(screen.getByText("1 / 4 sweeps completed")).toBeTruthy();
+    expect(screen.queryByText(/1 \/ 10 points/)).toBeNull();
+    expect(screen.getByText("28%")).toBeTruthy();
+    expect(
+      Number(screen.getByRole("progressbar", { name: "All sweeps" }).getAttribute("value")),
+    ).toBeCloseTo(27.5);
   });
+
+  it("shows whole-search ETA and hides the inner Rabi time-point count", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-27T09:00:05Z"));
+    render(
+      <ExecutionTaskProgress
+        status="running"
+        note={{
+          progress: {
+            current: 13,
+            total: 26,
+            phase: 7,
+            has_multiple_phases: true,
+            phase_total_min: 65,
+            phase_total_max: 65,
+            eta_seconds: 10,
+            overall_eta_seconds: 1200,
+            updated_at: "2026-08-27T09:00:00Z",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("6 / 65 sweeps completed")).toBeTruthy();
+    expect(screen.getByText("All sweeps · ~19m 55s remaining")).toBeTruthy();
+    expect(screen.getByText("10%")).toBeTruthy();
+    expect(screen.queryByText(/13 \/ 26/)).toBeNull();
+    expect(screen.queryByText(/This sweep/)).toBeNull();
+  });
+
+  it("does not substitute per-sweep ETA when the total estimate is unavailable", () => {
+    render(
+      <ExecutionTaskProgress
+        status="running"
+        note={{
+          progress: {
+            current: 13,
+            total: 26,
+            phase: 1,
+            has_multiple_phases: true,
+            phase_total_min: 65,
+            phase_total_max: 65,
+            eta_seconds: 10,
+            updated_at: new Date().toISOString(),
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("0 / 65 sweeps completed")).toBeTruthy();
+    expect(screen.getByText("Estimating remaining time for all sweeps…")).toBeTruthy();
+    expect(screen.queryByText(/This sweep/)).toBeNull();
+  });
+
+  it.each([25, 26])(
+    "does not announce completion before the last time point (%i / 26)",
+    (current) => {
+      render(
+        <ExecutionTaskProgress
+          status="running"
+          note={{
+            progress: {
+              current,
+              total: 26,
+              phase: 65,
+              has_multiple_phases: true,
+              phase_total_min: 65,
+              phase_total_max: 65,
+              overall_eta_seconds: current === 26 ? 0 : 2,
+              updated_at: new Date().toISOString(),
+            },
+          }}
+        />,
+      );
+      expect(screen.getByText(`${current === 26 ? 65 : 64} / 65 sweeps completed`)).toBeTruthy();
+      expect(screen.getByText(current === 26 ? "100%" : "99%")).toBeTruthy();
+      if (current === 26) expect(screen.getByText("Finishing measurement…")).toBeTruthy();
+    },
+  );
 
   it("shows honest phase-count bounds for an adaptive task", () => {
     render(
@@ -101,7 +184,53 @@ describe("ExecutionTaskProgress", () => {
     );
 
     expect(screen.getByText("Sweep 1 / 2–4")).toBeTruthy();
-    expect(screen.getByText("This adaptive task will run 2 to 4 sweeps in total.")).toBeTruthy();
-    expect(screen.getByRole("progressbar").getAttribute("aria-label")).toBe("50% complete");
+    expect(screen.getByRole("progressbar", { name: "Current sweep" })).toHaveAttribute(
+      "value",
+      "50",
+    );
+  });
+
+  it.each(["pending", "scheduled", "running"])(
+    "shows an explicit waiting state for %s without measurement progress",
+    (status) => {
+      render(<ExecutionTaskProgress status={status} />);
+      expect(screen.getByRole("status")).toHaveTextContent(
+        status === "running" ? "Preparing measurement" : "Waiting to start",
+      );
+      expect(screen.queryByRole("progressbar")).toBeNull();
+    },
+  );
+
+  it("shows the measured count without inventing a percentage when the total is unknown", () => {
+    render(
+      <ExecutionTaskProgress
+        status="running"
+        note={{
+          progress: { current: 7, total: null, updated_at: new Date().toISOString() },
+        }}
+      />,
+    );
+    expect(screen.getByText("7 points measured")).toBeTruthy();
+    expect(screen.getByText("Measuring · total count unavailable")).toBeTruthy();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+
+  it("does not show zero seconds remaining when a running measurement outlasts its estimate", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-27T09:01:00Z"));
+    render(
+      <ExecutionTaskProgress
+        status="running"
+        note={{
+          progress: {
+            current: 4,
+            total: 12,
+            eta_seconds: 10,
+            updated_at: "2026-08-27T09:00:00Z",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("Updating time estimate…")).toBeTruthy();
   });
 });

--- a/ui/src/components/features/tasks/TaskWorkbench.tsx
+++ b/ui/src/components/features/tasks/TaskWorkbench.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, Lock, Play, RefreshCw, RotateCcw } from "lucide-react";
@@ -36,6 +36,7 @@ function badgeClass(status?: string | null) {
 }
 
 export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
+  const runDisabledReasonId = useId();
   const toast = useToast();
   const queryClient = useQueryClient();
   const { data: chipsData } = useListChips();
@@ -135,6 +136,21 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
     isStarting ||
     (executionId.length > 0 &&
       (!execution || ["running", "scheduled", "pending"].includes(execution.status)));
+  const runDisabledReason = (() => {
+    if (!task.enabled) return `This task is not enabled for the ${backend} backend.`;
+    if (isStarting) return "Starting this task…";
+    if (isLockStatusLoading) return "Checking whether another calibration is running…";
+    if (isExecutionLocked)
+      return "Another calibration execution is running. Wait for it to finish before starting this task.";
+    if (isExecutionActive) {
+      if (executionError && !isExecutionPendingCreation)
+        return "Unable to confirm the previous execution status. Reload the page to check again.";
+      return "Waiting for this execution to finish before starting another run.";
+    }
+    if (!chipId) return "Select a chip to run this task.";
+    if (!target.trim()) return "Enter a qubit or coupling to run this task.";
+    return null;
+  })();
   const resultTasks = useMemo(
     () =>
       (execution?.task ?? []).filter(
@@ -156,7 +172,7 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
       : [];
 
   const handleRun = async () => {
-    if (!chipId || !target.trim()) return;
+    if (runDisabledReason) return;
     const requestedTarget = target.trim();
     setIsStarting(true);
     try {
@@ -444,30 +460,22 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
                 </div>
               )}
 
-              {isExecutionLocked && (
-                <div className="alert alert-warning py-2 text-xs">
-                  Another calibration execution is running. Wait for it to finish before starting
-                  this task.
+              {runDisabledReason && (
+                <div
+                  id={runDisabledReasonId}
+                  role="status"
+                  className="rounded-lg bg-base-200 p-3 text-xs text-base-content/70"
+                >
+                  {runDisabledReason}
                 </div>
               )}
 
               <button
                 className={`btn ${isExecutionLocked ? "btn-disabled" : "btn-primary"}`}
                 onClick={handleRun}
-                disabled={
-                  isStarting ||
-                  isLockStatusLoading ||
-                  isExecutionLocked ||
-                  isExecutionActive ||
-                  !task.enabled ||
-                  !chipId ||
-                  !target.trim()
-                }
-                title={
-                  isExecutionLocked
-                    ? "Execution locked - another calibration is running"
-                    : "Run task"
-                }
+                disabled={Boolean(runDisabledReason)}
+                aria-describedby={runDisabledReason ? runDisabledReasonId : undefined}
+                title={runDisabledReason ?? "Run task"}
               >
                 {isStarting ? (
                   <span className="loading loading-spinner loading-sm" />
@@ -539,12 +547,10 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
                   {(execution.status === "running" ||
                     execution.status === "scheduled" ||
                     execution.status === "pending") && (
-                    <>
-                      <ExecutionTaskProgress status={resultTask?.status} note={resultTask?.note} />
-                      {!resultTask?.note?.progress && (
-                        <progress className="progress progress-primary w-full" />
-                      )}
-                    </>
+                    <ExecutionTaskProgress
+                      status={resultTask?.status ?? execution.status}
+                      note={resultTask?.note}
+                    />
                   )}
 
                   <div className="flex h-56 items-center justify-start gap-3 overflow-x-auto rounded-lg bg-base-200/60 p-3">

--- a/ui/src/components/features/tasks/__tests__/TaskWorkbenchRun.test.tsx
+++ b/ui/src/components/features/tasks/__tests__/TaskWorkbenchRun.test.tsx
@@ -1,0 +1,172 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TaskInfo } from "@/schemas";
+
+import { TaskWorkbench } from "../TaskWorkbench";
+
+const mocks = vi.hoisted(() => ({
+  lock: vi.fn(),
+  chips: vi.fn(),
+  execution: vi.fn(),
+  post: vi.fn(),
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/client/chip/chip", () => ({
+  useListChips: mocks.chips,
+  getChipCoupling: vi.fn(),
+  getChipQubit: vi.fn(),
+}));
+vi.mock("@/client/execution/execution", () => ({
+  useGetExecutionLockStatus: mocks.lock,
+  useGetExecution: mocks.execution,
+  getGetExecutionLockStatusQueryKey: () => ["execution-lock"],
+}));
+vi.mock("@/lib/api/custom-instance", () => ({ AXIOS_INSTANCE: { post: mocks.post } }));
+vi.mock("@/components/ui/Toast", () => ({ useToast: () => mocks.toast }));
+vi.mock("@/components/charts/TaskFigure", () => ({ TaskFigure: () => null }));
+vi.mock("@/components/features/metrics/ParametersTable", () => ({
+  ParametersTable: () => null,
+}));
+
+const task: TaskInfo = {
+  name: "CheckCoarseReadoutParams",
+  class_name: "CheckCoarseReadoutParams",
+  file_path: "one_qubit_coarse/check_coarse_readout_params.py",
+  task_type: "qubit",
+  enabled: true,
+  input_parameters: {
+    qubit_frequency: { resolution: "database_required", value_type: "float", unit: "GHz" },
+  },
+};
+
+function renderWorkbench(
+  taskOverrides: Partial<TaskInfo> = {},
+  searchParams = "?chip=chip-1&target=0",
+) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <NuqsTestingAdapter searchParams={searchParams}>
+      <QueryClientProvider client={queryClient}>
+        <TaskWorkbench task={{ ...task, ...taskOverrides }} backend="qubex" />
+      </QueryClientProvider>
+    </NuqsTestingAdapter>,
+  );
+}
+
+beforeEach(() => {
+  mocks.chips.mockReturnValue({ data: { data: { chips: [{ chip_id: "chip-1" }] } } });
+  mocks.lock.mockReturnValue({ data: { data: { lock: false } }, isLoading: false });
+  mocks.execution.mockReturnValue({});
+  mocks.post.mockResolvedValue({ data: { execution_id: "execution-1" } });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TaskWorkbench run availability", () => {
+  it("explains when the selected task is disabled in backend configuration", () => {
+    renderWorkbench({ enabled: false });
+    const button = screen.getByRole("button", { name: "Run task" });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAccessibleDescription("This task is not enabled for the qubex backend.");
+    fireEvent.click(button);
+    expect(mocks.post).not.toHaveBeenCalled();
+  });
+
+  it("allows blank calibration overrides and submits them for runtime resolution", async () => {
+    renderWorkbench();
+    expect(screen.getByPlaceholderText("Use current value")).toHaveValue("");
+    const button = screen.getByRole("button", { name: "Run task" });
+    expect(button).toBeEnabled();
+    fireEvent.click(button);
+    await waitFor(() =>
+      expect(mocks.post).toHaveBeenCalledWith(
+        "/tasks/CheckCoarseReadoutParams/execute",
+        expect.objectContaining({ chip_id: "chip-1", qid: "0", input_parameter_overrides: {} }),
+      ),
+    );
+  });
+
+  it("explains the missing target", () => {
+    renderWorkbench({}, "?chip=chip-1");
+    expect(screen.getByRole("button", { name: "Run task" })).toHaveAccessibleDescription(
+      "Enter a qubit or coupling to run this task.",
+    );
+    expect(screen.getByRole("button", { name: "Run task" })).toBeDisabled();
+  });
+
+  it("explains the missing chip", () => {
+    mocks.chips.mockReturnValue({ data: { data: { chips: [] } } });
+    renderWorkbench({}, "?target=0");
+    expect(screen.getByRole("button", { name: "Run task" })).toHaveAccessibleDescription(
+      "Select a chip to run this task.",
+    );
+  });
+
+  it("retains the execution lock and explains why another run cannot start", () => {
+    mocks.lock.mockReturnValue({ data: { data: { lock: true } }, isLoading: false });
+    renderWorkbench();
+    const button = screen.getByRole("button", { name: "Locked" });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAccessibleDescription(/Another calibration execution is running/);
+    fireEvent.click(button);
+    expect(mocks.post).not.toHaveBeenCalled();
+  });
+
+  it("explains when lock status is still loading", () => {
+    mocks.lock.mockReturnValue({ isLoading: true });
+    renderWorkbench();
+    expect(screen.getByRole("button", { name: "Run task" })).toHaveAccessibleDescription(
+      "Checking whether another calibration is running…",
+    );
+    expect(screen.getByRole("button", { name: "Run task" })).toBeDisabled();
+  });
+
+  it("explains when a previous execution is still being awaited", () => {
+    renderWorkbench({}, "?chip=chip-1&target=0&execution=execution-1");
+    expect(screen.getByRole("button", { name: "Run task" })).toHaveAccessibleDescription(
+      "Waiting for this execution to finish before starting another run.",
+    );
+    expect(screen.getByRole("button", { name: "Run task" })).toBeDisabled();
+  });
+
+  it("shows preparation status before the worker reports task progress", () => {
+    mocks.execution.mockReturnValue({ data: { data: { status: "running", task: [] } } });
+    renderWorkbench({}, "?chip=chip-1&target=0&execution=execution-1");
+    expect(screen.getByText("Preparing measurement")).toBeTruthy();
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+
+  it("shows one labeled progress bar when measurements arrive", () => {
+    mocks.execution.mockReturnValue({
+      data: {
+        data: {
+          status: "running",
+          task: [
+            {
+              name: task.name,
+              qid: "0",
+              status: "running",
+              note: {
+                progress: { current: 13, total: 26, updated_at: new Date().toISOString() },
+              },
+            },
+          ],
+        },
+      },
+    });
+    renderWorkbench({}, "?chip=chip-1&target=0&execution=execution-1&executionTarget=0");
+    expect(screen.getAllByRole("progressbar")).toHaveLength(1);
+    expect(screen.getByRole("progressbar", { name: "Measurement progress" })).toHaveAttribute(
+      "value",
+      "50",
+    );
+    expect(screen.getByText("13 / 26 points")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Add coarse and fine 1Q calibration templates, with a smaller readout search, selected-fit validation, and progress measured across the complete search. Keep one Execution per calibration step without an extra empty parent record.
- Update Workflow, Tasks UI, backend configuration, and documentation. The scan now requires explicit calibration inputs; older snapshots missing those inputs cannot silently reuse current settings. Hardware validation is still needed.

## Changes

- Enable `CheckCoarseReadoutParams`, expose five calibration inputs and configurable scan/time ranges, and center the default scan on current readout settings (65 sweeps, 1024 shots). Apply the resolved drive settings and readout duration to Qubex.
- Require the selected candidate's finite R² to exceed the shared Rabi threshold of 0.6. Preserve diagnostics and block frequency/amplitude publication when validation fails.
- Register `coarse_one`: Configure → readout search → Configure → Rabi twice → HPI creation/check → T1/T2Echo → Ramsey, with explicit MUX or qubit targets.
- Register `fine_one` with two consecutive amplitude → frequency optimization pairs. Refresh Rabi, HPI, and DRAG PI before each pair because Qubex uses DRAG PI for the sweep and two HPI pulses for its final classifier. Run Configure immediately after each frequency optimization to apply the updated hardware settings. Recalibrate the pulse set at the final readout settings before classification and RB. Omit T1/T2 averages and the coherence-limit calculation that requires them. Enable readout-frequency optimization and preserve full-1Q pulse durations and explicit targeting.
- Compose `one_qubit` from the shared `coarse_one` and `fine_one` task lists, preserving coarse-only execution. Filter successful coarse results before fine-tuning, normalize batch success status, and avoid restoring all targets when that filter yields no candidates.
- In `ExecutionTaskProgress`, show completed sweeps, overall percentage, and estimated time remaining across all planned sweeps. Hide inner Rabi counts/ETA when displaying overall progress. In `TaskWorkbench`, explain disabled Run actions and show preparation status before progress arrives.
- Let the first calibration step adopt the API-reserved Execution and give later calibration steps their own records. Strategies and workers reuse their step ID; transform steps create no records. Remove template-level `skip_execution` settings while supporting saved templates that still pass the flag.
- Hold the project lock through the entire pipeline and preserve completed earlier steps on failure/cancellation. Terminal hooks also release locks owned by an already completed first step.
- Document the agreed frequency/YAML/UX policy and its remaining implementation gaps. Frequency persistence/export migration is not implemented by this PR.
- Regenerate the task catalog. No OpenAPI route/schema or generated client changes are required.
- Validation: 784 workflow/related execution tests passed, followed by 59 focused lifecycle tests including three additional cases, plus 62 template/API checks covering `fine_one` and enabled task ordering; 28 UI tests passed; changed Python files passed Mypy and Ruff; UI TypeScript/lint checks and the docs build passed. No hardware measurements or live-browser visual verification were performed.
