### PR TITLE
fix(workflow): persist initialization errors on executions

### DIFF
--- a/src/qdash/workflow/engine/execution/service.py
+++ b/src/qdash/workflow/engine/execution/service.py
@@ -177,8 +177,10 @@ class ExecutionService:
         self.state_manager.complete()
         return self.save()
 
-    def fail(self) -> "ExecutionService":
-        """Fail the execution and persist."""
+    def fail(self, error_message: str = "") -> "ExecutionService":
+        """Fail the execution and persist, preserving an existing message if none is given."""
+        if error_message:
+            self.state_manager.message = error_message
         self.state_manager.fail()
         return self.save()
 

--- a/src/qdash/workflow/engine/orchestrator.py
+++ b/src/qdash/workflow/engine/orchestrator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -165,20 +166,28 @@ class CalibOrchestrator:
         else:
             logger.info("Isolated session: ExecutionService created (no save/start)")
 
-        # Initialize TaskContext with optional provenance tracking
-        self._task_context = TaskContext(
-            username=config.username,
-            execution_id=config.execution_id,
-            qids=config.qids,
-            calib_dir=config.calib_data_path,
-            history_recorder=self._create_history_recorder(),
-            force_update_params=config.force_update_params,
-            persist_output_parameters=config.persist_output_parameters,
-        )
+        try:
+            # Initialize TaskContext with optional provenance tracking
+            self._task_context = TaskContext(
+                username=config.username,
+                execution_id=config.execution_id,
+                qids=config.qids,
+                calib_dir=config.calib_data_path,
+                history_recorder=self._create_history_recorder(),
+                force_update_params=config.force_update_params,
+                persist_output_parameters=config.persist_output_parameters,
+            )
 
-        # Initialize Backend
-        self._backend = self._create_backend()
-        self._backend.connect()
+            # Initialize Backend
+            self._backend = self._create_backend()
+            self._backend.connect()
+        except Exception:
+            if not config.skip_execution:
+                try:
+                    self._execution_service.fail(traceback.format_exc())
+                except Exception:
+                    logger.exception("Failed to persist session initialization error")
+            raise
 
         self._initialized = True
         logger.info(f"Session initialized: execution_id={config.execution_id}")

--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -1307,7 +1307,7 @@ class CalibService:
                 )
             # Reload and mark as failed
             if self.execution_service:
-                self.execution_service = self.execution_service.reload().fail()
+                self.execution_service = self.execution_service.reload().fail(error_message)
         finally:
             self._release_lock_if_acquired()
             self._initialized = False

--- a/tests/qdash/workflow/engine/test_orchestrator_initialization.py
+++ b/tests/qdash/workflow/engine/test_orchestrator_initialization.py
@@ -1,0 +1,69 @@
+"""Regression tests for failures before calibration tasks start."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from qdash.datamodel.execution import ExecutionStatusModel
+from qdash.repository.inmemory import InMemoryExecutionRepository
+from qdash.workflow.engine.config import CalibConfig
+from qdash.workflow.engine.execution.service import ExecutionService
+from qdash.workflow.engine.orchestrator import CalibOrchestrator
+
+
+@pytest.mark.parametrize("skip_execution", [False, True])
+@pytest.mark.parametrize("failure_stage", ["create", "connect"])
+def test_backend_initialization_failure_is_persisted(monkeypatch, skip_execution, failure_stage):
+    """Owned executions record the traceback; isolated workers leave their parent alone."""
+    config = CalibConfig(
+        username="alice",
+        chip_id="chip-1",
+        qids=["0"],
+        execution_id="exec-1",
+        project_id="project-1",
+        enable_github_pull=False,
+        skip_execution=skip_execution,
+    )
+    repo = InMemoryExecutionRepository()
+    service = ExecutionService.create(
+        username=config.username,
+        chip_id=config.chip_id,
+        execution_id=config.execution_id,
+        calib_data_path=config.calib_data_path,
+        project_id=config.project_id,
+        repository=repo,
+    )
+    service.save().start()
+    orchestrator = CalibOrchestrator(config)
+    monkeypatch.setattr(orchestrator, "_create_directories", MagicMock())
+    monkeypatch.setattr(orchestrator, "_create_history_recorder", lambda: None)
+    monkeypatch.setattr("qdash.workflow.engine.orchestrator.get_run_logger", MagicMock())
+    monkeypatch.setattr("qdash.workflow.engine.orchestrator.TaskContext", MagicMock())
+    monkeypatch.setattr(ExecutionService, "create", lambda **kwargs: service)
+    error = ConnectionError("Instrument connection failed")
+    backend = MagicMock()
+    factory = MagicMock(return_value=backend)
+    if failure_stage == "connect":
+        backend.connect.side_effect = error
+    else:
+        factory.side_effect = error
+    monkeypatch.setattr(orchestrator, "_create_backend", factory)
+
+    with pytest.raises(ConnectionError) as caught:
+        orchestrator.initialize()
+
+    assert caught.value is error
+    assert not orchestrator.is_initialized
+    saved = repo.find_by_id(config.execution_id)
+    assert saved is not None
+    if skip_execution:
+        assert saved.status == ExecutionStatusModel.RUNNING
+        assert saved.message == ""
+    else:
+        assert saved.status == ExecutionStatusModel.FAILED
+        assert saved.end_at is not None
+        assert "Traceback (most recent call last)" in saved.message
+        assert "ConnectionError: Instrument connection failed" in saved.message
+        # A later cleanup without a reason must retain the diagnostic.
+        service.reload().fail()
+        assert service.reload().message == saved.message

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -45,7 +45,7 @@ class MockExecutionService:
         self.completed = True
         return self
 
-    def fail(self):
+    def fail(self, error_message=""):
         return self
 
     def reload(self):
@@ -489,6 +489,8 @@ class TestCalibServiceInitialization:
             session.cancel_calibration()
 
         getattr(execution_service.reload.return_value, terminal).assert_called_once()
+        if terminal == "fail":
+            execution_service.reload.return_value.fail.assert_called_once_with("measurement failed")
         assert lock_repo.locked is False
         assert session._lock_acquired is False
 
@@ -840,7 +842,7 @@ def pipeline_execution_env(mock_flow_session_deps, monkeypatch):
                 ("cancel", "cancelled"),
             ):
 
-                def close(status=status):
+                def close(*args, status=status):
                     assert lock.locked  # No stage may release the pipeline lock.
                     record.status = status
                     return self._execution_service


### PR DESCRIPTION
## Ticket

- N/A

## Summary

- Record initialization failures, including `exp.connect()` errors, on the execution so it reaches `failed` with the exception traceback instead of remaining open without diagnostics.
- Limited to workflow error handling; no API, schema, or configuration changes. Isolated workers continue to leave their parent execution lifecycle untouched.

## Changes

- Persist initialization tracebacks while re-raising the original exception, even if recording the failure also fails.
- Forward `fail_calibration(error_message)` to execution persistence and retain existing diagnostics when no new message is supplied.
- Add regression coverage for backend creation and connection failures, isolated workers, and diagnostic preservation.
- Validation: 83 focused workflow tests passed; Ruff lint/format checks and `git diff --check` passed. Hardware connection testing was not performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failure details are now preserved in execution records when calibration or workflow initialization fails.
  * Backend setup errors now include diagnostic traceback information while still propagating the original error.
  * Existing failure messages are retained when no replacement message is provided.

* **Tests**
  * Added coverage for failures during backend creation and connection.
  * Updated calibration tests to verify that error messages are recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->