### PR TITLE
fix(ui): default tasks chip to latest active

### DIFF
--- a/ui/src/components/features/tasks/TaskWorkbench.tsx
+++ b/ui/src/components/features/tasks/TaskWorkbench.tsx
@@ -20,6 +20,7 @@ import { ExecutionTaskProgress } from "@/components/features/execution/Execution
 import { ParametersTable } from "@/components/features/metrics/ParametersTable";
 import { useToast } from "@/components/ui/Toast";
 import { AXIOS_INSTANCE } from "@/lib/api/custom-instance";
+import { sortChipsByDefaultPriority } from "@/lib/utils/chips";
 import { formatTaskParameter, parseTaskParameter } from "@/lib/utils/task-parameters";
 
 interface TaskWorkbenchProps {
@@ -40,7 +41,10 @@ export function TaskWorkbench({ task, backend }: TaskWorkbenchProps) {
   const toast = useToast();
   const queryClient = useQueryClient();
   const { data: chipsData } = useListChips();
-  const chips = chipsData?.data?.chips ?? [];
+  const chips = useMemo(
+    () => sortChipsByDefaultPriority(chipsData?.data?.chips ?? []),
+    [chipsData?.data?.chips],
+  );
   const defaultChipId = chips[0]?.chip_id ?? "";
 
   const [chipIdQuery, setChipIdQuery] = useQueryState("chip", parseAsString);

--- a/ui/src/components/features/tasks/__tests__/TaskWorkbenchRun.test.tsx
+++ b/ui/src/components/features/tasks/__tests__/TaskWorkbenchRun.test.tsx
@@ -101,6 +101,38 @@ describe("TaskWorkbench run availability", () => {
     expect(screen.getByRole("button", { name: "Run task" })).toBeDisabled();
   });
 
+  it("defaults to the newest active chip when none is selected", async () => {
+    mocks.chips.mockReturnValue({
+      data: {
+        data: {
+          chips: [
+            {
+              chip_id: "inactive-new",
+              activity_status: "inactive",
+              installed_at: "2026-06-01T00:00:00Z",
+            },
+            {
+              chip_id: "active-old",
+              activity_status: "active",
+              installed_at: "2024-06-01T00:00:00Z",
+            },
+            {
+              chip_id: "active-new",
+              activity_status: "active",
+              installed_at: "2025-06-01T00:00:00Z",
+            },
+          ],
+        },
+      },
+    });
+
+    renderWorkbench({}, "?target=0");
+
+    await waitFor(() =>
+      expect(screen.getByRole("combobox", { name: "Chip" })).toHaveValue("active-new"),
+    );
+  });
+
   it("explains the missing chip", () => {
     mocks.chips.mockReturnValue({ data: { data: { chips: [] } } });
     renderWorkbench({}, "?target=0");

--- a/ui/src/components/selectors/ChipSelector/index.tsx
+++ b/ui/src/components/selectors/ChipSelector/index.tsx
@@ -8,6 +8,7 @@ import type { SingleValue } from "react-select";
 
 import { useListChips } from "@/client/chip/chip";
 import { useSelectStyles } from "@/hooks/useSelectStyles";
+import { sortChipsByDefaultPriority } from "@/lib/utils/chips";
 import { formatDate } from "@/lib/utils/datetime";
 
 interface ChipOption {
@@ -34,27 +35,18 @@ export function ChipSelector({ selectedChip, onChipSelect }: ChipSelectorProps) 
   const sortedOptions = useMemo(() => {
     if (!chips?.data?.chips) return [];
 
-    return [...chips.data.chips]
-      .sort((a, b) => {
-        const statusA = a.activity_status === "inactive" ? 1 : 0;
-        const statusB = b.activity_status === "inactive" ? 1 : 0;
-        if (statusA !== statusB) return statusA - statusB;
-        const dateA = a.installed_at ? new Date(a.installed_at).getTime() : 0;
-        const dateB = b.installed_at ? new Date(b.installed_at).getTime() : 0;
-        return dateB - dateA;
-      })
-      .map((chip) => {
-        const activityStatus = chip.activity_status ?? "active";
-        const installedAt = chip.installed_at ? `(${formatDate(chip.installed_at)})` : "";
-        const inactiveLabel = activityStatus === "inactive" ? "Inactive" : "";
+    return sortChipsByDefaultPriority(chips.data.chips).map((chip) => {
+      const activityStatus = chip.activity_status ?? "active";
+      const installedAt = chip.installed_at ? `(${formatDate(chip.installed_at)})` : "";
+      const inactiveLabel = activityStatus === "inactive" ? "Inactive" : "";
 
-        return {
-          value: chip.chip_id,
-          label: [chip.chip_id, installedAt, inactiveLabel].filter(Boolean).join(" "),
-          installed_at: chip.installed_at,
-          activity_status: activityStatus,
-        };
-      });
+      return {
+        value: chip.chip_id,
+        label: [chip.chip_id, installedAt, inactiveLabel].filter(Boolean).join(" "),
+        installed_at: chip.installed_at,
+        activity_status: activityStatus,
+      };
+    });
   }, [chips]);
 
   const styles = useSelectStyles<ChipOption>();

--- a/ui/src/lib/utils/__tests__/chips.test.ts
+++ b/ui/src/lib/utils/__tests__/chips.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { sortChipsByDefaultPriority } from "@/lib/utils/chips";
+
+describe("sortChipsByDefaultPriority", () => {
+  it("places active chips first and then sorts by installed_at descending", () => {
+    const chips = [
+      {
+        chip_id: "inactive-new",
+        activity_status: "inactive",
+        installed_at: "2026-06-01T00:00:00Z",
+      },
+      {
+        chip_id: "active-old",
+        activity_status: "active",
+        installed_at: "2024-06-01T00:00:00Z",
+      },
+      {
+        chip_id: "active-new",
+        activity_status: "active",
+        installed_at: "2025-06-01T00:00:00Z",
+      },
+    ] as const;
+
+    expect(sortChipsByDefaultPriority(chips).map((chip) => chip.chip_id)).toEqual([
+      "active-new",
+      "active-old",
+      "inactive-new",
+    ]);
+  });
+});

--- a/ui/src/lib/utils/chips.ts
+++ b/ui/src/lib/utils/chips.ts
@@ -1,0 +1,17 @@
+import type { ChipResponse } from "@/schemas";
+
+type SortableChip = Pick<ChipResponse, "chip_id" | "installed_at" | "activity_status">;
+
+export function sortChipsByDefaultPriority<T extends SortableChip>(chips: readonly T[]): T[] {
+  return [...chips].sort((a, b) => {
+    const statusA = a.activity_status === "inactive" ? 1 : 0;
+    const statusB = b.activity_status === "inactive" ? 1 : 0;
+    if (statusA !== statusB) return statusA - statusB;
+
+    const dateA = a.installed_at ? new Date(a.installed_at).getTime() : 0;
+    const dateB = b.installed_at ? new Date(b.installed_at).getTime() : 0;
+    if (dateA !== dateB) return dateB - dateA;
+
+    return a.chip_id.localeCompare(b.chip_id);
+  });
+}


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Updates the Tasks page chip default so it selects the newest active chip when no chip is specified in the URL.
- UI-only change; no API, workflow, schema, or generated client changes are involved.

## Changes
- Added a shared chip sorting helper that prioritizes active chips and then sorts by installation time descending.
- Reused the shared sorting in `ChipSelector` and `TaskWorkbench` so displayed order and default selection match.
- Added focused Vitest coverage for the sorting helper and Tasks page workbench default selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Chip selectors now prioritize active chips and display the newest installed chip first by default.
  - Chip ordering is consistent across task workbench and chip selection experiences.

- **Bug Fixes**
  - When no chip is selected, the task workbench now defaults to the newest active chip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->