### PR TITLE
fix(workflow): allow Chevron amplitude endpoints and clarify range errors

### DIFF
--- a/src/qdash/api/services/task_file_service.py
+++ b/src/qdash/api/services/task_file_service.py
@@ -371,6 +371,8 @@ class TaskFileService:
                     "qid_role",
                     "greater_than",
                     "less_than",
+                    "greater_than_or_equal",
+                    "less_than_or_equal",
                 }:
                     continue
                 try:

--- a/src/qdash/datamodel/task.py
+++ b/src/qdash/datamodel/task.py
@@ -73,22 +73,30 @@ class RunParameterModel(BaseModel):
         """
         if self.value_type == "np.linspace":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.linspace requires a tuple/list of (start, stop, num)")
+                raise ValueError(
+                    f"np.linspace requires a tuple/list of (start, stop, num), got {self.value!r}"
+                )
             start, stop, num = self.value
             return np.linspace(float(start), float(stop), int(num))
         elif self.value_type == "np.logspace":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.logspace requires a tuple/list of (start, stop, num)")
+                raise ValueError(
+                    f"np.logspace requires a tuple/list of (start, stop, num), got {self.value!r}"
+                )
             start, stop, num = self.value
             return np.logspace(float(start), float(stop), int(num))
         elif self.value_type == "np.arange":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("np.arange requires a tuple/list of (start, stop, step)")
+                raise ValueError(
+                    f"np.arange requires a tuple/list of (start, stop, step), got {self.value!r}"
+                )
             start, stop, step = self.value
             return np.arange(float(start), float(stop), float(step))
         elif self.value_type == "range":
             if not isinstance(self.value, (list, tuple)) or len(self.value) != 3:
-                raise ValueError("range requires a tuple/list of (start, stop, step)")
+                raise ValueError(
+                    f"range requires a tuple/list of (start, stop, step), got {self.value!r}"
+                )
             start, stop, step = self.value
             return range(int(start), int(stop), int(step))
         elif self.value_type == "int":
@@ -144,6 +152,8 @@ class InputParameterSpec(ParameterSpec):
     qid_role: Literal["self", "control", "target", "coupling"] = "self"
     greater_than: float | None = None
     less_than: float | None = None
+    greater_than_or_equal: float | None = None
+    less_than_or_equal: float | None = None
 
     @classmethod
     def required_database(
@@ -199,19 +209,29 @@ class InputParameterSpec(ParameterSpec):
             raise ValueError("database_required must not declare a default")
         if self.resolution != "database_required" and self.default is None:
             raise ValueError(f"{self.resolution} requires a default")
-        if (
-            self.greater_than is not None
-            and self.less_than is not None
-            and self.greater_than >= self.less_than
-        ):
-            raise ValueError("greater_than must be less than less_than")
+        lower_bounds = [(self.greater_than, False), (self.greater_than_or_equal, True)]
+        upper_bounds = [(self.less_than, False), (self.less_than_or_equal, True)]
+        for lower, lower_inclusive in lower_bounds:
+            for upper, upper_inclusive in upper_bounds:
+                if lower is None or upper is None:
+                    continue
+                if lower > upper or (lower == upper and not (lower_inclusive and upper_inclusive)):
+                    raise ValueError("Numeric bounds must define a non-empty interval")
         return self
 
     def validate_effective_value(self, name: str, value: Any) -> None:
         """Validate a resolved value without changing it or applying a fallback."""
         if value is None:
             raise ValueError(f"Input parameter '{name}' was not resolved")
-        if self.greater_than is None and self.less_than is None:
+        if all(
+            bound is None
+            for bound in (
+                self.greater_than,
+                self.less_than,
+                self.greater_than_or_equal,
+                self.less_than_or_equal,
+            )
+        ):
             return
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise ValueError(f"Input parameter '{name}' must be numeric, got {value!r}")
@@ -225,6 +245,17 @@ class InputParameterSpec(ParameterSpec):
         if self.less_than is not None and numeric >= self.less_than:
             raise ValueError(
                 f"Input parameter '{name}' must be less than {self.less_than}, got {value!r}"
+            )
+
+        if self.greater_than_or_equal is not None and numeric < self.greater_than_or_equal:
+            raise ValueError(
+                f"Input parameter '{name}' must be greater than or equal to "
+                f"{self.greater_than_or_equal}, got {value!r}"
+            )
+        if self.less_than_or_equal is not None and numeric > self.less_than_or_equal:
+            raise ValueError(
+                f"Input parameter '{name}' must be less than or equal to "
+                f"{self.less_than_or_equal}, got {value!r}"
             )
 
     def create_model(self) -> "InputParameterModel":

--- a/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_chevron.py
+++ b/src/qdash/workflow/calibtasks/qubex/one_qubit_coarse/check_chevron.py
@@ -33,8 +33,8 @@ class CheckChevron(QubexTask):
         "readout_amplitude": InputParameterSpec.required_database(),
         "coarse_control_amplitude": InputParameterSpec.database_or_default(
             default=DEFAULT_COARSE_CONTROL_AMPLITUDE,
-            greater_than=CONTROL_AMPLITUDE_MIN,
-            less_than=CONTROL_AMPLITUDE_MAX,
+            greater_than_or_equal=CONTROL_AMPLITUDE_MIN,
+            less_than_or_equal=CONTROL_AMPLITUDE_MAX,
             unit="a.u.",
             description="Coarse control pulse amplitude",
         ),

--- a/src/qdash/workflow/calibtasks/task_catalog.json
+++ b/src/qdash/workflow/calibtasks/task_catalog.json
@@ -927,8 +927,8 @@
           "coarse_control_amplitude": {
             "default_value": 0.0625,
             "description": "Coarse control pulse amplitude",
-            "greater_than": 0.0001,
-            "less_than": 1.0,
+            "greater_than_or_equal": 0.0001,
+            "less_than_or_equal": 1.0,
             "resolution": "database_or_default",
             "unit": "a.u.",
             "user_override": "allowed"

--- a/tests/qdash/api/services/test_task_file_service.py
+++ b/tests/qdash/api/services/test_task_file_service.py
@@ -271,6 +271,11 @@ def test_extract_parameter_metadata_understands_named_spec_constructors() -> Non
                 user_override="forbidden",
                 greater_than=0.0,
             ),
+            "coarse_amplitude": InputParameterSpec.database_or_default(
+                default=0.0625,
+                greater_than_or_equal=0.0001,
+                less_than_or_equal=1.0,
+            ),
         }""",
         mode="eval",
     ).body
@@ -287,5 +292,12 @@ def test_extract_parameter_metadata_understands_named_spec_constructors() -> Non
             "user_override": "forbidden",
             "default_value": 0.1,
             "greater_than": 0.0,
+        },
+        "coarse_amplitude": {
+            "resolution": "database_or_default",
+            "user_override": "allowed",
+            "default_value": 0.0625,
+            "greater_than_or_equal": 0.0001,
+            "less_than_or_equal": 1.0,
         },
     }

--- a/tests/qdash/datamodel/test_task.py
+++ b/tests/qdash/datamodel/test_task.py
@@ -43,7 +43,7 @@ def test_calibration_input_validates_effective_numeric_bounds_without_fallback()
 
 
 def test_calibration_input_rejects_inverted_numeric_bounds() -> None:
-    with pytest.raises(ValidationError, match="greater_than must be less than"):
+    with pytest.raises(ValidationError, match="Numeric bounds must define a non-empty interval"):
         InputParameterSpec(
             resolution="database_or_default",
             user_override="allowed",
@@ -71,6 +71,38 @@ def test_parameter_specs_create_matching_runtime_models() -> None:
     assert run_model.value == 1024
     assert isinstance(output_model, OutputParameterModel)
     assert output_model.value == 0.5
+
+
+@pytest.mark.parametrize("value_type", ["np.linspace", "np.logspace", "np.arange", "range"])
+@pytest.mark.parametrize("value", [None, [1, 2], "invalid"])
+def test_invalid_run_parameter_range_reports_value(value_type, value) -> None:
+    parameter = RunParameterModel(value_type=value_type, value=value)
+
+    with pytest.raises(ValueError) as error:
+        parameter.get_value()
+
+    assert str(error.value).startswith(f"{value_type} requires a tuple/list")
+    assert f"got {value!r}" in str(error.value)
+
+
+@pytest.mark.parametrize(
+    "bounds",
+    [
+        {"greater_than_or_equal": 1.0, "less_than_or_equal": 0.0},
+        {"greater_than": 1.0, "less_than_or_equal": 1.0},
+        {"greater_than_or_equal": 1.0, "less_than": 1.0},
+    ],
+)
+def test_calibration_input_rejects_empty_mixed_bounds(bounds) -> None:
+    with pytest.raises(ValidationError, match="non-empty interval"):
+        InputParameterSpec.database_or_default(default=0.5, **bounds)
+
+
+def test_calibration_input_accepts_single_value_inclusive_interval() -> None:
+    declaration = InputParameterSpec.default_only(
+        default=1.0, greater_than_or_equal=1.0, less_than_or_equal=1.0
+    )
+    declaration.validate_effective_value("amplitude", 1.0)
 
 
 class TestBaseTaskResultModelRunParameters:

--- a/tests/qdash/workflow/calibtasks/qubex/test_check_chevron.py
+++ b/tests/qdash/workflow/calibtasks/qubex/test_check_chevron.py
@@ -15,6 +15,23 @@ else:
     QubexBackend = Any
 
 
+@pytest.mark.parametrize("value", [1e-4, 0.07, 1.0])
+def test_chevron_control_amplitude_accepts_inclusive_bounds(value: float) -> None:
+    CheckChevron.input_spec["coarse_control_amplitude"].validate_effective_value(
+        "coarse_control_amplitude", value
+    )
+
+
+@pytest.mark.parametrize(
+    "value", [0.000099, 1.000001, float("nan"), float("inf"), None, True, "0.5"]
+)
+def test_chevron_control_amplitude_rejects_invalid_values(value: Any) -> None:
+    with pytest.raises(ValueError, match="coarse_control_amplitude"):
+        CheckChevron.input_spec["coarse_control_amplitude"].validate_effective_value(
+            "coarse_control_amplitude", value
+        )
+
+
 class _DummyExperiment:
     def __init__(self) -> None:
         self.params = SimpleNamespace(readout_amplitude={"Q00": 0.0})


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Allow Chevron coarse control amplitudes at both endpoints (`0.0001` and `1.0`) and include invalid range values in run-parameter errors.
- Workflow validation remains strict for out-of-range and non-finite values; other tasks retain their existing exclusive bounds.

## Changes

- Add inclusive input bounds and apply them to Chevron, including task metadata extraction and the regenerated catalog.
- Include the rejected value in errors for `np.linspace`, `np.logspace`, `np.arange`, and `range` parameters.
- Add regression coverage for endpoints, invalid amplitudes, contradictory bounds, error messages, and metadata extraction.
- Validation: 107 focused tests passed; all 15 task-file service tests passed again after extending metadata coverage. Ruff lint, formatting, diff checks, and the pre-commit secret scan passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Parameter validation now supports inclusive minimum and maximum bounds.
  - Values exactly at configured boundaries are accepted when permitted.
  - Parameter metadata extraction recognizes inclusive bound settings.

- **Bug Fixes**
  - Improved validation for empty or inverted ranges across supported numeric parameters.
  - Error messages now include the invalid value to make configuration issues easier to diagnose.
  - The coarse control amplitude setting now correctly accepts its documented boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->