### PR TITLE
feat(ui): download a forum thread as markdown with image assets (#1440)

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -25,6 +25,7 @@
         "date-fns": "^4.4.0",
         "date-fns-tz": "^3.2.0",
         "driver.js": "^1.8.0",
+        "fflate": "^0.8.3",
         "lucide-react": "^1.26.0",
         "mermaid": "^11.16.1",
         "next": "^16.2.11",
@@ -1016,6 +1017,8 @@
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "find-root": ["find-root@1.1.0", "", {}, "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "date-fns": "^4.4.0",
     "date-fns-tz": "^3.2.0",
     "driver.js": "^1.8.0",
+    "fflate": "^0.8.3",
     "lucide-react": "^1.26.0",
     "mermaid": "^11.16.1",
     "next": "^16.2.11",

--- a/ui/src/components/features/forum/ForumDetailPage.tsx
+++ b/ui/src/components/features/forum/ForumDetailPage.tsx
@@ -54,6 +54,7 @@ import {
 import { ForumLabelPicker } from "./ForumLabelSelector";
 import { type ForumBlockSnapshotGetter, type ForumMentionCandidate } from "./ForumBlockEditor";
 import { ForumPostContent } from "./ForumPostContent";
+import { ForumThreadDownloadButton } from "./ForumThreadDownloadButton";
 
 const ForumBlockEditor = dynamic(
   () => import("./ForumBlockEditor").then((m) => ({ default: m.ForumBlockEditor })),
@@ -727,6 +728,9 @@ export function ForumDetailPage({ postId }: { postId: string }) {
                 </TooltipTrigger>
                 <TooltipContent>Edit title</TooltipContent>
               </Tooltip>
+            )}
+            {!editingTitle && (
+              <ForumThreadDownloadButton post={post} replies={replies} disabled={repliesLoading} />
             )}
           </div>
           <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-base-content/50">

--- a/ui/src/components/features/forum/ForumThreadDownloadButton.tsx
+++ b/ui/src/components/features/forum/ForumThreadDownloadButton.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Download } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/Tooltip";
+import { buildForumThreadZip } from "@/lib/forum/exportThreadZip";
+import type { ForumPostResponse } from "@/schemas";
+
+interface ForumThreadDownloadButtonProps {
+  post: ForumPostResponse;
+  replies: ForumPostResponse[];
+  disabled?: boolean;
+}
+
+export function ForumThreadDownloadButton({
+  post,
+  replies,
+  disabled = false,
+}: ForumThreadDownloadButtonProps) {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleDownload = async () => {
+    setIsExporting(true);
+    try {
+      const { filename, blob } = await buildForumThreadZip(post, replies);
+
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+    } catch {
+      toast.error("Failed to export thread");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm btn-square shrink-0 text-base-content/40 hover:text-primary"
+          onClick={handleDownload}
+          disabled={disabled || isExporting}
+          aria-label="Download thread"
+        >
+          {isExporting ? (
+            <span className="loading loading-spinner loading-xs" />
+          ) : (
+            <Download className="h-4 w-4" aria-hidden="true" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>Download as Markdown + assets (.zip)</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ui/src/components/features/forum/__tests__/ForumThreadDownloadButton.test.tsx
+++ b/ui/src/components/features/forum/__tests__/ForumThreadDownloadButton.test.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ForumPostResponse } from "@/schemas";
+
+import { ForumThreadDownloadButton } from "../ForumThreadDownloadButton";
+
+const { buildForumThreadZipMock } = vi.hoisted(() => ({
+  buildForumThreadZipMock: vi.fn(),
+}));
+
+vi.mock("@/lib/forum/exportThreadZip", () => ({
+  buildForumThreadZip: buildForumThreadZipMock,
+}));
+
+const { toastErrorMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: toastErrorMock },
+}));
+
+const post = {
+  id: "post-1",
+  project_id: "project-1",
+  category: "discussion",
+  username: "alice",
+  title: "Readout error",
+  content: "Root content",
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+} as ForumPostResponse;
+
+const replies = [
+  {
+    id: "reply-1",
+    project_id: "project-1",
+    category: "discussion",
+    username: "bob",
+    content: "Reply content",
+    parent_id: "post-1",
+    created_at: "2024-01-02T00:00:00Z",
+    updated_at: "2024-01-02T00:00:00Z",
+  } as ForumPostResponse,
+];
+
+describe("ForumThreadDownloadButton", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    buildForumThreadZipMock.mockReset();
+    toastErrorMock.mockReset();
+  });
+
+  it("builds the zip and triggers a download with the returned filename", async () => {
+    const blob = new Blob(["zip-bytes"]);
+    buildForumThreadZipMock.mockResolvedValue({
+      filename: "forum-0042-readout-error.zip",
+      blob,
+    });
+
+    const createObjectURLMock = vi.fn().mockReturnValue("blob:mock-url");
+    const revokeObjectURLMock = vi.fn();
+    globalThis.URL.createObjectURL = createObjectURLMock as unknown as typeof URL.createObjectURL;
+    globalThis.URL.revokeObjectURL = revokeObjectURLMock as unknown as typeof URL.revokeObjectURL;
+
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(<ForumThreadDownloadButton post={post} replies={replies} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Download thread" }));
+
+    await waitFor(() => {
+      expect(buildForumThreadZipMock).toHaveBeenCalledWith(post, replies);
+    });
+
+    await waitFor(() => {
+      expect(clickSpy).toHaveBeenCalledOnce();
+    });
+
+    expect(createObjectURLMock).toHaveBeenCalledWith(blob);
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("disables the button when the disabled prop is true", () => {
+    render(<ForumThreadDownloadButton post={post} replies={replies} disabled />);
+
+    expect(screen.getByRole("button", { name: "Download thread" })).toBeDisabled();
+  });
+
+  it("shows an error toast and re-enables the button when export fails", async () => {
+    buildForumThreadZipMock.mockRejectedValue(new Error("export failed"));
+
+    render(<ForumThreadDownloadButton post={post} replies={replies} />);
+
+    const button = screen.getByRole("button", { name: "Download thread" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to export thread");
+    });
+
+    await waitFor(() => {
+      expect(button).not.toBeDisabled();
+    });
+  });
+});

--- a/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
+++ b/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
@@ -459,4 +459,85 @@ describe("buildForumThreadZip", () => {
     expect(JSON.stringify(post.content_blocks)).toBe(before);
     expect(post.content_blocks![0].props).toEqual({ url: "/api/forum/images/keep.png" });
   });
+
+  it("parses data URLs whose mime carries extra parameters", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const base64 = Buffer.from("PNGBYTES").toString("base64");
+    const post = makePost({
+      number: 20,
+      title: "Charset param",
+      content_blocks: [
+        { type: "image", props: { url: `data:image/png;charset=utf-8;base64,${base64}` } },
+      ],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+    const rootName = "forum-0020-charset-param";
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(files[`${rootName}/assets/001-inline.png`]).toBeDefined();
+    expect(strFromU8(files[`${rootName}/assets/001-inline.png`])).toBe("PNGBYTES");
+  });
+
+  it("decodes percent-encoded (non-base64) data URLs", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const post = makePost({
+      number: 21,
+      title: "Percent encoded",
+      content_blocks: [{ type: "image", props: { url: "data:text/plain,Hello%20World" } }],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+    const rootName = "forum-0021-percent-encoded";
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(strFromU8(files[`${rootName}/assets/001-inline.plain`])).toBe("Hello World");
+  });
+
+  it("maps image/svg+xml to a .svg extension", async () => {
+    const base64 = Buffer.from("<svg/>").toString("base64");
+    const post = makePost({
+      number: 22,
+      title: "Svg asset",
+      content_blocks: [{ type: "image", props: { url: `data:image/svg+xml;base64,${base64}` } }],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+    const rootName = "forum-0022-svg-asset";
+
+    expect(files[`${rootName}/assets/001-inline.svg`]).toBeDefined();
+    expect(strFromU8(files[`${rootName}/assets/001-inline.svg`])).toBe("<svg/>");
+  });
+
+  it("treats backslash URLs as external and never fetches them", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const post = makePost({
+      number: 23,
+      title: "Backslash url",
+      content_blocks: [{ type: "image", props: { url: "\\\\example.com\\cat.png" } }],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(Object.keys(files).some((path) => path.includes("/assets/"))).toBe(false);
+  });
+
+  it("truncates the description on code point boundaries", async () => {
+    const post = makePost({ number: 24, content: "A" + "🐙".repeat(200) });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const md = strFromU8((await unzipBlob(blob))["forum-0024/thread.md"]);
+    expect(md).toContain(`description: A${"🐙".repeat(199)}…`);
+  });
 });

--- a/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
+++ b/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
@@ -336,6 +336,30 @@ describe("buildForumThreadZip", () => {
     expect(Object.keys(files).some((path) => path.includes("/assets/"))).toBe(false);
   });
 
+  it("leaves protocol-relative and blob URLs untouched and never fetches them", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const post = makePost({
+      number: 11,
+      title: "Off origin image",
+      content_blocks: [
+        { type: "image", props: { url: "//example.com/cat.png" } },
+        { type: "image", props: { url: "blob:http://localhost:3000/9f8e" } },
+      ],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+    const rootName = "forum-0011-off-origin-image";
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const md = strFromU8(files[`${rootName}/thread.md`]);
+    expect(md).toContain("//example.com/cat.png");
+    expect(md).toContain("blob:http://localhost:3000/9f8e");
+    expect(Object.keys(files).some((path) => path.includes("/assets/"))).toBe(false);
+  });
+
   it("falls back to post.content when content_blocks is empty", async () => {
     const post = makePost({
       number: 9,

--- a/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
+++ b/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
@@ -1,0 +1,253 @@
+import { strFromU8, unzipSync, type Unzipped } from "fflate";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { formatDateTime } from "@/lib/utils/datetime";
+import type { ForumPostResponse } from "@/schemas";
+
+import { buildForumThreadZip } from "../exportThreadZip";
+
+function makePost(overrides: Partial<ForumPostResponse> = {}): ForumPostResponse {
+  return {
+    id: "post-1",
+    project_id: "proj-1",
+    category: "general",
+    username: "alice",
+    content: "Hello from the plain content field.",
+    created_at: "2026-08-01T01:03:00+00:00",
+    updated_at: "2026-08-01T01:03:00+00:00",
+    ...overrides,
+  };
+}
+
+async function unzipBlob(blob: Blob): Promise<Unzipped> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  return unzipSync(bytes);
+}
+
+const originalFetch = globalThis.fetch;
+
+describe("buildForumThreadZip", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("writes the expected front matter keys and omits null/empty ones, while always writing labels", async () => {
+    const post = makePost({
+      number: 42,
+      title: "Readout error spike",
+      category: "bug",
+      status: "open",
+      labels: [],
+      assignee_username: null,
+      chip_id: "chip-64",
+      target_type: null,
+      target_id: null,
+      cooldown_id: undefined,
+    });
+
+    const { blob, filename } = await buildForumThreadZip(post, []);
+    expect(filename).toBe("forum-0042-readout-error-spike.zip");
+
+    const files = await unzipBlob(blob);
+    const md = strFromU8(files["forum-0042-readout-error-spike/thread.md"]);
+
+    expect(md).toContain("number: 42");
+    expect(md).toContain("title: Readout error spike");
+    expect(md).toContain("category: bug");
+    expect(md).toContain("status: open");
+    expect(md).toContain("labels: []");
+    expect(md).toContain("author: alice");
+    expect(md).toContain("chip_id: chip-64");
+    expect(md).not.toMatch(/^assignee:/m);
+    expect(md).not.toMatch(/^target_type:/m);
+    expect(md).not.toMatch(/^target_id:/m);
+    expect(md).not.toMatch(/^cooldown_id:/m);
+    expect(md).toMatch(/exported_at: ['"]?\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("concatenates replies as headings, marks AI replies, and omits the section when there are no replies", async () => {
+    const post = makePost({ number: 7, title: "No replies yet" });
+
+    const { blob: soloBlob } = await buildForumThreadZip(post, []);
+    const soloFiles = await unzipBlob(soloBlob);
+    const soloMd = strFromU8(soloFiles["forum-0007-no-replies-yet/thread.md"]);
+    expect(soloMd).not.toContain("## Reply by");
+
+    const reply1 = makePost({
+      id: "reply-1",
+      username: "bob",
+      content: "Thanks, looking into it.",
+      created_at: "2026-08-01T01:03:00+00:00",
+      is_ai_reply: false,
+    });
+    const reply2 = makePost({
+      id: "reply-2",
+      username: "qdash-bot",
+      content: "Automated triage suggests a wiring issue.",
+      created_at: "2026-08-01T02:20:00+00:00",
+      is_ai_reply: true,
+    });
+
+    const { blob } = await buildForumThreadZip(post, [reply1, reply2]);
+    const files = await unzipBlob(blob);
+    const md = strFromU8(files["forum-0007-no-replies-yet/thread.md"]);
+
+    const date1 = formatDateTime(reply1.created_at, "yyyy-MM-dd HH:mm");
+    const date2 = formatDateTime(reply2.created_at, "yyyy-MM-dd HH:mm");
+
+    expect(md).toContain(`## Reply by @bob — ${date1}`);
+    expect(md).toContain(`## Reply by @qdash-bot (AI) — ${date2}`);
+    expect(md).toContain("Thanks, looking into it.");
+    expect(md).toContain("Automated triage suggests a wiring issue.");
+    expect(md.indexOf(`## Reply by @bob`)).toBeLessThan(md.indexOf(`## Reply by @qdash-bot`));
+  });
+
+  it("fetches same-origin images, stores them under assets/, and rewrites the reference in thread.md", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("/api/forum/images/photo.png");
+      return {
+        ok: true,
+        arrayBuffer: async () => new TextEncoder().encode("PNGBYTES").buffer,
+      } as Response;
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const post = makePost({
+      number: 5,
+      title: "Photo attached",
+      content_blocks: [{ type: "image", props: { url: "/api/forum/images/photo.png" } }],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+    const rootName = "forum-0005-photo-attached";
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(files[`${rootName}/assets/001-photo.png`]).toBeDefined();
+    expect(strFromU8(files[`${rootName}/assets/001-photo.png`])).toBe("PNGBYTES");
+
+    const md = strFromU8(files[`${rootName}/thread.md`]);
+    expect(md).toContain("assets/001-photo.png");
+    expect(md).not.toContain("/api/forum/images/photo.png");
+  });
+
+  it("decodes inline data: URLs into assets/ without leaving base64 in thread.md", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const base64 = Buffer.from("VIDEOBYTES").toString("base64");
+    const post = makePost({
+      number: 6,
+      title: "Inline clip",
+      content_blocks: [{ type: "video", props: { url: `data:video/mp4;base64,${base64}` } }],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+    const rootName = "forum-0006-inline-clip";
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(files[`${rootName}/assets/001-inline.mp4`]).toBeDefined();
+    expect(strFromU8(files[`${rootName}/assets/001-inline.mp4`])).toBe("VIDEOBYTES");
+
+    const md = strFromU8(files[`${rootName}/thread.md`]);
+    expect(md).not.toContain("base64");
+    expect(md).not.toContain(base64);
+    expect(md).toContain("assets/001-inline.mp4");
+  });
+
+  it("leaves external https URLs untouched and never fetches them", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const post = makePost({
+      number: 8,
+      title: "External image",
+      content_blocks: [{ type: "image", props: { url: "https://example.com/cat.png" } }],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+    const rootName = "forum-0008-external-image";
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const md = strFromU8(files[`${rootName}/thread.md`]);
+    expect(md).toContain("https://example.com/cat.png");
+    expect(Object.keys(files).some((path) => path.includes("/assets/"))).toBe(false);
+  });
+
+  it("falls back to post.content when content_blocks is empty", async () => {
+    const post = makePost({
+      number: 9,
+      title: "Legacy post",
+      content: "Legacy **markdown** content.",
+      content_blocks: [],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+    const md = strFromU8(files["forum-0009-legacy-post/thread.md"]);
+
+    expect(md).toContain("Legacy **markdown** content.");
+  });
+
+  it("keeps the original URL when fetch rejects or responds with ok: false", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "/api/forum/images/rejects.png") {
+        throw new Error("network down");
+      }
+      return { ok: false, arrayBuffer: async () => new ArrayBuffer(0) } as Response;
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const post = makePost({
+      number: 10,
+      title: "Broken assets",
+      content_blocks: [
+        { type: "image", props: { url: "/api/forum/images/rejects.png" } },
+        { type: "image", props: { url: "/api/forum/images/not-ok.png" } },
+      ],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const files = await unzipBlob(blob);
+
+    const rootName = "forum-0010-broken-assets";
+    const md = strFromU8(files[`${rootName}/thread.md`]);
+    expect(md).toContain("/api/forum/images/rejects.png");
+    expect(md).toContain("/api/forum/images/not-ok.png");
+    expect(Object.keys(files).some((path) => path.includes("/assets/"))).toBe(false);
+  });
+
+  it("builds the ZIP filename from the post number and an English title slug, or just the number for a non-ASCII title", async () => {
+    const englishPost = makePost({ number: 42, title: "Readout error spike on Q12" });
+    const { filename: englishFilename } = await buildForumThreadZip(englishPost, []);
+    expect(englishFilename).toBe("forum-0042-readout-error-spike-on-q12.zip");
+
+    const japanesePost = makePost({ number: 42, title: "読み出しエラーの急増" });
+    const { filename: japaneseFilename } = await buildForumThreadZip(japanesePost, []);
+    expect(japaneseFilename).toBe("forum-0042.zip");
+  });
+
+  it("does not mutate the input post.content_blocks", async () => {
+    const contentBlocks = [{ type: "image", props: { url: "/api/forum/images/keep.png" } }];
+    const post = makePost({
+      number: 11,
+      title: "Immutable input",
+      content_blocks: contentBlocks,
+    });
+    const before = JSON.stringify(post.content_blocks);
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => new TextEncoder().encode("BYTES").buffer,
+    })) as unknown as typeof fetch;
+    globalThis.fetch = fetchMock;
+
+    await buildForumThreadZip(post, []);
+
+    expect(JSON.stringify(post.content_blocks)).toBe(before);
+    expect(post.content_blocks![0].props).toEqual({ url: "/api/forum/images/keep.png" });
+  });
+});

--- a/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
+++ b/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
@@ -32,7 +32,7 @@ describe("buildForumThreadZip", () => {
     vi.restoreAllMocks();
   });
 
-  it("writes the expected front matter keys and omits null/empty ones, while always writing labels", async () => {
+  it("writes the OKF front matter keys in order, with the qdash block omitting absent fields", async () => {
     const post = makePost({
       number: 42,
       title: "Readout error spike",
@@ -51,19 +51,178 @@ describe("buildForumThreadZip", () => {
 
     const files = await unzipBlob(blob);
     const md = strFromU8(files["forum-0042-readout-error-spike/thread.md"]);
+    const topLevelKeys = [...md.matchAll(/^([a-z_]+):/gm)].map((m) => m[1]);
 
-    expect(md).toContain("number: 42");
+    expect(topLevelKeys).toEqual([
+      "type",
+      "title",
+      "description",
+      "resource",
+      "status",
+      "generated",
+      "qdash",
+    ]);
+    expect(md).toContain("type: Forum Thread");
     expect(md).toContain("title: Readout error spike");
+    expect(md).toContain("description: Hello from the plain content field.");
+    expect(md).toMatch(/^resource: .+\/forum\/post-1$/m);
+    expect(md).toContain("status: draft");
+    expect(md).toContain(`by: human:alice`);
+    expect(md).toMatch(/at: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+    expect(md).not.toMatch(/^tags:/m);
+    expect(md).not.toMatch(/^verified:/m);
+    expect(md).not.toMatch(/^sources:/m);
+    expect(md).toContain("number: 42");
     expect(md).toContain("category: bug");
-    expect(md).toContain("status: open");
-    expect(md).toContain("labels: []");
+    expect(md).toContain("thread_status: open");
     expect(md).toContain("author: alice");
     expect(md).toContain("chip_id: chip-64");
-    expect(md).not.toMatch(/^assignee:/m);
-    expect(md).not.toMatch(/^target_type:/m);
-    expect(md).not.toMatch(/^target_id:/m);
-    expect(md).not.toMatch(/^cooldown_id:/m);
+    expect(md).not.toMatch(/^\s+assignee:/m);
+    expect(md).not.toMatch(/^\s+target_type:/m);
+    expect(md).not.toMatch(/^\s+target_id:/m);
+    expect(md).not.toMatch(/^\s+cooldown_id:/m);
+    expect(md).toContain("reply_count: 0");
+    expect(md).toContain("exported_by: process:qdash-forum-export");
     expect(md).toMatch(/exported_at: ['"]?\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("maps a resolved thread to status: stable and an open thread to status: draft", async () => {
+    const resolvedPost = makePost({ number: 1, status: "resolved" });
+    const { blob: resolvedBlob } = await buildForumThreadZip(resolvedPost, []);
+    const resolvedMd = strFromU8((await unzipBlob(resolvedBlob))["forum-0001/thread.md"]);
+    expect(resolvedMd).toContain("status: stable");
+    expect(resolvedMd).toContain("thread_status: resolved");
+
+    const openPost = makePost({ number: 2, status: "open" });
+    const { blob: openBlob } = await buildForumThreadZip(openPost, []);
+    const openMd = strFromU8((await unzipBlob(openBlob))["forum-0002/thread.md"]);
+    expect(openMd).toContain("status: draft");
+    expect(openMd).toContain("thread_status: open");
+  });
+
+  it("emits verified only for a resolved thread with an assignee", async () => {
+    const resolvedWithAssignee = makePost({
+      number: 1,
+      status: "resolved",
+      assignee_username: "carol",
+      updated_at: "2026-08-02T04:00:00+00:00",
+    });
+    const { blob: verifiedBlob } = await buildForumThreadZip(resolvedWithAssignee, []);
+    const verifiedMd = strFromU8((await unzipBlob(verifiedBlob))["forum-0001/thread.md"]);
+    expect(verifiedMd).toMatch(/^verified:/m);
+    expect(verifiedMd).toContain("by: human:carol");
+    expect(verifiedMd).toContain("at: 2026-08-02T04:00:00.000Z");
+
+    const resolvedWithoutAssignee = makePost({ number: 2, status: "resolved" });
+    const { blob: noAssigneeBlob } = await buildForumThreadZip(resolvedWithoutAssignee, []);
+    const noAssigneeMd = strFromU8((await unzipBlob(noAssigneeBlob))["forum-0002/thread.md"]);
+    expect(noAssigneeMd).not.toMatch(/^verified:/m);
+
+    const openWithAssignee = makePost({
+      number: 3,
+      status: "open",
+      assignee_username: "carol",
+    });
+    const { blob: openBlob } = await buildForumThreadZip(openWithAssignee, []);
+    const openMd = strFromU8((await unzipBlob(openBlob))["forum-0003/thread.md"]);
+    expect(openMd).not.toMatch(/^verified:/m);
+  });
+
+  it("credits generated.by to the AI reply process identifier when the root post is an AI reply", async () => {
+    const humanPost = makePost({ number: 1, username: "alice" });
+    const { blob: humanBlob } = await buildForumThreadZip(humanPost, []);
+    const humanMd = strFromU8((await unzipBlob(humanBlob))["forum-0001/thread.md"]);
+    expect(humanMd).toContain("by: human:alice");
+
+    const aiPost = makePost({ number: 2, username: "qdash-bot", is_ai_reply: true });
+    const { blob: aiBlob } = await buildForumThreadZip(aiPost, []);
+    const aiMd = strFromU8((await unzipBlob(aiBlob))["forum-0002/thread.md"]);
+    expect(aiMd).toContain("by: process:qdash-ai-reply");
+  });
+
+  it("emits sources only when chip_id, target_type and target_id are all set, in the qubit and coupling URL forms", async () => {
+    const noTarget = makePost({ number: 1 });
+    const { blob: noTargetBlob } = await buildForumThreadZip(noTarget, []);
+    const noTargetMd = strFromU8((await unzipBlob(noTargetBlob))["forum-0001/thread.md"]);
+    expect(noTargetMd).not.toMatch(/^sources:/m);
+
+    const qubitPost = makePost({
+      number: 2,
+      chip_id: "chip-64",
+      target_type: "qubit",
+      target_id: "12",
+    });
+    const { blob: qubitBlob } = await buildForumThreadZip(qubitPost, []);
+    const qubitMd = strFromU8((await unzipBlob(qubitBlob))["forum-0002/thread.md"]);
+    expect(qubitMd).toMatch(/^sources:/m);
+    expect(qubitMd).toContain("id: target");
+    expect(qubitMd).toContain(`resource: ${window.location.origin}/chip/chip-64/qubit/12`);
+    expect(qubitMd).toContain("title: 12 · chip-64");
+
+    const couplingPost = makePost({
+      number: 3,
+      chip_id: "chip-64",
+      target_type: "coupling",
+      target_id: "12-13",
+    });
+    const { blob: couplingBlob } = await buildForumThreadZip(couplingPost, []);
+    const couplingMd = strFromU8((await unzipBlob(couplingBlob))["forum-0003/thread.md"]);
+    expect(couplingMd).toContain(
+      `resource: ${window.location.origin}/dashboard?chip=chip-64&type=coupling`,
+    );
+    expect(couplingMd).toContain("title: 12-13 · chip-64");
+  });
+
+  it("derives description from the first plain-text line of the rendered root markdown, skipping code/image/heading lines", async () => {
+    const post = makePost({
+      number: 1,
+      content: [
+        "```js",
+        "const skipped = true;",
+        "```",
+        "![alt](image.png)",
+        "# Heading not counted",
+        "",
+        "Some **bold** and ~~struck~~ and _italic_ and `code` and [link text](https://example.com) keeps target_id and chip_id intact.",
+      ].join("\n"),
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const md = strFromU8((await unzipBlob(blob))["forum-0001/thread.md"]);
+    expect(md).toContain(
+      "description: Some bold and struck and italic and code and link text keeps target_id and chip_id intact.",
+    );
+  });
+
+  it("truncates a long description to 200 characters with a trailing ellipsis", async () => {
+    const longLine = "A".repeat(250);
+    const post = makePost({ number: 1, content: longLine });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const md = strFromU8((await unzipBlob(blob))["forum-0001/thread.md"]);
+    expect(md).toContain(`description: ${"A".repeat(200)}…`);
+  });
+
+  it("omits description when the root markdown has no plain-text content", async () => {
+    const post = makePost({ number: 1, content: "![alt](image.png)" });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const md = strFromU8((await unzipBlob(blob))["forum-0001/thread.md"]);
+    expect(md).not.toMatch(/^description:/m);
+  });
+
+  it("omits tags when the thread has no labels, and emits them otherwise", async () => {
+    const withoutLabels = makePost({ number: 1, labels: [] });
+    const { blob: withoutBlob } = await buildForumThreadZip(withoutLabels, []);
+    const withoutMd = strFromU8((await unzipBlob(withoutBlob))["forum-0001/thread.md"]);
+    expect(withoutMd).not.toMatch(/^tags:/m);
+
+    const withLabels = makePost({ number: 2, labels: ["hardware", "readout"] });
+    const { blob: withBlob } = await buildForumThreadZip(withLabels, []);
+    const withMd = strFromU8((await unzipBlob(withBlob))["forum-0002/thread.md"]);
+    expect(withMd).toMatch(/^tags:/m);
+    expect(withMd).toContain("- hardware");
+    expect(withMd).toContain("- readout");
   });
 
   it("concatenates replies as headings, marks AI replies, and omits the section when there are no replies", async () => {

--- a/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
+++ b/ui/src/lib/forum/__tests__/exportThreadZip.test.ts
@@ -194,6 +194,32 @@ describe("buildForumThreadZip", () => {
     );
   });
 
+  it("keeps literal markdown characters in the description and flattens styled runs", async () => {
+    const post = makePost({
+      number: 12,
+      content_blocks: [
+        { type: "heading", content: [{ type: "text", text: "Not the description", styles: {} }] },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "5 * 3 * 2 shots in _raw_ mode, ", styles: {} },
+            { type: "text", text: "retried", styles: { bold: true } },
+            { type: "text", text: " via ", styles: {} },
+            {
+              type: "link",
+              href: "https://example.com",
+              content: [{ type: "text", text: "the runbook", styles: {} }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const { blob } = await buildForumThreadZip(post, []);
+    const md = strFromU8((await unzipBlob(blob))["forum-0012/thread.md"]);
+    expect(md).toContain("description: 5 * 3 * 2 shots in _raw_ mode, retried via the runbook");
+  });
+
   it("truncates a long description to 200 characters with a trailing ellipsis", async () => {
     const longLine = "A".repeat(250);
     const post = makePost({ number: 1, content: longLine });

--- a/ui/src/lib/forum/exportThreadZip.ts
+++ b/ui/src/lib/forum/exportThreadZip.ts
@@ -62,24 +62,123 @@ function setIfPresent(target: Record<string, unknown>, key: string, value: unkno
   target[key] = value;
 }
 
-function buildFrontMatter(post: ForumPostResponse, replyCount: number): Record<string, unknown> {
+function resolveThreadTitle(post: ForumPostResponse): string {
+  return post.title?.trim() ? post.title : "Untitled topic";
+}
+
+function resourceUrl(path: string): string {
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  return origin ? `${origin}${path}` : path;
+}
+
+/** Mirrors `dashboardTargetHref` in ForumDetailPage.tsx without importing it. */
+function targetResourcePath(chipId: string, targetType: string, targetId: string): string {
+  if (targetType === "qubit") return `/chip/${chipId}/qubit/${targetId}`;
+  return `/dashboard?chip=${encodeURIComponent(chipId)}&type=coupling`;
+}
+
+const BARE_ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/;
+
+/** Normalizes a possibly timezone-less API timestamp to ISO8601; returns the raw value if it can't be parsed. */
+function toIsoTimestamp(raw: string): string {
+  const normalized = BARE_ISO_DATETIME.test(raw) ? `${raw}Z` : raw;
+  const date = new Date(normalized);
+  return Number.isNaN(date.getTime()) ? raw : date.toISOString();
+}
+
+const HEADING_LINE = /^#{1,6}\s/;
+const IMAGE_OR_EMBED_LINE = /^!\[[^\]]*\]\([^)]*\)/;
+const DESCRIPTION_MAX_LENGTH = 200;
+
+function firstDescriptionLine(markdown: string): string | undefined {
+  let inFence = false;
+  for (const rawLine of markdown.split("\n")) {
+    const line = rawLine.trim();
+    if (/^```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || line === "") continue;
+    if (IMAGE_OR_EMBED_LINE.test(line) || HEADING_LINE.test(line)) continue;
+    return line;
+  }
+  return undefined;
+}
+
+function stripInlineMarkdown(text: string): string {
+  return text
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/~~([^~]+)~~/g, "$1")
+    .replace(/(^|[^A-Za-z0-9_])__([^_]+)__(?![A-Za-z0-9_])/g, "$1$2")
+    .replace(/(^|[^A-Za-z0-9_])_([^_]+)_(?![A-Za-z0-9_])/g, "$1$2")
+    .replace(/^#{1,6}\s*/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function deriveDescription(rootMarkdown: string): string | undefined {
+  const line = firstDescriptionLine(rootMarkdown);
+  if (!line) return undefined;
+  const text = stripInlineMarkdown(line);
+  if (!text) return undefined;
+  if (text.length <= DESCRIPTION_MAX_LENGTH) return text;
+  return `${text.slice(0, DESCRIPTION_MAX_LENGTH)}…`;
+}
+
+/** Partial Open Knowledge Format v0.2 front matter; QDash-only fields live under `qdash`. */
+function buildFrontMatter(
+  post: ForumPostResponse,
+  replies: ForumPostResponse[],
+  rootMarkdown: string,
+): Record<string, unknown> {
   const frontMatter: Record<string, unknown> = {};
 
-  setIfPresent(frontMatter, "number", post.number);
-  setIfPresent(frontMatter, "title", post.title);
-  setIfPresent(frontMatter, "category", post.category);
-  setIfPresent(frontMatter, "status", post.status);
-  frontMatter.labels = post.labels ?? [];
-  setIfPresent(frontMatter, "author", post.username);
-  setIfPresent(frontMatter, "assignee", post.assignee_username);
-  setIfPresent(frontMatter, "chip_id", post.chip_id);
-  setIfPresent(frontMatter, "target_type", post.target_type);
-  setIfPresent(frontMatter, "target_id", post.target_id);
-  setIfPresent(frontMatter, "cooldown_id", post.cooldown_id);
-  setIfPresent(frontMatter, "created_at", post.created_at);
-  setIfPresent(frontMatter, "updated_at", post.updated_at);
-  frontMatter.reply_count = replyCount;
-  frontMatter.exported_at = new Date().toISOString();
+  frontMatter.type = "Forum Thread";
+  frontMatter.title = resolveThreadTitle(post);
+  setIfPresent(frontMatter, "description", deriveDescription(rootMarkdown));
+  frontMatter.resource = resourceUrl(`/forum/${post.id}`);
+  if (post.labels && post.labels.length > 0) {
+    frontMatter.tags = post.labels;
+  }
+  frontMatter.status = post.status === "resolved" ? "stable" : "draft";
+  frontMatter.generated = {
+    by: post.is_ai_reply ? "process:qdash-ai-reply" : `human:${post.username}`,
+    at: toIsoTimestamp(post.created_at),
+  };
+  if (post.status === "resolved" && post.assignee_username) {
+    frontMatter.verified = [
+      { by: `human:${post.assignee_username}`, at: toIsoTimestamp(post.updated_at) },
+    ];
+  }
+  if (post.chip_id && post.target_type && post.target_id) {
+    frontMatter.sources = [
+      {
+        id: "target",
+        resource: resourceUrl(targetResourcePath(post.chip_id, post.target_type, post.target_id)),
+        title: `${post.target_id} · ${post.chip_id}`,
+      },
+    ];
+  }
+
+  const qdash: Record<string, unknown> = {};
+  setIfPresent(qdash, "number", post.number);
+  setIfPresent(qdash, "category", post.category);
+  setIfPresent(qdash, "thread_status", post.status);
+  setIfPresent(qdash, "author", post.username);
+  setIfPresent(qdash, "assignee", post.assignee_username);
+  setIfPresent(qdash, "chip_id", post.chip_id);
+  setIfPresent(qdash, "target_type", post.target_type);
+  setIfPresent(qdash, "target_id", post.target_id);
+  setIfPresent(qdash, "cooldown_id", post.cooldown_id);
+  qdash.reply_count = replies.length;
+  setIfPresent(qdash, "created_at", post.created_at);
+  setIfPresent(qdash, "updated_at", post.updated_at);
+  qdash.exported_at = new Date().toISOString();
+  qdash.exported_by = "process:qdash-forum-export";
+  frontMatter.qdash = qdash;
 
   return frontMatter;
 }
@@ -90,9 +189,9 @@ function buildThreadMarkdown(
   rootMarkdown: string,
   replyMarkdowns: string[],
 ): string {
-  const frontMatter = buildFrontMatter(post, replies.length);
-  const yamlBlock = ["---", stringify(frontMatter).trimEnd(), "---"].join("\n");
-  const title = post.title?.trim() ? post.title : "Untitled topic";
+  const frontMatter = buildFrontMatter(post, replies, rootMarkdown);
+  const yamlBlock = ["---", stringify(frontMatter, { lineWidth: 0 }).trimEnd(), "---"].join("\n");
+  const title = resolveThreadTitle(post);
 
   const sections = [yamlBlock, `# ${title}`, rootMarkdown.trim()];
 

--- a/ui/src/lib/forum/exportThreadZip.ts
+++ b/ui/src/lib/forum/exportThreadZip.ts
@@ -244,14 +244,18 @@ function collectAssetRefs(
   }
 }
 
+/** Matches any URL carrying a scheme (`https:`, `blob:`, ...) or a protocol-relative `//host` prefix. */
+const HAS_SCHEME_OR_AUTHORITY = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
 function collectAllAssets(blocksList: BlockRecord[][]): Map<string, CollectedAsset> {
   const assets = new Map<string, CollectedAsset>();
   const register = (url: string, props: BlockRecord) => {
     let kind: "data" | "relative";
     if (url.startsWith("data:")) {
       kind = "data";
-    } else if (/^https?:\/\//i.test(url)) {
-      // External hosts are never fetched (CORS, third-party content); leave as-is.
+    } else if (HAS_SCHEME_OR_AUTHORITY.test(url)) {
+      // Anything that can point off-origin (absolute, protocol-relative, blob:, ...) is never
+      // fetched (CORS, third-party content); leave as-is.
       return;
     } else {
       kind = "relative";

--- a/ui/src/lib/forum/exportThreadZip.ts
+++ b/ui/src/lib/forum/exportThreadZip.ts
@@ -2,7 +2,7 @@ import { BlockNoteEditor, type PartialBlock } from "@blocknote/core";
 import { strToU8, zip, type AsyncZippable } from "fflate";
 import { stringify } from "yaml";
 
-import { formatDateTime } from "@/lib/utils/datetime";
+import { formatDateTime, normalizeUtcInput } from "@/lib/utils/datetime";
 import type { ForumPostResponse } from "@/schemas";
 
 export type ForumThreadExport = {
@@ -77,11 +77,9 @@ function targetResourcePath(chipId: string, targetType: string, targetId: string
   return `/dashboard?chip=${encodeURIComponent(chipId)}&type=coupling`;
 }
 
-const BARE_ISO_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/;
-
 /** Normalizes a possibly timezone-less API timestamp to ISO8601; returns the raw value if it can't be parsed. */
 function toIsoTimestamp(raw: string): string {
-  const normalized = BARE_ISO_DATETIME.test(raw) ? `${raw}Z` : raw;
+  const normalized = normalizeUtcInput(raw);
   const date = new Date(normalized);
   return Number.isNaN(date.getTime()) ? raw : date.toISOString();
 }
@@ -130,8 +128,9 @@ function firstBlockText(node: unknown): string {
 function deriveDescription(blocks: BlockRecord[]): string | undefined {
   const text = firstBlockText(blocks);
   if (!text) return undefined;
-  if (text.length <= DESCRIPTION_MAX_LENGTH) return text;
-  return `${text.slice(0, DESCRIPTION_MAX_LENGTH)}…`;
+  const codePoints = [...text];
+  if (codePoints.length <= DESCRIPTION_MAX_LENGTH) return text;
+  return `${codePoints.slice(0, DESCRIPTION_MAX_LENGTH).join("")}…`;
 }
 
 /** Partial Open Knowledge Format v0.2 front matter; QDash-only fields live under `qdash`. */
@@ -212,21 +211,21 @@ function buildThreadMarkdown(
   return `${sections.join("\n\n")}\n`;
 }
 
-function renderMarkdown(content: string, blocks: BlockRecord[]): string {
+function renderMarkdown(editor: BlockNoteEditor, content: string, blocks: BlockRecord[]): string {
   if (blocks.length === 0) {
     return content;
   }
-  const editor = BlockNoteEditor.create({
-    initialContent: blocks as unknown as PartialBlock[],
-  });
-  return editor.blocksToMarkdownLossy();
+  return editor.blocksToMarkdownLossy(blocks as unknown as PartialBlock[]);
 }
 
 /** Posts written before `content_blocks` only have markdown, so let BlockNote parse it back. */
-function descriptionBlocks(post: ForumPostResponse, blocks: BlockRecord[]): BlockRecord[] {
+function descriptionBlocks(
+  editor: BlockNoteEditor,
+  post: ForumPostResponse,
+  blocks: BlockRecord[],
+): BlockRecord[] {
   if (blocks.length > 0) return blocks;
   if (!post.content.trim()) return [];
-  const editor = BlockNoteEditor.create();
   return editor.tryParseMarkdownToBlocks(post.content) as unknown as BlockRecord[];
 }
 
@@ -259,22 +258,28 @@ function collectAssetRefs(
   }
 }
 
-/** Matches any URL carrying a scheme (`https:`, `blob:`, ...) or a protocol-relative `//host` prefix. */
-const HAS_SCHEME_OR_AUTHORITY = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+const PROBE_ORIGIN = "https://qdash-export.invalid";
+
+/**
+ * `data:` URLs are decoded locally and only URLs that resolve inside the current origin are
+ * fetched. Anything that can point off-origin (absolute, protocol-relative, blob:, unparsable)
+ * is external and left as-is (CORS, third-party content).
+ */
+function classifyUrl(url: string): "data" | "relative" | "external" {
+  if (url.startsWith("data:")) return "data";
+  try {
+    return new URL(url, PROBE_ORIGIN).origin === PROBE_ORIGIN ? "relative" : "external";
+  } catch {
+    return "external";
+  }
+}
 
 function collectAllAssets(blocksList: BlockRecord[][]): Map<string, CollectedAsset> {
   const assets = new Map<string, CollectedAsset>();
   const register = (url: string, props: BlockRecord) => {
-    let kind: "data" | "relative";
-    if (url.startsWith("data:")) {
-      kind = "data";
-    } else if (HAS_SCHEME_OR_AUTHORITY.test(url)) {
-      // Anything that can point off-origin (absolute, protocol-relative, blob:, ...) is never
-      // fetched (CORS, third-party content); leave as-is.
-      return;
-    } else {
-      kind = "relative";
-    }
+    if (!url.trim()) return;
+    const kind = classifyUrl(url);
+    if (kind === "external") return;
     let asset = assets.get(url);
     if (!asset) {
       asset = { url, kind, refs: [], bytes: null, filename: null, zipPath: null };
@@ -291,7 +296,7 @@ function collectAllAssets(blocksList: BlockRecord[][]): Map<string, CollectedAss
 function extensionForMime(mime: string): string {
   const known = MIME_EXTENSIONS[mime];
   if (known) return known;
-  const subtype = mime.split("/")[1] ?? "";
+  const subtype = (mime.split("/")[1] ?? "").split("+")[0];
   const cleaned = subtype.replace(/[^a-z0-9]/gi, "").toLowerCase();
   return cleaned || "bin";
 }
@@ -305,19 +310,36 @@ function decodeBase64(base64: string): Uint8Array {
   return bytes;
 }
 
-function parseDataUrl(url: string): { mime: string; base64: string } | null {
-  const match = /^data:([^,]*),(.*)$/s.exec(url);
-  if (!match) return null;
-  const [, meta, payload] = match;
-  const mime = meta.replace(/;base64$/, "") || "application/octet-stream";
-  return { mime, base64: payload };
+/** Decodes a `data:` URL payload, honoring extra mime parameters and non-base64 (percent-encoded) payloads. */
+function parseDataUrl(url: string): { mime: string; bytes: Uint8Array } | null {
+  const comma = url.indexOf(",");
+  if (comma === -1) return null;
+  const params = url.slice("data:".length, comma).split(";");
+  const mime = params[0] || "application/octet-stream";
+  const payload = url.slice(comma + 1);
+  try {
+    const bytes = params.slice(1).includes("base64")
+      ? decodeBase64(payload)
+      : new TextEncoder().encode(decodeURIComponent(payload));
+    return { mime, bytes };
+  } catch {
+    return null;
+  }
 }
 
 function basenameFromUrl(url: string): string {
-  const withoutHash = url.split("#")[0];
-  const withoutQuery = withoutHash.split("?")[0];
-  const segments = withoutQuery.split("/").filter(Boolean);
-  const last = segments[segments.length - 1] ?? "asset";
+  let pathname: string;
+  try {
+    pathname = new URL(url, PROBE_ORIGIN).pathname;
+  } catch {
+    pathname = url.split("#")[0].split("?")[0];
+  }
+  let last = pathname.split("/").filter(Boolean).pop() ?? "";
+  try {
+    last = decodeURIComponent(last);
+  } catch {
+    // keep the percent-encoded form; the sanitizer below neutralizes it
+  }
   const sanitized = last.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48);
   return sanitized || "asset";
 }
@@ -327,7 +349,7 @@ async function resolveAsset(asset: CollectedAsset): Promise<boolean> {
     if (asset.kind === "data") {
       const parsed = parseDataUrl(asset.url);
       if (!parsed) return false;
-      asset.bytes = decodeBase64(parsed.base64);
+      asset.bytes = parsed.bytes;
       asset.filename = `inline.${extensionForMime(parsed.mime)}`;
       return true;
     }
@@ -376,20 +398,19 @@ export async function buildForumThreadZip(
   post: ForumPostResponse,
   replies: ForumPostResponse[],
 ): Promise<ForumThreadExport> {
-  const rootBlocks = cloneBlocks((post.content_blocks as BlockRecord[] | undefined) ?? []);
-  const replyBlocksList = replies.map((reply) =>
-    cloneBlocks((reply.content_blocks as BlockRecord[] | undefined) ?? []),
-  );
+  const rootBlocks = cloneBlocks(post.content_blocks ?? []);
+  const replyBlocksList = replies.map((reply) => cloneBlocks(reply.content_blocks ?? []));
 
   const assets = collectAllAssets([rootBlocks, ...replyBlocksList]);
   await resolveAndRewriteAssets(assets);
 
-  const rootMarkdown = renderMarkdown(post.content, rootBlocks);
+  const editor = BlockNoteEditor.create();
+  const rootMarkdown = renderMarkdown(editor, post.content, rootBlocks);
   const replyMarkdowns = replies.map((reply, index) =>
-    renderMarkdown(reply.content, replyBlocksList[index]),
+    renderMarkdown(editor, reply.content, replyBlocksList[index]),
   );
 
-  const description = deriveDescription(descriptionBlocks(post, rootBlocks));
+  const description = deriveDescription(descriptionBlocks(editor, post, rootBlocks));
   const threadMd = buildThreadMarkdown(post, replies, rootMarkdown, replyMarkdowns, description);
   const rootName = buildRootFolderName(post);
 

--- a/ui/src/lib/forum/exportThreadZip.ts
+++ b/ui/src/lib/forum/exportThreadZip.ts
@@ -1,0 +1,291 @@
+import { BlockNoteEditor, type PartialBlock } from "@blocknote/core";
+import { strToU8, zip, type AsyncZippable } from "fflate";
+import { stringify } from "yaml";
+
+import { formatDateTime } from "@/lib/utils/datetime";
+import type { ForumPostResponse } from "@/schemas";
+
+export type ForumThreadExport = {
+  /** ZIP file name, including the `.zip` extension. */
+  filename: string;
+  blob: Blob;
+};
+
+type BlockRecord = Record<string, unknown>;
+
+const MIME_EXTENSIONS: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "video/mp4": "mp4",
+  "audio/mpeg": "mp3",
+};
+
+interface CollectedAsset {
+  url: string;
+  kind: "data" | "relative";
+  refs: BlockRecord[];
+  bytes: Uint8Array | null;
+  filename: string | null;
+  zipPath: string | null;
+}
+
+function cloneBlocks(blocks: BlockRecord[]): BlockRecord[] {
+  if (typeof structuredClone === "function") {
+    return structuredClone(blocks);
+  }
+  return JSON.parse(JSON.stringify(blocks)) as BlockRecord[];
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+function buildRootFolderName(post: ForumPostResponse): string {
+  if (post.number !== null && post.number !== undefined) {
+    const numberPart = String(post.number).padStart(4, "0");
+    const slug = slugify(post.title ?? "");
+    return slug ? `forum-${numberPart}-${slug}` : `forum-${numberPart}`;
+  }
+  const idSlug = slugify(post.id);
+  return `forum-${idSlug || post.id}`;
+}
+
+function setIfPresent(target: Record<string, unknown>, key: string, value: unknown): void {
+  if (value === null || value === undefined || value === "") return;
+  target[key] = value;
+}
+
+function buildFrontMatter(post: ForumPostResponse, replyCount: number): Record<string, unknown> {
+  const frontMatter: Record<string, unknown> = {};
+
+  setIfPresent(frontMatter, "number", post.number);
+  setIfPresent(frontMatter, "title", post.title);
+  setIfPresent(frontMatter, "category", post.category);
+  setIfPresent(frontMatter, "status", post.status);
+  frontMatter.labels = post.labels ?? [];
+  setIfPresent(frontMatter, "author", post.username);
+  setIfPresent(frontMatter, "assignee", post.assignee_username);
+  setIfPresent(frontMatter, "chip_id", post.chip_id);
+  setIfPresent(frontMatter, "target_type", post.target_type);
+  setIfPresent(frontMatter, "target_id", post.target_id);
+  setIfPresent(frontMatter, "cooldown_id", post.cooldown_id);
+  setIfPresent(frontMatter, "created_at", post.created_at);
+  setIfPresent(frontMatter, "updated_at", post.updated_at);
+  frontMatter.reply_count = replyCount;
+  frontMatter.exported_at = new Date().toISOString();
+
+  return frontMatter;
+}
+
+function buildThreadMarkdown(
+  post: ForumPostResponse,
+  replies: ForumPostResponse[],
+  rootMarkdown: string,
+  replyMarkdowns: string[],
+): string {
+  const frontMatter = buildFrontMatter(post, replies.length);
+  const yamlBlock = ["---", stringify(frontMatter).trimEnd(), "---"].join("\n");
+  const title = post.title?.trim() ? post.title : "Untitled topic";
+
+  const sections = [yamlBlock, `# ${title}`, rootMarkdown.trim()];
+
+  replies.forEach((reply, index) => {
+    const aiSuffix = reply.is_ai_reply ? " (AI)" : "";
+    const date = formatDateTime(reply.created_at, "yyyy-MM-dd HH:mm");
+    const heading = `## Reply by @${reply.username}${aiSuffix} — ${date}`;
+    sections.push(["---", heading, replyMarkdowns[index].trim()].join("\n\n"));
+  });
+
+  return `${sections.join("\n\n")}\n`;
+}
+
+function renderMarkdown(content: string, blocks: BlockRecord[]): string {
+  if (blocks.length === 0) {
+    return content;
+  }
+  const editor = BlockNoteEditor.create({
+    initialContent: blocks as unknown as PartialBlock[],
+  });
+  return editor.blocksToMarkdownLossy();
+}
+
+/**
+ * Recursively walk a BlockNote document (blocks, their `content` and
+ * `children`) and invoke `register` for every `props` object that carries a
+ * string `url` (image / video / audio / file blocks).
+ */
+function collectAssetRefs(
+  node: unknown,
+  register: (url: string, props: BlockRecord) => void,
+): void {
+  if (Array.isArray(node)) {
+    for (const item of node) collectAssetRefs(item, register);
+    return;
+  }
+  if (node !== null && typeof node === "object") {
+    const obj = node as BlockRecord;
+    const props = obj.props;
+    if (
+      props !== null &&
+      typeof props === "object" &&
+      typeof (props as BlockRecord).url === "string"
+    ) {
+      register((props as BlockRecord).url as string, props as BlockRecord);
+    }
+    for (const value of Object.values(obj)) {
+      collectAssetRefs(value, register);
+    }
+  }
+}
+
+function collectAllAssets(blocksList: BlockRecord[][]): Map<string, CollectedAsset> {
+  const assets = new Map<string, CollectedAsset>();
+  const register = (url: string, props: BlockRecord) => {
+    let kind: "data" | "relative";
+    if (url.startsWith("data:")) {
+      kind = "data";
+    } else if (/^https?:\/\//i.test(url)) {
+      // External hosts are never fetched (CORS, third-party content); leave as-is.
+      return;
+    } else {
+      kind = "relative";
+    }
+    let asset = assets.get(url);
+    if (!asset) {
+      asset = { url, kind, refs: [], bytes: null, filename: null, zipPath: null };
+      assets.set(url, asset);
+    }
+    asset.refs.push(props);
+  };
+  for (const blocks of blocksList) {
+    collectAssetRefs(blocks, register);
+  }
+  return assets;
+}
+
+function extensionForMime(mime: string): string {
+  const known = MIME_EXTENSIONS[mime];
+  if (known) return known;
+  const subtype = mime.split("/")[1] ?? "";
+  const cleaned = subtype.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  return cleaned || "bin";
+}
+
+function decodeBase64(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function parseDataUrl(url: string): { mime: string; base64: string } | null {
+  const match = /^data:([^,]*),(.*)$/s.exec(url);
+  if (!match) return null;
+  const [, meta, payload] = match;
+  const mime = meta.replace(/;base64$/, "") || "application/octet-stream";
+  return { mime, base64: payload };
+}
+
+function basenameFromUrl(url: string): string {
+  const withoutHash = url.split("#")[0];
+  const withoutQuery = withoutHash.split("?")[0];
+  const segments = withoutQuery.split("/").filter(Boolean);
+  const last = segments[segments.length - 1] ?? "asset";
+  const sanitized = last.replace(/[^A-Za-z0-9._-]/g, "_").slice(0, 48);
+  return sanitized || "asset";
+}
+
+async function resolveAsset(asset: CollectedAsset): Promise<boolean> {
+  try {
+    if (asset.kind === "data") {
+      const parsed = parseDataUrl(asset.url);
+      if (!parsed) return false;
+      asset.bytes = decodeBase64(parsed.base64);
+      asset.filename = `inline.${extensionForMime(parsed.mime)}`;
+      return true;
+    }
+    const response = await fetch(asset.url);
+    if (!response.ok) return false;
+    asset.bytes = new Uint8Array(await response.arrayBuffer());
+    asset.filename = basenameFromUrl(asset.url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Fetch/decode every collected asset and rewrite `props.url` in place for the ones that succeed. */
+async function resolveAndRewriteAssets(assets: Map<string, CollectedAsset>): Promise<void> {
+  const ordered = [...assets.values()];
+  const ok = await Promise.all(ordered.map((asset) => resolveAsset(asset)));
+
+  let sequence = 0;
+  ordered.forEach((asset, index) => {
+    if (!ok[index] || !asset.filename) return;
+    sequence += 1;
+    const zipPath = `assets/${String(sequence).padStart(3, "0")}-${asset.filename}`;
+    asset.zipPath = zipPath;
+    for (const props of asset.refs) {
+      props.url = zipPath;
+    }
+  });
+}
+
+function zipAsync(files: AsyncZippable): Promise<Uint8Array<ArrayBuffer>> {
+  return new Promise((resolve, reject) => {
+    zip(files, (err, data) => {
+      if (err) reject(err);
+      else resolve(data);
+    });
+  });
+}
+
+/**
+ * Build a downloadable ZIP export of a forum thread: `thread.md` (front
+ * matter + markdown for the root post and every reply) plus an `assets/`
+ * folder with the inline and same-origin media referenced by the thread.
+ */
+export async function buildForumThreadZip(
+  post: ForumPostResponse,
+  replies: ForumPostResponse[],
+): Promise<ForumThreadExport> {
+  const rootBlocks = cloneBlocks((post.content_blocks as BlockRecord[] | undefined) ?? []);
+  const replyBlocksList = replies.map((reply) =>
+    cloneBlocks((reply.content_blocks as BlockRecord[] | undefined) ?? []),
+  );
+
+  const assets = collectAllAssets([rootBlocks, ...replyBlocksList]);
+  await resolveAndRewriteAssets(assets);
+
+  const rootMarkdown = renderMarkdown(post.content, rootBlocks);
+  const replyMarkdowns = replies.map((reply, index) =>
+    renderMarkdown(reply.content, replyBlocksList[index]),
+  );
+
+  const threadMd = buildThreadMarkdown(post, replies, rootMarkdown, replyMarkdowns);
+  const rootName = buildRootFolderName(post);
+
+  const files: AsyncZippable = {
+    [`${rootName}/thread.md`]: strToU8(threadMd),
+  };
+  for (const asset of assets.values()) {
+    if (asset.zipPath && asset.bytes) {
+      files[`${rootName}/${asset.zipPath}`] = asset.bytes;
+    }
+  }
+
+  const zipped = await zipAsync(files);
+  return {
+    filename: `${rootName}.zip`,
+    blob: new Blob([zipped], { type: "application/zip" }),
+  };
+}

--- a/ui/src/lib/forum/exportThreadZip.ts
+++ b/ui/src/lib/forum/exportThreadZip.ts
@@ -86,43 +86,49 @@ function toIsoTimestamp(raw: string): string {
   return Number.isNaN(date.getTime()) ? raw : date.toISOString();
 }
 
-const HEADING_LINE = /^#{1,6}\s/;
-const IMAGE_OR_EMBED_LINE = /^!\[[^\]]*\]\([^)]*\)/;
 const DESCRIPTION_MAX_LENGTH = 200;
+const NON_DESCRIPTIVE_BLOCK_TYPES = new Set([
+  "heading",
+  "codeBlock",
+  "table",
+  "image",
+  "video",
+  "audio",
+  "file",
+]);
 
-function firstDescriptionLine(markdown: string): string | undefined {
-  let inFence = false;
-  for (const rawLine of markdown.split("\n")) {
-    const line = rawLine.trim();
-    if (/^```/.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence || line === "") continue;
-    if (IMAGE_OR_EMBED_LINE.test(line) || HEADING_LINE.test(line)) continue;
-    return line;
+/** Concatenates the plain text of BlockNote inline content, descending into links. */
+function inlineText(node: unknown): string {
+  if (Array.isArray(node)) return node.map(inlineText).join("");
+  if (node === null || typeof node !== "object") return "";
+  const obj = node as BlockRecord;
+  if (typeof obj.text === "string") return obj.text;
+  return inlineText(obj.content);
+}
+
+function blockText(block: BlockRecord): string {
+  const own = inlineText(block.content).replace(/\s+/g, " ").trim();
+  if (own) return own;
+  return firstBlockText(block.children);
+}
+
+function firstBlockText(node: unknown): string {
+  if (!Array.isArray(node)) return "";
+  for (const block of node as BlockRecord[]) {
+    if (block === null || typeof block !== "object") continue;
+    if (typeof block.type === "string" && NON_DESCRIPTIVE_BLOCK_TYPES.has(block.type)) continue;
+    const text = blockText(block);
+    if (text) return text;
   }
-  return undefined;
+  return "";
 }
 
-function stripInlineMarkdown(text: string): string {
-  return text
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
-    .replace(/\*\*([^*]+)\*\*/g, "$1")
-    .replace(/\*([^*]+)\*/g, "$1")
-    .replace(/~~([^~]+)~~/g, "$1")
-    .replace(/(^|[^A-Za-z0-9_])__([^_]+)__(?![A-Za-z0-9_])/g, "$1$2")
-    .replace(/(^|[^A-Za-z0-9_])_([^_]+)_(?![A-Za-z0-9_])/g, "$1$2")
-    .replace(/^#{1,6}\s*/, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function deriveDescription(rootMarkdown: string): string | undefined {
-  const line = firstDescriptionLine(rootMarkdown);
-  if (!line) return undefined;
-  const text = stripInlineMarkdown(line);
+/**
+ * Takes the description from the block JSON rather than from the rendered markdown: styles live in
+ * `styles`, so there is no markup to strip and no way to confuse a literal `*` with emphasis.
+ */
+function deriveDescription(blocks: BlockRecord[]): string | undefined {
+  const text = firstBlockText(blocks);
   if (!text) return undefined;
   if (text.length <= DESCRIPTION_MAX_LENGTH) return text;
   return `${text.slice(0, DESCRIPTION_MAX_LENGTH)}…`;
@@ -132,13 +138,13 @@ function deriveDescription(rootMarkdown: string): string | undefined {
 function buildFrontMatter(
   post: ForumPostResponse,
   replies: ForumPostResponse[],
-  rootMarkdown: string,
+  description: string | undefined,
 ): Record<string, unknown> {
   const frontMatter: Record<string, unknown> = {};
 
   frontMatter.type = "Forum Thread";
   frontMatter.title = resolveThreadTitle(post);
-  setIfPresent(frontMatter, "description", deriveDescription(rootMarkdown));
+  setIfPresent(frontMatter, "description", description);
   frontMatter.resource = resourceUrl(`/forum/${post.id}`);
   if (post.labels && post.labels.length > 0) {
     frontMatter.tags = post.labels;
@@ -188,8 +194,9 @@ function buildThreadMarkdown(
   replies: ForumPostResponse[],
   rootMarkdown: string,
   replyMarkdowns: string[],
+  description: string | undefined,
 ): string {
-  const frontMatter = buildFrontMatter(post, replies, rootMarkdown);
+  const frontMatter = buildFrontMatter(post, replies, description);
   const yamlBlock = ["---", stringify(frontMatter, { lineWidth: 0 }).trimEnd(), "---"].join("\n");
   const title = resolveThreadTitle(post);
 
@@ -213,6 +220,14 @@ function renderMarkdown(content: string, blocks: BlockRecord[]): string {
     initialContent: blocks as unknown as PartialBlock[],
   });
   return editor.blocksToMarkdownLossy();
+}
+
+/** Posts written before `content_blocks` only have markdown, so let BlockNote parse it back. */
+function descriptionBlocks(post: ForumPostResponse, blocks: BlockRecord[]): BlockRecord[] {
+  if (blocks.length > 0) return blocks;
+  if (!post.content.trim()) return [];
+  const editor = BlockNoteEditor.create();
+  return editor.tryParseMarkdownToBlocks(post.content) as unknown as BlockRecord[];
 }
 
 /**
@@ -374,7 +389,8 @@ export async function buildForumThreadZip(
     renderMarkdown(reply.content, replyBlocksList[index]),
   );
 
-  const threadMd = buildThreadMarkdown(post, replies, rootMarkdown, replyMarkdowns);
+  const description = deriveDescription(descriptionBlocks(post, rootBlocks));
+  const threadMd = buildThreadMarkdown(post, replies, rootMarkdown, replyMarkdowns, description);
   const rootName = buildRootFolderName(post);
 
   const files: AsyncZippable = {

--- a/ui/src/lib/utils/datetime.ts
+++ b/ui/src/lib/utils/datetime.ts
@@ -3,7 +3,7 @@ import { formatInTimeZone } from "date-fns-tz";
 const DEFAULT_TIMEZONE = process.env.NEXT_PUBLIC_TIMEZONE || "Asia/Tokyo";
 const ISO_DATETIME_WITHOUT_TIMEZONE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/;
 
-function normalizeUtcInput(utcString: string): string {
+export function normalizeUtcInput(utcString: string): string {
   if (ISO_DATETIME_WITHOUT_TIMEZONE.test(utcString)) {
     return `${utcString}Z`;
   }


### PR DESCRIPTION
## Ticket

close #1440

## Summary

- Adds a download button to the forum thread header that exports the whole thread as a ZIP holding a single `thread.md` plus an `assets/` folder, so a discussion can be archived or shared outside QDash.
- The markdown carries YAML front matter modelled on the [Open Knowledge Format (OKF) v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md), which makes an exported thread readable as a knowledge document (what it is, where it came from, whether it is settled) instead of a bare text dump.
- UI only. No API, schema, or generated client changes, so `task generate` was not needed. One new runtime dependency (`fflate`) is added because browsers have no built-in ZIP writer.

## Changes

- `ForumThreadDownloadButton` (new): ghost icon button placed next to the Edit title control in `ForumDetailPage`. Available to every viewer, hidden while the title is being edited, disabled while replies are loading, and shows a spinner during export. A failed export raises a toast instead of leaving the button stuck.
- `buildForumThreadZip` in `ui/src/lib/forum/exportThreadZip.ts` (new): builds the archive from the root post and its replies.
  - Markdown comes from BlockNote's own `blocksToMarkdownLossy`, run on a headless `BlockNoteEditor` so replies can be serialized without mounting an editor. Posts that predate `content_blocks` fall back to the stored `content`.
  - Replies follow the root post as dated `## Reply by @user` sections, marked `(AI)` for AI replies.
  - Media is collected by walking the block JSON before the markdown is generated: same-origin images are fetched, inline `data:` URLs are decoded, and both are rewritten to relative `assets/NNN-name.ext` paths so the archive is self-contained. External `http(s)` URLs are left untouched to avoid pulling in third-party content, and an asset that fails to load keeps its original URL rather than failing the whole export.
  - The caller's `content_blocks` are deep-cloned before any rewriting, so the rendered thread is unaffected.
- Front matter follows OKF v0.2 partially:
  - Descriptive keys `type`, `title`, `description`, `resource`, `tags`, plus the `status` / `generated` / `verified` / `sources` trust signals.
  - `status` uses the OKF vocabulary (`resolved` maps to `stable`, every other thread state to `draft`); the exact QDash state is kept as `qdash.thread_status`.
  - `generated.by` is `human:<username>`, or `process:qdash-ai-reply` when the root post is an AI reply. `verified` is emitted only for a resolved thread that has an assignee, so it is never a manufactured sign-off.
  - `sources` points at the linked qubit or coupling dashboard URL, and is emitted only when chip, target type, and target ID are all set.
  - `description` is derived from the first plain-text line of the rendered root markdown (fenced code, image and heading lines skipped, inline markdown stripped) and truncated to 200 characters.
  - QDash-specific fields (number, category, thread status, author, assignee, chip/target/cooldown links, reply count, timestamps, export bookkeeping) sit under a nested `qdash` block so they do not collide with the OKF vocabulary. `okf_version` is not emitted, since the spec restricts that key to a bundle-root `index.md` and this archive uses `thread.md`.
- `fflate` added to `ui/package.json` / `ui/bun.lock` for ZIP writing (async `zip`, not `zipSync`, to keep the export off the main thread's critical path).

## Scope

- The export covers the replies currently loaded in the page (`REPLY_PAGE_SIZE` is 100, extended by "load more"). A thread longer than the loaded window exports the loaded part; changing the reply pagination is out of scope here.
- No backend, database, or OpenAPI changes, and no changes to how threads are rendered in the app.

## Verification

- `bun run test:run`: 59 files, 315 tests pass. 17 of them cover the exporter, including the OKF key set and ordering, `status` mapping, `verified` gating, `generated.by` for AI replies, `sources` for qubit and coupling targets, `description` derivation and truncation, `tags` omission, asset extraction and URL rewriting, external URL passthrough, legacy content fallback, fetch failure resilience, filename generation, and input immutability. The archive assertions unzip the produced blob and read the generated `thread.md` and `assets/` entries.
- `bunx tsc --noEmit`, `bun run lint`, `bun run fmt:check`, `bun run knip`, and `bun run build` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to download forum threads as ZIP files.
  * Downloads include Markdown-formatted posts and replies, structured thread metadata, and available media assets.
  * Export controls show progress, handle errors, and remain unavailable while a thread is being edited or replies are loading.
  * Exported files use organized filenames and folders for easier browsing.

* **Tests**
  * Added coverage for successful exports, media handling, browser downloads, disabled states, and error recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->