### PR TITLE
fix(workflow): serialize Qubex configuration pushes

### DIFF
--- a/src/qdash/workflow/calibtasks/qubex/box_setup/configure.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/configure.py
@@ -50,7 +50,7 @@ class Configure(QubexTask):
             load_kwargs["configuration_mode"] = exp.configuration_mode
         exp.system_manager.load(**load_kwargs)
         print(f"[Configure] Pushing system_manager for {label} (box_ids={exp.box_ids})")
-        exp.system_manager.push(box_ids=exp.box_ids, confirm=False)
+        exp.system_manager.push(box_ids=exp.box_ids, confirm=False, parallel=False)
         print(f"[Configure] Done for {label}")
         self.save_calibration(backend)
         return RunResult(raw_result=None)

--- a/src/qdash/workflow/calibtasks/qubex/box_setup/configure_all.py
+++ b/src/qdash/workflow/calibtasks/qubex/box_setup/configure_all.py
@@ -65,6 +65,6 @@ class ConfigureAll(QubexTask):
             params_dir=exp.params_path,
         )
         print(f"[ConfigureAll] Pushing system_manager (box_ids={exp.box_ids})")
-        exp.system_manager.push(box_ids=exp.box_ids, confirm=False)
+        exp.system_manager.push(box_ids=exp.box_ids, confirm=False, parallel=False)
         print("[ConfigureAll] Done")
         return RunResult(raw_result={"mux_ids": mux_ids, "box_ids": exp.box_ids})


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Runs Qubex system-manager configuration pushes sequentially for both single-qubit and all-box setup tasks.
- Affects workflow execution only; no API, schema, generated-client, or configuration changes are required.

## Changes

- Pass `parallel=False` when `Configure` pushes its selected box configuration.
- Pass `parallel=False` when `ConfigureAll` pushes all selected box configurations.
- Verified the full-calibration template tests (4 passed), Ruff, and mypy.