### PR TITLE
fix: allow manual correction for failed qubit spectroscopy

### DIFF
--- a/src/qdash/api/services/manual_update_service.py
+++ b/src/qdash/api/services/manual_update_service.py
@@ -55,6 +55,16 @@ _MANUALLY_CORRECTABLE_TASKS = {
     "CheckResonatorSpectroscopy",
 }
 
+_FAILED_TASK_CORRECTABLE_PARAMETERS = {
+    "CheckQubitSpectroscopy": {
+        "coarse_qubit_frequency",
+        "anharmonicity",
+        "f01_repr_db",
+        "f01_quality_level",
+        "coarse_control_amplitude",
+    },
+}
+
 
 class ManualUpdateService:
     """Service for manually updating calibration parameters."""
@@ -352,6 +362,8 @@ class ManualUpdateService:
             )
 
         allowed_names = set(source_doc.output_parameter_names)
+        if source_doc.status == "failed":
+            allowed_names.update(_FAILED_TASK_CORRECTABLE_PARAMETERS.get(source_doc.name, set()))
         unknown_names = sorted(set(request.parameters) - allowed_names)
         if unknown_names:
             raise HTTPException(

--- a/tests/qdash/api/services/test_manual_update_service.py
+++ b/tests/qdash/api/services/test_manual_update_service.py
@@ -43,6 +43,7 @@ def _source(**overrides: Any) -> SimpleNamespace:
     values: dict[str, Any] = {
         "task_id": "source-task",
         "name": "CheckResonatorSpectroscopy",
+        "status": "completed",
         "chip_id": "16Q",
         "qid": "4",
         "output_parameter_names": ["readout_frequency", "optimal_power"],
@@ -71,6 +72,64 @@ def test_validate_source_accepts_failed_spectroscopy_result() -> None:
     ) as find_one:
         find_one.return_value.run.return_value = source
         assert service._validate_source_task(_request(), "project") is source
+
+
+def test_validate_source_accepts_declared_parameter_from_failed_qubit_spectroscopy() -> None:
+    service = ManualUpdateService()
+    source = _source(
+        name="CheckQubitSpectroscopy",
+        status="failed",
+        output_parameter_names=[],
+    )
+    request = _request(parameters={"coarse_qubit_frequency": {"value": 5.0, "unit": "GHz"}})
+
+    with patch(
+        "qdash.api.services.manual_update_service.TaskResultHistoryDocument.find_one"
+    ) as find_one:
+        find_one.return_value.run.return_value = source
+        assert service._validate_source_task(request, "project") is source
+
+
+def test_validate_source_does_not_invent_parameters_for_completed_qubit_spectroscopy() -> None:
+    service = ManualUpdateService()
+    source = _source(
+        name="CheckQubitSpectroscopy",
+        status="completed",
+        output_parameter_names=[],
+    )
+
+    with (
+        patch(
+            "qdash.api.services.manual_update_service.TaskResultHistoryDocument.find_one"
+        ) as find_one,
+        pytest.raises(HTTPException, match="Unknown source output parameter"),
+    ):
+        find_one.return_value.run.return_value = source
+        service._validate_source_task(
+            _request(parameters={"coarse_qubit_frequency": {"value": 5.0, "unit": "GHz"}}),
+            "project",
+        )
+
+
+def test_validate_source_rejects_unknown_parameter_from_failed_qubit_spectroscopy() -> None:
+    service = ManualUpdateService()
+    source = _source(
+        name="CheckQubitSpectroscopy",
+        status="failed",
+        output_parameter_names=[],
+    )
+
+    with (
+        patch(
+            "qdash.api.services.manual_update_service.TaskResultHistoryDocument.find_one"
+        ) as find_one,
+        pytest.raises(HTTPException, match="Unknown source output parameter"),
+    ):
+        find_one.return_value.run.return_value = source
+        service._validate_source_task(
+            _request(parameters={"unsupported": {"value": 5.0, "unit": "GHz"}}),
+            "project",
+        )
 
 
 @pytest.mark.parametrize(

--- a/ui/src/components/features/task-results/SpectroscopyManualCorrection.tsx
+++ b/ui/src/components/features/task-results/SpectroscopyManualCorrection.tsx
@@ -26,11 +26,22 @@ const PARAMETER_UNITS: Record<string, string> = {
   coarse_control_amplitude: "a.u.",
 };
 
+const FAILED_TASK_PARAMETER_NAMES: Record<string, readonly string[]> = {
+  CheckQubitSpectroscopy: [
+    "coarse_qubit_frequency",
+    "anharmonicity",
+    "f01_repr_db",
+    "f01_quality_level",
+    "coarse_control_amplitude",
+  ],
+};
+
 interface SpectroscopyManualCorrectionProps {
   chipId: string;
   qid: string;
   taskId: string;
   taskName: string;
+  taskStatus: string;
   outputParameters: Record<string, unknown>;
   outputParameterNames: string[];
   jsonFigurePaths: string[];
@@ -47,6 +58,7 @@ export function SpectroscopyManualCorrection({
   qid,
   taskId,
   taskName,
+  taskStatus,
   outputParameters,
   outputParameterNames,
   jsonFigurePaths,
@@ -65,8 +77,14 @@ export function SpectroscopyManualCorrection({
   const { data: qubitResponse } = useGetChipQubit(chipId, qid);
 
   const names = useMemo(
-    () => [...new Set([...outputParameterNames, ...Object.keys(outputParameters)])],
-    [outputParameterNames, outputParameters],
+    () =>
+      spectroscopyCorrectionParameterNames(
+        taskName,
+        taskStatus,
+        outputParameterNames,
+        outputParameters,
+      ),
+    [taskName, taskStatus, outputParameterNames, outputParameters],
   );
   const currentData = (qubitResponse?.data?.data ?? {}) as Record<string, unknown>;
 
@@ -433,6 +451,19 @@ export function SpectroscopyManualCorrection({
       </Dialog>
     </div>
   );
+}
+
+export function spectroscopyCorrectionParameterNames(
+  taskName: string,
+  taskStatus: string,
+  outputParameterNames: string[],
+  outputParameters: Record<string, unknown>,
+): string[] {
+  const failedTaskNames =
+    taskStatus === "failed" ? (FAILED_TASK_PARAMETER_NAMES[taskName] ?? []) : [];
+  return [
+    ...new Set([...outputParameterNames, ...Object.keys(outputParameters), ...failedTaskNames]),
+  ];
 }
 
 function parameterValue(raw: unknown): number | null {

--- a/ui/src/components/features/task-results/TaskResultDetailPage.tsx
+++ b/ui/src/components/features/task-results/TaskResultDetailPage.tsx
@@ -744,6 +744,7 @@ export function TaskResultDetailPage({ taskId }: { taskId: string }) {
             qid={taskResult.qid}
             taskId={taskResult.task_id}
             taskName={taskResult.task_name}
+            taskStatus={taskResult.status}
             outputParameters={(taskResult.output_parameters ?? {}) as Record<string, unknown>}
             outputParameterNames={taskResult.output_parameter_names ?? []}
             jsonFigurePaths={taskResult.json_figure_path ?? []}

--- a/ui/src/components/features/task-results/__tests__/SpectroscopyManualCorrection.test.ts
+++ b/ui/src/components/features/task-results/__tests__/SpectroscopyManualCorrection.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { spectroscopyCorrectionParameterNames } from "../SpectroscopyManualCorrection";
+
+describe("spectroscopyCorrectionParameterNames", () => {
+  it("restores declared correction fields for failed qubit spectroscopy", () => {
+    expect(
+      spectroscopyCorrectionParameterNames("CheckQubitSpectroscopy", "failed", [], {}),
+    ).toEqual([
+      "coarse_qubit_frequency",
+      "anharmonicity",
+      "f01_repr_db",
+      "f01_quality_level",
+      "coarse_control_amplitude",
+    ]);
+  });
+
+  it("keeps recorded fields and appends missing declarations after failure", () => {
+    expect(
+      spectroscopyCorrectionParameterNames(
+        "CheckQubitSpectroscopy",
+        "failed",
+        ["coarse_qubit_frequency"],
+        { f01_repr_db: { value: -30 } },
+      ),
+    ).toEqual([
+      "coarse_qubit_frequency",
+      "f01_repr_db",
+      "anharmonicity",
+      "f01_quality_level",
+      "coarse_control_amplitude",
+    ]);
+  });
+
+  it("does not add undeclared fields to a completed result", () => {
+    expect(
+      spectroscopyCorrectionParameterNames(
+        "CheckQubitSpectroscopy",
+        "completed",
+        ["coarse_qubit_frequency"],
+        {},
+      ),
+    ).toEqual(["coarse_qubit_frequency"]);
+  });
+});


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Enables manual correction when `CheckQubitSpectroscopy` fails and records no output parameters.
- Affects the task-result UI and manual-update API only; the change is backward-compatible and requires no schema, config, OpenAPI, or generated-client updates.

## Changes

- Populate the `SpectroscopyManualCorrection` form with the five declared qubit-spectroscopy outputs for failed results.
- Allow only those declared outputs through source-task validation when the source qubit-spectroscopy result failed.
- Preserve the existing recorded-output validation for completed results and reject unsupported parameters.
- Add API and UI regression tests.
- Verified with 28 manual-update API tests, 3 focused UI tests, Ruff, Oxfmt, Oxlint, and TypeScript type checking.