### PR TITLE
refactor(workflow): make template task lists explicit

### DIFF
--- a/docs/development/workflow/quickstart.md
+++ b/docs/development/workflow/quickstart.md
@@ -52,6 +52,24 @@ orchestrator.complete()
 2. `orchestrator.run_task()` - Executes a single calibration task
 3. `orchestrator.complete()` - Finalizes session, saves results to MongoDB
 
+## Writing Flow Templates
+
+Flow templates are user-editable recipes. Keep each step's task names and execution
+order visible in the template file itself.
+
+- Define task lists as explicit lists of task-name strings in the template, or pass
+  a literal list directly to `tasks=`. Do not import task lists from other templates
+  or rely on a calibration step's default task list.
+- Add short comments explaining each stage, repeated calibration round, filter,
+  and hardware configuration checkpoint.
+- When a combined template reproduces standalone stages, keep the task lists
+  explicit in both places and test that their contents and order agree.
+- Preserve intentional repetitions: repeated Rabi checks and readout optimization
+  rounds should remain visible so users can review and edit them.
+
+`one_qubit.py` lists its coarse and fine tasks locally, with a status filter between
+them. Its tests compare those lists with `coarse_one.py` and `fine_one.py`.
+
 ## Adding a New Calibration Task
 
 1. Create a task class in `workflow/calibtasks/`:

--- a/src/qdash/workflow/templates/fast_full_calibration.py
+++ b/src/qdash/workflow/templates/fast_full_calibration.py
@@ -63,6 +63,17 @@ FAST_1Q_FINE_TUNE_TASKS: list[str] = [
     "X90InterleavedRandomizedBenchmarking",
 ]
 
+# Final step: calibrate and validate each scheduled coupling, then benchmark it.
+FAST_2Q_TASKS: list[str] = [
+    "CheckCrossResonance",
+    "CreateZX90",
+    "CheckZX90",
+    "CheckBellState",
+    "CheckBellStateTomography",
+    "Check2QGateCoherenceLimit",
+    "ZX90InterleavedRandomizedBenchmarking",
+]
+
 
 @flow(
     on_cancellation=[on_flow_cancellation],
@@ -116,7 +127,7 @@ def fast_full_calibration(
         OneQubitFineTune(mode="synchronized", tasks=FAST_1Q_FINE_TUNE_TASKS),
         FilterByMetric(metric="x90_fidelity", threshold=fidelity_threshold),
         GenerateCRSchedule(max_parallel_ops=max_parallel_ops, inverse=inverse),
-        TwoQubitCalibration(),
+        TwoQubitCalibration(tasks=FAST_2Q_TASKS),
     ]
 
     cal = CalibService(

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -29,12 +29,58 @@ from qdash.workflow.service.steps import (
     Step,
 )
 from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
-from qdash.workflow.templates.coarse_one import COARSE_ONE_TASKS
-from qdash.workflow.templates.fine_one import FINE_ONE_TASKS
 
-# Keep the standalone templates as the source of truth for both stages.
-ONE_QUBIT_CHECK_TASKS: list[str] = list(COARSE_ONE_TASKS)
-ONE_QUBIT_FINE_TUNE_TASKS: list[str] = list(FINE_ONE_TASKS)
+# Task lists are explicit so this template can be reviewed and edited on its own.
+# Tests keep these stages aligned with coarse_one and fine_one.
+# Step 1: coarse calibration through Ramsey.
+ONE_QUBIT_CHECK_TASKS: list[str] = [
+    "Configure",  # Apply the starting configuration before the readout search.
+    "CheckCoarseReadoutParams",
+    "Configure",  # Apply the updated readout settings before pulse calibration.
+    "CheckRabi",  # Update control amplitude from the measured Rabi frequency.
+    "CheckRabi",  # Measure again at the updated amplitude for HPI creation.
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CheckT1",
+    "CheckT2Echo",
+    "CheckRamsey",
+]
+
+# Step 3: fine calibration after the successful-qubit filter.
+ONE_QUBIT_FINE_TUNE_TASKS: list[str] = [
+    "Configure",
+    # Round 1: prepare the state pulses, then tune amplitude and frequency consecutively.
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "CheckOptimalReadoutAmplitude",
+    "CheckOptimalReadoutFrequency",
+    "Configure",  # Apply round 1's readout frequency before recalibrating pulses.
+    # Round 2: refresh the state pulses at the updated settings, then repeat the pair.
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "CheckOptimalReadoutAmplitude",
+    "CheckOptimalReadoutFrequency",
+    "Configure",  # Apply the final readout frequency before final pulse calibration.
+    # Calibrate all pulses at the final readout settings before classification and RB.
+    "CheckRabi",
+    "CreateHPIPulse",
+    "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
+    "ReadoutClassification",
+    "RandomizedBenchmarking",
+    "X90InterleavedRandomizedBenchmarking",
+]
 
 
 @flow(
@@ -81,12 +127,12 @@ def one_qubit(
 
     steps: list[Step]
     if check_only:
-        # Basic check only
+        # Run only the coarse stage shown above.
         steps = [
             OneQubitCheck(mode="synchronized", tasks=ONE_QUBIT_CHECK_TASKS),
         ]
     else:
-        # Full 1Q calibration
+        # Run coarse -> filter successful qubits -> fine, with one Execution per calibration stage.
         steps = [
             OneQubitCheck(mode="synchronized", tasks=ONE_QUBIT_CHECK_TASKS),
             FilterByStatus(),  # Only proceed with successful qubits

--- a/tests/qdash/workflow/test_fast_full_calibration_template.py
+++ b/tests/qdash/workflow/test_fast_full_calibration_template.py
@@ -60,6 +60,11 @@ def test_fast_full_calibration_uses_shortened_one_qubit_steps(monkeypatch) -> No
     assert "CheckT2EchoAverage" not in one_qubit_fine_tune.tasks
     assert "Check1QGateCoherenceLimit" not in one_qubit_fine_tune.tasks
 
+    # Making the default tasks visible in the template must preserve their order.
+    from qdash.workflow.service.tasks import FULL_2Q_TASKS
+
+    assert steps[6].tasks == FULL_2Q_TASKS
+
 
 def test_fast_full_calibration_requires_explicit_mux_ids(monkeypatch) -> None:
     monkeypatch.setattr(fast_full_module, "CalibService", FakeCalibService)


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Make each workflow template show its task names and execution order directly, so users can review and edit each stage in one file.
- Workflow templates and documentation only; existing calibration tasks and their order are preserved.

## Changes
- List the coarse and fine stages explicitly in `one_qubit.py`, with comments explaining repeated readout optimization rounds and configuration checkpoints.
- Specify the full 2Q task list in `fast_full_calibration.py` instead of relying on defaults.
- Document template conventions and verify task-list parity with standalone templates and existing defaults.
- Validation: 51 related tests passed; Ruff, mypy, and the documentation build passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Improvements**
  - Calibration workflows now use explicit, clearly ordered task sequences for one- and two-qubit procedures.
  - Fast two-qubit calibration includes defined steps for cross-resonance, ZX90, Bell-state, coherence-limit, and randomized benchmarking checks.
  - Existing task ordering and intentional repetitions are preserved across combined and standalone workflows.

- **Documentation**
  - Added guidance for writing workflow templates, documenting stages and checkpoints, and keeping task lists consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->