### PR TITLE
fix(workflow): calibrate all pulses before readout tuning

### DIFF
--- a/src/qdash/workflow/templates/fine_one.py
+++ b/src/qdash/workflow/templates/fine_one.py
@@ -4,8 +4,9 @@ Run this after coarse_one or an equivalent calibration has established the
 qubit frequency, control amplitude, and readout settings. The flow applies
 those settings and tunes readout amplitude -> frequency -> amplitude -> frequency.
 Configure applies the updated frequency after each amplitude/frequency pair.
-Each amplitude/frequency pair starts with fresh Rabi, HPI, and DRAG PI calibration: the
-sweep prepares |1> with DRAG PI, and its final classifier uses two HPI pulses.
+Each amplitude/frequency pair starts with fresh Rabi and full pulse calibration
+in HPI -> PI -> DRAG HPI -> DRAG PI order, including a check of each pulse.
+This refreshes the base pulses as well as the DRAG pulses used for state preparation.
 After both rounds, all pulses are calibrated at the final readout settings
 before readout classification and randomized benchmarking.
 
@@ -28,19 +29,27 @@ from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
 
 FINE_ONE_TASKS: list[str] = [
     "Configure",
-    # Round 1: prepare the state pulses, then tune amplitude and frequency consecutively.
+    # Round 1: calibrate HPI -> PI -> DRAG HPI -> DRAG PI, then tune amplitude/frequency.
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
     "CreateDRAGPIPulse",
     "CheckDRAGPIPulse",
     "CheckOptimalReadoutAmplitude",
     "CheckOptimalReadoutFrequency",
     "Configure",  # Apply round 1's readout frequency before recalibrating pulses.
-    # Round 2: refresh the state pulses at the updated settings, then repeat the pair.
+    # Round 2: recalibrate all four pulse types at the updated settings, then repeat the pair.
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
     "CreateDRAGPIPulse",
     "CheckDRAGPIPulse",
     "CheckOptimalReadoutAmplitude",

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -49,19 +49,27 @@ ONE_QUBIT_CHECK_TASKS: list[str] = [
 # Step 3: fine calibration after the successful-qubit filter.
 ONE_QUBIT_FINE_TUNE_TASKS: list[str] = [
     "Configure",
-    # Round 1: prepare the state pulses, then tune amplitude and frequency consecutively.
+    # Round 1: calibrate HPI -> PI -> DRAG HPI -> DRAG PI, then tune amplitude/frequency.
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
     "CreateDRAGPIPulse",
     "CheckDRAGPIPulse",
     "CheckOptimalReadoutAmplitude",
     "CheckOptimalReadoutFrequency",
     "Configure",  # Apply round 1's readout frequency before recalibrating pulses.
-    # Round 2: refresh the state pulses at the updated settings, then repeat the pair.
+    # Round 2: recalibrate all four pulse types at the updated settings, then repeat the pair.
     "CheckRabi",
     "CreateHPIPulse",
     "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
     "CreateDRAGPIPulse",
     "CheckDRAGPIPulse",
     "CheckOptimalReadoutAmplitude",

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -42,7 +42,7 @@
   {
     "id": "fine_one",
     "name": "Fine 1Q Calibration",
-    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> two amplitude/frequency optimization pairs, recalibrating Rabi/HPI/DRAG PI before each pair and applying Configure after each frequency update -> final pulse calibration -> readout classification -> randomized benchmarking. Requires explicit mux_ids or qids.",
+    "description": "Fine 1-qubit calibration after coarse_one or equivalent calibration: Configure -> two amplitude/frequency optimization pairs, running Rabi and calibrating/checking HPI -> PI -> DRAG HPI -> DRAG PI before each pair and applying Configure after each frequency update -> final full pulse calibration -> readout classification -> randomized benchmarking. Requires explicit mux_ids or qids.",
     "category": "production",
     "filename": "fine_one.py",
     "function_name": "fine_one"

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -130,12 +130,15 @@ def test_fine_one_optimizes_readout_before_classification_in_fine_tune_stage(
     ):
         assert frequency_index == amplitude_index + 1
         assert tasks[frequency_index + 1] == "Configure"
-        # Both the sweep's DRAG PI preparation and classifier's HPI preparation
-        # must be recalibrated before each amplitude/frequency pair.
-        assert tasks[amplitude_index - 5 : amplitude_index] == [
+        # Refresh the base pulses and both DRAG pulses, with checks, before each pair.
+        assert tasks[amplitude_index - 9 : amplitude_index] == [
             "CheckRabi",
             "CreateHPIPulse",
             "CheckHPIPulse",
+            "CreatePIPulse",
+            "CheckPIPulse",
+            "CreateDRAGHPIPulse",
+            "CheckDRAGHPIPulse",
             "CreateDRAGPIPulse",
             "CheckDRAGPIPulse",
         ]


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Calibrate and check HPI, PI, DRAG HPI, and DRAG PI before each readout amplitude/frequency optimization pair in `fine_one` and the fine stage of `one`.
- Previously, these rounds refreshed only HPI and DRAG PI, leaving the other pulse calibrations stale. Each fine stage now performs eight additional tasks, increasing calibration time.

## Changes
- Run Rabi, then create/check HPI -> PI -> DRAG HPI -> DRAG PI before both optimization rounds, with all tasks explicitly listed in each template.
- Preserve consecutive amplitude/frequency optimization, Configure after frequency updates, and full pulse calibration before final classification and benchmarking.
- Update the template description and regression assertions for pulse ordering and standalone/combined template parity.
- Validation: 51 related tests passed; Ruff lint/format and mypy passed. Hardware execution was not performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Fine-tuning workflows now calibrate and verify all four pulse types—HPI, PI, DRAG HPI, and DRAG PI—during each optimization round.
  * Each round begins with fresh Rabi calibration and follows a consistent pulse-calibration sequence.
  * Workflow descriptions now reflect the expanded calibration process and final full pulse calibration.

* **Tests**
  * Updated workflow checks to validate the revised calibration order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->