### PR TITLE
fix(workflow): calibrate all pulses in coarse checks

### DIFF
--- a/src/qdash/workflow/templates/coarse_one.py
+++ b/src/qdash/workflow/templates/coarse_one.py
@@ -2,7 +2,8 @@
 
 Run this after bring-up has established the qubit frequency, control amplitude,
 and readout settings. The flow applies the current hardware configuration,
-refines readout settings, calibrates Rabi/HPI, and measures T1/T2Echo and Ramsey
+refines readout settings, runs Rabi and calibrates/checks HPI, PI, DRAG HPI, and
+DRAG PI, then measures T1/T2Echo and Ramsey
 for explicitly selected MUXes or qubits.
 
 Example:
@@ -30,6 +31,12 @@ COARSE_ONE_TASKS: list[str] = [
     "CheckRabi",  # Measure again at the updated amplitude for HPI creation.
     "CreateHPIPulse",
     "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
     "CheckT1",
     "CheckT2Echo",
     "CheckRamsey",
@@ -85,6 +92,8 @@ def coarse_one(
         default_run_parameters={
             "hpi_duration": {"value": 32, "value_type": "int"},
             "pi_duration": {"value": 32, "value_type": "int"},
+            "drag_hpi_duration": {"value": 16, "value_type": "int"},
+            "drag_pi_duration": {"value": 24, "value_type": "int"},
             "interval": {"value": 150 * 1024, "value_type": "int"},
         },
     )

--- a/src/qdash/workflow/templates/one_qubit.py
+++ b/src/qdash/workflow/templates/one_qubit.py
@@ -32,7 +32,7 @@ from qdash.workflow.service.targets import MuxTargets, QubitTargets, Target
 
 # Task lists are explicit so this template can be reviewed and edited on its own.
 # Tests keep these stages aligned with coarse_one and fine_one.
-# Step 1: coarse calibration through Ramsey.
+# Step 1: coarse calibration through Ramsey, calibrating and checking all four pulse types.
 ONE_QUBIT_CHECK_TASKS: list[str] = [
     "Configure",  # Apply the starting configuration before the readout search.
     "CheckCoarseReadoutParams",
@@ -41,6 +41,12 @@ ONE_QUBIT_CHECK_TASKS: list[str] = [
     "CheckRabi",  # Measure again at the updated amplitude for HPI creation.
     "CreateHPIPulse",
     "CheckHPIPulse",
+    "CreatePIPulse",
+    "CheckPIPulse",
+    "CreateDRAGHPIPulse",
+    "CheckDRAGHPIPulse",
+    "CreateDRAGPIPulse",
+    "CheckDRAGPIPulse",
     "CheckT1",
     "CheckT2Echo",
     "CheckRamsey",
@@ -117,7 +123,7 @@ def one_qubit(
         qids: Qubit IDs to calibrate when mux_ids is not set
         flow_name: Flow name (auto-injected)
         project_id: Project ID (auto-injected)
-        check_only: If True, run only the coarse_one stage
+        check_only: If True, run only the coarse stage with all four pulse types
 
     Returns:
         Pipeline results with typed step outputs

--- a/src/qdash/workflow/templates/templates.json
+++ b/src/qdash/workflow/templates/templates.json
@@ -34,7 +34,7 @@
   {
     "id": "coarse_one",
     "name": "Coarse 1Q Calibration",
-    "description": "Coarse 1-qubit calibration after bring-up: Configure -> readout parameter search -> Configure -> Rabi/HPI calibration -> T1/T2Echo -> Ramsey. Requires explicit mux_ids or qids and ends after the check stage.",
+    "description": "Coarse 1-qubit calibration after bring-up: Configure -> readout parameter search -> Configure -> Rabi -> calibration and checks for HPI, PI, DRAG HPI, and DRAG PI -> T1/T2Echo -> Ramsey. Requires explicit mux_ids or qids and ends after the check stage.",
     "category": "production",
     "filename": "coarse_one.py",
     "function_name": "coarse_one"

--- a/tests/qdash/workflow/test_coarse_one_template.py
+++ b/tests/qdash/workflow/test_coarse_one_template.py
@@ -27,7 +27,7 @@ def fake_calibration_service(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(coarse_one_module, "CalibService", FakeCalibService)
 
 
-def test_coarse_one_configures_before_readout_search_and_runs_one_hpi_cycle() -> None:
+def test_coarse_one_configures_before_readout_search_and_calibrates_all_pulses() -> None:
     result = coarse_one_module.coarse_one(username="alice", chip_id="64Q", qids=["0"])
 
     assert len(result["steps"]) == 1
@@ -42,6 +42,12 @@ def test_coarse_one_configures_before_readout_search_and_runs_one_hpi_cycle() ->
         "CheckRabi",
         "CreateHPIPulse",
         "CheckHPIPulse",
+        "CreatePIPulse",
+        "CheckPIPulse",
+        "CreateDRAGHPIPulse",
+        "CheckDRAGHPIPulse",
+        "CreateDRAGPIPulse",
+        "CheckDRAGPIPulse",
         "CheckT1",
         "CheckT2Echo",
         "CheckRamsey",
@@ -88,6 +94,8 @@ def test_coarse_one_forwards_execution_context_and_preserves_task_scan_defaults(
         "default_run_parameters": {
             "hpi_duration": {"value": 32, "value_type": "int"},
             "pi_duration": {"value": 32, "value_type": "int"},
+            "drag_hpi_duration": {"value": 16, "value_type": "int"},
+            "drag_pi_duration": {"value": 24, "value_type": "int"},
             "interval": {"value": 150 * 1024, "value_type": "int"},
         },
     }

--- a/tests/qdash/workflow/test_one_qubit_template.py
+++ b/tests/qdash/workflow/test_one_qubit_template.py
@@ -69,17 +69,33 @@ def test_one_qubit_template_passes_template_task_lists(monkeypatch) -> None:
     assert steps[2].tasks == FINE_ONE_TASKS
 
 
-def test_one_qubit_template_check_only_passes_template_task_list(monkeypatch) -> None:
-    from qdash.workflow.templates.coarse_one import COARSE_ONE_TASKS
-
+@pytest.mark.parametrize("check_only", [False, True])
+def test_one_qubit_template_check_calibrates_and_checks_all_pulses(monkeypatch, check_only) -> None:
     monkeypatch.setattr(one_qubit_module, "CalibService", FakeCalibService)
 
     result = one_qubit_module.one_qubit(
-        username="alice", chip_id="64Q", mux_ids=[0], check_only=True
+        username="alice", chip_id="64Q", mux_ids=[0], check_only=check_only
     )
 
-    assert len(result["steps"]) == 1
-    assert result["steps"][0].tasks == COARSE_ONE_TASKS
+    assert len(result["steps"]) == (1 if check_only else 3)
+    assert result["steps"][0].tasks == [
+        "Configure",
+        "CheckCoarseReadoutParams",
+        "Configure",
+        "CheckRabi",
+        "CheckRabi",
+        "CreateHPIPulse",
+        "CheckHPIPulse",
+        "CreatePIPulse",
+        "CheckPIPulse",
+        "CreateDRAGHPIPulse",
+        "CheckDRAGHPIPulse",
+        "CreateDRAGPIPulse",
+        "CheckDRAGPIPulse",
+        "CheckT1",
+        "CheckT2Echo",
+        "CheckRamsey",
+    ]
 
 
 @pytest.mark.parametrize("use_mux", [False, True])


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Calibrate and check HPI, PI, DRAG HPI, and DRAG PI in the coarse stage of `one_qubit` and `coarse_one` before coherence measurements.
- Workflow impact: the coarse stage runs six additional tasks, including when `check_only=True`, increasing calibration time.

## Changes

- Add PI, DRAG HPI, and DRAG PI creation and checks after the existing HPI tasks.
- Align coarse DRAG pulse durations with `one_qubit` (HPI: 16 ns; PI: 24 ns) and update the template description.
- Verify task order, normal and check-only execution, and coarse defaults: all 14 focused template tests passed; `git diff --check` passed.
