### PR TITLE
fix(workflow): preserve params push allowlist across steps

### DIFF
--- a/src/qdash/workflow/service/calib_service.py
+++ b/src/qdash/workflow/service/calib_service.py
@@ -1004,14 +1004,17 @@ class CalibService:
         except Exception as e:
             logger.warning(f"Failed to finalize tasks on cancel: {e}")
 
-    def _sync_backend_params_before_push(self, logger: Any) -> None:
+    def _sync_backend_params_before_push(self, logger: Any) -> GitHubPushConfig:
         """Sync recent calibration results into backend YAML params prior to GitHub push."""
         assert self.execution_service is not None, "ExecutionService not initialized"
         assert self.github_push_config is not None, "GitHubPushConfig not initialized"
+        # The session reuses its configured allowlist across pipeline steps.
+        # Filter a per-push copy so earlier steps cannot exclude later outputs.
+        push_config = self.github_push_config.model_copy(deep=True)
         self._merge_task_result_calib_data_before_push(logger)
         updater_instance = get_params_updater(self.backend, self.chip_id)
         if updater_instance is None:
-            return
+            return push_config
 
         from qdash.workflow.engine.params_updater import resolve_param_yaml_file_names
 
@@ -1025,9 +1028,9 @@ class CalibService:
             except Exception as exc:
                 logger.warning(f"Failed to sync params for qid={qid}: {exc}")
 
-        configured_param_files = self.github_push_config.params_file_names
+        configured_param_files = push_config.params_file_names
         if configured_param_files is not None:
-            self.github_push_config.params_file_names = [
+            push_config.params_file_names = [
                 file_name
                 for file_name in configured_param_files
                 if file_name in push_candidate_files
@@ -1038,6 +1041,7 @@ class CalibService:
                     "Skipping params files not touched by this calibration: %s",
                     ", ".join(skipped_files),
                 )
+        return push_config
 
     def _merge_task_result_calib_data_before_push(self, logger: Any) -> None:
         """Reload completed task outputs into parent calib_data before GitHub push.
@@ -1246,10 +1250,10 @@ class CalibService:
         if not should_push:
             return None
 
-        self._sync_backend_params_before_push(logger)
+        push_config = self._sync_backend_params_before_push(logger)
         if GitHubIntegration.check_credentials() and self.github_integration is not None:
             try:
-                push_results = self.github_integration.push_files(self.github_push_config)
+                push_results = self.github_integration.push_files(push_config)
                 if push_results:
                     self.execution_service.note.github_push_results = push_results
                     self.execution_service.save()

--- a/tests/qdash/workflow/service/test_calib_service.py
+++ b/tests/qdash/workflow/service/test_calib_service.py
@@ -583,6 +583,53 @@ class TestCalibServiceInitialization:
 class TestCalibServiceParameterManagement:
     """Test parameter get/set operations."""
 
+    def test_later_step_pushes_readout_amplitude_after_frequency_only_step(
+        self, monkeypatch, tmp_path
+    ):
+        """Each step must filter its own push without narrowing later steps' allowlist."""
+        from ruamel.yaml import YAML
+
+        from qdash.common.config.params_updater import YamlParamsUpdater
+        from qdash.workflow.service.github import GitHubPushConfig
+
+        updater = YamlParamsUpdater(params_dir=tmp_path, label="Q00")
+        monkeypatch.setattr(
+            "qdash.workflow.service.calib_service.get_params_updater",
+            lambda backend, chip_id: updater,
+        )
+        monkeypatch.setattr(
+            "qdash.workflow.service.calib_service.GitHubIntegration.check_credentials",
+            lambda: True,
+        )
+        orchestrator = MagicMock()
+        orchestrator._execution_service = MockExecutionService()
+        session = CalibService.__new__(CalibService)
+        session.chip_id = "chip_1"
+        session._orchestrator = orchestrator
+        session.github_push_config = GitHubPushConfig(
+            enabled=True,
+            params_file_names=["qubit_frequency.yaml", "readout_amplitude.yaml"],
+        )
+        session.github_integration = MagicMock()
+        session.github_integration.push_files.return_value = None
+        pushed_files = []
+        session.github_integration.push_files.side_effect = lambda config: pushed_files.append(
+            list(config.params_file_names)
+        )
+        logger = MagicMock()
+
+        session.execution_service.calib_data.qubit = {"0": {"qubit_frequency": 5.0}}
+        session._push_to_github_if_configured(logger, None)
+        session.execution_service.calib_data.qubit = {"0": {"readout_amplitude": 0.15}}
+        session._push_to_github_if_configured(logger, None)
+
+        assert pushed_files == [["qubit_frequency.yaml"], ["readout_amplitude.yaml"]]
+        assert session.github_push_config.params_file_names == [
+            "qubit_frequency.yaml",
+            "readout_amplitude.yaml",
+        ]
+        assert YAML().load(tmp_path / "readout_amplitude.yaml")["data"]["Q00"] == 0.15
+
     def test_set_and_get_parameter(self, mock_flow_session_deps, mock_lock_repo, mock_user_repo):
         """Test setting and getting parameters."""
         session = CalibService(
@@ -653,9 +700,10 @@ class TestCalibServiceParameterManagement:
         )
         logger = MagicMock()
 
-        session._sync_backend_params_before_push(logger)
+        push_config = session._sync_backend_params_before_push(logger)
 
-        assert session.github_push_config.params_file_names == ["t1.yaml"]
+        assert push_config.params_file_names == ["t1.yaml"]
+        assert session.github_push_config.params_file_names == ["t1.yaml", "t2_echo.yaml"]
         logger.info.assert_called_once()
 
     def test_sync_backend_params_keeps_touched_files_when_already_updated(
@@ -702,9 +750,10 @@ class TestCalibServiceParameterManagement:
         )
         logger = MagicMock()
 
-        session._sync_backend_params_before_push(logger)
+        push_config = session._sync_backend_params_before_push(logger)
 
-        assert session.github_push_config.params_file_names == ["t1.yaml"]
+        assert push_config.params_file_names == ["t1.yaml"]
+        assert session.github_push_config.params_file_names == ["t1.yaml", "t2_echo.yaml"]
         logger.info.assert_called_once()
 
     def test_merge_task_result_calib_data_before_push_loads_completed_outputs(


### PR DESCRIPTION
## Ticket
- N/A

## Summary
- Preserve the configured params YAML allowlist across calibration pipeline steps. A frequency-only step previously excluded `readout_amplitude.yaml` from a later step's GitHub push, even when that step updated it locally.
- Affects workflow result publishing; no API or configuration changes. Omitted local changes can subsequently be overwritten by repository synchronization, though the reported live readout-amplitude rollback has not been confirmed.

## Changes
- Filter a separate push configuration for each step instead of mutating the session's shared allowlist.
- Add a regression test covering consecutive frequency and readout-amplitude updates, including local YAML contents and files passed to the GitHub publisher.
- Validation: 155 focused tests passed across parameter persistence, calibration service, GitHub publishing, and coarse readout calibration; Ruff lint and diff checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GitHub parameter pushes now include only files relevant to the current calibration step.
  - Configured file allowlists remain unchanged across multiple pushes, preventing unintended cross-step filtering.

- **Tests**
  - Added coverage confirming per-step filtering and preservation of the original configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->